### PR TITLE
f-vue-icons@0.15.1 Removed babel rule for ignoring polyfills

### DIFF
--- a/packages/f-vue-icons/CHANGELOG.md
+++ b/packages/f-vue-icons/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.15.1
+------------------------------
+*July 31, 2019*
+
+### Changed
+- Removed babel rule for ignoring polyfills for now
+
+
 v0.15.0
 ------------------------------
 *July 29, 2019*

--- a/packages/f-vue-icons/babel.config.js
+++ b/packages/f-vue-icons/babel.config.js
@@ -1,11 +1,22 @@
-module.exports = {
-    presets: [
-        [
-            '@vue/app',
-            {
-                useBuiltIns: 'false',
-                polyfills: 'false'
-            }
-        ]
-    ]
+module.exports = api => {
+    // Use isTest to determine what presets and plugins to use with jest
+    const isTest = api.env('test');
+    const isSettings = api.env('settings');
+    const presets = [];
+    const plugins = [];
+
+    if (!isTest) {
+        if (!isSettings) {
+            api.cache(true);
+            presets.push(['@vue/app']);
+        }
+    }
+
+    // use for both test and dev/live
+    presets.push('@babel/env');
+
+    return {
+        presets,
+        plugins
+    };
 };

--- a/packages/f-vue-icons/babel.config.js
+++ b/packages/f-vue-icons/babel.config.js
@@ -5,11 +5,9 @@ module.exports = api => {
     const presets = [];
     const plugins = [];
 
-    if (!isTest) {
-        if (!isSettings) {
-            api.cache(true);
-            presets.push(['@vue/app']);
-        }
+    if (!isTest && !isSettings) {
+        api.cache(true);
+        presets.push(['@vue/app']);
     }
 
     // use for both test and dev/live

--- a/packages/f-vue-icons/package.json
+++ b/packages/f-vue-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-vue-icons",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "main": "dist/f-vue-icons.umd.min.js",
   "files": [
     "dist"


### PR DESCRIPTION
Removed babel rule for ignoring polyfills from the package for now to resolve IE11 errors. 