### PR TITLE
f-header@2.0.0-beta.17-add-order-tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@babel/cli": "7.5.0",
-    "@babel/plugin-proposal-optional-chaining": "^7.6.0",
+    "@babel/plugin-proposal-optional-chaining": "7.6.0",
     "@babel/preset-env": "7.5.4",
     "@justeat/browserslist-config-fozzie": "1.1.1",
     "@justeat/eslint-config-fozzie": "3.1.1",

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -34,7 +34,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "^0.7.0",
+    "@justeat/f-services": "0.9.0",
     "@justeat/f-vue-icons": "1.0.0-beta.4",
     "lodash-es": "4.17.15",
     "v-click-outside": "2.1.3",

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -9,8 +9,6 @@ v2.0.0-beta-16
 *October 1, 2019*
 
 ### Added
- - New method `orderCountSupported` for order count tracking
- - New `input` tag in the header `data-order-count-supported` for order count tracking
  - New methods added for getting and setting local storage with order count `setAnalyticsBlob` and `getLocalAnalyticsBlob`
  - New method added for saving the users data `saveUserData`
  - New method added for pushing the user data to the windows data layer `pushUserData`

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -11,7 +11,7 @@ v2.0.0-beta-16
 ### Added
  - New method `orderCountSupported` for order count tracking
  - New `input` tag in the header `data-order-count-supported` for order count tracking
- - New methods added for getting and setting local storage with order count `setAnanlyticsBlob` and `getLocalAnalyticsBlob`
+ - New methods added for getting and setting local storage with order count `setAnalyticsBlob` and `getLocalAnalyticsBlob`
  - New method added for saving the users data `saveUserData`
  - New method added for pushing the user data to the windows data layer `pushUserData`
  - New method for fetching the order count through GET request `fetchOrderCountAndSave`

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+
+v2.0.0-beta-16
+------------------------------
+*September 30, 2019*
+
+### Removed
+ - Methods and added them to `f-services`
+
+
 v2.0.0-beta-15
 ------------------------------
 *September 27, 2019*

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta-16
+------------------------------
+*October 1, 2019*
+
+### Added
+ - New method `orderCountSupported` for order count tracking
+ - New `input` tag in the header `data-order-count-supported` for order count tracking
+
+
 v2.0.0-beta-15
 ------------------------------
 *September 27, 2019*
@@ -54,7 +63,7 @@ v2.0.0-beta-10
 *September 20, 2019*
 
 ### Changed
-- Name of method from `setUserDetails` to `setUserInfo`
+- Name of method from `setUserDetails` to `fetchUserInfo`
 
 ### Added
 - New prop for `userInfo` coming from outside the component

--- a/packages/f-header/README.md
+++ b/packages/f-header/README.md
@@ -63,6 +63,6 @@
 
     `showDeliveryEnquiry` - Boolean property with `false` as a default value, defines if it is necessary to show the "Deliver with Just Eat" link in the header.
 
-    `justLog` - Function passed in for logging errors with the `setUserInfo` method. It has empty function as a default value
+    `justLog` - Function passed in for logging errors with the `fetchUserInfo` method. It has empty function as a default value
 
 ## Documentation to be completed once module is in stable state.

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -35,9 +35,10 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "0.7.0",
-    "@justeat/f-vue-icons": "1.0.0-beta.4",
-    "axios": "0.19.0",
+    "@justeat/f-services": "^0.8.0",
+    "@justeat/f-vue-icons": "^1.0.0-beta.4",
+    "axios": "^0.19.0",
+    "lite-ready": "^1.0.4",
     "lodash-es": "4.17.15"
   },
   "peerDependencies": {

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@justeat/f-services": "0.9.0",
     "@justeat/f-vue-icons": "1.0.0-beta.4",
-    "axios": "^0.19.0",
+    "axios": "0.19.0",
     "lodash-es": "4.17.15"
   },
   "peerDependencies": {

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -35,8 +35,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "0.8.0",
-    "@justeat/f-vue-icons": "1.0.0-beta.4",
+    "@justeat/f-services": "^0.8.0",
+    "@justeat/f-vue-icons": "^1.0.0-beta.4",
     "axios": "0.19.0",
     "lodash-es": "4.17.15"
   },

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -35,10 +35,9 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "^0.8.0",
-    "@justeat/f-vue-icons": "^1.0.0-beta.4",
+    "@justeat/f-services": "0.9.0",
+    "@justeat/f-vue-icons": "1.0.0-beta.4",
     "axios": "^0.19.0",
-    "lite-ready": "^1.0.4",
     "lodash-es": "4.17.15"
   },
   "peerDependencies": {

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.15",
+  "version": "v2.0.0-beta.16",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"
@@ -35,7 +35,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "0.7.0",
+    "@justeat/f-services": "0.8.0",
     "@justeat/f-vue-icons": "1.0.0-beta.4",
     "axios": "0.19.0",
     "lodash-es": "4.17.15"

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -27,6 +27,7 @@
                 :user-info-prop="userInfoProp"
                 :user-info-url="userInfoUrl"
                 :order-count-url="orderCountUrl"
+                :is-order-count-supported="isOrderCountSupported"
                 @onMobileNavToggle="mobileNavToggled" />
         </div>
     </header>
@@ -74,6 +75,10 @@ export default {
         orderCountUrl: {
             type: String,
             default: '/api/analytics/ordercount'
+        },
+        isOrderCountSupported: {
+            type: Boolean,
+            default: true
         }
     },
     data () {
@@ -81,13 +86,11 @@ export default {
         const localeConfig = tenantConfigs[locale];
         const theme = sharedServices.getTheme(locale);
         const mobileNavIsOpen = false;
-        const isOrderCountSupported = true;
 
         return {
             copy: { ...localeConfig },
             theme,
-            mobileNavIsOpen,
-            isOrderCountSupported
+            mobileNavIsOpen
         };
     },
     computed: {

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -1,29 +1,37 @@
 <template>
-    <header
-        :data-theme="theme"
-        :class="['c-header', { 'c-header--transparent c-header--gradient': showTransparentHeader }]">
-        <skip-to-main
-            :text="copy.skipToMainContentText"
-            :transparent-bg="showTransparentHeader" />
-        <div class="c-header-container">
-            <logo
-                :theme="theme"
-                :is-transparent="showTransparentHeader"
-                :company-name="copy.companyName"
-                :logo-gtm-label="copy.logo.gtm" />
-            <navigation
-                :nav-links="copy.navLinks"
-                :help="copy.help"
-                :account-logout="copy.accountLogout"
-                :account-login="copy.accountLogin"
-                :open-menu-text="copy.openMenuText"
-                :delivery-enquiry="copy.deliveryEnquiry"
-                :show-delivery-enquiry="showDeliveryEnquiryWithContent"
-                :user-info-prop="userInfoProp"
-                :just-log="justLog"
-                @onMobileNavToggle="mobileNavToggled" />
-        </div>
-    </header>
+    <section>
+        <input
+            data-order-count-supported
+            type="hidden"
+            :value="isOrderCountSupported">
+        <header
+            :data-theme="theme"
+            :class="['c-header', { 'c-header--transparent c-header--gradient': showTransparentHeader }]">
+            <skip-to-main
+                :text="copy.skipToMainContentText"
+                :transparent-bg="showTransparentHeader" />
+            <div class="c-header-container">
+                <logo
+                    :theme="theme"
+                    :is-transparent="showTransparentHeader"
+                    :company-name="copy.companyName"
+                    :logo-gtm-label="copy.logo.gtm" />
+                <navigation
+                    :nav-links="copy.navLinks"
+                    :help="copy.help"
+                    :account-logout="copy.accountLogout"
+                    :account-login="copy.accountLogin"
+                    :open-menu-text="copy.openMenuText"
+                    :delivery-enquiry="copy.deliveryEnquiry"
+                    :show-delivery-enquiry="showDeliveryEnquiryWithContent"
+                    :just-log="justLog"
+                    :user-info-prop="userInfoProp"
+                    :user-info-url="userInfoUrl"
+                    :order-count-url="orderCountUrl"
+                    @onMobileNavToggle="mobileNavToggled" />
+            </div>
+        </header>
+    </section>
 </template>
 
 <script>
@@ -60,6 +68,14 @@ export default {
         userInfoProp: {
             type: [Object, Boolean],
             default: false
+        },
+        userInfoUrl: {
+            type: String,
+            default: '/api/account/details'
+        },
+        orderCountUrl: {
+            type: String,
+            default: '/api/analytics/ordercount'
         }
     },
     data () {
@@ -67,11 +83,13 @@ export default {
         const localeConfig = tenantConfigs[locale];
         const theme = sharedServices.getTheme(locale);
         const mobileNavIsOpen = false;
+        const isOrderCountSupported = true;
 
         return {
             copy: { ...localeConfig },
             theme,
-            mobileNavIsOpen
+            mobileNavIsOpen,
+            isOrderCountSupported
         };
     },
     computed: {

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -1,37 +1,35 @@
 <template>
-    <section>
+    <header
+        :data-theme="theme"
+        :class="['c-header', { 'c-header--transparent c-header--gradient': showTransparentHeader }]">
         <input
             data-order-count-supported
             type="hidden"
             :value="isOrderCountSupported">
-        <header
-            :data-theme="theme"
-            :class="['c-header', { 'c-header--transparent c-header--gradient': showTransparentHeader }]">
-            <skip-to-main
-                :text="copy.skipToMainContentText"
-                :transparent-bg="showTransparentHeader" />
-            <div class="c-header-container">
-                <logo
-                    :theme="theme"
-                    :is-transparent="showTransparentHeader"
-                    :company-name="copy.companyName"
-                    :logo-gtm-label="copy.logo.gtm" />
-                <navigation
-                    :nav-links="copy.navLinks"
-                    :help="copy.help"
-                    :account-logout="copy.accountLogout"
-                    :account-login="copy.accountLogin"
-                    :open-menu-text="copy.openMenuText"
-                    :delivery-enquiry="copy.deliveryEnquiry"
-                    :show-delivery-enquiry="showDeliveryEnquiryWithContent"
-                    :just-log="justLog"
-                    :user-info-prop="userInfoProp"
-                    :user-info-url="userInfoUrl"
-                    :order-count-url="orderCountUrl"
-                    @onMobileNavToggle="mobileNavToggled" />
-            </div>
-        </header>
-    </section>
+        <skip-to-main
+            :text="copy.skipToMainContentText"
+            :transparent-bg="showTransparentHeader" />
+        <div class="c-header-container">
+            <logo
+                :theme="theme"
+                :is-transparent="showTransparentHeader"
+                :company-name="copy.companyName"
+                :logo-gtm-label="copy.logo.gtm" />
+            <navigation
+                :nav-links="copy.navLinks"
+                :help="copy.help"
+                :account-logout="copy.accountLogout"
+                :account-login="copy.accountLogin"
+                :open-menu-text="copy.openMenuText"
+                :delivery-enquiry="copy.deliveryEnquiry"
+                :show-delivery-enquiry="showDeliveryEnquiryWithContent"
+                :just-log="justLog"
+                :user-info-prop="userInfoProp"
+                :user-info-url="userInfoUrl"
+                :order-count-url="orderCountUrl"
+                @onMobileNavToggle="mobileNavToggled" />
+        </div>
+    </header>
 </template>
 
 <script>

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -2,10 +2,6 @@
     <header
         :data-theme="theme"
         :class="['c-header', { 'c-header--transparent c-header--gradient': showTransparentHeader }]">
-        <input
-            data-order-count-supported
-            type="hidden"
-            :value="isOrderCountSupported">
         <skip-to-main
             :text="copy.skipToMainContentText"
             :transparent-bg="showTransparentHeader" />

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -202,7 +202,6 @@ export default {
         ProfileIcon,
         DeliveryIcon
     },
-
     props: {
         accountLogin: {
             type: Object,
@@ -249,7 +248,6 @@ export default {
             default: '/api/analytics/ordercount'
         }
     },
-
     data () {
         return {
             navIsOpen: false,
@@ -258,7 +256,6 @@ export default {
             orderCountInfo: false
         };
     },
-
     computed: {
         isBelowMid () {
             return this.currentScreenWidth <= 767;
@@ -274,31 +271,25 @@ export default {
             return `${this.accountLogout.url}${this.returnUrl}`;
         }
     },
-
     mounted () {
         if (!this.userInfo) {
             this.fetchUserInfo();
         }
         sharedServices.addEvent('resize', 100, this.onResize);
     },
-
     destroyed () {
         sharedServices.removeEvent('resize', this.onResize);
     },
-
     methods: {
         onNavToggle () {
             this.navIsOpen = !this.navIsOpen;
         },
-
         closeNav () {
             this.navIsOpen = false;
         },
-
         openNav () {
             this.navIsOpen = true;
         },
-
         onResize () {
             this.currentScreenWidth = sharedServices.getWindowHeight();
         },
@@ -307,7 +298,6 @@ export default {
             this.onNavToggle();
             this.$emit('onMobileNavToggle', this.navIsOpen);
         },
-
         // If userInfoProp wasn't passed we make a call for userInfo on mounted hook
         async fetchUserInfo () {
             try {

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -202,52 +202,69 @@ export default {
         ProfileIcon,
         DeliveryIcon
     },
+
     props: {
         accountLogin: {
             type: Object,
             default: () => ({})
         },
+
         accountLogout: {
             type: Object,
             default: () => ({})
         },
+
         navLinks: {
             type: Object,
             required: true
         },
+
         help: {
             type: Object,
             default: () => ({})
         },
+
         openMenuText: {
             type: String,
             default: ''
         },
+
         deliveryEnquiry: {
             type: Object,
             default: () => ({})
         },
+
         showDeliveryEnquiry: {
             type: Boolean,
             default: false
         },
+
         justLog: {
             type: Object,
             default: () => ({})
         },
+
         userInfoProp: {
             type: [Object, Boolean],
             default: false
         },
+
         userInfoUrl: {
             type: String,
             default: '/api/account/details'
         },
+
         orderCountUrl: {
             type: String,
             default: '/api/analytics/ordercount'
+        },
+
+        isOrderCountSupported: {
+            type: Boolean,
+            default: true
         }
     },
+
     data () {
         return {
             navIsOpen: false,
@@ -256,48 +273,60 @@ export default {
             orderCountInfo: false
         };
     },
+
     computed: {
         isBelowMid () {
             return this.currentScreenWidth <= 767;
         },
+
         returnUrl () {
             if (!this.$route) return encodeURIComponent(document.location.pathname);
             return encodeURIComponent(this.$route.name);
         },
+
         returnLoginUrl () {
             return `${this.accountLogin.url}${this.returnUrl}`;
         },
+
         returnLogoutUrl () {
             return `${this.accountLogout.url}${this.returnUrl}`;
         }
     },
+
     mounted () {
         if (!this.userInfo) {
             this.fetchUserInfo();
         }
         sharedServices.addEvent('resize', 100, this.onResize);
     },
+
     destroyed () {
         sharedServices.removeEvent('resize', this.onResize);
     },
+
     methods: {
         onNavToggle () {
             this.navIsOpen = !this.navIsOpen;
         },
+
         closeNav () {
             this.navIsOpen = false;
         },
+
         openNav () {
             this.navIsOpen = true;
         },
+
         onResize () {
             this.currentScreenWidth = sharedServices.getWindowHeight();
         },
+
         // When hamburger menu is clicked we want to trigger toggling of navigation and emit the state to the parent to add transparent class
         onHamburgerMenuClick () {
             this.onNavToggle();
             this.$emit('onMobileNavToggle', this.navIsOpen);
         },
+
         // If userInfoProp wasn't passed we make a call for userInfo on mounted hook
         async fetchUserInfo () {
             try {
@@ -318,6 +347,7 @@ export default {
                 }
             }
         },
+
         // fetches the order count for the user
         async fetchOrderCountAndSave () {
             try {
@@ -338,38 +368,34 @@ export default {
                 }
             }
         },
+
         // Sets the order count info in local storage
         setAnanlyticsBlob () {
             window.localStorage.setItem('je-analytics', JSON.stringify(this.orderCountInfo));
         },
+
         // Gets the order count info in local storage
         getLocalAnalyticsBlob () {
             return window.localStorage.getItem('je-analytics');
         },
+
         // Updates the user information with the count
         enrichUserDataWithCount () {
             this.userInfo.orderCount = this.orderCountInfo.Count;
         },
+
         // Pushes the user info to the windows data layer
         pushUserData () {
             window.dataLayer.push(this.userInfo);
         },
-        // Checks that the element exist's
-        orderCountSupported () {
-            const supportedEl = document.querySelector('[data-order-count-supported]');
-            if (supportedEl && supportedEl.value) {
-                // Case insensitive regex test for value="true"
-                return /^true$/i.test(supportedEl.value);
-            }
-            return false;
-        },
+
         // Saves the user data and calls the nessesary methods based on what is already there
         saveUserData () {
             const localOrderCount = JSON.parse(this.getLocalAnalyticsBlob);
             const currentTime = new Date().getTime();
             const localOrderCountExpires = Date.parse(localOrderCount.Expires);
 
-            if (!this.orderCountSupported()) {
+            if (!this.isOrderCountSupported()) {
                 this.pushUserData();
             }
             if (!this.getLocalAnalyticsBlob) {

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -194,7 +194,7 @@
 
 <script>
 import { ProfileIcon, DeliveryIcon } from '@justeat/f-vue-icons';
-import { throttle } from 'lodash-es';
+import sharedServices from '@justeat/f-services';
 import axios from 'axios';
 
 export default {
@@ -202,6 +202,7 @@ export default {
         ProfileIcon,
         DeliveryIcon
     },
+
     props: {
         accountLogin: {
             type: Object,
@@ -244,13 +245,15 @@ export default {
             default: '/api/account/details'
         }
     },
+
     data () {
         return {
             navIsOpen: false,
-            currentScreenWidth: 0,
+            currentScreenWidth: sharedServices.getWindowHeight(),
             userInfo: this.userInfoProp
         };
     },
+
     computed: {
         isBelowMid () {
             return this.currentScreenWidth <= 767;
@@ -266,29 +269,35 @@ export default {
             return `${this.accountLogout.url}${this.returnUrl}`;
         }
     },
+
     mounted () {
         if (!this.userInfo) {
             this.setUserInfo();
         }
-        this.currentScreenWidth = window.innerWidth;
-        window.addEventListener('resize', throttle(this.onResize, 100));
+        sharedServices.addEvent('resize', 100, this.onResize);
     },
+
     destroyed () {
-        window.removeEventListener('resize', this.resize);
+        sharedServices.removeEvent('resize', this.onResize);
     },
+
     methods: {
         onNavToggle () {
             this.navIsOpen = !this.navIsOpen;
         },
+
         closeNav () {
             this.navIsOpen = false;
         },
+
         openNav () {
             this.navIsOpen = true;
         },
+
         onResize () {
-            this.currentScreenWidth = window.innerWidth;
+            this.currentScreenWidth = sharedServices.getWindowHeight();
         },
+
         // If userInfoProp wasn't passed we make a call for userInfo on mounted hook
         async setUserInfo () {
             try {
@@ -306,6 +315,7 @@ export default {
                 }
             }
         },
+
         // When hamburger menu is clicked we want to trigger toggling of navigation
         // + emit the state of `navIsOpen` attr to the header component to change header styles in case of transparency
         // in open nav state mobile header should become white, not transparent

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -358,7 +358,7 @@ export default {
                 });
                 if (data) {
                     this.orderCountInfo = data;
-                    this.setAnanlyticsBlob();
+                    this.setAnalyticsBlob();
                     this.enrichUserDataWithCount(data);
                     this.pushUserData();
                 }
@@ -370,7 +370,7 @@ export default {
         },
 
         // Sets the order count info in local storage
-        setAnanlyticsBlob () {
+        setAnalyticsBlob () {
             window.localStorage.setItem('je-analytics', JSON.stringify(this.orderCountInfo));
         },
 

--- a/packages/f-services/CHANGELOG.md
+++ b/packages/f-services/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 0.9.0
 ------------------------------
-*September 30, 2019*
+*October 1, 2019*
 
  ### Added
 - `lodash-es` throttle for the `addEvent` service

--- a/packages/f-services/CHANGELOG.md
+++ b/packages/f-services/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+0.9.0
+------------------------------
+*September 30, 2019*
+
+ ### Added
+- `lodash-es` throttle for the `addEvent` service
+
+
 0.8.0
 ------------------------------
 *September 30, 2019*
@@ -13,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `getWindowHeight` method for returning the current height of the window
 - `addEvent` method for listening to a given event and applying a given function at a given time
 - `removeEvent` method for clearing the listener for a given event and function
+
 
 0.7.0
 ------------------------------

--- a/packages/f-services/package.json
+++ b/packages/f-services/package.json
@@ -39,6 +39,6 @@
     "@vue/test-utils": "1.0.0-beta.29"
   },
   "dependencies": {
-    "lodash-es": "^4.17.15"
+    "lodash-es": "4.17.15"
   }
 }

--- a/packages/f-services/package.json
+++ b/packages/f-services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-services",
   "description": "Fozzie Services - Shared Services for Components and projects",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "dist/f-services.umd.min.js",
   "files": [
     "dist"
@@ -37,5 +37,8 @@
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "3.9.0",
     "@vue/test-utils": "1.0.0-beta.29"
+  },
+  "dependencies": {
+    "lodash-es": "^4.17.15"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,7 +1024,7 @@
 "@justeat/f-footer@file:packages/f-footer":
   version "2.0.0-beta.22"
   dependencies:
-    "@justeat/f-services" "^0.7.0"
+    "@justeat/f-services" "0.9.0"
     "@justeat/f-vue-icons" "1.0.0-beta.4"
     lodash-es "4.17.15"
     v-click-outside "2.1.3"
@@ -1033,9 +1033,9 @@
 "@justeat/f-header@file:packages/f-header":
   version "2.0.0-beta.16"
   dependencies:
-    "@justeat/f-services" "^0.8.0"
-    "@justeat/f-vue-icons" "^1.0.0-beta.4"
-    axios "0.19.0"
+    "@justeat/f-services" "0.9.0"
+    "@justeat/f-vue-icons" "1.0.0-beta.4"
+    axios "^0.19.0"
     lodash-es "4.17.15"
 
 "@justeat/f-icons@1.29.0":
@@ -1059,24 +1059,15 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-logger/-/f-logger-0.7.1.tgz#06e728d3c65733cab7c9bbfc813b401fa68ba82b"
   integrity sha512-qi1wDK5ijmQ6nE+2bIv68AuWVxCvogzVoXvHd4D0oZCw4PQmVfw9i25m/fw6AiipL6yxkiIGM4LfBlnm+FncDA==
 
-<<<<<<< HEAD
-=======
 "@justeat/f-metadata@file:packages/f-metadata":
   version "0.1.0"
   dependencies:
     appboy-web-sdk "2.4.0"
 
->>>>>>> d3066facec2006ebfc963b4a92fa38eb8ac26092
-"@justeat/f-services@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.7.0.tgz#899c826ed2e564ff1f495c1052f2f8fd6dbc5077"
-  integrity sha512-O9BseOP+wUip3xUpUHZqjAnr7obfHby1jP/jCLp+wmvU37QH6yi44iWaXmWQy8wSQegU2VDu3z7dKzgPRZB82g==
-<<<<<<< HEAD
-=======
-
 "@justeat/f-services@file:packages/f-services":
-  version "0.8.0"
->>>>>>> d3066facec2006ebfc963b4a92fa38eb8ac26092
+  version "0.9.0"
+  dependencies:
+    lodash-es "^4.17.15"
 
 "@justeat/f-utils@0.2.0":
   version "0.2.0"
@@ -1088,7 +1079,7 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.3.0.tgz#1f18ba13ad7061e21c2112387234a77ba45fb5d3"
   integrity sha512-hqRiGA2lP++Z1oqawsv1V2Duf3YShaAbJ3S5JEPTpTMP5RjH36Xpc8nRbIVFBmwnZCu7L9iF7AebYTUX8XhiZA==
 
-"@justeat/f-vue-icons@1.0.0-beta.4", "@justeat/f-vue-icons@^1.0.0-beta.4":
+"@justeat/f-vue-icons@1.0.0-beta.4":
   version "1.0.0-beta.4"
   resolved "http://packages.je-labs.com/npm/private-npm/@justeat/f-vue-icons/-/f-vue-icons-1.0.0-beta.4.tgz#aef8a22b43f04f3ad0ca287f50ed1d68804c605a"
   integrity sha1-rviiK0PwTzrQyih/UO0daIBMYFo=
@@ -3028,6 +3019,14 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
+
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -4859,7 +4858,7 @@ debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0:
+debug@3.1.0, debug@=3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -6330,6 +6329,13 @@ follow-redirects@0.0.7:
     debug "^2.2.0"
     stream-consume "^0.1.0"
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 follow-redirects@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.9.0.tgz#8d5bcdc65b7108fe1508649c79c12d732dcedb4f"
@@ -7545,6 +7551,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.4:
   version "1.1.4"
@@ -8787,11 +8798,6 @@ lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
-
-lite-ready@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/lite-ready/-/lite-ready-1.0.4.tgz#6dfe50f45a5a2840c87c8406a7abf3088bfd255e"
-  integrity sha1-bf5Q9FpaKEDIfIQGp6vzCIv9JV4=
 
 load-json-file@^1.0.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,10 +305,10 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
 
-"@babel/plugin-proposal-optional-chaining@^7.6.0":
+"@babel/plugin-proposal-optional-chaining@7.6.0":
   version "7.6.0"
-  resolved "http://packages.je-labs.com/npm/private-npm/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.6.0.tgz#e9bf1f9b9ba10c77c033082da75f068389041af8"
-  integrity sha1-6b8fm5uhDHfAMwgtp18Gg4kEGvg=
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.6.0.tgz#e9bf1f9b9ba10c77c033082da75f068389041af8"
+  integrity sha512-kj4gkZ6qUggkprRq3Uh5KP8XnE1MdIO0J7MhdDX8+rAbB6dJ2UrensGIS+0NPZAaaJ1Vr0PN6oLUgXMU1uMcSg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-chaining" "^7.2.0"
@@ -1035,7 +1035,7 @@
   dependencies:
     "@justeat/f-services" "0.9.0"
     "@justeat/f-vue-icons" "1.0.0-beta.4"
-    axios "^0.19.0"
+    axios "0.19.0"
     lodash-es "4.17.15"
 
 "@justeat/f-icons@1.29.0":
@@ -3019,7 +3019,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@^0.19.0:
+axios@0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
   integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,23 +1021,6 @@
   dependencies:
     qwery "4.0.0"
 
-"@justeat/f-footer@file:packages/f-footer":
-  version "2.0.0-beta.22"
-  dependencies:
-    "@justeat/f-services" "^0.7.0"
-    "@justeat/f-vue-icons" "1.0.0-beta.4"
-    lodash-es "4.17.15"
-    v-click-outside "2.1.3"
-    vue "2.6.10"
-
-"@justeat/f-header@file:packages/f-header":
-  version "2.0.0-beta.15"
-  dependencies:
-    "@justeat/f-services" "0.7.0"
-    "@justeat/f-vue-icons" "1.0.0-beta.4"
-    axios "0.19.0"
-    lodash-es "4.17.15"
-
 "@justeat/f-icons@1.29.0":
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-1.29.0.tgz#87adc2ac052cb8cade9090e87eefcf0cfdfdae1b"
@@ -1059,20 +1042,10 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-logger/-/f-logger-0.7.1.tgz#06e728d3c65733cab7c9bbfc813b401fa68ba82b"
   integrity sha512-qi1wDK5ijmQ6nE+2bIv68AuWVxCvogzVoXvHd4D0oZCw4PQmVfw9i25m/fw6AiipL6yxkiIGM4LfBlnm+FncDA==
 
-"@justeat/f-metadata@file:packages/f-metadata":
-  version "0.1.0"
-  dependencies:
-    appboy-web-sdk "2.4.0"
-
-"@justeat/f-services@0.7.0", "@justeat/f-services@^0.7.0":
+"@justeat/f-services@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.7.0.tgz#899c826ed2e564ff1f495c1052f2f8fd6dbc5077"
   integrity sha512-O9BseOP+wUip3xUpUHZqjAnr7obfHby1jP/jCLp+wmvU37QH6yi44iWaXmWQy8wSQegU2VDu3z7dKzgPRZB82g==
-
-"@justeat/f-services@file:packages/f-services":
-  version "0.9.0"
-  dependencies:
-    lodash-es "^4.17.15"
 
 "@justeat/f-utils@0.2.0":
   version "0.2.0"
@@ -1084,19 +1057,13 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.3.0.tgz#1f18ba13ad7061e21c2112387234a77ba45fb5d3"
   integrity sha512-hqRiGA2lP++Z1oqawsv1V2Duf3YShaAbJ3S5JEPTpTMP5RjH36Xpc8nRbIVFBmwnZCu7L9iF7AebYTUX8XhiZA==
 
-"@justeat/f-vue-icons@1.0.0-beta.4":
+"@justeat/f-vue-icons@1.0.0-beta.4", "@justeat/f-vue-icons@^1.0.0-beta.4":
   version "1.0.0-beta.4"
   resolved "http://packages.je-labs.com/npm/private-npm/@justeat/f-vue-icons/-/f-vue-icons-1.0.0-beta.4.tgz#aef8a22b43f04f3ad0ca287f50ed1d68804c605a"
   integrity sha1-rviiK0PwTzrQyih/UO0daIBMYFo=
   dependencies:
     "@justeat/f-icons" "2.0.0-beta.6"
     babel-helper-vue-jsx-merge-props "^2.0.3"
-
-"@justeat/f-vue-icons@file:packages/f-vue-icons":
-  version "0.16.0"
-  dependencies:
-    "@justeat/f-icons" "1.29.0"
-    vue "2.6.10"
 
 "@justeat/fozzie-colour-palette@2.3.0":
   version "2.3.0"
@@ -3024,14 +2991,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
-  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
-  dependencies:
-    follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
-
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -4863,7 +4822,7 @@ debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@=3.1.0:
+debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -6334,13 +6293,6 @@ follow-redirects@0.0.7:
     debug "^2.2.0"
     stream-consume "^0.1.0"
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
-
 follow-redirects@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.9.0.tgz#8d5bcdc65b7108fe1508649c79c12d732dcedb4f"
@@ -7556,11 +7508,6 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
-
-is-buffer@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
-  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-callable@^1.1.4:
   version "1.1.4"
@@ -8803,6 +8750,11 @@ lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
+lite-ready@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/lite-ready/-/lite-ready-1.0.4.tgz#6dfe50f45a5a2840c87c8406a7abf3088bfd255e"
+  integrity sha1-bf5Q9FpaKEDIfIQGp6vzCIv9JV4=
 
 load-json-file@^1.0.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,7 +1030,7 @@
     v-click-outside "2.1.3"
     vue "2.6.10"
 
-"@justeat/f-header@file:packages/f-header":
+"@justeat/f-header@0.9.0":
   version "2.0.0-beta.16"
   dependencies:
     "@justeat/f-services" "0.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,6 +1021,23 @@
   dependencies:
     qwery "4.0.0"
 
+"@justeat/f-footer@file:packages/f-footer":
+  version "2.0.0-beta.22"
+  dependencies:
+    "@justeat/f-services" "^0.7.0"
+    "@justeat/f-vue-icons" "1.0.0-beta.4"
+    lodash-es "4.17.15"
+    v-click-outside "2.1.3"
+    vue "2.6.10"
+
+"@justeat/f-header@file:packages/f-header":
+  version "2.0.0-beta.15"
+  dependencies:
+    "@justeat/f-services" "0.7.0"
+    "@justeat/f-vue-icons" "1.0.0-beta.4"
+    axios "0.19.0"
+    lodash-es "4.17.15"
+
 "@justeat/f-icons@1.29.0":
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-1.29.0.tgz#87adc2ac052cb8cade9090e87eefcf0cfdfdae1b"
@@ -1042,10 +1059,20 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-logger/-/f-logger-0.7.1.tgz#06e728d3c65733cab7c9bbfc813b401fa68ba82b"
   integrity sha512-qi1wDK5ijmQ6nE+2bIv68AuWVxCvogzVoXvHd4D0oZCw4PQmVfw9i25m/fw6AiipL6yxkiIGM4LfBlnm+FncDA==
 
-"@justeat/f-services@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.4.0.tgz#d6d5f7e3de0f62e0ac064746c671942fb0f86c62"
-  integrity sha512-920I7U+bcZUTBq8KeU+ky1Z1cFrMWrU+2MgBFwTYLsFN6Fkbv4NO2Rvp0UnAotw3oPLbBJ03aUlyAxEb8+ZOtg==
+"@justeat/f-metadata@file:packages/f-metadata":
+  version "0.1.0"
+  dependencies:
+    appboy-web-sdk "2.4.0"
+
+"@justeat/f-services@0.7.0", "@justeat/f-services@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.7.0.tgz#899c826ed2e564ff1f495c1052f2f8fd6dbc5077"
+  integrity sha512-O9BseOP+wUip3xUpUHZqjAnr7obfHby1jP/jCLp+wmvU37QH6yi44iWaXmWQy8wSQegU2VDu3z7dKzgPRZB82g==
+
+"@justeat/f-services@file:packages/f-services":
+  version "0.9.0"
+  dependencies:
+    lodash-es "^4.17.15"
 
 "@justeat/f-utils@0.2.0":
   version "0.2.0"
@@ -1064,6 +1091,12 @@
   dependencies:
     "@justeat/f-icons" "2.0.0-beta.6"
     babel-helper-vue-jsx-merge-props "^2.0.3"
+
+"@justeat/f-vue-icons@file:packages/f-vue-icons":
+  version "0.16.0"
+  dependencies:
+    "@justeat/f-icons" "1.29.0"
+    vue "2.6.10"
 
 "@justeat/fozzie-colour-palette@2.3.0":
   version "2.3.0"
@@ -8850,7 +8883,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash-es@4.17.15:
+lodash-es@4.17.15, lodash-es@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,7 +1064,7 @@
   dependencies:
     appboy-web-sdk "2.4.0"
 
-"@justeat/f-services@file:packages/f-services":
+"@justeat/f-services@0.9.0":
   version "0.9.0"
   dependencies:
     lodash-es "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,6 +1021,23 @@
   dependencies:
     qwery "4.0.0"
 
+"@justeat/f-footer@file:packages/f-footer":
+  version "2.0.0-beta.22"
+  dependencies:
+    "@justeat/f-services" "^0.7.0"
+    "@justeat/f-vue-icons" "1.0.0-beta.4"
+    lodash-es "4.17.15"
+    v-click-outside "2.1.3"
+    vue "2.6.10"
+
+"@justeat/f-header@file:packages/f-header":
+  version "2.0.0-beta.16"
+  dependencies:
+    "@justeat/f-services" "^0.8.0"
+    "@justeat/f-vue-icons" "^1.0.0-beta.4"
+    axios "0.19.0"
+    lodash-es "4.17.15"
+
 "@justeat/f-icons@1.29.0":
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-1.29.0.tgz#87adc2ac052cb8cade9090e87eefcf0cfdfdae1b"
@@ -1042,10 +1059,18 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-logger/-/f-logger-0.7.1.tgz#06e728d3c65733cab7c9bbfc813b401fa68ba82b"
   integrity sha512-qi1wDK5ijmQ6nE+2bIv68AuWVxCvogzVoXvHd4D0oZCw4PQmVfw9i25m/fw6AiipL6yxkiIGM4LfBlnm+FncDA==
 
-"@justeat/f-services@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.4.0.tgz#d6d5f7e3de0f62e0ac064746c671942fb0f86c62"
-  integrity sha512-920I7U+bcZUTBq8KeU+ky1Z1cFrMWrU+2MgBFwTYLsFN6Fkbv4NO2Rvp0UnAotw3oPLbBJ03aUlyAxEb8+ZOtg==
+"@justeat/f-metadata@file:packages/f-metadata":
+  version "0.1.0"
+  dependencies:
+    appboy-web-sdk "2.4.0"
+
+"@justeat/f-services@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.7.0.tgz#899c826ed2e564ff1f495c1052f2f8fd6dbc5077"
+  integrity sha512-O9BseOP+wUip3xUpUHZqjAnr7obfHby1jP/jCLp+wmvU37QH6yi44iWaXmWQy8wSQegU2VDu3z7dKzgPRZB82g==
+
+"@justeat/f-services@file:packages/f-services":
+  version "0.8.0"
 
 "@justeat/f-utils@0.2.0":
   version "0.2.0"
@@ -1057,13 +1082,19 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.3.0.tgz#1f18ba13ad7061e21c2112387234a77ba45fb5d3"
   integrity sha512-hqRiGA2lP++Z1oqawsv1V2Duf3YShaAbJ3S5JEPTpTMP5RjH36Xpc8nRbIVFBmwnZCu7L9iF7AebYTUX8XhiZA==
 
-"@justeat/f-vue-icons@1.0.0-beta.4":
+"@justeat/f-vue-icons@1.0.0-beta.4", "@justeat/f-vue-icons@^1.0.0-beta.4":
   version "1.0.0-beta.4"
   resolved "http://packages.je-labs.com/npm/private-npm/@justeat/f-vue-icons/-/f-vue-icons-1.0.0-beta.4.tgz#aef8a22b43f04f3ad0ca287f50ed1d68804c605a"
   integrity sha1-rviiK0PwTzrQyih/UO0daIBMYFo=
   dependencies:
     "@justeat/f-icons" "2.0.0-beta.6"
     babel-helper-vue-jsx-merge-props "^2.0.3"
+
+"@justeat/f-vue-icons@file:packages/f-vue-icons":
+  version "0.16.0"
+  dependencies:
+    "@justeat/f-icons" "1.29.0"
+    vue "2.6.10"
 
 "@justeat/fozzie-colour-palette@2.3.0":
   version "2.3.0"


### PR DESCRIPTION
### Changelog

### Added
 - New method `orderCountSupported` for order count tracking
 - New `input` tag in the header `data-order-count-supported` for order count tracking
 - New methods added for getting and setting local storage with order count `setAnanlyticsBlob` and `getLocalAnalyticsBlob`
 - New method added for saving the users data `saveUserData`
 - New method added for pushing the user data to the windows data layer `pushUserData`
 - New method for fetching the order count through GET request `fetchOrderCountAndSave`
 - New method for updating the order count `enrichUserDataWithCount`
 - New props for `orderCountUrl`

### Changed
 - `f-services` versions for header and footer

 ### Removed
 - Methods and added them to `f-services`

### Todo
 - Write tests for new methods and props