### PR TITLE
f-header@2.0.0-beta.11 - mobile transparent menu styles for open state

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta-11
+------------------------------
+*September 25, 2019*
+
+### Added
+- `no-js` css for mobile hamburger menu
+
+### Changed
+- Styling for mobile open menu state header when transparent
+
+
 v2.0.0-beta-10
 ------------------------------
 *September 20, 2019*

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.10",
+  "version": "v2.0.0-beta.11",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -1,14 +1,14 @@
 <template>
     <header
         :data-theme="theme"
-        :class="['c-header', { 'c-header--transparent c-header--gradient': isTransparent }]">
+        :class="['c-header', { 'c-header--transparent c-header--gradient': showTransparentHeader }]">
         <skip-to-main
             :text="copy.skipToMainContentText"
-            :transparent-bg="isTransparent" />
+            :transparent-bg="showTransparentHeader" />
         <div class="c-header-container">
             <logo
                 :theme="theme"
-                :is-transparent="isTransparent"
+                :is-transparent="showTransparentHeader"
                 :company-name="copy.companyName"
                 :logo-gtm-label="copy.logo.gtm" />
             <navigation
@@ -20,7 +20,8 @@
                 :delivery-enquiry="copy.deliveryEnquiry"
                 :show-delivery-enquiry="showDeliveryEnquiryWithContent"
                 :user-info-prop="userInfoProp"
-                :just-log="justLog" />
+                :just-log="justLog"
+                @onMobileNavToggle="mobileNavToggled" />
         </div>
     </header>
 </template>
@@ -69,15 +70,25 @@ export default {
         const locale = sharedService.getLocale(tenantConfigs, this.locale, this.$118n);
         const localeConfig = tenantConfigs[locale];
         const theme = sharedService.getTheme(locale);
+        const mobileNavIsOpen = false;
 
         return {
             copy: { ...localeConfig },
-            theme
+            theme,
+            mobileNavIsOpen
         };
     },
     computed: {
         showDeliveryEnquiryWithContent () {
             return this.copy.deliveryEnquiry && this.showDeliveryEnquiry;
+        },
+        showTransparentHeader () {
+            return this.isTransparent && this.!mobileNavIsOpen;
+        }
+    },
+    methods: {
+        mobileNavToggled (value) {
+            this.mobileNavIsOpen = value;
         }
     }
 };

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -43,12 +43,10 @@ export default {
     props: {
         locale: {
             type: String,
-            required: false,
             default: ''
         },
         isTransparent: {
             type: Boolean,
-            required: false,
             default: false
         },
         showDeliveryEnquiry: {
@@ -56,14 +54,12 @@ export default {
             default: false
         },
         justLog: {
-            type: Function,
-            default: () => ({}),
-            required: false
+            type: Object,
+            default: () => ({})
         },
         userInfoProp: {
             type: [Object, Boolean],
-            default: false,
-            required: false
+            default: false
         }
     },
     data () {

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -83,10 +83,12 @@ export default {
             return this.copy.deliveryEnquiry && this.showDeliveryEnquiry;
         },
         showTransparentHeader () {
-            return this.isTransparent && this.!mobileNavIsOpen;
+            return this.isTransparent && !this.mobileNavIsOpen;
         }
     },
     methods: {
+        // This method emits `navIsOpen` state from the navigation component
+        // to be able to deside when to show transparent header styles on mobile view
         mobileNavToggled (value) {
             this.mobileNavIsOpen = value;
         }

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -287,6 +287,7 @@ export default {
         onResize () {
             this.currentScreenWidth = window.innerWidth;
         },
+        // If userInfoProp wasn't passed we make a call for userInfo on mounted hook
         async setUserInfo () {
             try {
                 const { data } = await axios.get('/api/account/details', {
@@ -303,6 +304,9 @@ export default {
                 }
             }
         },
+        // When hamburger menu is clicked we want to trigger toggling of navigation
+        // + emit the state of `navIsOpen` attr to the header component to change header styles in case of transparency
+        // in open nav state mobile header should become white, not transparent
         onHamburgerMenuClick () {
             this.onNavToggle();
             this.$emit('onMobileNavToggle', this.navIsOpen);

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -1,25 +1,30 @@
 <template>
     <nav class="c-nav c-nav--global">
         <button
-            class="c-nav-trigger"
+            data-js-test="nav-toggle"
+            :class="['c-nav-trigger c-nav-toggle is-hidden--noJS', {
+                'is-open': navIsOpen
+            }]"
             type="button"
             :aria-expanded="navIsOpen ? 'true' : 'false'"
             :aria-label="openMenuText"
-            @click="onNavToggle" />
+            @click="onHamburgerMenuClick">
+            <span class="c-nav-toggle-icon" />
+        </button>
 
         <input
             id="nav-trigger"
             v-model="navIsOpen"
             type="checkbox"
-            class="c-nav-trigger is-hidden">
+            class="c-nav-trigger is-hidden is-shown--noJS">
 
         <label
-            data-js-test="nav-toggle"
-            :class="['c-nav-toggle', {
+            :class="['c-nav-toggle is-hidden is-shown--noJS', {
                 'is-open': navIsOpen
             }]"
-            for="nav-trigger">
-            <span class="c-nav-toggle-icon">{{ openMenuText }}</span>
+            for="nav-trigger"
+            :aria-label="openMenuText">
+            <span class="c-nav-toggle-icon" />
         </label>
 
         <div
@@ -297,6 +302,10 @@ export default {
                     this.justLog.error('Error handling "setUserInfo" action', err);
                 }
             }
+        },
+        onHamburgerMenuClick () {
+            this.onNavToggle();
+            this.$emit('onMobileNavToggle', this.navIsOpen);
         }
     }
 };
@@ -305,9 +314,16 @@ export default {
 <style lang="scss">
 
 // Hide from both screenreaders and browsers: h5bp.com/u
-.is-hidden {
+.is-hidden,
+.no-js .is-hidden--noJS {
     display: none !important;
     visibility: hidden !important;
+}
+
+.is-shown,
+.no-js .is-shown--noJS {
+    display: block !important;
+    visibility: visible !important;
 }
 
 /**
@@ -665,12 +681,12 @@ $nav-trigger-focus-bg--ml          : $green--offWhite;
     }
 }
 
-
-
 // Navigation Trigger
 // This is the checkbox that controls the menu active state without JS via :checked
 .c-nav-trigger {
     position: absolute;
+    width: $nav-trigger-length;
+    height: $nav-trigger-length;
     top: -100px;
     left: -100px;
 
@@ -705,9 +721,12 @@ $nav-trigger-focus-bg--ml          : $green--offWhite;
     cursor: pointer;
 
     // hide on wider views
-    // TODO – ACCESSIBILITY MAY NOT WANT TO COMPLETELY HIDE THIS
     @include media('>=mid') {
         display: none;
+
+        &.is-shown--noJS {
+            display: none !important;
+        }
     }
 }
 

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -232,14 +232,12 @@ export default {
             default: false
         },
         justLog: {
-            type: Function,
-            default: () => ({}),
-            required: false
+            type: Object,
+            default: () => ({})
         },
         userInfoProp: {
             type: [Object, Boolean],
-            default: false,
-            required: false
+            default: false
         }
     },
     data () {
@@ -299,7 +297,7 @@ export default {
                     this.userInfo = data;
                 }
             } catch (err) {
-                if (this.justLog) {
+                if (this.justLog.error) {
                     this.justLog.error('Error handling "setUserInfo" action', err);
                 }
             }

--- a/packages/f-header/src/components/tests/__snapshots__/Header.test.js.snap
+++ b/packages/f-header/src/components/tests/__snapshots__/Header.test.js.snap
@@ -5,9 +5,7 @@ exports[`Header should render default component markup 1`] = `
   <skip-to-main-stub text="Skip to main content" transparentbg="true"></skip-to-main-stub>
   <div class="c-header-container">
     <logo-stub theme="je" istransparent="true" companyname="Just Eat" logogtmlabel="click_logo"></logo-stub>
-    <navigation-stub accountlogin="[object Object]" accountlogout="[object Object]" navlinks="[object Object]" help="[object Object]" openmenutext="Open Menu" deliveryenquiry="[object Object]" justlog="function _default() {
-        return {};
-      }"></navigation-stub>
+    <navigation-stub accountlogin="[object Object]" accountlogout="[object Object]" navlinks="[object Object]" help="[object Object]" openmenutext="Open Menu" deliveryenquiry="[object Object]" justlog="[object Object]"></navigation-stub>
   </div>
 </header>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,21 +1021,6 @@
   dependencies:
     qwery "4.0.0"
 
-"@justeat/f-footer@file:packages/f-footer":
-  version "2.0.0-beta.18"
-  dependencies:
-    "@justeat/f-vue-icons" "1.0.0-beta.4"
-    lodash-es "4.17.15"
-    v-click-outside "2.1.3"
-    vue "2.6.10"
-
-"@justeat/f-header@file:packages/f-header":
-  version "2.0.0-beta.9"
-  dependencies:
-    "@justeat/f-vue-icons" "1.0.0-beta.4"
-    axios "0.19.0"
-    lodash-es "4.17.15"
-
 "@justeat/f-icons@1.29.0":
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-1.29.0.tgz#87adc2ac052cb8cade9090e87eefcf0cfdfdae1b"
@@ -1057,11 +1042,6 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-logger/-/f-logger-0.7.1.tgz#06e728d3c65733cab7c9bbfc813b401fa68ba82b"
   integrity sha512-qi1wDK5ijmQ6nE+2bIv68AuWVxCvogzVoXvHd4D0oZCw4PQmVfw9i25m/fw6AiipL6yxkiIGM4LfBlnm+FncDA==
 
-"@justeat/f-metadata@file:packages/f-metadata":
-  version "0.1.0"
-  dependencies:
-    appboy-web-sdk "2.4.0"
-
 "@justeat/f-utils@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.2.0.tgz#b2333b5ddf20b4157af25091e6bc54706358100c"
@@ -1079,12 +1059,6 @@
   dependencies:
     "@justeat/f-icons" "2.0.0-beta.6"
     babel-helper-vue-jsx-merge-props "^2.0.3"
-
-"@justeat/f-vue-icons@file:packages/f-vue-icons":
-  version "0.16.0"
-  dependencies:
-    "@justeat/f-icons" "1.29.0"
-    vue "2.6.10"
 
 "@justeat/fozzie-colour-palette@2.3.0":
   version "2.3.0"


### PR DESCRIPTION
### Added
- `no-js` css for mobile hamburger menu

### Changed
- Styling for mobile open menu state header when transparent

[![Image from Gyazo](https://i.gyazo.com/f5a9460c16083e7271ee88f6605b9899.gif)](https://gyazo.com/f5a9460c16083e7271ee88f6605b9899)