### PR TITLE
f-header@v2.0.0-beta.25 - Removing typography SCSS include

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.25
+------------------------------
+*November 7, 2019*
+
+### Removed
+- Typography include from styles, as not needed
+
+
 v2.0.0-beta.24
 ------------------------------
 *October 24, 2019*

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.24",
+  "version": "v2.0.0-beta.25",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-header/src/assets/scss/common.scss
+++ b/packages/f-header/src/assets/scss/common.scss
@@ -9,7 +9,6 @@ $theme: 'je' !default;
 @import '~@justeat/fozzie/src/scss/settings/variables';
 @import '~@justeat/fozzie/src/scss/base/reset';
 @import '~@justeat/fozzie-colour-palette/src/scss/';
-@import '~@justeat/fozzie/src/scss/base/typography';
 
 /**
  * Component Variables


### PR DESCRIPTION
### Removed
- Typography include from styles, as not needed