### PR TITLE
f-header@2.0.0-beta.5 Remove Deliver with JE link from mobile screen size

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,11 +4,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta-5
+------------------------------
+*September 18, 2019*
+
+### Changed
+ - Add a logic to hide "Deliver with Just Eat" link from mobile screen size
+ - DeliveryEnquiry gtm label changed to be 'click_courier_signup'
+
+### Removed
+- Cleaned up unused css styles
+
+
 v2.0.0-beta-4
 ------------------------------
 *September 16, 2019*
 
- ### Added
+### Added
 - Styles for the header component
 - Some ml css variable overrides
 - User email rendering for mobile view
@@ -18,7 +30,7 @@ v2.0.0-beta-3
 ------------------------------
 *September 13, 2019*
 
- ### Added
+### Added
 - Navigation component
 - `f-trak` attributes to the links
 

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.4",
+  "version": "v2.0.0-beta.5",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"
@@ -35,7 +35,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-vue-icons": "1.0.0-beta.4"
+    "@justeat/f-vue-icons": "1.0.0-beta.4",
+    "lodash-es": "4.17.15"
   },
   "peerDependencies": {
     "@justeat/f-trak": "0.6.0"

--- a/packages/f-header/src/assets/scss/common.scss
+++ b/packages/f-header/src/assets/scss/common.scss
@@ -21,8 +21,6 @@ $header-height--narrow              : 56px;
 $header-button--height              : $header-height--narrow;
 $header-button--width               : 56px;
 $header-height                      : 76px;
-$languageSwitcher-height            : 34px;
-$header-height--narrow--multiLang   : $header-height--narrow + $languageSwitcher-height;
 $header-bg                          : $white;
 $header-separator                   : 1px;
 $header-separator                   : 4px;

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -25,7 +25,7 @@
             :class="['c-nav-container', { 'is-visible': navIsOpen }]">
             <ul class="c-nav-list">
                 <li
-                    v-if="showDeliveryEnquiry"
+                    v-if="showDeliveryEnquiry && !isBelowMid"
                     class="c-nav-list-item">
                     <a
                         :data-trak='`{
@@ -141,7 +141,7 @@
 
 <script>
 import { ProfileIcon, DeliveryIcon } from '@justeat/f-vue-icons';
-
+import { throttle } from 'lodash-es';
 
 export default {
     components: {
@@ -184,8 +184,21 @@ export default {
     },
     data () {
         return {
-            navIsOpen: false
+            navIsOpen: false,
+            currentScreenWidth: 0
         };
+    },
+    computed: {
+        isBelowMid () {
+            return this.currentScreenWidth <= 767;
+        }
+    },
+    mounted () {
+        this.currentScreenWidth = window.innerWidth;
+        window.addEventListener('resize', throttle(this.onResize, 100));
+    },
+    destroyed () {
+        window.removeEventListener('resize', this.resize);
     },
     methods: {
         onNavToggle () {
@@ -196,6 +209,9 @@ export default {
         },
         openNav () {
             this.navIsOpen = true;
+        },
+        onResize () {
+            this.currentScreenWidth = window.innerWidth;
         }
     }
 };
@@ -279,10 +295,6 @@ $nav-trigger-focus-bg--ml          : $green--offWhite;
             position: fixed;
             width: 100%;
             padding-top: $header-height--narrow;
-
-            @at-root .is-multiLanguage#{&} {
-                padding-top: $header-height--narrow--multiLang;
-            }
         }
     }
 }
@@ -324,11 +336,6 @@ $nav-trigger-focus-bg--ml          : $green--offWhite;
 
             &.is-visible {
                 @include nav-container-visible();
-            }
-
-            .is-multiLanguage & {
-                top: $header-height--narrow--multiLang;
-                height: calc(100% - (#{$header-height--narrow--multiLang}));
             }
         }
     }

--- a/packages/f-header/src/tenants/en-GB.js
+++ b/packages/f-header/src/tenants/en-GB.js
@@ -65,6 +65,6 @@ export default {
     deliveryEnquiry: {
         text: 'Deliver with Just Eat',
         url: 'https://couriers.just-eat.co.uk/application?utm_medium=referrer&utm_source=just-eat.co.uk&utm_campaign=ex1140-header',
-        gtm: 'click_delivery_job'
+        gtm: 'click_courier_signup'
     }
 };


### PR DESCRIPTION
### Changed
 - Add a logic to hide "Deliver with Just Eat" link from mobile screen size
 - DeliveryEnquiry gtm label changed to be 'click_courier_signup'

### Removed
- Cleaned up unused css styles