### PR TITLE
f-header@2.0.0-beta.13-update-to-header-logic

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta-21
+------------------------------
+*September 26, 2019*
+
+### Changed
+ - Reference to `$i18n` localization library
+
+
 v2.0.0-beta-20
 ------------------------------
 *September 26, 2019*

--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta-20
+------------------------------
+*September 26, 2019*
+
+### Changed
+ - Updated version of `f-services`
+
 
 v2.0.0-beta-19
 ------------------------------

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -34,7 +34,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "0.6.0",
+    "@justeat/f-services": "^0.6.0",
     "@justeat/f-vue-icons": "1.0.0-beta.4",
     "lodash-es": "4.17.15",
     "v-click-outside": "2.1.3",

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "v2.0.0-beta.19",
+  "version": "v2.0.0-beta.20",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"
@@ -34,7 +34,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "0.4.0",
+    "@justeat/f-services": "0.5.0",
     "@justeat/f-vue-icons": "1.0.0-beta.4",
     "lodash-es": "4.17.15",
     "v-click-outside": "2.1.3",

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -34,7 +34,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "0.5.0",
+    "@justeat/f-services": "0.6.0",
     "@justeat/f-vue-icons": "1.0.0-beta.4",
     "lodash-es": "4.17.15",
     "v-click-outside": "2.1.3",

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "v2.0.0-beta.20",
+  "version": "v2.0.0-beta.21",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/src/components/Footer.vue
+++ b/packages/f-footer/src/components/Footer.vue
@@ -89,7 +89,7 @@ export default {
     },
 
     data () {
-        const locale = sharedServices.getLocale(tenantConfigs, this.locale, this.$118n);
+        const locale = sharedServices.getLocale(tenantConfigs, this.locale, this.$i18n);
         const localeConfig = tenantConfigs[locale];
         const theme = sharedServices.getTheme(locale);
 

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -10,6 +10,7 @@ v2.0.0-beta-15
 
 ### Changed
  - Reference to `$i18n` localization library
+ - Added prop for `userInfoUrl`
 
 
 v2.0.0-beta-14

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta-15
+------------------------------
+*September 26, 2019*
+
+### Changed
+ - Reference to `$i18n` localization library
+
+
 v2.0.0-beta-14
 ------------------------------
 *September 26, 2019*

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta-14
+------------------------------
+*September 26, 2019*
+
+### Changed
+ - Updated version of `f-services`
+
+
 v2.0.0-beta-13
 ------------------------------
 *September 26, 2019*

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta-13
+------------------------------
+*September 26, 2019*
+
+### Changed
+ - Condition against data in in `getUserInfo`
+
+
 v2.0.0-beta-12
 ------------------------------
 *September 25, 2019*

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -35,7 +35,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "0.5.0",
+    "@justeat/f-services": "0.6.0",
     "@justeat/f-vue-icons": "1.0.0-beta.4",
     "axios": "0.19.0",
     "lodash-es": "4.17.15"

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.14",
+  "version": "v2.0.0-beta.15",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.12",
+  "version": "v2.0.0-beta.13",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@justeat/f-services": "0.4.0",
-    "@justeat/f-vue-icons": "1.0.0-beta.4",
+    "@justeat/f-vue-icons": "^1.0.0-beta.4",
     "axios": "0.19.0",
     "lodash-es": "4.17.15"
   },

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -35,7 +35,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "0.6.0",
+    "@justeat/f-services": "^0.6.0",
     "@justeat/f-vue-icons": "1.0.0-beta.4",
     "axios": "0.19.0",
     "lodash-es": "4.17.15"

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.13",
+  "version": "v2.0.0-beta.14",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"
@@ -35,8 +35,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "0.4.0",
-    "@justeat/f-vue-icons": "^1.0.0-beta.4",
+    "@justeat/f-services": "0.5.0",
+    "@justeat/f-vue-icons": "1.0.0-beta.4",
     "axios": "0.19.0",
     "lodash-es": "4.17.15"
   },

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -63,7 +63,7 @@ export default {
         }
     },
     data () {
-        const locale = sharedServices.getLocale(tenantConfigs, this.locale, this.$118n);
+        const locale = sharedServices.getLocale(tenantConfigs, this.locale, this.$i18n);
         const localeConfig = tenantConfigs[locale];
         const theme = sharedServices.getTheme(locale);
         const mobileNavIsOpen = false;

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -60,6 +60,10 @@ export default {
         userInfoProp: {
             type: [Object, Boolean],
             default: false
+        },
+        userInfoUrl: {
+            type: String,
+            default: '/api/account/details'
         }
     },
     data () {

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -293,7 +293,7 @@ export default {
                         credentials: 'same-origin'
                     }
                 });
-                if (data) {
+                if (data !== {}) {
                     this.userInfo = data;
                 }
             } catch (err) {

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -238,6 +238,10 @@ export default {
         userInfoProp: {
             type: [Object, Boolean],
             default: false
+        },
+        userInfoUrl: {
+            type: String,
+            default: '/api/account/details'
         }
     },
     data () {
@@ -288,7 +292,7 @@ export default {
         // If userInfoProp wasn't passed we make a call for userInfo on mounted hook
         async setUserInfo () {
             try {
-                const { data } = await axios.get('/api/account/details', {
+                const { data } = await axios.get(this.userInfoUrl, {
                     headers: {
                         credentials: 'same-origin'
                     }

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -50,7 +50,7 @@
                 </li>
 
                 <li
-                    :class="['c-nav-list-item has-sublist', { 'is-hidden': !userInfo, 'open': navIsOpen }]"
+                    :class="['c-nav-list-item has-sublist', { 'is-hidden': !userInfo.isAuthenticated, 'open': navIsOpen }]"
                     @mouseover="openNav"
                     @mouseleave="closeNav"
                     @keyup.esc="closeNav">
@@ -117,7 +117,7 @@
                 </li>
 
                 <li
-                    v-if="!userInfo"
+                    v-if="!userInfo.isAuthenticated"
                     class="c-nav-list-item"
                     data-js-test="login">
                     <a
@@ -152,7 +152,7 @@
                     </li>
 
                     <li
-                        v-if="userInfo"
+                        v-if="userInfo.isAuthenticated"
                         class="c-nav-list-item"
                         data-js-test="logout">
                         <a
@@ -288,12 +288,12 @@ export default {
         // If userInfoProp wasn't passed we make a call for userInfo on mounted hook
         async setUserInfo () {
             try {
-                const { data } = await axios.get('/api/account/details', {
+                const { data } = await axios.get('https://uk-publicweb-haproxy-staging-uk.staging-uk.je-labs.com/api/account/details', {
                     headers: {
                         credentials: 'same-origin'
                     }
                 });
-                if (data !== {}) {
+                if (data) {
                     this.userInfo = data;
                 }
             } catch (err) {

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -288,7 +288,7 @@ export default {
         // If userInfoProp wasn't passed we make a call for userInfo on mounted hook
         async setUserInfo () {
             try {
-                const { data } = await axios.get('https://uk-publicweb-haproxy-staging-uk.staging-uk.je-labs.com/api/account/details', {
+                const { data } = await axios.get('/api/account/details', {
                     headers: {
                         credentials: 'same-origin'
                     }

--- a/packages/f-services/CHANGELOG.md
+++ b/packages/f-services/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+0.5.0
+------------------------------
+*September 26, 2019*
+
+ ### Added
+- Made a new method for transforming the locale
+
+
 0.4.0
 ------------------------------
 *September 25, 2019*

--- a/packages/f-services/CHANGELOG.md
+++ b/packages/f-services/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *September 26, 2019*
 
+ ### Changed
+- Webpack config to add babel polyfill
+
+
+0.5.0
+------------------------------
+*September 26, 2019*
+
  ### Added
 - Made a new method for transforming the locale
 

--- a/packages/f-services/package.json
+++ b/packages/f-services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-services",
   "description": "Fozzie Services - Shared Services for Components and projects",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "dist/f-services.umd.min.js",
   "files": [
     "dist"
@@ -37,5 +37,8 @@
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "3.9.0",
     "@vue/test-utils": "1.0.0-beta.29"
+  },
+  "dependencies": {
+    "@babel/polyfill": "^7.6.0"
   }
 }

--- a/packages/f-services/package.json
+++ b/packages/f-services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-services",
   "description": "Fozzie Services - Shared Services for Components and projects",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/f-services.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-services/src/services/shared.service.js
+++ b/packages/f-services/src/services/shared.service.js
@@ -5,6 +5,13 @@
  */
 
 /**
+ * Returns the locale in correct format
+ *
+ * @param {locale} string of the current locale.
+ */
+const transformLocale = locale => `${locale.slice(0, -3)}${locale.slice(locale.lastIndexOf('-')).toUpperCase()}`;
+
+/**
  * Returns the locale for translation localization
  *
  * @param {tenantConfigs} object of localization strings.
@@ -13,18 +20,15 @@
  * @returns {String}
  */
 const getLocale = (tenantConfigs, tenantString, globalTenant) => {
-    const locale = tenantString === '' ? globalTenant?.locale : tenantString;
-
-    // makes sure the locale is the same format as the tenants - 'en-GB'
-    let transformedLocale = `${locale.slice(0, -3)}${locale.slice(locale.lastIndexOf('-')).toUpperCase()}`;
+    let locale = transformLocale(tenantString === '' ? globalTenant?.locale : tenantString);
 
     // if the locale is either
     // a) not set
     // or b) set to a country code that this component does not recognise
     // it will be set to 'en-GB'
-    if (!tenantConfigs[transformedLocale]) transformedLocale = 'en-GB';
+    if (!tenantConfigs[locale]) locale = 'en-GB';
 
-    return transformedLocale;
+    return locale;
 };
 
 /**

--- a/packages/f-services/src/services/shared.service.js
+++ b/packages/f-services/src/services/shared.service.js
@@ -5,9 +5,10 @@
  */
 
 /**
- * Returns the locale in correct format
+ * Returns the locale in correct format 'en-GB'
  *
  * @param {locale} string of the current locale.
+ * @returns {String}
  */
 const transformLocale = locale => `${locale.slice(0, -3)}${locale.slice(locale.lastIndexOf('-')).toUpperCase()}`;
 

--- a/packages/f-services/src/services/shared.service.js
+++ b/packages/f-services/src/services/shared.service.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * Returns the locale in correct format 'en-GB'
+ * Returns the locale in correct case format 'en-GB'
  *
  * @param {locale} string of the current locale.
  * @returns {String}

--- a/packages/f-services/webpack.config.js
+++ b/packages/f-services/webpack.config.js
@@ -1,15 +1,24 @@
 const path = require('path');
 
 module.exports = {
-    mode: 'production',
-    entry: './src/index.js',
+    entry: {
+        main: [
+            '@babel/polyfill',
+            './src/index.js'
+        ]
+    },
+    mode: 'development',
     output: {
-        path: path.resolve(__dirname, 'dist'),
-        filename: 'bundle.js'
+        filename: 'demo.js',
+        path: path.resolve(__dirname, 'dist')
     },
     module: {
-        rules: [
-            { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' }
-        ]
+        rules: [{
+            test: /\.js$/,
+            exclude: /node_modules/,
+            use: {
+                loader: 'babel-loader'
+            }
+        }]
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,18 +1030,18 @@
     qwery "4.0.0"
 
 "@justeat/f-footer@file:packages/f-footer":
-  version "2.0.0-beta.20"
+  version "2.0.0-beta.21"
   dependencies:
-    "@justeat/f-services" "0.6.0"
+    "@justeat/f-services" "^0.6.0"
     "@justeat/f-vue-icons" "1.0.0-beta.4"
     lodash-es "4.17.15"
     v-click-outside "2.1.3"
     vue "2.6.10"
 
 "@justeat/f-header@file:packages/f-header":
-  version "2.0.0-beta.14"
+  version "2.0.0-beta.15"
   dependencies:
-    "@justeat/f-services" "0.6.0"
+    "@justeat/f-services" "^0.6.0"
     "@justeat/f-vue-icons" "1.0.0-beta.4"
     axios "0.19.0"
     lodash-es "4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,19 +1022,19 @@
     qwery "4.0.0"
 
 "@justeat/f-footer@file:packages/f-footer":
-  version "2.0.0-beta.19"
+  version "2.0.0-beta.20"
   dependencies:
-    "@justeat/f-services" "0.4.0"
+    "@justeat/f-services" "0.5.0"
     "@justeat/f-vue-icons" "1.0.0-beta.4"
     lodash-es "4.17.15"
     v-click-outside "2.1.3"
     vue "2.6.10"
 
 "@justeat/f-header@file:packages/f-header":
-  version "2.0.0-beta.13"
+  version "2.0.0-beta.14"
   dependencies:
-    "@justeat/f-services" "0.4.0"
-    "@justeat/f-vue-icons" "^1.0.0-beta.4"
+    "@justeat/f-services" "0.5.0"
+    "@justeat/f-vue-icons" "1.0.0-beta.4"
     axios "0.19.0"
     lodash-es "4.17.15"
 
@@ -1065,7 +1065,7 @@
     appboy-web-sdk "2.4.0"
 
 "@justeat/f-services@file:packages/f-services":
-  version "0.4.0"
+  version "0.5.0"
 
 "@justeat/f-utils@0.2.0":
   version "0.2.0"
@@ -1077,7 +1077,7 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.3.0.tgz#1f18ba13ad7061e21c2112387234a77ba45fb5d3"
   integrity sha512-hqRiGA2lP++Z1oqawsv1V2Duf3YShaAbJ3S5JEPTpTMP5RjH36Xpc8nRbIVFBmwnZCu7L9iF7AebYTUX8XhiZA==
 
-"@justeat/f-vue-icons@1.0.0-beta.4", "@justeat/f-vue-icons@^1.0.0-beta.4":
+"@justeat/f-vue-icons@1.0.0-beta.4":
   version "1.0.0-beta.4"
   resolved "http://packages.je-labs.com/npm/private-npm/@justeat/f-vue-icons/-/f-vue-icons-1.0.0-beta.4.tgz#aef8a22b43f04f3ad0ca287f50ed1d68804c605a"
   integrity sha1-rviiK0PwTzrQyih/UO0daIBMYFo=

--- a/yarn.lock
+++ b/yarn.lock
@@ -634,6 +634,14 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.5.4"
 
+"@babel/polyfill@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.6.0.tgz#6d89203f8b6cd323e8d946e47774ea35dc0619cc"
+  integrity sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/preset-env@7.5.4":
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.5.4.tgz#64bc15041a3cbb0798930319917e70fcca57713d"
@@ -1024,7 +1032,7 @@
 "@justeat/f-footer@file:packages/f-footer":
   version "2.0.0-beta.20"
   dependencies:
-    "@justeat/f-services" "0.5.0"
+    "@justeat/f-services" "0.6.0"
     "@justeat/f-vue-icons" "1.0.0-beta.4"
     lodash-es "4.17.15"
     v-click-outside "2.1.3"
@@ -1033,7 +1041,7 @@
 "@justeat/f-header@file:packages/f-header":
   version "2.0.0-beta.14"
   dependencies:
-    "@justeat/f-services" "0.5.0"
+    "@justeat/f-services" "0.6.0"
     "@justeat/f-vue-icons" "1.0.0-beta.4"
     axios "0.19.0"
     lodash-es "4.17.15"
@@ -1065,7 +1073,9 @@
     appboy-web-sdk "2.4.0"
 
 "@justeat/f-services@file:packages/f-services":
-  version "0.5.0"
+  version "0.6.0"
+  dependencies:
+    "@babel/polyfill" "^7.6.0"
 
 "@justeat/f-utils@0.2.0":
   version "0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,7 +1022,7 @@
     qwery "4.0.0"
 
 "@justeat/f-footer@file:packages/f-footer":
-  version "2.0.0-beta.18"
+  version "2.0.0-beta.19"
   dependencies:
     "@justeat/f-services" "0.4.0"
     "@justeat/f-vue-icons" "1.0.0-beta.4"
@@ -1031,10 +1031,10 @@
     vue "2.6.10"
 
 "@justeat/f-header@file:packages/f-header":
-  version "2.0.0-beta.11"
+  version "2.0.0-beta.13"
   dependencies:
     "@justeat/f-services" "0.4.0"
-    "@justeat/f-vue-icons" "1.0.0-beta.4"
+    "@justeat/f-vue-icons" "^1.0.0-beta.4"
     axios "0.19.0"
     lodash-es "4.17.15"
 
@@ -1077,7 +1077,7 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.3.0.tgz#1f18ba13ad7061e21c2112387234a77ba45fb5d3"
   integrity sha512-hqRiGA2lP++Z1oqawsv1V2Duf3YShaAbJ3S5JEPTpTMP5RjH36Xpc8nRbIVFBmwnZCu7L9iF7AebYTUX8XhiZA==
 
-"@justeat/f-vue-icons@1.0.0-beta.4":
+"@justeat/f-vue-icons@1.0.0-beta.4", "@justeat/f-vue-icons@^1.0.0-beta.4":
   version "1.0.0-beta.4"
   resolved "http://packages.je-labs.com/npm/private-npm/@justeat/f-vue-icons/-/f-vue-icons-1.0.0-beta.4.tgz#aef8a22b43f04f3ad0ca287f50ed1d68804c605a"
   integrity sha1-rviiK0PwTzrQyih/UO0daIBMYFo=


### PR DESCRIPTION
### Changelog

### Changed
- Logic in the `getUserInfo` method inside `Navigation.vue`
- Versions for `f-services`, `f-header` and `f-footer`
- Conditionals to point at `isAuthenticated` as `userData` will always be returned
- Webpack on `f-services` to babel polyfill
 - Reference to `$i18n` localization library in `f-header` and `f-footer`

### Added
 - Prop for `userInfoUrl`
