### PR TITLE
f-footer@2.0.0-beta-18 fix collapsed state of nav tabs

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v2.0.0-beta-18
+------------------------------
+*September 19, 2019*
+
+### Changed
+ - Removed css module style call from non-module css class
+ - Moved some css styles out of css module to be reusable
+
+
 v2.0.0-beta-17
 ------------------------------
 *September 18, 2019*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "v2.0.0-beta.17",
+  "version": "v2.0.0-beta.18",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/src/components/Footer.vue
+++ b/packages/f-footer/src/components/Footer.vue
@@ -142,6 +142,35 @@ export default {
     }
 }
 
+.c-footer-heading--button {
+    align-items: center;
+    background: none;
+    border-style: none;
+    color: $color-headings;
+    display: flex;
+    font-family: $font-family-headings;
+    font-weight: $font-weight-headings;
+    justify-content: space-between;
+    margin: 0;
+    padding: spacing(x2);
+    text-align: left;
+    width: 100%;
+    @include font-size(mid);
+
+    @include theme(ml) {
+        font-family: $font-family-headings--ml;
+        font-weight: $font-weight-headings--ml;
+    }
+
+    @include media('<wide') {
+        cursor: pointer;
+    }
+
+    @include media('>=wide') {
+        padding: 0;
+    }
+}
+
 .c-footer-row {
     display: flex;
     flex-flow: column nowrap;

--- a/packages/f-footer/src/components/LinkList.vue
+++ b/packages/f-footer/src/components/LinkList.vue
@@ -2,7 +2,7 @@
     <div
         v-if="linkList.links.length"
         :class="[$style['c-footer-panel'], {
-            [$style['is-collapsed']]: panelCollapsed && isBelowWide
+            'is-collapsed': panelCollapsed && isBelowWide
         }]"
         data-js-test="linkList-wrapper">
         <h2>
@@ -15,8 +15,7 @@
                 :aria-controls="listId"
                 :class="[
                     'c-footer-heading',
-                    'c-footer-heading--button',
-                    $style['c-footer-heading--button']
+                    'c-footer-heading--button'
                 ]"
                 data-js-test="linkList-header"
                 @click="onPanelClick">
@@ -125,35 +124,6 @@ export default {
         &:last-of-type {
             border-bottom: none;
         }
-    }
-}
-
-.c-footer-heading--button {
-    align-items: center;
-    background: none;
-    border-style: none;
-    color: $color-headings;
-    display: flex;
-    font-family: $font-family-headings;
-    font-weight: $font-weight-headings;
-    justify-content: space-between;
-    margin: 0;
-    padding: spacing(x2);
-    text-align: left;
-    width: 100%;
-    @include font-size(mid);
-
-    @include theme(ml) {
-        font-family: $font-family-headings--ml;
-        font-weight: $font-weight-headings--ml;
-    }
-
-    @include media('<wide') {
-        cursor: pointer;
-    }
-
-    @include media('>=wide') {
-        padding: 0;
     }
 }
 


### PR DESCRIPTION
### Changed
 - Removed css module style call from non-module css class
 - Moved some css styles out of css module to be reusable