### PR TITLE
f-services@0.10.0-add-tests-for-new-services

### DIFF
--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -297,7 +297,7 @@ export default {
         if (!this.userInfo) {
             this.fetchUserInfo();
         }
-        sharedServices.addEvent('resize', 100, this.onResize);
+        sharedServices.addEvent('resize', this.onResize, 100);
     },
 
     destroyed () {

--- a/packages/f-services/CHANGELOG.md
+++ b/packages/f-services/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+0.10.0
+------------------------------
+*October 2, 2019*
+
+ ### Added
+- Tests for new services that have been added
+
+ ### Changed
+- `webpack.config.js` and packages for a better build
+- Name of the export in the `index.js` to `sharedServices` for consistency
+
+
 0.9.0
 ------------------------------
 *October 1, 2019*

--- a/packages/f-services/package.json
+++ b/packages/f-services/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@justeat/f-services",
   "description": "Fozzie Services - Shared Services for Components and projects",
-  "version": "0.9.0",
-  "main": "dist/f-services.umd.min.js",
+  "version": "0.10.0",
+  "main": "dist/shared.services.bundle.js",
   "files": [
     "dist"
   ],
@@ -26,19 +26,23 @@
   ],
   "scripts": {
     "prepare": "yarn test && yarn build",
-    "build": "webpack",
+    "build": "webpack --config ./webpack.config.js --mode=production",
     "test": "jest"
   },
   "browserslist": [
     "extends @justeat/browserslist-config-fozzie"
   ],
-  "devDependencies": {
-    "@vue/cli-plugin-babel": "3.9.2",
-    "@vue/cli-plugin-eslint": "3.9.2",
-    "@vue/cli-plugin-unit-jest": "3.9.0",
-    "@vue/test-utils": "1.0.0-beta.29"
-  },
   "dependencies": {
+    "@babel/polyfill": "7.6.0",
     "lodash-es": "4.17.15"
+  },
+  "devDependencies": {
+    "@babel/cli": "7.6.2",
+    "@babel/core": "7.6.2",
+    "@babel/node": "7.6.2",
+    "@babel/preset-env": "7.6.2",
+    "babel-loader": "8.0.6",
+    "webpack": "4.41.0",
+    "webpack-cli": "3.3.9"
   }
 }

--- a/packages/f-services/src/index.js
+++ b/packages/f-services/src/index.js
@@ -6,7 +6,7 @@
 
 
 // Import vue component
-import Services from './services/shared.service';
+import sharedServices from './services/shared.service';
 
 // To allow use as module (npm/webpack/etc.) export component
-export default Services;
+export default sharedServices;

--- a/packages/f-services/src/services/shared.service.js
+++ b/packages/f-services/src/services/shared.service.js
@@ -63,7 +63,7 @@ const getWindowHeight = () => window.innerHeight;
  * @param {eventName} integer for setting the name of the event listened to.
  * @param {callBackFunction} function for running when the event is listened to.
  */
-const addEvent = (eventName, throttleTime, callBackFunction) => {
+const addEvent = (eventName, callBackFunction, throttleTime) => {
     if (throttleTime > 0) {
         return window.addEventListener(eventName, throttle(callBackFunction, throttleTime));
     }

--- a/packages/f-services/src/services/tests/Services.test.js
+++ b/packages/f-services/src/services/tests/Services.test.js
@@ -1,3 +1,4 @@
+import { throttle } from 'lodash-es';
 import sharedServices from '../shared.service';
 
 describe('sharedServices', () => {
@@ -98,7 +99,6 @@ describe('sharedServices', () => {
             // Arrange
             const locale = 'en-GB';
 
-
             // Act
             const result = sharedServices.getTheme(locale);
 
@@ -138,6 +138,50 @@ describe('sharedServices', () => {
 
             // Assert
             expect(result).toBe(375);
+        });
+    });
+
+    describe('addEvent', () => {
+        const eventName = 'resize';
+        const callBackFunction = jest.fn();
+
+        it('returns the correct event to be listened to WITHOUT being throttled', () => {
+            // Arrange
+            const throttleTime = 0;
+
+            // Act
+            sharedServices.addEvent(eventName, callBackFunction, throttleTime);
+            resizeWindow(windowWidth, windowHeight);
+
+            // Assert
+            expect(callBackFunction).toHaveBeenCalled();
+        });
+
+        it('returns the correct event to be listened to being throttled', () => {
+            // Arrange
+            const throttleTime = 10;
+
+            // Act
+            sharedServices.addEvent(eventName, callBackFunction, throttleTime);
+            resizeWindow(windowWidth, windowHeight);
+
+            // Assert
+            expect(callBackFunction).toHaveBeenCalled();
+        });
+    });
+
+    describe('removeEvent', () => {
+        it('removes given event listener', () => {
+            // Arrange
+            const eventName = 'resize';
+            const callBackFunction = jest.fn();
+
+            // Act
+            sharedServices.removeEvent(eventName, callBackFunction);
+            resizeWindow(windowWidth, windowHeight);
+
+            // Assert
+            expect(callBackFunction).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/f-services/src/services/tests/Services.test.js
+++ b/packages/f-services/src/services/tests/Services.test.js
@@ -12,7 +12,6 @@ describe('sharedServices', () => {
                 locale: 'da-DK'
             };
 
-
             // Act
             const result = sharedServices.getLocale(tenantConfigs, tenantString, globalTenant);
 
@@ -29,7 +28,6 @@ describe('sharedServices', () => {
             const globalTenant = {
                 locale: 'it-IT'
             };
-
 
             // Act
             const result = sharedServices.getLocale(tenantConfigs, tenantString, globalTenant);
@@ -48,7 +46,6 @@ describe('sharedServices', () => {
                 locale: 'it-IT'
             };
 
-
             // Act
             const result = sharedServices.getLocale(tenantConfigs, tenantString, globalTenant);
 
@@ -66,7 +63,6 @@ describe('sharedServices', () => {
                 locale: 'da-DK'
             };
 
-
             // Act
             const result = sharedServices.getLocale(tenantConfigs, tenantString, globalTenant);
 
@@ -80,7 +76,6 @@ describe('sharedServices', () => {
             // Arrange
             const locale = 'en-AU';
 
-
             // Act
             const result = sharedServices.getTheme(locale);
 
@@ -91,7 +86,6 @@ describe('sharedServices', () => {
         it('returns "ml" for Menu Log theme if locale is "en-NZ"', () => {
             // Arrange
             const locale = 'en-NZ';
-
 
             // Act
             const result = sharedServices.getTheme(locale);
@@ -110,6 +104,40 @@ describe('sharedServices', () => {
 
             // Assert
             expect(result).toBe('je');
+        });
+    });
+
+    const windowWidth = 667;
+    const windowHeight = 375;
+    const resizeWindow = (x, y) => {
+        window.innerWidth = x;
+        window.innerHeight = y;
+        window.dispatchEvent(new Event('resize'));
+    };
+
+    describe('getWindowWidth', () => {
+        it('returns a float of the window width', () => {
+            // Arrange
+            resizeWindow(windowWidth, windowHeight);
+
+            // Act
+            const result = window.innerWidth;
+
+            // Assert
+            expect(result).toBe(667);
+        });
+    });
+
+    describe('getWindowHeight', () => {
+        it('returns a float of the window height', () => {
+            // Arrange
+            resizeWindow(windowWidth, windowHeight);
+
+            // Act
+            const result = window.innerHeight;
+
+            // Assert
+            expect(result).toBe(375);
         });
     });
 });

--- a/packages/f-services/webpack.config.js
+++ b/packages/f-services/webpack.config.js
@@ -5,11 +5,17 @@ module.exports = {
     entry: './src/index.js',
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: 'bundle.js'
+        filename: 'shared.services.bundle.js',
+        library: 'f-services',
+        libraryTarget: 'umd'
     },
     module: {
         rules: [
-            { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' }
+            {
+                test: /\.(js|jsx)$/,
+                exclude: /node_modules/,
+                use: ['babel-loader']
+            }
         ]
     }
 };


### PR DESCRIPTION
### Changelog

### Added
- Tests for new services that have been added (`getWindowWidth`, `getWindowHeight`, `addEvent`, `removeEvent`)

### Changed
- `webpack.config.js` and packages for a better build
- Name of the export in the `index.js` to `sharedServices` for consistency