### PR TITLE
f-footer@2.0.0-beta.11 data-gtm attr for all the links

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -9,8 +9,9 @@ v2.0.0-beta.11
 *August 6, 2019*
 
 ### Added
-- `data-gtm` attributes for all the footer links
+- `data-trak` attributes for all the footer links
 - `gtm` data in resource files for all the tenants
+- `@justeat/f-trak` as a peer dependency
 
 ### Changed
 - Some AU resource links according to the latest changes in live version of the footer 

--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.11
+------------------------------
+*August 6, 2019*
+
+### Added
+- `data-gtm` attributes for all the footer links
+- `gtm` data in resource files for all the tenants
+
+### Changed
+- Some AU resource links according to the latest changes in live version of the footer 
+
+
 v2.0.0-beta.10
 ------------------------------
 *August 6, 2019*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -39,6 +39,9 @@
     "v-click-outside": "2.1.3",
     "vue": "2.6.10"
   },
+  "peerDependencies": {
+    "@justeat/f-trak": "0.6.0"
+  },
   "devDependencies": {
     "@vue/cli-plugin-babel": "3.9.2",
     "@vue/cli-plugin-eslint": "3.9.2",

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "v2.0.0-beta.10",
+  "version": "v2.0.0-beta.11",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/src/components/ButtonList.vue
+++ b/packages/f-footer/src/components/ButtonList.vue
@@ -9,7 +9,8 @@
                 :key="index"
                 :href="button.url"
                 target="_blank"
-                class="c-buttonList-button">
+                class="c-buttonList-button"
+                :data-gtm="['engagement|footer|' + button.gtm]">
                 {{ button.title }}
             </a>
         </div>

--- a/packages/f-footer/src/components/ButtonList.vue
+++ b/packages/f-footer/src/components/ButtonList.vue
@@ -10,7 +10,12 @@
                 :href="button.url"
                 target="_blank"
                 class="c-buttonList-button"
-                :data-gtm="['engagement|footer|' + button.gtm]">
+                :data-trak="`{
+                    event: 'click'
+                    category: 'engagement'
+                    action: 'footer'
+                    label: '${button.gtm}'
+                }`">
                 {{ button.title }}
             </a>
         </div>

--- a/packages/f-footer/src/components/CountrySelector.vue
+++ b/packages/f-footer/src/components/CountrySelector.vue
@@ -34,6 +34,7 @@
                     <a
                         class="c-countrySelector-link"
                         data-js-test="countrySelector-countryLink"
+                        :data-gtm="['engagement|footer|' + country.gtm]"
                         :href="country.siteUrl">
                         <flag-icon :country-code="country.key" />
                         <p>

--- a/packages/f-footer/src/components/CountrySelector.vue
+++ b/packages/f-footer/src/components/CountrySelector.vue
@@ -34,7 +34,12 @@
                     <a
                         class="c-countrySelector-link"
                         data-js-test="countrySelector-countryLink"
-                        :data-gtm="['engagement|footer|' + country.gtm]"
+                        :data-trak="`{
+                            event: 'click'
+                            category: 'engagement'
+                            action: 'footer'
+                            label: '${country.gtm}'
+                        }`"
                         :href="country.siteUrl">
                         <flag-icon :country-code="country.key" />
                         <p>

--- a/packages/f-footer/src/components/FeedbackBlock.vue
+++ b/packages/f-footer/src/components/FeedbackBlock.vue
@@ -2,7 +2,12 @@
     <div
         class="c-feedback"
         data-gtm-feedback
-        data-gtm="engagement|footer|click_feedback">
+        data-trak="{
+            event: 'click'
+            category: 'engagement'
+            action: 'footer'
+            label: 'click_feedback'
+        }">
         <h2 class="c-footer-heading c-footer-heading--shortBelowWide">
             {{ title }}
         </h2>

--- a/packages/f-footer/src/components/FeedbackBlock.vue
+++ b/packages/f-footer/src/components/FeedbackBlock.vue
@@ -1,7 +1,8 @@
 <template>
     <div
         class="c-feedback"
-        data-gtm-feedback>
+        data-gtm-feedback
+        data-gtm="engagement|footer|click_feedback">
         <h2 class="c-footer-heading c-footer-heading--shortBelowWide">
             {{ title }}
         </h2>

--- a/packages/f-footer/src/components/IconList.vue
+++ b/packages/f-footer/src/components/IconList.vue
@@ -13,7 +13,8 @@
                 <a
                     v-if="icon.url"
                     :href="icon.url"
-                    :title="icon.alt">
+                    :title="icon.alt"
+                    :data-gtm="['engagement|footer|' + icon.gtm]">
                     <component
                         :is="iconChoice"
                         v-bind="icon"

--- a/packages/f-footer/src/components/IconList.vue
+++ b/packages/f-footer/src/components/IconList.vue
@@ -14,7 +14,12 @@
                     v-if="icon.url"
                     :href="icon.url"
                     :title="icon.alt"
-                    :data-gtm="['engagement|footer|' + icon.gtm]">
+                    :data-trak="`{
+                        event: 'click'
+                        category: 'engagement'
+                        action: 'footer'
+                        label: '${icon.gtm}'
+                    }`">
                     <component
                         :is="iconChoice"
                         v-bind="icon"

--- a/packages/f-footer/src/components/LinkList.vue
+++ b/packages/f-footer/src/components/LinkList.vue
@@ -31,7 +31,12 @@
                 <a
                     :href="link.url"
                     :rel="link.rel"
-                    :data-gtm="['engagement|footer|' + link.gtm]">
+                    :data-trak="`{
+                        event: 'click'
+                        category: 'engagement'
+                        action: 'footer'
+                        label: '${link.gtm}'
+                    }`">
                     {{ link.text }}
                 </a>
             </li>

--- a/packages/f-footer/src/components/LinkList.vue
+++ b/packages/f-footer/src/components/LinkList.vue
@@ -30,7 +30,8 @@
                 :key="index">
                 <a
                     :href="link.url"
-                    :rel="link.rel">
+                    :rel="link.rel"
+                    :data-gtm="['engagement|footer|' + link.gtm]">
                     {{ link.text }}
                 </a>
             </li>

--- a/packages/f-footer/src/tenants/da-DK.js
+++ b/packages/f-footer/src/tenants/da-DK.js
@@ -6,27 +6,33 @@ export default {
             links: [
                 {
                     url: '/help',
-                    text: 'Hjælp'
+                    text: 'Hjælp',
+                    gtm: 'click_service_help'
                 },
                 {
                     url: 'https://external-ordering.gavekortet.dk/justeat',
-                    text: 'Gavekort'
+                    text: 'Gavekort',
+                    gtm: 'click_service_giftcard'
                 },
                 {
                     url: '/takeaway/prisgaranti',
-                    text: 'Prisgaranti'
+                    text: 'Prisgaranti',
+                    gtm: 'click_service_best_price_guarantee'
                 },
                 {
                     url: '/takeaway/firmaaftale',
-                    text: 'Firmaaftale'
+                    text: 'Firmaaftale',
+                    gtm: 'click_service_company_agreement'
                 },
                 {
                     url: '/blog',
-                    text: 'Just Eat Blog'
+                    text: 'Just Eat Blog',
+                    gtm: 'click_service_blog'
                 },
                 {
                     url: 'http://justeat-premium.dk/',
-                    text: 'Just Eat Premium'
+                    text: 'Just Eat Premium',
+                    gtm: 'click_service_premium'
                 }
             ]
         },
@@ -35,35 +41,43 @@ export default {
             links: [
                 {
                     url: '/takeaway',
-                    text: 'Takeaway'
+                    text: 'Takeaway',
+                    gtm: 'click_cuisine_takeaway'
                 },
                 {
                     url: '/takeaway/italiensk',
-                    text: 'Pizza'
+                    text: 'Pizza',
+                    gtm: 'click_cuisine_pizza'
                 },
                 {
                     url: '/takeaway/sushi',
-                    text: 'Sushi'
+                    text: 'Sushi',
+                    gtm: 'click_cuisine_suchi'
                 },
                 {
                     url: '/takeaway/indisk',
-                    text: 'Indisk'
+                    text: 'Indisk',
+                    gtm: 'click_cuisine_indian'
                 },
                 {
                     url: '/takeaway/kinesisk',
-                    text: 'Kinesisk'
+                    text: 'Kinesisk',
+                    gtm: 'click_cuisine_chinese'
                 },
                 {
                     url: '/takeaway/amerikansk',
-                    text: 'Amerikansk & burger'
+                    text: 'Amerikansk & burger',
+                    gtm: 'click_cuisine_american'
                 },
                 {
                     url: '/takeaway/premium-gourmet',
-                    text: 'Premium & Gourmet'
+                    text: 'Premium & Gourmet',
+                    gtm: 'click_cuisine_premium_gourmet'
                 },
                 {
                     url: '/takeaway/typer-foedevarer',
-                    text: 'Alle køkkentyper'
+                    text: 'Alle køkkentyper',
+                    gtm: 'click_cuisine_view_all'
                 }
             ]
         },
@@ -72,31 +86,38 @@ export default {
             links: [
                 {
                     url: '/takeaway/koebenhavn',
-                    text: 'København'
+                    text: 'København',
+                    gtm: 'click_location_copenhagen'
                 },
                 {
                     url: '/takeaway/roskilde',
-                    text: 'Roskilde'
+                    text: 'Roskilde',
+                    gtm: 'click_location_roskilde'
                 },
                 {
                     url: '/takeaway/aarhus',
-                    text: 'Aarhus'
+                    text: 'Aarhus',
+                    gtm: 'click_location_aarhus'
                 },
                 {
                     url: '/takeaway/odense',
-                    text: 'Odense'
+                    text: 'Odense',
+                    gtm: 'click_location_odense'
                 },
                 {
                     url: '/takeaway/aalborg',
-                    text: 'Aalborg'
+                    text: 'Aalborg',
+                    gtm: 'click_location_aalborg'
                 },
                 {
                     url: '/takeaway/kgs-lyngby',
-                    text: 'Lyngby'
+                    text: 'Lyngby',
+                    gtm: 'click_location_lyngby'
                 },
                 {
                     url: '/takeaway/alle-byer',
-                    text: 'Alle byer'
+                    text: 'Alle byer',
+                    gtm: 'click_location_view_all'
                 }
             ]
         },
@@ -109,31 +130,38 @@ export default {
             links: [
                 {
                     url: 'https://restaurants.just-eat.dk/',
-                    text: 'Restaurant påmelding'
+                    text: 'Restaurant påmelding',
+                    gtm: 'click_about_restaurant_singup'
                 },
                 {
                     url: '/about',
-                    text: 'Hvem er vi'
+                    text: 'Hvem er vi',
+                    gtm: 'click_about_about_us'
                 },
                 {
                     url: 'https://partner.just-eat.dk/',
-                    text: 'Partner centre'
+                    text: 'Partner centre',
+                    gtm: 'click_about_partner_centre'
                 },
                 {
                     url: 'http://partnerblog.just-eat.dk/',
-                    text: 'Partnerblog'
+                    text: 'Partnerblog',
+                    gtm: 'click_about_partner_blog'
                 },
                 {
                     url: '/jobs',
-                    text: 'Arbejd for os'
+                    text: 'Arbejd for os',
+                    gtm: 'click_about_work_with_us'
                 },
                 {
                     url: '/privacy-policy',
-                    text: 'Handelsbetingelser'
+                    text: 'Handelsbetingelser',
+                    gtm: 'click_about_privacy_policy'
                 },
                 {
                     url: '/cookiespolicy',
-                    text: 'Brug af cookies'
+                    text: 'Brug af cookies',
+                    gtm: 'click_about_cookie_policy'
                 }
             ]
         }
@@ -144,17 +172,20 @@ export default {
         {
             url: 'https://170720.measurementapi.com/serve?action=click&publisher_id=170720&site_id=109400&my_campaign=website-app-page',
             name: 'ios',
-            alt: 'Hent i App Store'
+            alt: 'Hent i App Store',
+            gtm: 'click_download_ios_app'
         },
         {
             url: 'https://170720.measurementapi.com/serve?action=click&publisher_id=170720&site_id=108390&my_campaign=website-app-page',
             name: 'android',
-            alt: 'Hent i Google Play'
+            alt: 'Hent i Google Play',
+            gtm: 'click_download_android_app'
         },
         {
             url: 'https://www.microsoft.com/store/apps/9nblggh4vk8q',
             name: 'microsoft',
-            alt: 'Hent i Windows Store'
+            alt: 'Hent i Windows Store',
+            gtm: 'click_download_windows_app'
         }
     ],
     feedback: 'Feedback',
@@ -165,17 +196,20 @@ export default {
         {
             url: 'https://www.facebook.com/JustEatDK/',
             name: 'facebook',
-            alt: 'Facebook'
+            alt: 'Facebook',
+            gtm: 'click_follow_facebook'
         },
         {
             url: 'https://twitter.com/justeatdk',
             name: 'twitter',
-            alt: 'Twitter'
+            alt: 'Twitter',
+            gtm: 'click_follow_twitter'
         },
         {
             url: 'https://www.instagram.com/justeatdk/?hl=dk',
             name: 'instagram',
-            alt: 'Instagram'
+            alt: 'Instagram',
+            gtm: 'click_follow_instagram'
         }
     ],
     currentCountryName: 'Danmark',
@@ -184,57 +218,68 @@ export default {
         {
             key: 'au',
             localisedName: 'Australien',
-            siteUrl: 'https://www.menulog.com.au'
+            siteUrl: 'https://www.menulog.com.au',
+            gtm: 'click_country_au'
         },
         {
             key: 'br',
             localisedName: 'Brasilien',
-            siteUrl: 'https://www.ifood.com.br'
+            siteUrl: 'https://www.ifood.com.br',
+            gtm: 'click_country_br'
         },
         {
             key: 'ca',
             localisedName: 'Canada',
-            siteUrl: 'https://www.just-eat.ca'
+            siteUrl: 'https://www.just-eat.ca',
+            gtm: 'click_country_ca'
         },
         {
             key: 'fr',
             localisedName: 'Frankrig',
-            siteUrl: 'https://www.just-eat.fr/'
+            siteUrl: 'https://www.just-eat.fr/',
+            gtm: 'click_country_fr'
         },
         {
             key: 'ie',
             localisedName: 'Irland',
-            siteUrl: 'https://www.just-eat.ie'
+            siteUrl: 'https://www.just-eat.ie',
+            gtm: 'click_country_ie'
         },
         {
             key: 'it',
             localisedName: 'Italien',
-            siteUrl: 'https://www.justeat.it'
+            siteUrl: 'https://www.justeat.it',
+            gtm: 'click_country_it'
         },
         {
             key: 'nz',
             localisedName: 'New Zealand',
-            siteUrl: 'https://www.menulog.co.nz'
+            siteUrl: 'https://www.menulog.co.nz',
+            gtm: 'click_country_nz'
         },
         {
             key: 'no',
             localisedName: 'Norge',
-            siteUrl: 'https://www.just-eat.no'
+            siteUrl: 'https://www.just-eat.no',
+            gtm: 'click_country_no'
         },
         {
             key: 'ch',
             localisedName: 'Schweiz',
-            siteUrl: 'https://www.eat.ch'
+            siteUrl: 'https://www.eat.ch',
+            gtm: 'click_country_ch'
         },
         {
             key: 'es',
             localisedName: 'Spanien',
-            siteUrl: 'https://www.just-eat.es'
+            siteUrl: 'https://www.just-eat.es',
+            gtm: 'click_country_es'
         },
         {
             key: 'gb',
             localisedName: 'Storbritannien',
-            siteUrl: 'https://www.just-eat.co.uk'
+            siteUrl: 'https://www.just-eat.co.uk',
+            gtm: 'click_country_gb'
         }
     ],
     changeCurrentCountry: 'Du er på den danske website, klik her for at skifte.',

--- a/packages/f-footer/src/tenants/en-AU.js
+++ b/packages/f-footer/src/tenants/en-AU.js
@@ -6,27 +6,33 @@ export default {
             links: [
                 {
                     url: '/content/contact-us/',
-                    text: 'Contact us'
+                    text: 'Contact us',
+                    gtm: 'click_service_contact_us'
                 },
                 {
                     url: '/account/login/',
-                    text: 'Log in'
+                    text: 'Log in',
+                    gtm: 'click_service_login'
                 },
                 {
                     url: '/account/register/',
-                    text: 'Sign up'
+                    text: 'Sign up',
+                    gtm: 'click_service_singup'
                 },
                 {
                     url: '/account/info/',
-                    text: 'My account'
+                    text: 'My account',
+                    gtm: 'click_service_account'
                 },
                 {
                     url: '/blog/',
-                    text: 'Menulog blog'
+                    text: 'Menulog blog',
+                    gtm: 'click_service_blog'
                 },
                 {
                     url: '/help/',
-                    text: 'Help centre'
+                    text: 'Help centre',
+                    gtm: 'click_service_help'
                 }
             ]
         },
@@ -35,43 +41,53 @@ export default {
             links: [
                 {
                     url: '/takeaway/nearme/burgers',
-                    text: 'Burgers Delivery'
+                    text: 'Burgers Delivery',
+                    gtm: 'click_cuisine_burgers'
                 },
                 {
                     url: '/takeaway/nearme/chinese',
-                    text: 'Chinese Delivery'
+                    text: 'Chinese Delivery',
+                    gtm: 'click_cuisine_chinese'
                 },
                 {
                     url: '/takeaway/nearme/indian',
-                    text: 'Indian Delivery'
+                    text: 'Indian Delivery',
+                    gtm: 'click_cuisine_indian'
                 },
                 {
                     url: '/takeaway/nearme/italian',
-                    text: 'Italian Delivery'
+                    text: 'Italian Delivery',
+                    gtm: 'click_cuisine_italian'
                 },
                 {
                     url: '/takeaway/nearme/japanese',
-                    text: 'Japanese Delivery'
+                    text: 'Japanese Delivery',
+                    gtm: 'click_cuisine_japanese'
                 },
                 {
                     url: '/takeaway/nearme/korean',
-                    text: 'Korean Delivery'
+                    text: 'Korean Delivery',
+                    gtm: 'click_cuisine_korean'
                 },
                 {
                     url: '/takeaway/nearme/pizza',
-                    text: 'Pizza Delivery'
+                    text: 'Pizza Delivery',
+                    gtm: 'click_cuisine_pizza'
                 },
                 {
                     url: '/takeaway/nearme/thai',
-                    text: 'Thai Delivery'
+                    text: 'Thai Delivery',
+                    gtm: 'click_cuisine_thai'
                 },
                 {
                     url: '/takeaway/nearme/vietnamese',
-                    text: 'Vietnamese Delivery'
+                    text: 'Vietnamese Delivery',
+                    gtm: 'click_cuisine_vietnamese'
                 },
                 {
                     url: '/takeaway/nearme/',
-                    text: 'View all cuisines'
+                    text: 'Browse more cuisines',
+                    gtm: 'click_cuisine_view_all'
                 }
             ]
         },
@@ -80,43 +96,53 @@ export default {
             links: [
                 {
                     url: '/takeaway/sydney-city-and-inner-south-nsw',
-                    text: 'Sydney food delivery'
+                    text: 'Sydney food delivery',
+                    gtm: 'click_location_sydney'
                 },
                 {
                     url: '/takeaway/melbourne-city-vic',
-                    text: 'Melbourne food delivery'
+                    text: 'Melbourne food delivery',
+                    gtm: 'click_location_melbourne'
                 },
                 {
                     url: '/takeaway/perth-city-wa',
-                    text: 'Perth food delivery'
+                    text: 'Perth food delivery',
+                    gtm: 'click_location_perth'
                 },
                 {
                     url: '/takeaway/brisbane-inner-city-qld',
-                    text: 'Brisbane food delivery'
+                    text: 'Brisbane food delivery',
+                    gtm: 'click_location_brisbane'
                 },
                 {
                     url: '/takeaway/canberra-queanbeyan-actt',
-                    text: 'Canberra food delivery'
+                    text: 'Canberra food delivery',
+                    gtm: 'click_location_canberra'
                 },
                 {
                     url: '/takeaway/adelaide-city-sa',
-                    text: 'Adelaide food delivery'
+                    text: 'Adelaide food delivery',
+                    gtm: 'click_location_adelaide'
                 },
                 {
                     url: '/takeaway/hobart-inner-tas',
-                    text: 'Hobart food delivery'
+                    text: 'Hobart food delivery',
+                    gtm: 'click_location_hobart'
                 },
                 {
                     url: '/takeaway/gold-coast-qld',
-                    text: 'Gold Coast food delivery'
+                    text: 'Gold Coast food delivery',
+                    gtm: 'click_location_gold_coast'
                 },
                 {
                     url: '/takeaway/newcastle-and-lake-macquarie-nsw',
-                    text: 'Newcastle food delivery'
+                    text: 'Newcastle food delivery',
+                    gtm: 'click_location_newcastle'
                 },
                 {
                     url: '/takeaway/',
-                    text: 'View all locations'
+                    text: 'Browse more cities',
+                    gtm: 'click_location_view_all'
                 }
             ]
         },
@@ -125,43 +151,53 @@ export default {
             links: [
                 {
                     url: '/content/brands/hungry-jacks/',
-                    text: "Hungry Jack's Delivery"
+                    text: "Hungry Jack's Delivery",
+                    gtm: 'click_brands_hungry-jacks'
                 },
                 {
                     url: '/content/brands/kfc/',
-                    text: 'KFC Delivery'
+                    text: 'KFC Delivery',
+                    gtm: 'click_brands_kfc'
                 },
                 {
                     url: '/content/brands/crust/',
-                    text: 'Crust Delivery'
+                    text: 'Crust Delivery',
+                    gtm: 'click_brands_crust'
                 },
                 {
                     url: '/content/brands/hogs-breath/',
-                    text: "Hog's Breath Delivery"
+                    text: "Hog's Breath Delivery",
+                    gtm: 'click_brands_hogs-breath'
                 },
                 {
                     url: '/content/brands/oporto/',
-                    text: 'Oporto Delivery'
+                    text: 'Oporto Delivery',
+                    gtm: 'click_brands_oporto'
                 },
                 {
                     url: '/content/brands/pizza-hut/',
-                    text: 'Pizza Hut Delivery'
+                    text: 'Pizza Hut Delivery',
+                    gtm: 'click_brands_pizza-hut'
                 },
                 {
                     url: '/content/brands/red-rooster/',
-                    text: 'Red Rooster Delivery'
+                    text: 'Red Rooster Delivery',
+                    gtm: 'click_brands_red-rooster'
                 },
                 {
                     url: '/content/brands/subway/',
-                    text: 'Subway Delivery'
+                    text: 'Subway Delivery',
+                    gtm: 'click_brands_subway'
                 },
                 {
                     url: '/content/brands/zambrero/',
-                    text: 'Zambrero Delivery'
+                    text: 'Zambrero Delivery',
+                    gtm: 'click_brands_zambrero'
                 },
                 {
                     url: '/browse/',
-                    text: 'View all brands'
+                    text: 'Browse more brands',
+                    gtm: 'click_brands_view_all'
                 }
             ]
         },
@@ -169,32 +205,34 @@ export default {
             title: 'A bit more about us',
             links: [
                 {
-                    url: '/content/',
-                    text: 'About Menulog'
+                    url: '/info/about-us',
+                    text: 'About Menulog',
+                    gtm: 'click_about_us'
                 },
                 {
-                    url: '/content/our-price-promise/',
-                    text: 'Price promise'
+                    url: '/info/our-price-promise',
+                    text: 'Our Price Promise',
+                    gtm: 'click_about_price_promise'
                 },
                 {
-                    url: '/content/partner-with-us/',
-                    text: 'Partner with us'
+                    url: '/info/partner-with-us/',
+                    text: 'Partner with Us',
+                    gtm: 'click_about_partner_with_us'
                 },
                 {
-                    url: '/content/partner-with-us/',
-                    text: 'Menulog careers'
+                    url: '/info/corporate-partners',
+                    text: 'Corporate partners',
+                    gtm: 'click_about_corporate_partners'
                 },
                 {
-                    url: '/content/corporate-partners/',
-                    text: 'Corporate partners'
+                    url: '/blog/menulog-news',
+                    text: 'Media Centre',
+                    gtm: 'click_about_menulog_news'
                 },
                 {
-                    url: '/blog/category/press/',
-                    text: 'Media Centre'
-                },
-                {
-                    url: '/privacy-policy/',
-                    text: 'Privacy Policy and Terms of Use'
+                    url: '/info/privacy-policy',
+                    text: 'Privacy Policy and Terms of Use',
+                    gtm: 'click_about_privacy_policy'
                 }
             ]
         }
@@ -205,11 +243,13 @@ export default {
             buttons: [
                 {
                     title: 'List your restaurant',
-                    url: '/content/join-menulog'
+                    url: '/info/join-menulog',
+                    gtm: 'click_about_restaurant_singup'
                 },
                 {
                     title: 'Become a courier',
-                    url: 'https://couriers.menulog.com.au/application/'
+                    url: 'https://couriers.menulog.com.au/application/',
+                    gtm: 'click_about_couriers'
                 }
             ]
         },
@@ -218,11 +258,13 @@ export default {
             buttons: [
                 {
                     title: 'Partner centre',
-                    url: 'https://partner.menulog.com.au/'
+                    url: 'https://partner.menulog.com.au/',
+                    gtm: 'click_about_partner_centre'
                 },
                 {
                     title: 'Courier portal',
-                    url: 'https://couriers.menulog.com.au/'
+                    url: 'https://couriers.menulog.com.au/login',
+                    gtm: 'click_about_courier_portal'
                 }
             ]
         }
@@ -232,12 +274,14 @@ export default {
         {
             url: 'https://itunes.apple.com/au/app/id327982905?mt=8&amp;&amp;referrer=click%3D73fe5f13-4f3b-4048-9a2e-ee96d517a632&amp;&amp;referrer=click%3De31ca6d6-04b6-4e31-820b-d276ee56ffb4',
             name: 'ios',
-            alt: 'Download on the App Store'
+            alt: 'Download on the App Store',
+            gtm: 'click_download_ios_app'
         },
         {
             url: 'https://play.google.com/store/apps/details?id=com.menulog.m',
             name: 'android',
-            alt: 'Get it on Google Play'
+            alt: 'Get it on Google Play',
+            gtm: 'click_download_android_app'
         }
     ],
     feedback: 'Feedback',
@@ -248,17 +292,20 @@ export default {
         {
             url: 'https://www.facebook.com/Menulog.com.au/',
             name: 'facebook',
-            alt: 'Menu Log on Facebook'
+            alt: 'Menu Log on Facebook',
+            gtm: 'click_follow_facebook'
         },
         {
             url: 'https://twitter.com/menulog',
             name: 'twitter',
-            alt: 'Menu Log on Twitter'
+            alt: 'Menu Log on Twitter',
+            gtm: 'click_follow_twitter'
         },
         {
             url: 'https://www.instagram.com/menulog/',
             name: 'instagram',
-            alt: 'Menu Log on Instagram'
+            alt: 'Menu Log on Instagram',
+            gtm: 'click_follow_instagram'
         }
     ],
     currentCountryName: 'Australia',
@@ -267,57 +314,68 @@ export default {
         {
             key: 'br',
             localisedName: 'Brazil',
-            siteUrl: 'https://www.ifood.com.br'
+            siteUrl: 'https://www.ifood.com.br',
+            gtm: 'click_country_br'
         },
         {
             key: 'ca',
             localisedName: 'Canada',
-            siteUrl: 'https://www.just-eat.ca'
+            siteUrl: 'https://www.just-eat.ca',
+            gtm: 'click_country_ca'
         },
         {
             key: 'dk',
             localisedName: 'Denmark',
-            siteUrl: 'https://www.just-eat.dk'
+            siteUrl: 'https://www.just-eat.dk',
+            gtm: 'click_country_dk'
         },
         {
             key: 'fr',
             localisedName: 'France',
-            siteUrl: 'https://www.just-eat.fr/'
+            siteUrl: 'https://www.just-eat.fr/',
+            gtm: 'click_country_fr'
         },
         {
             key: 'ie',
             localisedName: 'Ireland',
-            siteUrl: 'https://www.just-eat.ie'
+            siteUrl: 'https://www.just-eat.ie',
+            gtm: 'click_country_ie'
         },
         {
             key: 'it',
             localisedName: 'Italy',
-            siteUrl: 'https://www.justeat.it'
+            siteUrl: 'https://www.justeat.it',
+            gtm: 'click_country_it'
         },
         {
             key: 'nz',
             localisedName: 'New Zealand',
-            siteUrl: 'https://www.menulog.co.nz'
+            siteUrl: 'https://www.menulog.co.nz',
+            gtm: 'click_country_nz'
         },
         {
             key: 'no',
             localisedName: 'Norway',
-            siteUrl: 'https://www.just-eat.no'
+            siteUrl: 'https://www.just-eat.no',
+            gtm: 'click_country_no'
         },
         {
             key: 'es',
             localisedName: 'Spain',
-            siteUrl: 'https://www.just-eat.es'
+            siteUrl: 'https://www.just-eat.es',
+            gtm: 'click_country_es'
         },
         {
             key: 'ch',
             localisedName: 'Switzerland',
-            siteUrl: 'https://www.eat.ch'
+            siteUrl: 'https://www.eat.ch',
+            gtm: 'click_country_ch'
         },
         {
             key: 'gb',
             localisedName: 'United Kingdom',
-            siteUrl: 'https://www.just-eat.co.uk'
+            siteUrl: 'https://www.just-eat.co.uk',
+            gtm: 'click_country_gb'
         }
     ],
     changeCurrentCountry: 'You are on the AU website, click here to change.',

--- a/packages/f-footer/src/tenants/en-GB.js
+++ b/packages/f-footer/src/tenants/en-GB.js
@@ -6,28 +6,34 @@ export default {
             links: [
                 {
                     url: '/contact',
-                    text: 'Contact us'
+                    text: 'Contact us',
+                    gtm: 'click_service_contact_us'
                 },
                 {
                     url: '/account/login',
                     text: 'Log in',
-                    rel: 'nofollow'
+                    rel: 'nofollow',
+                    gtm: 'click_service_login'
                 },
                 {
                     url: '/account/register',
-                    text: 'Sign up'
+                    text: 'Sign up',
+                    gtm: 'click_service_singup'
                 },
                 {
                     url: '/blog',
-                    text: 'Blog'
+                    text: 'Blog',
+                    gtm: 'click_service_blog'
                 },
                 {
                     url: '/apps',
-                    text: 'Mobile apps'
+                    text: 'Mobile apps',
+                    gtm: 'click_service_apps'
                 },
                 {
                     url: '/member/updateuserinfo',
-                    text: 'My account'
+                    text: 'My account',
+                    gtm: 'click_service_account'
                 }
             ]
         },
@@ -36,27 +42,33 @@ export default {
             links: [
                 {
                     url: '/takeaway/nearme/chinese',
-                    text: 'Chinese'
+                    text: 'Chinese',
+                    gtm: 'click_cuisine_chinese'
                 },
                 {
                     url: '/takeaway/nearme/indian',
-                    text: 'Indian'
+                    text: 'Indian',
+                    gtm: 'click_cuisine_indian'
                 },
                 {
                     url: '/takeaway/nearme/italian',
-                    text: 'Italian'
+                    text: 'Italian',
+                    gtm: 'click_cuisine_italian'
                 },
                 {
                     url: '/takeaway/nearme/sushi',
-                    text: 'Sushi'
+                    text: 'Sushi',
+                    gtm: 'click_cuisine_suchi'
                 },
                 {
                     url: '/takeaway/nearme/pizza',
-                    text: 'Pizza'
+                    text: 'Pizza',
+                    gtm: 'click_cuisine_pizza'
                 },
                 {
                     url: '/takeaway/nearme',
-                    text: 'View all cuisines'
+                    text: 'View all cuisines',
+                    gtm: 'click_cuisine_view_all'
                 }
             ]
         },
@@ -65,27 +77,33 @@ export default {
             links: [
                 {
                     url: '/takeaway/birmingham',
-                    text: 'Birmingham'
+                    text: 'Birmingham',
+                    gtm: 'click_location_birmingham'
                 },
                 {
                     url: '/takeaway/cardiff',
-                    text: 'Cardiff'
+                    text: 'Cardiff',
+                    gtm: 'click_location_cardiff'
                 },
                 {
                     url: '/takeaway/glasgow',
-                    text: 'Glasgow'
+                    text: 'Glasgow',
+                    gtm: 'click_location_glasgow'
                 },
                 {
                     url: '/takeaway/leeds',
-                    text: 'Leeds'
+                    text: 'Leeds',
+                    gtm: 'click_location_leeds'
                 },
                 {
                     url: '/takeaway/manchester',
-                    text: 'Manchester'
+                    text: 'Manchester',
+                    gtm: 'click_location_manchester'
                 },
                 {
                     url: '/takeaway',
-                    text: 'View all locations'
+                    text: 'View all locations',
+                    gtm: 'click_location_view_all'
                 }
             ]
         },
@@ -98,44 +116,54 @@ export default {
             links: [
                 {
                     url: 'https://restaurants.just-eat.co.uk/',
-                    text: 'Restaurant sign up'
+                    text: 'Restaurant sign up',
+                    gtm: 'click_about_restaurant_singup'
                 },
                 {
                     url: 'https://couriers.just-eat.co.uk/application',
-                    text: 'Deliver with Just Eat'
+                    text: 'Deliver with Just Eat',
+                    gtm: 'click_about_couriers'
                 },
                 {
                     url: '/pricepromise',
-                    text: 'Price promise'
+                    text: 'Price promise',
+                    gtm: 'click_about_price_promise'
                 },
                 {
                     url: '/privacy-policy',
-                    text: 'Privacy policy'
+                    text: 'Privacy policy',
+                    gtm: 'click_about_privacy_policy'
                 },
                 {
                     url: '/termsandconditions',
-                    text: 'Terms and Conditions'
+                    text: 'Terms and Conditions',
+                    gtm: 'click_about_tandcs'
                 },
                 {
                     url: '/cookiespolicy',
-                    text: 'Cookie Policy'
+                    text: 'Cookie Policy',
+                    gtm: 'click_about_cookie_policy'
                 },
                 {
                     url: 'https://www.justeatplc.com/about-us/our-business',
-                    text: 'About us'
+                    text: 'About us',
+                    gtm: 'click_about_about_us'
                 },
                 {
                     url: 'https://www.just-eat.com/',
-                    text: 'Company website'
+                    text: 'Company website',
+                    gtm: 'click_about_company'
                 },
                 {
                     url: 'https://careers.just-eat.com/',
-                    text: 'Careers'
+                    text: 'Careers',
+                    gtm: 'click_about_careers'
                 },
                 {
                     url: 'https://www.justeatplc.com/download_file/view/435/1',
                     text: 'Modern Slavery Statement',
-                    target: '_blank'
+                    target: '_blank',
+                    gtm: 'click_about_modern_slavery_statement'
                 }
             ]
         }
@@ -146,12 +174,14 @@ export default {
         {
             url: 'https://app.adjust.com/oc511o_1455tm?utm_medium=internal&campaign=homepage',
             name: 'ios',
-            alt: 'Download on the App Store'
+            alt: 'Download on the App Store',
+            gtm: 'click_download_ios_app'
         },
         {
             url: 'https://app.adjust.com/1455tm?utm_medium=internal&campaign=homepage',
             name: 'android',
-            alt: 'Get it on Google Play'
+            alt: 'Get it on Google Play',
+            gtm: 'click_download_android_app'
         }
     ],
     feedback: 'Feedback',
@@ -162,17 +192,20 @@ export default {
         {
             url: 'https://www.facebook.com/justeat',
             name: 'facebook',
-            alt: 'Just Eat on Facebook'
+            alt: 'Just Eat on Facebook',
+            gtm: 'click_follow_facebook'
         },
         {
             url: 'https://twitter.com/JustEatUK',
             name: 'twitter',
-            alt: 'Just Eat on Twitter'
+            alt: 'Just Eat on Twitter',
+            gtm: 'click_follow_twitter'
         },
         {
             url: 'https://www.youtube.com/user/TVjusteat',
             name: 'youtube',
-            alt: 'Just Eat on YouTube'
+            alt: 'Just Eat on YouTube',
+            gtm: 'click_follow_youtube'
         }
     ],
     currentCountryName: 'United Kingdom',
@@ -181,57 +214,68 @@ export default {
         {
             key: 'au',
             localisedName: 'Australia',
-            siteUrl: 'https://www.menulog.com.au'
+            siteUrl: 'https://www.menulog.com.au',
+            gtm: 'click_country_au'
         },
         {
             key: 'br',
             localisedName: 'Brazil',
-            siteUrl: 'https://www.ifood.com.br'
+            siteUrl: 'https://www.ifood.com.br',
+            gtm: 'click_country_br'
         },
         {
             key: 'ca',
             localisedName: 'Canada',
-            siteUrl: 'https://www.just-eat.ca'
+            siteUrl: 'https://www.just-eat.ca',
+            gtm: 'click_country_ca'
         },
         {
             key: 'dk',
             localisedName: 'Denmark',
-            siteUrl: 'https://www.just-eat.dk'
+            siteUrl: 'https://www.just-eat.dk',
+            gtm: 'click_country_dk'
         },
         {
             key: 'fr',
             localisedName: 'France',
-            siteUrl: 'https://www.just-eat.fr/'
+            siteUrl: 'https://www.just-eat.fr/',
+            gtm: 'click_country_fr'
         },
         {
             key: 'ie',
             localisedName: 'Ireland',
-            siteUrl: 'https://www.just-eat.ie'
+            siteUrl: 'https://www.just-eat.ie',
+            gtm: 'click_country_ie'
         },
         {
             key: 'it',
             localisedName: 'Italy',
-            siteUrl: 'https://www.justeat.it'
+            siteUrl: 'https://www.justeat.it',
+            gtm: 'click_country_it'
         },
         {
             key: 'nz',
             localisedName: 'New Zealand',
-            siteUrl: 'https://www.menulog.co.nz'
+            siteUrl: 'https://www.menulog.co.nz',
+            gtm: 'click_country_nz'
         },
         {
             key: 'no',
             localisedName: 'Norway',
-            siteUrl: 'https://www.just-eat.no'
+            siteUrl: 'https://www.just-eat.no',
+            gtm: 'click_country_no'
         },
         {
             key: 'es',
             localisedName: 'Spain',
-            siteUrl: 'https://www.just-eat.es'
+            siteUrl: 'https://www.just-eat.es',
+            gtm: 'click_country_es'
         },
         {
             key: 'ch',
             localisedName: 'Switzerland',
-            siteUrl: 'https://www.eat.ch'
+            siteUrl: 'https://www.eat.ch',
+            gtm: 'click_country_ch'
         }
     ],
     changeCurrentCountry: 'You are on the UK website, click here to change.',

--- a/packages/f-footer/src/tenants/en-IE.js
+++ b/packages/f-footer/src/tenants/en-IE.js
@@ -6,23 +6,28 @@ export default {
             links: [
                 {
                     url: '/contact',
-                    text: 'Contact us'
+                    text: 'Contact us',
+                    gtm: 'click_service_contact_us'
                 },
                 {
                     url: '/faq',
-                    text: 'FAQs'
+                    text: 'FAQs',
+                    gtm: 'click_service_faq'
                 },
                 {
                     url: '/pricepromise',
-                    text: 'Price Promise'
+                    text: 'Price Promise',
+                    gtm: 'click_service_price_promise'
                 },
                 {
                     url: 'https://restaurants.just-eat.ie/',
-                    text: 'Restaurant sign-up'
+                    text: 'Restaurant sign-up',
+                    gtm: 'click_service_restaurant_singup'
                 },
                 {
                     url: 'https://partner.just-eat.ie/',
-                    text: 'Partner centre'
+                    text: 'Partner centre',
+                    gtm: 'click_service_partner_centre'
                 }
             ]
         },
@@ -31,23 +36,28 @@ export default {
             links: [
                 {
                     url: '/takeaway/nearme/pizza',
-                    text: 'Order Pizza'
+                    text: 'Order Pizza',
+                    gtm: 'click_cuisine_pizza'
                 },
                 {
                     url: '/takeaway/nearme/chinese',
-                    text: 'Order Chinese'
+                    text: 'Order Chinese',
+                    gtm: 'click_cuisine_chinese'
                 },
                 {
                     url: '/takeaway/nearme/indian',
-                    text: 'Order Indian'
+                    text: 'Order Indian',
+                    gtm: 'click_cuisine_indian'
                 },
                 {
                     url: '/takeaway/nearme/mexican',
-                    text: 'Order Mexican'
+                    text: 'Order Mexican',
+                    gtm: 'click_cuisine_mexican'
                 },
                 {
                     url: '/takeaway/nearme/thai',
-                    text: 'Order Thai'
+                    text: 'Order Thai',
+                    gtm: 'click_cuisine_thai'
                 }
             ]
         },
@@ -56,23 +66,28 @@ export default {
             links: [
                 {
                     url: '/takeaway/dublin-area',
-                    text: 'Dublin'
+                    text: 'Dublin',
+                    gtm: 'click_location_dublin'
                 },
                 {
                     url: '/takeaway/limerick-city-centre',
-                    text: 'Limerick'
+                    text: 'Limerick',
+                    gtm: 'click_location_limerick'
                 },
                 {
                     url: '/takeaway/cork-city-centre',
-                    text: 'Cork'
+                    text: 'Cork',
+                    gtm: 'click_location_cork'
                 },
                 {
                     url: '/takeaway/galway-city-centre',
-                    text: 'Galway'
+                    text: 'Galway',
+                    gtm: 'click_location_galway'
                 },
                 {
                     url: '/takeaway/waterford',
-                    text: 'Waterford'
+                    text: 'Waterford',
+                    gtm: 'click_location_waterford'
                 }
             ]
         },
@@ -85,27 +100,33 @@ export default {
             links: [
                 {
                     url: '/info/about-us',
-                    text: 'About us'
+                    text: 'About us',
+                    gtm: 'click_about_about_us'
                 },
                 {
                     url: '/takeaway/nearme',
-                    text: 'Browse Takeaways'
+                    text: 'Browse Takeaways',
+                    gtm: 'click_about_takeaway_near_me'
                 },
                 {
                     url: '/privacy-policy',
-                    text: 'Privacy Policy'
+                    text: 'Privacy Policy',
+                    gtm: 'click_about_privacy_policy'
                 },
                 {
                     url: '/cookiespolicy',
-                    text: 'Cookie Policy'
+                    text: 'Cookie Policy',
+                    gtm: 'click_about_cookie_policy'
                 },
                 {
                     url: 'https://www.justeatshop.ie/gift-vouchers',
-                    text: 'Just Eat Gift Cards'
+                    text: 'Just Eat Gift Cards',
+                    gtm: 'click_about_gift_cards'
                 },
                 {
                     url: '/blog',
-                    text: 'Just Eat Blog'
+                    text: 'Just Eat Blog',
+                    gtm: 'click_about_blog'
                 }
             ]
         }
@@ -116,12 +137,14 @@ export default {
         {
             url: 'https://170722.measurementapi.com/serve?action=click&publisher_id=170722&site_id=109406&my_campaign=IEHomepageOngoing&my_publisher=IEHomePage&my_site=just-eat.ie&my_placement=IE4thBox',
             name: 'ios',
-            alt: 'Download on the App Store'
+            alt: 'Download on the App Store',
+            gtm: 'click_download_ios_app'
         },
         {
             url: 'https://170722.measurementapi.com/serve?action=click&publisher_id=170722&site_id=108388&my_campaign=IEHomepageOngoing&my_publisher=IEHomePage&my_site=just-eat.ie&my_placement=IE4thBox',
             name: 'android',
-            alt: 'Get it on Google Play'
+            alt: 'Get it on Google Play',
+            gtm: 'click_download_android_app'
         }
     ],
     feedback: 'Feedback',
@@ -132,7 +155,8 @@ export default {
         {
             url: 'https://www.facebook.com/JustEatIreland',
             name: 'facebook',
-            alt: 'Just Eat on Facebook'
+            alt: 'Just Eat on Facebook',
+            gtm: 'click_follow_facebook'
         },
         {
             url: 'https://www.twitter.com/JustEatIE',
@@ -142,17 +166,20 @@ export default {
         {
             url: 'https://www.just-eat.ie/blog',
             name: 'rss',
-            alt: 'Just Eat blog'
+            alt: 'Just Eat blog',
+            gtm: 'click_follow_twitter'
         },
         {
             url: 'https://instagram.com/justeatie/',
             name: 'instagram',
-            alt: 'Just Eat on Instagram'
+            alt: 'Just Eat on Instagram',
+            gtm: 'click_follow_instagram'
         },
         {
             url: 'https://www.pinterest.com/justeatie/',
             name: 'pinterest',
-            alt: 'Just Eat on Pinterest'
+            alt: 'Just Eat on Pinterest',
+            gtm: 'click_follow_pinterest'
         }
     ],
     currentCountryName: 'Ireland',
@@ -161,57 +188,68 @@ export default {
         {
             key: 'au',
             localisedName: 'Australia',
-            siteUrl: 'https://www.menulog.com.au'
+            siteUrl: 'https://www.menulog.com.au',
+            gtm: 'click_country_au'
         },
         {
             key: 'br',
             localisedName: 'Brazil',
-            siteUrl: 'https://www.ifood.com.br'
+            siteUrl: 'https://www.ifood.com.br',
+            gtm: 'click_country_br'
         },
         {
             key: 'ca',
             localisedName: 'Canada',
-            siteUrl: 'https://www.just-eat.ca'
+            siteUrl: 'https://www.just-eat.ca',
+            gtm: 'click_country_ca'
         },
         {
             key: 'dk',
             localisedName: 'Denmark',
-            siteUrl: 'https://www.just-eat.dk'
+            siteUrl: 'https://www.just-eat.dk',
+            gtm: 'click_country_dk'
         },
         {
             key: 'fr',
             localisedName: 'France',
-            siteUrl: 'https://www.just-eat.fr/'
+            siteUrl: 'https://www.just-eat.fr/',
+            gtm: 'click_country_fr'
         },
         {
             key: 'it',
             localisedName: 'Italy',
-            siteUrl: 'https://www.justeat.it'
+            siteUrl: 'https://www.justeat.it',
+            gtm: 'click_country_it'
         },
         {
             key: 'nz',
             localisedName: 'New Zealand',
-            siteUrl: 'https://www.menulog.co.nz'
+            siteUrl: 'https://www.menulog.co.nz',
+            gtm: 'click_country_nz'
         },
         {
             key: 'no',
             localisedName: 'Norway',
-            siteUrl: 'https://www.just-eat.no'
+            siteUrl: 'https://www.just-eat.no',
+            gtm: 'click_country_no'
         },
         {
             key: 'es',
             localisedName: 'Spain',
-            siteUrl: 'https://www.just-eat.es'
+            siteUrl: 'https://www.just-eat.es',
+            gtm: 'click_country_es'
         },
         {
             key: 'ch',
             localisedName: 'Switzerland',
-            siteUrl: 'https://www.eat.ch'
+            siteUrl: 'https://www.eat.ch',
+            gtm: 'click_country_ch'
         },
         {
             key: 'gb',
             localisedName: 'United Kingdom',
-            siteUrl: 'https://www.just-eat.co.uk'
+            siteUrl: 'https://www.just-eat.co.uk',
+            gtm: 'click_country_gb'
         }
     ],
     changeCurrentCountry: 'You are on the Irish website, click here to change.',

--- a/packages/f-footer/src/tenants/en-NZ.js
+++ b/packages/f-footer/src/tenants/en-NZ.js
@@ -6,27 +6,33 @@ export default {
             links: [
                 {
                     url: '/content/contact-us/',
-                    text: 'Contact us'
+                    text: 'Contact us',
+                    gtm: 'click_service_contact_us'
                 },
                 {
                     url: '/account/login/',
-                    text: 'Log in'
+                    text: 'Log in',
+                    gtm: 'click_service_login'
                 },
                 {
                     url: '/account/register/',
-                    text: 'Sign up'
+                    text: 'Sign up',
+                    gtm: 'click_service_singup'
                 },
                 {
                     url: '/account/info/',
-                    text: 'My account'
+                    text: 'My account',
+                    gtm: 'click_service_account'
                 },
                 {
                     url: '/blog/',
-                    text: 'Menulog blog'
+                    text: 'Menulog blog',
+                    gtm: 'click_service_blog'
                 },
                 {
                     url: '/help/',
-                    text: 'Help centre'
+                    text: 'Help centre',
+                    gtm: 'click_service_help'
                 }
             ]
         },
@@ -35,23 +41,28 @@ export default {
             links: [
                 {
                     url: '/browse/cuisines/chinese',
-                    text: 'Chinese'
+                    text: 'Chinese',
+                    gtm: 'click_cuisine_chinese'
                 },
                 {
                     url: '/browse/cuisines/indian',
-                    text: 'Indian'
+                    text: 'Indian',
+                    gtm: 'click_cuisine_indian'
                 },
                 {
                     url: '/browse/cuisines/thai',
-                    text: 'Thai'
+                    text: 'Thai',
+                    gtm: 'click_cuisine_thai'
                 },
                 {
                     url: '/browse/cuisines/pizza',
-                    text: 'Pizza'
+                    text: 'Pizza',
+                    gtm: 'click_cuisine_pizza'
                 },
                 {
                     url: '/browse',
-                    text: 'View all cuisines'
+                    text: 'View all cuisines',
+                    gtm: 'click_cuisine_view_all'
                 }
             ]
         },
@@ -60,19 +71,23 @@ export default {
             links: [
                 {
                     url: '/browse/locations/auckland/',
-                    text: 'Auckland'
+                    text: 'Auckland',
+                    gtm: 'click_location_auckland'
                 },
                 {
                     url: '/browse/locations/wellington/',
-                    text: 'Wellington'
+                    text: 'Wellington',
+                    gtm: 'click_location_wellington'
                 },
                 {
                     url: '/browse/locations/christchurch/',
-                    text: 'Christchurch'
+                    text: 'Christchurch',
+                    gtm: 'click_location_christchurch'
                 },
                 {
                     url: '/browse/locations/dunedin/',
-                    text: 'Dunedin'
+                    text: 'Dunedin',
+                    gtm: 'click_location_dunedin'
                 }
             ]
         },
@@ -85,19 +100,23 @@ export default {
             links: [
                 {
                     url: '/about_menulog',
-                    text: 'Get to know us'
+                    text: 'Get to know us',
+                    gtm: 'click_about_about_menulog'
                 },
                 {
                     url: '/privacy-policy#privacy_policy',
-                    text: 'Privacy Policy / Terms & Conditions'
+                    text: 'Privacy Policy / Terms & Conditions',
+                    gtm: 'click_about_privacy_policy'
                 },
                 {
                     url: 'https://connect.menulog.co.nz/login?client_id=RappsOrigPartnerCentre&response_type=code&redirect_uri=https:%2F%2Fpartner.menulog.co.nz%2Fsignin-jeconnect&state=QaF4ae5nfj7FUpuoevTVCHvmMBxIA1hO_4mDtePNEJOasCly6wdTLaHjTuvS7_If4SwPYZelgwT0ZFYb7CCZvfIIr9X0OVLKiRpdCLYU9zJPuorMgnFjjRlyQNdU8L_5ZvkfGGBtXJx-jNOlh5lU_aqiQ-KgrKthGa83ZbYH8GjV81bwGb7iJ8PRFJPYbwTyys-zclUwNFxXhfdsOpqIWsIlfpQ',
-                    text: 'Partner Centre'
+                    text: 'Partner Centre',
+                    gtm: 'click_about_partner_centre'
                 },
                 {
                     url: '/join_takeaway_section',
-                    text: 'Restaurant sign up'
+                    text: 'Restaurant sign up',
+                    gtm: 'click_about_restaurant_singup'
                 }
             ]
         }
@@ -108,12 +127,14 @@ export default {
         {
             url: 'https://itunes.apple.com/nz/app/menulog-order-takeaway-food/id485249021?mt=8&&referrer=click%3D69811f6e-2144-4706-bafc-3d9ae07efd62',
             name: 'ios',
-            alt: 'Download on the App Store'
+            alt: 'Download on the App Store',
+            gtm: 'click_download_ios_app'
         },
         {
             url: 'https://play.google.com/store/apps/details?id=nz.co.menulog.m',
             name: 'android',
-            alt: 'Get it on Google Play'
+            alt: 'Get it on Google Play',
+            gtm: 'click_download_android_app'
         }
     ],
     feedback: 'Feedback',
@@ -124,17 +145,20 @@ export default {
         {
             url: 'https://www.facebook.com/Menulog.co.nz',
             name: 'facebook',
-            alt: 'Menu Log on Facebook'
+            alt: 'Menu Log on Facebook',
+            gtm: 'click_follow_facebook'
         },
         {
             url: 'https://twitter.com/Menulog',
             name: 'twitter',
-            alt: 'Menu Log on Twitter'
+            alt: 'Menu Log on Twitter',
+            gtm: 'click_follow_twitter'
         },
         {
             url: 'https://www.instagram.com/menulog/',
             name: 'instagram',
-            alt: 'Menu Log on Instagram'
+            alt: 'Menu Log on Instagram',
+            gtm: 'click_follow_instagram'
         }
     ],
     currentCountryName: 'New Zealand',
@@ -143,57 +167,68 @@ export default {
         {
             key: 'au',
             localisedName: 'Australia',
-            siteUrl: 'https://www.menulog.com.au'
+            siteUrl: 'https://www.menulog.com.au',
+            gtm: 'click_country_au'
         },
         {
             key: 'br',
             localisedName: 'Brazil',
-            siteUrl: 'https://www.ifood.com.br'
+            siteUrl: 'https://www.ifood.com.br',
+            gtm: 'click_country_br'
         },
         {
             key: 'ca',
             localisedName: 'Canada',
-            siteUrl: 'https://www.just-eat.ca'
+            siteUrl: 'https://www.just-eat.ca',
+            gtm: 'click_country_ca'
         },
         {
             key: 'dk',
             localisedName: 'Denmark',
-            siteUrl: 'https://www.just-eat.dk'
+            siteUrl: 'https://www.just-eat.dk',
+            gtm: 'click_country_dk'
         },
         {
             key: 'fr',
             localisedName: 'France',
-            siteUrl: 'https://www.just-eat.fr/'
+            siteUrl: 'https://www.just-eat.fr/',
+            gtm: 'click_country_fr'
         },
         {
             key: 'ie',
             localisedName: 'Ireland',
-            siteUrl: 'https://www.just-eat.ie'
+            siteUrl: 'https://www.just-eat.ie',
+            gtm: 'click_country_ie'
         },
         {
             key: 'it',
             localisedName: 'Italy',
-            siteUrl: 'https://www.justeat.it'
+            siteUrl: 'https://www.justeat.it',
+            gtm: 'click_country_it'
         },
         {
             key: 'no',
             localisedName: 'Norway',
-            siteUrl: 'https://www.just-eat.no'
+            siteUrl: 'https://www.just-eat.no',
+            gtm: 'click_country_no'
         },
         {
             key: 'es',
             localisedName: 'Spain',
-            siteUrl: 'https://www.just-eat.es'
+            siteUrl: 'https://www.just-eat.es',
+            gtm: 'click_country_es'
         },
         {
             key: 'ch',
             localisedName: 'Switzerland',
-            siteUrl: 'https://www.eat.ch'
+            siteUrl: 'https://www.eat.ch',
+            gtm: 'click_country_ch'
         },
         {
             key: 'gb',
             localisedName: 'United Kingdom',
-            siteUrl: 'https://www.just-eat.co.uk'
+            siteUrl: 'https://www.just-eat.co.uk',
+            gtm: 'click_country_gb'
         }
     ],
     changeCurrentCountry: 'You are on the NZ website, click here to change.',

--- a/packages/f-footer/src/tenants/es-ES.js
+++ b/packages/f-footer/src/tenants/es-ES.js
@@ -6,19 +6,23 @@ export default {
             links: [
                 {
                     url: '/account/login/',
-                    text: 'Inicia Sesión'
+                    text: 'Inicia Sesión',
+                    gtm: 'click_service_login'
                 },
                 {
                     url: '/account/register/',
-                    text: 'Regístrate'
+                    text: 'Regístrate',
+                    gtm: 'click_service_singup'
                 },
                 {
                     url: '/blog/',
-                    text: 'Nuestro blog'
+                    text: 'Nuestro blog',
+                    gtm: 'click_service_blog'
                 },
                 {
                     url: '/account/info/',
-                    text: 'Información De La Cuenta'
+                    text: 'Información De La Cuenta',
+                    gtm: 'click_service_account'
                 }
             ]
         },
@@ -27,27 +31,33 @@ export default {
             links: [
                 {
                     url: '/a-domicilio/cerca-de-mi/pizza/',
-                    text: 'Pizza a domicilio'
+                    text: 'Pizza a domicilio',
+                    gtm: 'click_cuisine_pizza'
                 },
                 {
                     url: '/a-domicilio/cerca-de-mi/kebab/',
-                    text: 'Kebab a domicilio'
+                    text: 'Kebab a domicilio',
+                    gtm: 'click_cuisine_kebab'
                 },
                 {
                     url: '/a-domicilio/cerca-de-mi/comida-china/',
-                    text: 'Comida china a domicilio'
+                    text: 'Comida china a domicilio',
+                    gtm: 'click_cuisine_chinese'
                 },
                 {
                     url: '/a-domicilio/cerca-de-mi/sushi/',
-                    text: 'Sushi a domicilio'
+                    text: 'Sushi a domicilio',
+                    gtm: 'click_cuisine_suchi'
                 },
                 {
                     url: '/a-domicilio/cerca-de-mi/hamburguesas/',
-                    text: 'Hamburguesas a domicilio'
+                    text: 'Hamburguesas a domicilio',
+                    gtm: 'click_cuisine_burgers'
                 },
                 {
                     url: '/a-domicilio/cerca-de-mi/',
-                    text: 'Mas tipos de cocina'
+                    text: 'Mas tipos de cocina',
+                    gtm: 'click_cuisine_view_all'
                 }
             ]
         },
@@ -56,27 +66,33 @@ export default {
             links: [
                 {
                     url: '/a-domicilio/madrid/',
-                    text: 'Madrid'
+                    text: 'Madrid',
+                    gtm: 'click_location_madrid'
                 },
                 {
                     url: '/a-domicilio/barcelona/',
-                    text: 'Barcelona'
+                    text: 'Barcelona',
+                    gtm: 'click_location_barcelona'
                 },
                 {
                     url: '/a-domicilio/valencia/',
-                    text: 'Valencia'
+                    text: 'Valencia',
+                    gtm: 'click_location_valencia'
                 },
                 {
                     url: '/a-domicilio/zaragoza/',
-                    text: 'Zaragoza'
+                    text: 'Zaragoza',
+                    gtm: 'click_location_saragossa'
                 },
                 {
                     url: '/a-domicilio/palmas-de-gran-canaria/',
-                    text: 'Las Palmas'
+                    text: 'Las Palmas',
+                    gtm: 'click_location_las_palmas'
                 },
                 {
                     url: '/a-domicilio/',
-                    text: 'Más ciudades'
+                    text: 'Más ciudades',
+                    gtm: 'click_location_view_all'
                 }
             ]
         },
@@ -89,43 +105,53 @@ export default {
             links: [
                 {
                     url: 'https://restaurantes.just-eat.es/',
-                    text: 'Registrarse en el restaurante'
+                    text: 'Registrarse en el restaurante',
+                    gtm: 'click_about_restaurant_singup'
                 },
                 {
                     url: '/info/acerca-de-just-eat/',
-                    text: 'Quienes somos'
+                    text: 'Quienes somos',
+                    gtm: 'click_about_about_us'
                 },
                 {
                     url: '/help/',
-                    text: 'Ayuda'
+                    text: 'Ayuda',
+                    gtm: 'click_about_help'
                 },
                 {
                     url: '/info/garantia-de-precio/',
-                    text: 'Garantía de precio'
+                    text: 'Garantía de precio',
+                    gtm: 'click_about_price_guarantee'
                 },
                 {
                     url: '/info/politica-de-privacidad/',
-                    text: 'Política de Privacidad'
+                    text: 'Política de Privacidad',
+                    gtm: 'click_about_privacy_policy'
                 },
                 {
                     url: '/info/terminos-y-condiciones/',
-                    text: 'Términos y Condiciones'
+                    text: 'Términos y Condiciones',
+                    gtm: 'click_about_tandcs'
                 },
                 {
                     url: '/info/politica-de-cookies/',
-                    text: 'Política de Cookies'
+                    text: 'Política de Cookies',
+                    gtm: 'click_about_cookie_policy'
                 },
                 {
                     url: '/blog/descuento-5e-just-eat/',
-                    text: '5€ de descuento'
+                    text: '5€ de descuento',
+                    gtm: 'click_about_discount'
                 },
                 {
                     url: '/campana/afiliacion',
-                    text: 'Programa de Afiliación'
+                    text: 'Programa de Afiliación',
+                    gtm: 'click_about_affiliate_program'
                 },
                 {
                     url: 'https://partner.just-eat.es/',
-                    text: 'Gestiona tu restaurante'
+                    text: 'Gestiona tu restaurante',
+                    gtm: 'click_about_partner_centre'
                 }
             ]
         }
@@ -136,12 +162,14 @@ export default {
         {
             url: 'https://itunes.apple.com/es/app/just-eat/id615238455?&mt=8',
             name: 'ios',
-            alt: 'Consíguelo en el App Store'
+            alt: 'Consíguelo en el App Store',
+            gtm: 'click_download_ios_app'
         },
         {
             url: 'https://play.google.com/store/apps/details?id=com.justeat.app.es',
             name: 'android',
-            alt: 'Disponible en Google play'
+            alt: 'Disponible en Google play',
+            gtm: 'click_download_android_app'
         }
     ],
     feedback: 'Opinión',
@@ -152,22 +180,26 @@ export default {
         {
             url: 'https://www.facebook.com/JustEat.es',
             name: 'facebook',
-            alt: 'Facebook'
+            alt: 'Facebook',
+            gtm: 'click_follow_facebook'
         },
         {
             url: 'https://twitter.com/JustEat_es',
             name: 'twitter',
-            alt: 'Twitter'
+            alt: 'Twitter',
+            gtm: 'click_follow_twitter'
         },
         {
             url: 'https://www.just-eat.es/blog',
             name: 'rss',
-            alt: 'Blog'
+            alt: 'Blog',
+            gtm: 'click_follow_blog'
         },
         {
             url: 'https://www.instagram.com/justeat_es/',
             name: 'instagram',
-            alt: 'Instagram'
+            alt: 'Instagram',
+            gtm: 'click_follow_instagram'
         }
     ],
     currentCountryName: 'España',
@@ -176,57 +208,68 @@ export default {
         {
             key: 'au',
             localisedName: 'Australia',
-            siteUrl: 'https://www.menulog.com.au'
+            siteUrl: 'https://www.menulog.com.au',
+            gtm: 'click_country_au'
         },
         {
             key: 'br',
             localisedName: 'Brasil',
-            siteUrl: 'https://www.ifood.com.br'
+            siteUrl: 'https://www.ifood.com.br',
+            gtm: 'click_country_br'
         },
         {
             key: 'ca',
             localisedName: 'Canadá',
-            siteUrl: 'https://www.just-eat.ca'
+            siteUrl: 'https://www.just-eat.ca',
+            gtm: 'click_country_ca'
         },
         {
             key: 'dk',
             localisedName: 'Dinamarca',
-            siteUrl: 'https://www.just-eat.dk'
+            siteUrl: 'https://www.just-eat.dk',
+            gtm: 'click_country_dk'
         },
         {
             key: 'fr',
             localisedName: 'Francia',
-            siteUrl: 'https://www.just-eat.fr/'
+            siteUrl: 'https://www.just-eat.fr/',
+            gtm: 'click_country_fr'
         },
         {
             key: 'ie',
             localisedName: 'Irlanda',
-            siteUrl: 'https://www.just-eat.ie'
+            siteUrl: 'https://www.just-eat.ie',
+            gtm: 'click_country_ie'
         },
         {
             key: 'it',
             localisedName: 'Italia',
-            siteUrl: 'https://www.justeat.it'
+            siteUrl: 'https://www.justeat.it',
+            gtm: 'click_country_it'
         },
         {
             key: 'no',
             localisedName: 'Noruega',
-            siteUrl: 'https://www.just-eat.no'
+            siteUrl: 'https://www.just-eat.no',
+            gtm: 'click_country_no'
         },
         {
             key: 'nz',
             localisedName: 'Nueva Zelanda',
-            siteUrl: 'https://www.menulog.co.nz'
+            siteUrl: 'https://www.menulog.co.nz',
+            gtm: 'click_country_nz'
         },
         {
             key: 'gb',
             localisedName: 'Reino Unido',
-            siteUrl: 'https://www.just-eat.co.uk'
+            siteUrl: 'https://www.just-eat.co.uk',
+            gtm: 'click_country_gb'
         },
         {
             key: 'ch',
             localisedName: 'Suiza',
-            siteUrl: 'https://www.eat.ch'
+            siteUrl: 'https://www.eat.ch',
+            gtm: 'click_country_ch'
         }
     ],
     changeCurrentCountry: 'Estás en Just Eat España, haz clic aquí para cambiar país.',

--- a/packages/f-footer/src/tenants/it-IT.js
+++ b/packages/f-footer/src/tenants/it-IT.js
@@ -6,23 +6,28 @@ export default {
             links: [
                 {
                     url: '/account/login/',
-                    text: 'Accedi'
+                    text: 'Accedi',
+                    gtm: 'click_service_login'
                 },
                 {
                     url: '/account/register/',
-                    text: 'Registrati'
+                    text: 'Registrati',
+                    gtm: 'click_service_singup'
                 },
                 {
                     url: '/blog/',
-                    text: 'Blog'
+                    text: 'Blog',
+                    gtm: 'click_service_blog'
                 },
                 {
                     url: '/account/info/',
-                    text: 'Il mio account'
+                    text: 'Il mio account',
+                    gtm: 'click_service_account'
                 },
                 {
                     url: '/help/',
-                    text: 'Aiuto?'
+                    text: 'Aiuto?',
+                    gtm: 'click_service_help'
                 }
             ]
         },
@@ -31,23 +36,28 @@ export default {
             links: [
                 {
                     url: '/domicilio/vicino-a-me/pizza/',
-                    text: 'Pizza a domicilio'
+                    text: 'Pizza a domicilio',
+                    gtm: 'click_cuisine_pizza'
                 },
                 {
                     url: '/domicilio/vicino-a-me/cinese',
-                    text: 'Cinese a domicilio'
+                    text: 'Cinese a domicilio',
+                    gtm: 'click_cuisine_chinese'
                 },
                 {
                     url: '/domicilio/vicino-a-me/sushi-giapponese/',
-                    text: 'Sushi a domicilio'
+                    text: 'Sushi a domicilio',
+                    gtm: 'click_cuisine_suchi'
                 },
                 {
                     url: '/domicilio/vicino-a-me/kebab/',
-                    text: 'Kebab a domicilio'
+                    text: 'Kebab a domicilio',
+                    gtm: 'click_cuisine_kebab'
                 },
                 {
                     url: '/domicilio/vicino-a-me/',
-                    text: 'Tutti i tipi di cucine'
+                    text: 'Tutti i tipi di cucine',
+                    gtm: 'click_cuisine_view_all'
                 }
             ]
         },
@@ -56,31 +66,38 @@ export default {
             links: [
                 {
                     url: '/domicilio/palermo/',
-                    text: 'Palermo'
+                    text: 'Palermo',
+                    gtm: 'click_location_palermo'
                 },
                 {
                     url: '/domicilio/roma/',
-                    text: 'Roma'
+                    text: 'Roma',
+                    gtm: 'click_location_rome'
                 },
                 {
                     url: '/domicilio/milano/',
-                    text: 'Milano'
+                    text: 'Milano',
+                    gtm: 'click_location_milan'
                 },
                 {
                     url: '/domicilio/napoli/',
-                    text: 'Napoli'
+                    text: 'Napoli',
+                    gtm: 'click_location_naples'
                 },
                 {
                     url: '/domicilio/torino/',
-                    text: 'Torino'
+                    text: 'Torino',
+                    gtm: 'click_location_turin'
                 },
                 {
                     url: '/domicilio/bologna/',
-                    text: 'Bologna'
+                    text: 'Bologna',
+                    gtm: 'click_location_bologna'
                 },
                 {
                     url: '/domicilio/citta/',
-                    text: 'Tutte le città'
+                    text: 'Tutte le città',
+                    gtm: 'click_location_view_all'
                 }
             ]
         },
@@ -93,39 +110,48 @@ export default {
             links: [
                 {
                     url: '/informazioni/privacy-policy/',
-                    text: 'Termini e Condizioni'
+                    text: 'Termini e Condizioni',
+                    gtm: 'click_about_tandcs'
                 },
                 {
                     url: '/informazioni/politica-dei-cookie/',
-                    text: 'Cookie Policy'
+                    text: 'Cookie Policy',
+                    gtm: 'click_about_cookie_policy'
                 },
                 {
                     url: '/informazioni/about-us/',
-                    text: 'Informazioni su Just Eat'
+                    text: 'Informazioni su Just Eat',
+                    gtm: 'click_about_about_us'
                 },
                 {
                     url: '/faq/',
-                    text: 'Domande frequenti'
+                    text: 'Domande frequenti',
+                    gtm: 'click_about_faq'
                 },
                 {
                     url: '/informazioni/miglior-prezzo-garantito/',
-                    text: 'Miglior Prezzo Garantito'
+                    text: 'Miglior Prezzo Garantito',
+                    gtm: 'click_about_best_price_guarantee'
                 },
                 {
                     url: '/informazioni/lavora-con-noi/',
-                    text: 'Lavora con noi'
+                    text: 'Lavora con noi',
+                    gtm: 'click_about_work_with_us'
                 },
                 {
                     url: '/informazioni/driver-partner/',
-                    text: 'Diventa un Rider'
+                    text: 'Diventa un Rider',
+                    gtm: 'click_about_couriers'
                 },
                 {
                     url: '/informazioni/media-and-press/',
-                    text: 'Area stampa'
+                    text: 'Area stampa',
+                    gtm: 'click_about_media_and_press'
                 },
                 {
                     url: '/app/',
-                    text: 'Le nostre App'
+                    text: 'Le nostre App',
+                    gtm: 'click_about_app'
                 }
             ]
         }
@@ -136,12 +162,14 @@ export default {
         {
             url: 'https://itunes.apple.com/it/app/justeat.it-ristoranti-domicilio/id495607955?mt=8',
             name: 'ios',
-            alt: 'Scarica su App Store'
+            alt: 'Scarica su App Store',
+            gtm: 'click_download_ios_app'
         },
         {
             url: 'https://play.google.com/store/apps/details?id=com.justeat.app.it',
             name: 'android',
-            alt: 'Disponibile su Google Play'
+            alt: 'Disponibile su Google Play',
+            gtm: 'click_download_android_app'
         }
     ],
     feedback: 'Feedback',
@@ -152,12 +180,14 @@ export default {
         {
             url: 'https://www.facebook.com/justeatitaly',
             name: 'facebook',
-            alt: 'Facebook'
+            alt: 'Facebook',
+            gtm: 'click_follow_facebook'
         },
         {
             url: 'https://twitter.com/JustEat_it',
             name: 'twitter',
-            alt: 'Twitter'
+            alt: 'Twitter',
+            gtm: 'click_follow_twitter'
         }
     ],
     currentCountryName: 'Italia',
@@ -166,57 +196,68 @@ export default {
         {
             key: 'au',
             localisedName: 'Australia',
-            siteUrl: 'https://www.menulog.com.au'
+            siteUrl: 'https://www.menulog.com.au',
+            gtm: 'click_country_au'
         },
         {
             key: 'br',
             localisedName: 'Brasile',
-            siteUrl: 'https://www.ifood.com.br'
+            siteUrl: 'https://www.ifood.com.br',
+            gtm: 'click_country_br'
         },
         {
             key: 'ca',
             localisedName: 'Canada',
-            siteUrl: 'https://www.just-eat.ca'
+            siteUrl: 'https://www.just-eat.ca',
+            gtm: 'click_country_ca'
         },
         {
             key: 'dk',
             localisedName: 'Danimarca',
-            siteUrl: 'https://www.just-eat.dk'
+            siteUrl: 'https://www.just-eat.dk',
+            gtm: 'click_country_dk'
         },
         {
             key: 'fr',
             localisedName: 'Francia',
-            siteUrl: 'https://www.just-eat.fr/'
+            siteUrl: 'https://www.just-eat.fr/',
+            gtm: 'click_country_fr'
         },
         {
             key: 'ie',
             localisedName: 'Irlanda',
-            siteUrl: 'https://www.just-eat.ie'
+            siteUrl: 'https://www.just-eat.ie',
+            gtm: 'click_country_ie'
         },
         {
             key: 'no',
             localisedName: 'Norvegia',
-            siteUrl: 'https://www.just-eat.no'
+            siteUrl: 'https://www.just-eat.no',
+            gtm: 'click_country_no'
         },
         {
             key: 'nz',
             localisedName: 'Nuova Zelanda',
-            siteUrl: 'https://www.menulog.co.nz'
+            siteUrl: 'https://www.menulog.co.nz',
+            gtm: 'click_country_nz'
         },
         {
             key: 'gb',
             localisedName: 'Regno Unito',
-            siteUrl: 'https://www.just-eat.co.uk'
+            siteUrl: 'https://www.just-eat.co.uk',
+            gtm: 'click_country_uk'
         },
         {
             key: 'es',
             localisedName: 'Spagna',
-            siteUrl: 'https://www.just-eat.es'
+            siteUrl: 'https://www.just-eat.es',
+            gtm: 'click_country_es'
         },
         {
             key: 'ch',
             localisedName: 'Svizzera',
-            siteUrl: 'https://www.eat.ch'
+            siteUrl: 'https://www.eat.ch',
+            gtm: 'click_country_ch'
         }
     ],
     paymentIcons: [

--- a/packages/f-footer/src/tenants/nb-NO.js
+++ b/packages/f-footer/src/tenants/nb-NO.js
@@ -6,16 +6,19 @@ export default {
             links: [
                 {
                     url: '/help',
-                    text: 'Hjelp'
+                    text: 'Hjelp',
+                    gtm: 'click_service_help'
                 },
                 {
                     url: '/account/login',
                     text: 'Logg inn',
-                    rel: 'nofollow'
+                    rel: 'nofollow',
+                    gtm: 'click_service_login'
                 },
                 {
                     url: '/account/register',
-                    text: 'Registrer deg'
+                    text: 'Registrer deg',
+                    gtm: 'click_service_singup'
                 }
             ]
         },
@@ -24,31 +27,38 @@ export default {
             links: [
                 {
                     url: '/take-away',
-                    text: 'Take-away'
+                    text: 'Take-away',
+                    gtm: 'click_cuisine_take_away'
                 },
                 {
                     url: '/take-away/pizza',
-                    text: 'Pizza'
+                    text: 'Pizza',
+                    gtm: 'click_cuisine_pizza'
                 },
                 {
                     url: '/take-away/sushi',
-                    text: 'Sushi'
+                    text: 'Sushi',
+                    gtm: 'click_cuisine_suchi'
                 },
                 {
                     url: '/take-away/indisk',
-                    text: 'Indisk'
+                    text: 'Indisk',
+                    gtm: 'click_cuisine_indian'
                 },
                 {
                     url: '/take-away/thaimat',
-                    text: 'Thaimat'
+                    text: 'Thaimat',
+                    gtm: 'click_cuisine_thai'
                 },
                 {
                     url: '/take-away/kebab',
-                    text: 'Kebab'
+                    text: 'Kebab',
+                    gtm: 'click_cuisine_kebab'
                 },
                 {
                     url: '/take-away/cuisines',
-                    text: 'Alle kjøkkentyper'
+                    text: 'Alle kjøkkentyper',
+                    gtm: 'click_cuisine_view_all'
                 }
             ]
         },
@@ -57,31 +67,38 @@ export default {
             links: [
                 {
                     url: '/take-away/Oslo',
-                    text: 'Oslo'
+                    text: 'Oslo',
+                    gtm: 'click_location_oslo'
                 },
                 {
                     url: '/take-away/Bergen',
-                    text: 'Bergen'
+                    text: 'Bergen',
+                    gtm: 'click_location_bergen'
                 },
                 {
                     url: '/take-away/Trondheim',
-                    text: 'Trondheim'
+                    text: 'Trondheim',
+                    gtm: 'click_location_trondheim'
                 },
                 {
                     url: '/take-away/Drammen',
-                    text: 'Drammen'
+                    text: 'Drammen',
+                    gtm: 'click_location_drammen'
                 },
                 {
                     url: '/take-away/Fredrikstad',
-                    text: 'Fredrikstad'
+                    text: 'Fredrikstad',
+                    gtm: 'click_location_fredrikstad'
                 },
                 {
                     url: '/take-away/Asker',
-                    text: 'Asker & Bærum'
+                    text: 'Asker & Bærum',
+                    gtm: 'click_location_asker'
                 },
                 {
                     url: '/take-away/cities',
-                    text: 'Alle byer'
+                    text: 'Alle byer',
+                    gtm: 'click_location_view_all'
                 }
             ]
         },
@@ -94,27 +111,33 @@ export default {
             links: [
                 {
                     url: '/take-away/bedrift-overtidsmat',
-                    text: 'Restaurant påmelding'
+                    text: 'Restaurant påmelding',
+                    gtm: 'click_about_restaurant_singup'
                 },
                 {
                     url: '/about',
-                    text: 'Om oss'
+                    text: 'Om oss',
+                    gtm: 'click_about_about_us'
                 },
                 {
                     url: 'https://partner.just-eat.no/',
-                    text: 'Partner centre'
+                    text: 'Partner centre',
+                    gtm: 'click_about_partner_centre'
                 },
                 {
                     url: '/jobs',
-                    text: 'Ledige stillinger'
+                    text: 'Ledige stillinger',
+                    gtm: 'click_about_careers'
                 },
                 {
                     url: '/cookiespolicy',
-                    text: 'Cookies'
+                    text: 'Cookies',
+                    gtm: 'click_about_cookie_policy'
                 },
                 {
                     url: '/privacy-policy',
-                    text: 'Handelsvilkår'
+                    text: 'Handelsvilkår',
+                    gtm: 'click_about_privacy_policy'
                 }
             ]
         }
@@ -125,12 +148,14 @@ export default {
         {
             url: 'https://itunes.apple.com/no/app/just-eat.no/id748246908?ls=1&mt=8',
             name: 'ios',
-            alt: 'Hent i App Store'
+            alt: 'Hent i App Store',
+            gtm: 'click_download_ios_app'
         },
         {
             url: 'https://play.google.com/store/apps/details?id=com.justeat.app.no',
             name: 'android',
-            alt: 'Finn den på Google Play'
+            alt: 'Finn den på Google Play',
+            gtm: 'click_download_android_app'
         }
     ],
     feedback: 'Tilbakemelding',
@@ -141,12 +166,14 @@ export default {
         {
             url: 'https://www.facebook.com/JustEatNO/',
             name: 'facebook',
-            alt: 'Facebook'
+            alt: 'Facebook',
+            gtm: 'click_follow_facebook'
         },
         {
             url: '/blog',
             name: 'rss',
-            alt: 'Blog'
+            alt: 'Blog',
+            gtm: 'click_follow_blog'
         }
     ],
     currentCountryName: 'Norge',
@@ -155,57 +182,68 @@ export default {
         {
             key: 'au',
             localisedName: 'Australia',
-            siteUrl: 'https://www.menulog.com.au'
+            siteUrl: 'https://www.menulog.com.au',
+            gtm: 'click_country_au'
         },
         {
             key: 'br',
             localisedName: 'Brasil',
-            siteUrl: 'https://www.ifood.com.br'
+            siteUrl: 'https://www.ifood.com.br',
+            gtm: 'click_country_br'
         },
         {
             key: 'ca',
             localisedName: 'Canada',
-            siteUrl: 'https://www.just-eat.ca'
+            siteUrl: 'https://www.just-eat.ca',
+            gtm: 'click_country_ca'
         },
         {
             key: 'dk',
             localisedName: 'Danmark',
-            siteUrl: 'https://www.just-eat.dk'
+            siteUrl: 'https://www.just-eat.dk',
+            gtm: 'click_country_dk'
         },
         {
             key: 'fr',
             localisedName: 'Frankrike',
-            siteUrl: 'https://www.just-eat.fr/'
+            siteUrl: 'https://www.just-eat.fr/',
+            gtm: 'click_country_fr'
         },
         {
             key: 'ie',
             localisedName: 'Irland',
-            siteUrl: 'https://www.just-eat.ie'
+            siteUrl: 'https://www.just-eat.ie',
+            gtm: 'click_country_ie'
         },
         {
             key: 'it',
             localisedName: 'Italia',
-            siteUrl: 'https://www.justeat.it'
+            siteUrl: 'https://www.justeat.it',
+            gtm: 'click_country_it'
         },
         {
             key: 'nz',
             localisedName: 'New Zealand',
-            siteUrl: 'https://www.menulog.co.nz'
+            siteUrl: 'https://www.menulog.co.nz',
+            gtm: 'click_country_nz'
         },
         {
             key: 'es',
             localisedName: 'Spania',
-            siteUrl: 'https://www.just-eat.es'
+            siteUrl: 'https://www.just-eat.es',
+            gtm: 'click_country_es'
         },
         {
             key: 'gb',
             localisedName: 'Storbritannia',
-            siteUrl: 'https://www.just-eat.co.uk'
+            siteUrl: 'https://www.just-eat.co.uk',
+            gtm: 'click_country_gb'
         },
         {
             key: 'ch',
             localisedName: 'Sveits',
-            siteUrl: 'https://www.eat.ch'
+            siteUrl: 'https://www.eat.ch',
+            gtm: 'click_country_ch'
         }
     ],
     changeCurrentCountry: 'Du er på den norske nettsiden, klikk her for å endre.',


### PR DESCRIPTION
### Added
- `data-trak` attributes for all the footer links
- `gtm` data in resource files for all the tenants
- `@justeat/f-trak` as a peer dependency

### Changed
- Some AU resource links according to the latest changes in live version of the footer 