### PR TITLE
f-header@2.0.0-beta.1 logo component + tenants resource files

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta-1
+------------------------------
+*September 5, 2019*
+
+### Added
+- Logo component
+- Tenants resource files
+- Vue.config.js for rewriting default vue cli webpack config
+- common.scss base styles imports
+- theme and locale logic for Header component (later will be moved to independant package because it repeats in footer and searchbox already)
+
+
 v2.0.0-beta-0
 ------------------------------
 *September 4, 2019*

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -31,9 +31,6 @@
     "lint": "vue-cli-service lint --fix",
     "test": "vue-cli-service test:unit"
   },
-  "stylelint": {
-    "extends": "@justeat/stylelint-config-fozzie"
-  },
   "browserslist": [
     "extends @justeat/browserslist-config-fozzie"
   ],
@@ -45,7 +42,7 @@
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "3.9.2",
-    "@vue/cli-plugin-eslint": "3.9.1",
+    "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "3.9.0",
     "@vue/test-utils": "1.0.0-beta.29",
     "node-sass-magic-importer": "5.3.2"

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.0",
+  "version": "v2.0.0-beta.1",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"
@@ -38,7 +38,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-
+    "@justeat/f-vue-icons": "1.0.0-beta.3"
   },
   "peerDependencies": {
     "@justeat/f-trak": "0.6.0"

--- a/packages/f-header/src/assets/scss/common.scss
+++ b/packages/f-header/src/assets/scss/common.scss
@@ -1,0 +1,50 @@
+// Set $theme variable so that fozzie doesn't complain when vars are pulled in
+// n.b. This isn't used currently (unless there are theme specific vars from fozzie)
+// The theme is handled via a data-attribute on the component
+$theme: 'je' !default;
+
+@import '~@justeat/f-utils/src/scss/functions/index';
+@import '~@justeat/f-utils/src/scss/mixins/index';
+@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
+@import '~@justeat/fozzie/src/scss/settings/variables';
+@import '~@justeat/fozzie/src/scss/base/reset';
+@import '~@justeat/fozzie-colour-palette/src/scss/';
+@import '~@justeat/fozzie/src/scss/base/typography';
+
+/**
+ * Component Variables
+ */
+$header-logo-color                 : $brand--red;
+$header-logo-color--transparent    : $white;
+
+$header-height--narrow              : 56px;
+$header-button--height              : $header-height--narrow;
+$header-button--width               : 56px;
+$header-height                      : 76px;
+// $header-height--narrow--multiLang   : $header-height--narrow + $languageSwitcher-height;
+$header-bg                          : $white;
+$header-separator                   : 1px;
+$header-separator                   : 4px;
+$header-border-color                : $grey--lightest;
+$header-buttonIcon-color            : $blue;
+$header-buttonCount-bg              : $blue;
+$header-buttonCount-color           : $white;
+$header-buttonCount-borderColor     : $white;
+
+
+$header--transparent-gradient-color : $black;
+$header--transparent-gradient       : 115px;
+$header--transparent-opacity        : 0.7;
+
+/**
+ * Global variables which need to be changed depending on the theme (TODO: move to separate component)
+//  */
+
+$header-buttonIcon-color--ml: $green;
+$header-buttonCount-bg--ml: $green;
+
+@mixin theme($type) {
+    [data-theme="#{$type}"] & {
+        @content;
+    }
+}

--- a/packages/f-header/src/components/Demo.vue
+++ b/packages/f-header/src/components/Demo.vue
@@ -7,8 +7,8 @@
             name="viewport"
             content="width=device-width, initial-scale=1">
         <vue-header
-            :is-transparent=true
-            locale="en-AU" />
+            :is-transparent="true"
+            locale="en-GB" />
     </div>
 </template>
 

--- a/packages/f-header/src/components/Demo.vue
+++ b/packages/f-header/src/components/Demo.vue
@@ -7,7 +7,8 @@
             name="viewport"
             content="width=device-width, initial-scale=1">
         <vue-header
-            locale="en-GB" />
+            :is-transparent=true
+            locale="en-AU" />
     </div>
 </template>
 

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -4,7 +4,7 @@
         class="c-header">
         <logo
             :theme="theme"
-            :is-transparent=isTransparent
+            :is-transparent="isTransparent"
             :company-name="copy.companyName" />
     </header>
 </template>
@@ -50,7 +50,6 @@ export default {
             if (!tenantConfigs[locale]) {
                 locale = 'en-GB';
             }
-
             return locale;
         },
         getTheme (locale) {

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -1,15 +1,70 @@
 <template>
-    <header class="c-header">
-        I am Header
+    <header
+        :data-theme="theme"
+        class="c-header">
+        <logo
+            :theme="theme"
+            :is-transparent=isTransparent
+            :company-name="copy.companyName" />
     </header>
 </template>
 
 <script>
+import Logo from './Logo.vue';
+import tenantConfigs from '../tenants';
+
 export default {
-    name: 'VueHeader'
+    name: 'VueHeader',
+    components: {
+        Logo
+    },
+    props: {
+        locale: {
+            type: String,
+            required: false,
+            default: ''
+        },
+        isTransparent: {
+            type: Boolean,
+            required: true
+        }
+    },
+    data () {
+        const locale = this.getLocale();
+        const localeConfig = tenantConfigs[locale];
+        const theme = this.getTheme(locale);
+
+        return {
+            copy: { ...localeConfig },
+            theme
+        };
+    },
+    methods: {
+        getLocale () {
+            let locale = this.locale || (this.$i18n ? this.$i18n.locale : null); // use prop, or the i18n locale value set
+
+            // if the locale is either
+            // a) not set
+            // or b) set to a country code that this component does not recognise
+            // it will be set to 'en-GB'
+            if (!tenantConfigs[locale]) {
+                locale = 'en-GB';
+            }
+
+            return locale;
+        },
+        getTheme (locale) {
+            switch (locale) {
+                case 'en-AU':
+                case 'en-NZ':
+                    return 'ml';
+                default:
+                    return 'je';
+            }
+        }
+    }
 };
 </script>
 
 <style lang="scss">
-
 </style>

--- a/packages/f-header/src/components/Logo.vue
+++ b/packages/f-header/src/components/Logo.vue
@@ -1,0 +1,113 @@
+<template>
+    <a
+        :aria-label="linkAltText"
+        href="/"
+        class="c-logo" >
+        <component
+            :is="iconComponent"
+            :class="[iconClassName, 'c-logo-img', {'je-icon--transparent': isTransparent}]" />
+    </a>
+</template>
+
+<script>
+import {
+    JeLogoNoColourIcon as JeLogo,
+    MlLogoIcon as MlLogo
+} from '@justeat/f-vue-icons';
+
+export default {
+    components: {
+        JeLogo,
+        MlLogo
+    },
+    props: {
+        theme: {
+            type: String,
+            required: true
+        },
+        isTransparent: {
+            type: Boolean,
+            required: true
+        },
+        companyName: {
+            type: String,
+            required: true
+        }
+    },
+    computed: {
+        iconComponent () {
+            return `${this.theme}-logo`;
+        },
+        iconClassName () {
+            return `${this.theme}-icon`;
+        },
+        linkAltText () {
+            return `Go to ${this.companyName} homepage`;
+        }
+    }
+};
+</script>
+
+<style lang="scss" scoped>
+    // link with the logo
+    .c-logo {
+        display: block;
+        display: flex;
+        justify-content: center;
+        height: $header-height--narrow;
+        padding-top: 22px;
+
+
+        @include theme(ml) {
+            padding-top: 12px;
+        }
+
+        @include media('>=mid') {
+            justify-content: left;
+            height: $header-height;
+            padding-top: 24px;
+
+            @include theme(ml) {
+                padding-top: 10px;
+            }
+        }
+    }
+
+    .c-logo-img {
+        // default logo image height and width (as should be an inline SVG)
+        width: 82px;
+        height: 16px;
+
+        @include media('>=mid') {
+            width: 165px;
+            height: 32px;
+        }
+
+        // Menulog logo, as it has multiple fill values built in. We just hide the outline on transparent mode.
+        @include theme(ml) {
+            width: 118px;
+            height: 40px;
+            margin-left: -10.5px; //half of hamburger menu width
+
+            @include media('>=mid') {
+                width: 180px;
+                height: 61px;
+                margin-left: 0;
+            }
+
+            path:first-child {
+                .c-header--transparent & {
+                    display: none;
+                }
+            }
+        }
+    }
+
+    .je-icon g {
+        fill: $header-logo-color;
+    }
+
+    .je-icon--transparent g {
+        fill: $header-logo-color--transparent;
+    }
+</style>

--- a/packages/f-header/src/components/Logo.vue
+++ b/packages/f-header/src/components/Logo.vue
@@ -5,9 +5,9 @@
         class="c-logo">
         <component
             :is="iconComponent"
-            :class="[iconClassName, isTransparent && iconComponent == 'je-logo' ? 'c-icon-je--transparentBckgrnd' : '']"
-            :data-js-test="iconClassName"
-            class="c-logo-img" />
+            :class="[iconClassName, isTransparent && iconComponent === 'je-logo' ? 'c-icon-je--transparentBg' : '']"
+            class="c-logo-img"
+            :data-js-test="iconClassName" />
     </a>
 </template>
 
@@ -109,7 +109,7 @@ export default {
         fill: $header-logo-color;
     }
 
-    .c-icon-je--transparentBckgrnd g {
+    .c-icon-je--transparentBg g {
         fill: $header-logo-color--transparent;
     }
 </style>

--- a/packages/f-header/src/components/Logo.vue
+++ b/packages/f-header/src/components/Logo.vue
@@ -5,7 +5,7 @@
         class="c-logo">
         <component
             :is="iconComponent"
-            :class="[isTransparent ? 'je-icon--transparent' : '', iconClassName]"
+            :class="[iconClassName, isTransparent && iconComponent == 'je-logo' ? 'c-icon-je--transparentBckgrnd' : '']"
             :data-js-test="iconClassName"
             class="c-logo-img" />
     </a>
@@ -41,7 +41,7 @@ export default {
             return `${this.theme}-logo`;
         },
         iconClassName () {
-            return `${this.theme}-icon`;
+            return `c-icon--${this.theme}`;
         },
         linkAltText () {
             return `Go to ${this.companyName} homepage`;
@@ -50,7 +50,7 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
     // link with the logo
     .c-logo {
         display: block;
@@ -105,11 +105,11 @@ export default {
         }
     }
 
-    .je-icon g {
+    .c-icon--je g {
         fill: $header-logo-color;
     }
 
-    .je-icon--transparent g {
+    .c-icon-je--transparentBckgrnd g {
         fill: $header-logo-color--transparent;
     }
 </style>

--- a/packages/f-header/src/components/Logo.vue
+++ b/packages/f-header/src/components/Logo.vue
@@ -2,10 +2,12 @@
     <a
         :aria-label="linkAltText"
         href="/"
-        class="c-logo" >
+        class="c-logo">
         <component
             :is="iconComponent"
-            :class="[iconClassName, 'c-logo-img', {'je-icon--transparent': isTransparent}]" />
+            :class="[isTransparent ? 'je-icon--transparent' : '', iconClassName]"
+            :data-js-test="iconClassName"
+            class="c-logo-img" />
     </a>
 </template>
 

--- a/packages/f-header/src/components/tests/Header.test.js
+++ b/packages/f-header/src/components/tests/Header.test.js
@@ -11,10 +11,12 @@ describe('Header', () => {
     });
 
     it('should render default component markup', () => {
-        // Arrange & Act
+        // Arrange
         const propsData = {
             isTransparent: true
         };
+
+        // Act
         const wrapper = shallowMount(Header, { propsData });
 
         // Assert
@@ -23,11 +25,13 @@ describe('Header', () => {
 
 
     it('should render ml themed component if AU local passed', () => {
-        // Arrange & Act
+        // Arrange
         const propsData = {
             locale: 'en-AU',
             isTransparent: true
         };
+
+        // Act
         const wrapper = shallowMount(Header, { propsData });
 
         // Assert
@@ -35,11 +39,13 @@ describe('Header', () => {
     });
 
     it('should render ml themed component if NZ local passed', () => {
-        // Arrange & Act
+        // Arrange
         const propsData = {
             locale: 'en-NZ',
             isTransparent: true
         };
+
+        // Act
         const wrapper = shallowMount(Header, { propsData });
 
         // Assert
@@ -47,11 +53,13 @@ describe('Header', () => {
     });
 
     it('should render je themed component if NO local passed', () => {
-        // Arrange & Act
+        // Arrange
         const propsData = {
             locale: 'nb-NO',
             isTransparent: true
         };
+
+        // Act
         const wrapper = shallowMount(Header, { propsData });
 
         // Assert

--- a/packages/f-header/src/components/tests/Header.test.js
+++ b/packages/f-header/src/components/tests/Header.test.js
@@ -3,15 +3,58 @@ import Header from '../Header.vue';
 
 describe('Header', () => {
     it('should be defined', () => {
-        const wrapper = shallowMount(Header);
+        const propsData = {
+            isTransparent: true
+        };
+        const wrapper = shallowMount(Header, { propsData });
         expect(wrapper.exists()).toBe(true);
     });
 
     it('should render default component markup', () => {
         // Arrange & Act
-        const wrapper = shallowMount(Header);
+        const propsData = {
+            isTransparent: true
+        };
+        const wrapper = shallowMount(Header, { propsData });
 
         // Assert
         expect(wrapper).toMatchSnapshot();
+    });
+
+
+    it('should render ml themed component if AU local passed', () => {
+        // Arrange & Act
+        const propsData = {
+            locale: 'en-AU',
+            isTransparent: true
+        };
+        const wrapper = shallowMount(Header, { propsData });
+
+        // Assert
+        expect(wrapper.attributes('data-theme')).toBe('ml');
+    });
+
+    it('should render ml themed component if NZ local passed', () => {
+        // Arrange & Act
+        const propsData = {
+            locale: 'en-NZ',
+            isTransparent: true
+        };
+        const wrapper = shallowMount(Header, { propsData });
+
+        // Assert
+        expect(wrapper.attributes('data-theme')).toBe('ml');
+    });
+
+    it('should render je themed component if NO local passed', () => {
+        // Arrange & Act
+        const propsData = {
+            locale: 'nb-NO',
+            isTransparent: true
+        };
+        const wrapper = shallowMount(Header, { propsData });
+
+        // Assert
+        expect(wrapper.attributes('data-theme')).toBe('je');
     });
 });

--- a/packages/f-header/src/components/tests/Logo.test.js
+++ b/packages/f-header/src/components/tests/Logo.test.js
@@ -1,9 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import Logo from '../Logo.vue';
-// import {
-//     JeLogoNoColourIcon as JeLogo,
-//     MlLogoIcon as MlLogo
-// } from '@justeat/f-vue-icons';
 
 describe('Logo', () => {
     it('should be defined', () => {
@@ -17,12 +13,14 @@ describe('Logo', () => {
     });
 
     it('should render ml logo if ml theme passed', () => {
-        // Arrange & Act
+        // Arrange
         const propsData = {
             theme: 'ml',
             isTransparent: true,
             companyName: 'MenuLog'
         };
+
+        // Act
         const wrapper = shallowMount(Logo, { propsData });
         const logo = wrapper.find('[data-js-test="c-icon--ml"]');
 
@@ -31,12 +29,14 @@ describe('Logo', () => {
     });
 
     it('should render je logo if je theme passed', () => {
-        // Arrange & Act
+        // Arrange
         const propsData = {
             theme: 'je',
             isTransparent: true,
             companyName: 'Just Eat'
         };
+
+        // Act
         const wrapper = shallowMount(Logo, { propsData });
         const logo = wrapper.find('[data-js-test="c-icon--je"]');
 
@@ -44,37 +44,41 @@ describe('Logo', () => {
         expect(logo).toBeDefined();
     });
 
-    it('should have "c-icon-je--transparentBckgrnd" class if "isTransparent" property is true', () => {
-        // Arrange & Act
+    it('should have "c-icon-je--transparentBg" class if "isTransparent" property is true', () => {
+        // Arrange
         const propsData = {
             theme: 'je',
             isTransparent: true,
             companyName: 'Just Eat'
         };
+
+        // Act
         const wrapper = shallowMount(Logo, { propsData });
         const logo = wrapper.find('[data-js-test="c-icon--je"]');
 
         // Assert
         // with dynamically rendered components
         // dynamic classes returned as one string in the array
-        // so have to check for 'c-icon--je,c-icon-je--transparentBckgrnd' not just 'c-icon-je--transparentBckgrnd'
-        expect(logo.classes()).toContain('c-icon--je,c-icon-je--transparentBckgrnd');
+        // so have to check for 'c-icon--je,c-icon-je--transparentBg' not just 'c-icon-je--transparentBg'
+        expect(logo.classes()).toContain('c-icon--je,c-icon-je--transparentBg');
     });
 
-    it('shouldn\'t have "c-icon-je--transparentBckgrnd" class if "isTransparent" property is false', () => {
-        // Arrange & Act
+    it('shouldn\'t have "c-icon-je--transparentBg" class if "isTransparent" property is false', () => {
+        // Arrange
         const propsData = {
             theme: 'je',
             isTransparent: false,
             companyName: 'Just Eat'
         };
+
+        // Act
         const wrapper = shallowMount(Logo, { propsData });
         const logo = wrapper.find('[data-js-test="c-icon--je"]');
 
         // Assert
         // with dynamically rendered components
         // dynamic classes returned as one string in the array
-        // so have to check for 'c-icon--je,c-icon-je--transparentBckgrnd' not just 'c-icon-je--transparentBckgrnd'
-        expect(logo.classes()).not.toContain('c-icon--je,c-icon-je--transparentBckgrnd');
+        // so have to check for 'c-icon--je,c-icon-je--transparentBg' not just 'c-icon-je--transparentBg'
+        expect(logo.classes()).not.toContain('c-icon--je,c-icon-je--transparentBg');
     });
 });

--- a/packages/f-header/src/components/tests/Logo.test.js
+++ b/packages/f-header/src/components/tests/Logo.test.js
@@ -24,7 +24,7 @@ describe('Logo', () => {
             companyName: 'MenuLog'
         };
         const wrapper = shallowMount(Logo, { propsData });
-        const logo = wrapper.find('[data-js-test="ml-icon"]');
+        const logo = wrapper.find('[data-js-test="c-icon--ml"]');
 
         // Assert
         expect(logo).toBeDefined();
@@ -38,13 +38,13 @@ describe('Logo', () => {
             companyName: 'Just Eat'
         };
         const wrapper = shallowMount(Logo, { propsData });
-        const logo = wrapper.find('[data-js-test="je-icon"]');
+        const logo = wrapper.find('[data-js-test="c-icon--je"]');
 
         // Assert
         expect(logo).toBeDefined();
     });
 
-    it('should have "je-icon--transparent" class if "isTransparent" property is true', () => {
+    it('should have "c-icon-je--transparentBckgrnd" class if "isTransparent" property is true', () => {
         // Arrange & Act
         const propsData = {
             theme: 'je',
@@ -52,16 +52,16 @@ describe('Logo', () => {
             companyName: 'Just Eat'
         };
         const wrapper = shallowMount(Logo, { propsData });
-        const logo = wrapper.find('[data-js-test="je-icon"]');
+        const logo = wrapper.find('[data-js-test="c-icon--je"]');
 
         // Assert
         // with dynamically rendered components
         // dynamic classes returned as one string in the array
-        // so have to check for 'je-icon--transparent,je-icon' not just 'je-icon--transparen'
-        expect(logo.classes()).toContain('je-icon--transparent,je-icon');
+        // so have to check for 'c-icon--je,c-icon-je--transparentBckgrnd' not just 'c-icon-je--transparentBckgrnd'
+        expect(logo.classes()).toContain('c-icon--je,c-icon-je--transparentBckgrnd');
     });
 
-    it('shouldn\'t have "je-icon--transparent" class if "isTransparent" property is false', () => {
+    it('shouldn\'t have "c-icon-je--transparentBckgrnd" class if "isTransparent" property is false', () => {
         // Arrange & Act
         const propsData = {
             theme: 'je',
@@ -69,12 +69,12 @@ describe('Logo', () => {
             companyName: 'Just Eat'
         };
         const wrapper = shallowMount(Logo, { propsData });
-        const logo = wrapper.find('[data-js-test="je-icon"]');
+        const logo = wrapper.find('[data-js-test="c-icon--je"]');
 
         // Assert
         // with dynamically rendered components
         // dynamic classes returned as one string in the array
-        // so have to check for 'je-icon--transparent,je-icon' not just 'je-icon--transparen'
-        expect(logo.classes()).not.toContain('je-icon--transparent,je-icon');
+        // so have to check for 'c-icon--je,c-icon-je--transparentBckgrnd' not just 'c-icon-je--transparentBckgrnd'
+        expect(logo.classes()).not.toContain('c-icon--je,c-icon-je--transparentBckgrnd');
     });
 });

--- a/packages/f-header/src/components/tests/Logo.test.js
+++ b/packages/f-header/src/components/tests/Logo.test.js
@@ -1,0 +1,80 @@
+import { shallowMount } from '@vue/test-utils';
+import Logo from '../Logo.vue';
+// import {
+//     JeLogoNoColourIcon as JeLogo,
+//     MlLogoIcon as MlLogo
+// } from '@justeat/f-vue-icons';
+
+describe('Logo', () => {
+    it('should be defined', () => {
+        const propsData = {
+            theme: 'je',
+            isTransparent: true,
+            companyName: 'Just Eat'
+        };
+        const wrapper = shallowMount(Logo, { propsData });
+        expect(wrapper.exists()).toBe(true);
+    });
+
+    it('should render ml logo if ml theme passed', () => {
+        // Arrange & Act
+        const propsData = {
+            theme: 'ml',
+            isTransparent: true,
+            companyName: 'MenuLog'
+        };
+        const wrapper = shallowMount(Logo, { propsData });
+        const logo = wrapper.find('[data-js-test="ml-icon"]');
+
+        // Assert
+        expect(logo).toBeDefined();
+    });
+
+    it('should render je logo if je theme passed', () => {
+        // Arrange & Act
+        const propsData = {
+            theme: 'je',
+            isTransparent: true,
+            companyName: 'Just Eat'
+        };
+        const wrapper = shallowMount(Logo, { propsData });
+        const logo = wrapper.find('[data-js-test="je-icon"]');
+
+        // Assert
+        expect(logo).toBeDefined();
+    });
+
+    it('should have "je-icon--transparent" class if "isTransparent" property is true', () => {
+        // Arrange & Act
+        const propsData = {
+            theme: 'je',
+            isTransparent: true,
+            companyName: 'Just Eat'
+        };
+        const wrapper = shallowMount(Logo, { propsData });
+        const logo = wrapper.find('[data-js-test="je-icon"]');
+
+        // Assert
+        // with dynamically rendered components
+        // dynamic classes returned as one string in the array
+        // so have to check for 'je-icon--transparent,je-icon' not just 'je-icon--transparen'
+        expect(logo.classes()).toContain('je-icon--transparent,je-icon');
+    });
+
+    it('shouldn\'t have "je-icon--transparent" class if "isTransparent" property is false', () => {
+        // Arrange & Act
+        const propsData = {
+            theme: 'je',
+            isTransparent: false,
+            companyName: 'Just Eat'
+        };
+        const wrapper = shallowMount(Logo, { propsData });
+        const logo = wrapper.find('[data-js-test="je-icon"]');
+
+        // Assert
+        // with dynamically rendered components
+        // dynamic classes returned as one string in the array
+        // so have to check for 'je-icon--transparent,je-icon' not just 'je-icon--transparen'
+        expect(logo.classes()).not.toContain('je-icon--transparent,je-icon');
+    });
+});

--- a/packages/f-header/src/components/tests/__snapshots__/Header.test.js.snap
+++ b/packages/f-header/src/components/tests/__snapshots__/Header.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Header should render default component markup 1`] = `
-<header class="c-header">
-  I am Header
+<header data-theme="je" class="c-header">
+  <logo-stub theme="je" istransparent="true" companyname="Just Eat"></logo-stub>
 </header>
 `;

--- a/packages/f-header/src/tenants/da-DK.js
+++ b/packages/f-header/src/tenants/da-DK.js
@@ -1,0 +1,15 @@
+export default {
+    locale: 'da-DK',
+    companyName: 'Just Eat',
+    openMenuText: 'Open Menu',
+    loginLinkText: 'Log ind',
+    loginNoScriptLinkText: 'Profil',
+    helpLinkText: 'Hjælp',
+    logoutLinkText: 'Log ud',
+    skipToMainContentText: 'Gå til hovedindhold',
+    accountInfo: 'Brugerinformation',
+    accountOrderHistory: 'Ordre',
+    accountCredit: 'Gavekort saldo',
+    paymentMethods: 'Betalingsmetoder',
+    deliveryAddresses: 'Leveringsadresse'
+};

--- a/packages/f-header/src/tenants/en-AU.js
+++ b/packages/f-header/src/tenants/en-AU.js
@@ -1,0 +1,15 @@
+export default {
+    locale: 'en-AU',
+    companyName: 'Menulog',
+    openMenuText: 'Open Menu',
+    loginLinkText: 'Log in',
+    loginNoScriptLinkText: 'Account',
+    helpLinkText: 'Help',
+    logoutLinkText: 'Log out',
+    skipToMainContentText: 'Skip to main content',
+    accountInfo: 'Account info',
+    accountOrderHistory: 'Orders',
+    accountCredit: 'Account credit',
+    paymentMethods: 'Payment methods',
+    deliveryAddresses: 'Delivery addresses'
+};

--- a/packages/f-header/src/tenants/en-GB.js
+++ b/packages/f-header/src/tenants/en-GB.js
@@ -1,0 +1,18 @@
+export default {
+    locale: 'en-GB',
+    companyName: 'Just Eat',
+    openMenuText: 'Open Menu',
+    loginLinkText: 'Log in',
+    loginNoScriptLinkText: 'Account',
+    helpLinkText: 'Help',
+    logoutLinkText: 'Log out',
+    skipToMainContentText: 'Skip to main content',
+    accountInfo: 'Your account',
+    accountOrderHistory: 'Your orders',
+    accountCredit: 'Account credit',
+    paymentMethods: 'Your saved cards',
+    deliveryAddresses: 'Your address book',
+    redeemVoucher: 'Redeem a voucher',
+    redeemGiftcard: 'Redeem a gift card',
+    contactPreferences: 'Contact preferences'
+};

--- a/packages/f-header/src/tenants/en-IE.js
+++ b/packages/f-header/src/tenants/en-IE.js
@@ -1,0 +1,15 @@
+export default {
+    locale: 'en-IE',
+    companyName: 'Just Eat',
+    openMenuText: 'Open Menu',
+    loginLinkText: 'Log in',
+    loginNoScriptLinkText: 'Account',
+    helpLinkText: 'Help',
+    logoutLinkText: 'Log out',
+    skipToMainContentText: 'Skip to main content',
+    accountInfo: 'Account info',
+    accountOrderHistory: 'Orders',
+    accountCredit: 'Account credit',
+    paymentMethods: 'Payment methods',
+    deliveryAddresses: 'Delivery addresses'
+};

--- a/packages/f-header/src/tenants/en-NZ.js
+++ b/packages/f-header/src/tenants/en-NZ.js
@@ -1,0 +1,15 @@
+export default {
+    locale: 'en-NZ',
+    companyName: 'Menulog',
+    openMenuText: 'Open Menu',
+    loginLinkText: 'Log in',
+    loginNoScriptLinkText: 'Account',
+    helpLinkText: 'Help',
+    logoutLinkText: 'Log out',
+    skipToMainContentText: 'Skip to main content',
+    accountInfo: 'Account info',
+    accountOrderHistory: 'Orders',
+    accountCredit: 'Account credit',
+    paymentMethods: 'Payment methods',
+    deliveryAddresses: 'Delivery addresses'
+};

--- a/packages/f-header/src/tenants/es-ES.js
+++ b/packages/f-header/src/tenants/es-ES.js
@@ -1,0 +1,15 @@
+export default {
+    locale: 'es-ES',
+    companyName: 'Just Eat',
+    openMenuText: 'Open Menu',
+    loginLinkText: 'Inicia sesión',
+    loginNoScriptLinkText: 'Cuenta',
+    helpLinkText: 'Ayuda',
+    logoutLinkText: 'Salir',
+    skipToMainContentText: 'Ir al contenido principal',
+    accountInfo: 'Información de la cuenta',
+    accountOrderHistory: 'Pedidos',
+    accountCredit: 'Crédito de la cuenta',
+    paymentMethods: 'Métodos de pago',
+    deliveryAddresses: 'Direcciones de reparto'
+};

--- a/packages/f-header/src/tenants/index.js
+++ b/packages/f-header/src/tenants/index.js
@@ -1,0 +1,21 @@
+import uk from './en-GB';
+import au from './en-AU';
+import nz from './en-NZ';
+import dk from './da-DK';
+import es from './es-ES';
+import ie from './en-IE';
+import it from './it-IT';
+import no from './nb-NO';
+
+const tenantConfigs = {
+    'en-GB': uk,
+    'en-AU': au,
+    'en-NZ': nz,
+    'da-DK': dk,
+    'es-ES': es,
+    'en-IE': ie,
+    'it-IT': it,
+    'nb-NO': no
+};
+
+export default tenantConfigs;

--- a/packages/f-header/src/tenants/it-IT.js
+++ b/packages/f-header/src/tenants/it-IT.js
@@ -1,0 +1,15 @@
+export default {
+    locale: 'it-IT',
+    companyName: 'Just Eat',
+    openMenuText: 'Open Menu',
+    loginLinkText: 'Accedi',
+    loginNoScriptLinkText: 'Account',
+    helpLinkText: 'Aiuto?',
+    logoutLinkText: 'Esci',
+    skipToMainContentText: 'Vai al contenuto principale',
+    accountInfo: 'Account',
+    accountOrderHistory: 'Ordini',
+    accountCredit: 'Credito dell\'account',
+    paymentMethods: 'Metodi di pagamento',
+    deliveryAddresses: 'Indirizzi di consegna'
+};

--- a/packages/f-header/src/tenants/nb-NO.js
+++ b/packages/f-header/src/tenants/nb-NO.js
@@ -1,0 +1,15 @@
+export default {
+    locale: 'nb-NO',
+    companyName: 'Just Eat',
+    openMenuText: 'Open Menu',
+    loginLinkText: 'Logg inn',
+    loginNoScriptLinkText: 'Konto',
+    helpLinkText: 'Hjelp',
+    logoutLinkText: 'Logg ut',
+    skipToMainContentText: 'Hopp til hovedinnhold',
+    accountInfo: 'Kontoinformasjon',
+    accountOrderHistory: 'Ordre',
+    accountCredit: 'Gavekort saldo',
+    paymentMethods: 'Betalingsmetoder',
+    deliveryAddresses: 'Leveringsadresse'
+};

--- a/packages/f-header/vue.config.js
+++ b/packages/f-header/vue.config.js
@@ -1,0 +1,17 @@
+const magicImporter = require('node-sass-magic-importer');
+
+// vue.config.js
+module.exports = {
+    chainWebpack: config => {
+        config.module
+            .rule('scss-importer')
+            .test(/\.scss$/)
+            .use('importer')
+            .loader('sass-loader')
+            .options({
+                importer: magicImporter(),
+                // eslint-disable-next-line quotes
+                data: `@import "@/assets/scss/common.scss";`
+            });
+    }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1006,19 +1006,6 @@
   dependencies:
     qwery "4.0.0"
 
-"@justeat/f-footer@file:packages/f-footer":
-  version "2.0.0-beta.15"
-  dependencies:
-    "@justeat/f-vue-icons" "1.0.0-beta.2"
-    lodash-es "4.17.15"
-    v-click-outside "2.1.3"
-    vue "2.6.10"
-
-"@justeat/f-header@file:packages/f-header":
-  version "2.0.0-beta.0"
-  dependencies:
-    vue "2.6.10"
-
 "@justeat/f-icons@1.29.0":
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-1.29.0.tgz#87adc2ac052cb8cade9090e87eefcf0cfdfdae1b"
@@ -1026,6 +1013,14 @@
   dependencies:
     "@justeat/f-utils" "0.3.0"
     include-media "1.4.9"
+
+"@justeat/f-icons@2.0.0-beta.5":
+  version "2.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-2.0.0-beta.5.tgz#925d84c522f56011e756711ded525b397c1a2423"
+  integrity sha512-MFsK+5tiztC7ej0LgGArx/q7TcfkEuyyVpKMxStSOMBO7fVb69/uQEUvLQlUvdgwCJnDvD3uhoquhEn7kWiLyw==
+  dependencies:
+    classnames "2.2.5"
+    core-js "3.1.3"
 
 "@justeat/f-icons@^2.0.0-beta.4":
   version "2.0.0-beta.4"
@@ -1058,11 +1053,13 @@
     "@justeat/f-icons" "^2.0.0-beta.4"
     babel-helper-vue-jsx-merge-props "^2.0.3"
 
-"@justeat/f-vue-icons@file:packages/f-vue-icons":
-  version "0.16.0"
+"@justeat/f-vue-icons@1.0.0-beta.3":
+  version "1.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.0.0-beta.3.tgz#050138fb615cc511cd39ece25bc47e1c47668379"
+  integrity sha512-HQLZtUZChvf7xk/upFzdHYGLfacZM7hUltyA5H75T2QsQrNRF4lbTs2AO6igBuOJn9Jtep6u7e1X30pohzuaFA==
   dependencies:
-    "@justeat/f-icons" "1.29.0"
-    vue "2.6.10"
+    "@justeat/f-icons" "2.0.0-beta.5"
+    babel-helper-vue-jsx-merge-props "^2.0.3"
 
 "@justeat/fozzie-colour-palette@2.3.0":
   version "2.3.0"
@@ -2050,6 +2047,21 @@
     "@vue/cli-shared-utils" "^3.9.0"
     babel-loader "^8.0.5"
     webpack ">=4 < 4.29"
+
+"@vue/cli-plugin-eslint@3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@vue/cli-plugin-eslint/-/cli-plugin-eslint-3.9.1.tgz#11f3bdc425619ea2f9e2ab74a8f89f75aa6c2657"
+  integrity sha512-j/ZF3G+OhtYO229UIkH6ef6UekW6MER9+o5jGOkwWed4ZheeT2ssFD2rCSJMXCuV7ygJvKOFGaBJBULL8Ibmzg==
+  dependencies:
+    "@vue/cli-shared-utils" "^3.9.0"
+    babel-eslint "^10.0.1"
+    eslint-loader "^2.1.2"
+    globby "^9.2.0"
+    webpack ">=4 < 4.29"
+    yorkie "^2.0.0"
+  optionalDependencies:
+    eslint "^4.19.1"
+    eslint-plugin-vue "^4.7.1"
 
 "@vue/cli-plugin-eslint@3.9.2":
   version "3.9.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1006,6 +1006,19 @@
   dependencies:
     qwery "4.0.0"
 
+"@justeat/f-footer@file:packages/f-footer":
+  version "2.0.0-beta.15"
+  dependencies:
+    "@justeat/f-vue-icons" "1.0.0-beta.2"
+    lodash-es "4.17.15"
+    v-click-outside "2.1.3"
+    vue "2.6.10"
+
+"@justeat/f-header@file:packages/f-header":
+  version "2.0.0-beta.1"
+  dependencies:
+    "@justeat/f-vue-icons" "1.0.0-beta.3"
+
 "@justeat/f-icons@1.29.0":
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-1.29.0.tgz#87adc2ac052cb8cade9090e87eefcf0cfdfdae1b"
@@ -1060,6 +1073,12 @@
   dependencies:
     "@justeat/f-icons" "2.0.0-beta.5"
     babel-helper-vue-jsx-merge-props "^2.0.3"
+
+"@justeat/f-vue-icons@file:packages/f-vue-icons":
+  version "0.16.0"
+  dependencies:
+    "@justeat/f-icons" "1.29.0"
+    vue "2.6.10"
 
 "@justeat/fozzie-colour-palette@2.3.0":
   version "2.3.0"
@@ -2047,21 +2066,6 @@
     "@vue/cli-shared-utils" "^3.9.0"
     babel-loader "^8.0.5"
     webpack ">=4 < 4.29"
-
-"@vue/cli-plugin-eslint@3.9.1":
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/@vue/cli-plugin-eslint/-/cli-plugin-eslint-3.9.1.tgz#11f3bdc425619ea2f9e2ab74a8f89f75aa6c2657"
-  integrity sha512-j/ZF3G+OhtYO229UIkH6ef6UekW6MER9+o5jGOkwWed4ZheeT2ssFD2rCSJMXCuV7ygJvKOFGaBJBULL8Ibmzg==
-  dependencies:
-    "@vue/cli-shared-utils" "^3.9.0"
-    babel-eslint "^10.0.1"
-    eslint-loader "^2.1.2"
-    globby "^9.2.0"
-    webpack ">=4 < 4.29"
-    yorkie "^2.0.0"
-  optionalDependencies:
-    eslint "^4.19.1"
-    eslint-plugin-vue "^4.7.1"
 
 "@vue/cli-plugin-eslint@3.9.2":
   version "3.9.2"


### PR DESCRIPTION
### Added
- Logo component
- Tenants resource files
- Vue.config.js for rewriting default vue cli webpack config
- common.scss base styles imports
- theme and locale logic for Header component (later will be moved to independant package because it repeats in footer and searchbox already)