### PR TITLE
f-header@2.0.0-beta.20-changed-prop

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta-20
+------------------------------
+*October 9, 2019*
+
+### Changed
+ - Prop default and value for `errorLog`
+
+
 v2.0.0-beta-19
 ------------------------------
 *October 8, 2019*

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.19",
+  "version": "v2.0.0-beta.20",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -48,30 +48,37 @@ export default {
             type: String,
             default: ''
         },
+
         isTransparent: {
             type: Boolean,
             default: false
         },
+
         showDeliveryEnquiry: {
             type: Boolean,
             default: false
         },
+
         errorLog: {
-            type: Object,
-            default: () => ({})
+            type: [Function, Boolean],
+            default: false
         },
+
         userInfoProp: {
             type: [Object, Boolean],
             default: false
         },
+
         userInfoUrl: {
             type: String,
             default: '/api/account/details'
         },
+
         orderCountUrl: {
             type: String,
             default: '/api/analytics/ordercount'
         },
+
         isOrderCountSupported: {
             type: Boolean,
             default: true

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -240,8 +240,8 @@ export default {
         },
 
         errorLog: {
-            type: Object,
-            default: () => ({})
+            type: [Function, Boolean],
+            default: false
         },
 
         userInfoProp: {

--- a/packages/f-header/src/components/tests/__snapshots__/Header.test.js.snap
+++ b/packages/f-header/src/components/tests/__snapshots__/Header.test.js.snap
@@ -5,7 +5,7 @@ exports[`Header should render default component markup 1`] = `
   <skip-to-main-stub text="Skip to main content" transparentbg="true"></skip-to-main-stub>
   <div class="c-header-container">
     <logo-stub theme="je" istransparent="true" companyname="Just Eat" logogtmlabel="click_logo"></logo-stub>
-    <navigation-stub accountlogin="[object Object]" accountlogout="[object Object]" navlinks="[object Object]" help="[object Object]" openmenutext="Open Menu" deliveryenquiry="[object Object]" errorlog="[object Object]" userinfourl="/api/account/details" ordercounturl="/api/analytics/ordercount" isordercountsupported="true"></navigation-stub>
+    <navigation-stub accountlogin="[object Object]" accountlogout="[object Object]" navlinks="[object Object]" help="[object Object]" openmenutext="Open Menu" deliveryenquiry="[object Object]" userinfourl="/api/account/details" ordercounturl="/api/analytics/ordercount" isordercountsupported="true"></navigation-stub>
   </div>
 </header>
 `;


### PR DESCRIPTION
### Changelog

### Changed
 - Prop default and value for `errorLog`
 - Snapshot for tests