### PR TITLE
f-vue-icons@0.15.0 add @vue/cli-plugin-babel to projects dependencies

### DIFF
--- a/packages/f-vue-icons/CHANGELOG.md
+++ b/packages/f-vue-icons/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.15.0
+------------------------------
+*July 29, 2019*
+
+### Added
+- `@vue/cli-plugin-babel` to the package dev dependencies, it wasn't picked up from the root monorepo level 
+
+### Changed
+- Small Readme amends
+
+
 v0.14.0
 ------------------------------
 *July 29, 2019*

--- a/packages/f-vue-icons/README.md
+++ b/packages/f-vue-icons/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 <h1>f-vue-icons</h1>
 
-<img width="125" alt="Fozzie Bear" src="../bear.png" />
+<img width="125" alt="Fozzie Bear" src="../../bear.png" />
 
 <p>Shared Icon Components for Vue.js.</p>
 </div>
@@ -18,7 +18,7 @@
 1. Add the module to your project
 
     ```bash
-    yarn install @justeat/f-vue-icons
+    yarn add @justeat/f-vue-icons
     ```
 
 1. Import Individually at the component level (recommended)
@@ -74,7 +74,7 @@
 
 1. Browser Support
 
-    There is some config included in this module but it is untested.
+    The component extends [@justeat/browserslist-config-fozzie](https://github.com/justeat/browserslist-config-fozzie) package for the list of browsers to support
 
 1. Building the Module
 
@@ -82,4 +82,4 @@
 
 1. Running the Tests
 
-    Run `yarn test:unit` to run the tests.
+    Run `yarn test` to run the tests.

--- a/packages/f-vue-icons/package.json
+++ b/packages/f-vue-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-vue-icons",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "main": "dist/f-vue-icons.umd.min.js",
   "files": [
     "dist"
@@ -26,7 +26,7 @@
   "scripts": {
     "prepare": "yarn test && yarn build",
     "build": "yarn lint && vue-cli-service build --target lib --formats umd-min --name f-vue-icons ./src/index.js",
-    "lint": "vue-cli-service lint",
+    "lint": "vue-cli-service lint --fix",
     "test": "vue-cli-service test:unit"
   },
   "browserslist": [
@@ -37,7 +37,8 @@
     "vue": "2.6.10"
   },
   "devDependencies": {
-    "@vue/cli-plugin-eslint": "3.9.1",
+    "@vue/cli-plugin-babel": "3.9.2",
+    "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "3.9.0",
     "@vue/test-utils": "1.0.0-beta.29"
   }


### PR DESCRIPTION
### Added
- `@vue/cli-plugin-babel` to the package dev dependencies, it wasn't picked up from the root monorepo level 

### Changed
- Small Readme amends