### PR TITLE
2.0.0-beta.26 Updated UK brand links

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.26
+------------------------------
+*October 25, 2019*
+
+### Added
+- Updated `UK` brand links.
+
+
 v2.0.0-beta.25
 ------------------------------
 *October 21, 2019*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "v2.0.0-beta.25",
+  "version": "v2.0.0-beta.26",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/src/tenants/en-GB.js
+++ b/packages/f-footer/src/tenants/en-GB.js
@@ -121,11 +121,6 @@ export default {
                     gtm: 'click_brands_burger-king'
                 },
                 {
-                    url: '/takeaway/brands/dominos-pizza',
-                    text: 'Domino\'s Pizza',
-                    gtm: 'click_brands_dominos-pizza'
-                },
-                {
                     url: '/takeaway/brands/subway',
                     text: 'Subway',
                     gtm: 'click_brands_subway'
@@ -136,7 +131,7 @@ export default {
                     gtm: 'click_brands_yo-sushi'
                 },
                 {
-                    url: '/takeaway/chains',
+                    url: '/takeaway/brands',
                     text: 'View all brands',
                     gtm: 'click_brands_view_all'
                 }


### PR DESCRIPTION
## Changes
1. Removed Domino's brand link.
2. Updated "View all brands" URL.