### PR TITLE
f-footer@v2.0.0-beta.27 - remove typography include from styles

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.27
+------------------------------
+*November 7, 2019*
+
+### Removed
+- Typography include from styles, as not needed
+
+
 v2.0.0-beta.26
 ------------------------------
 *October 25, 2019*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "v2.0.0-beta.26",
+  "version": "v2.0.0-beta.27",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/src/assets/scss/common.scss
+++ b/packages/f-footer/src/assets/scss/common.scss
@@ -9,7 +9,6 @@ $theme: 'je' !default;
 @import '~@justeat/fozzie/src/scss/settings/variables';
 @import '~@justeat/fozzie/src/scss/base/reset';
 @import '~@justeat/fozzie-colour-palette/src/scss/';
-@import '~@justeat/fozzie/src/scss/base/typography';
 
 /**
  * Component Variables


### PR DESCRIPTION
### Removed
- Typography include from styles, as not needed