### PR TITLE
f-header@2.0.0-beta.29 - Fixing returnUrl

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v2.0.0-beta.29
+------------------------------
+*November 14, 2019*
+
+### Changed
+- Encode current path for `returnUrl` rather than route name
+
+
 v2.0.0-beta.28
 ------------------------------
 *November 11, 2019*

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.28",
+  "version": "v2.0.0-beta.29",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -286,9 +286,7 @@ export default {
 
         returnUrl () {
             if (this.$route) {
-                const { name } = this.$route;
-                const { href } = this.$router.resolve({ name });
-                return encodeURIComponent(href);
+                return encodeURIComponent(this.$route.path);
             }
             if (typeof document !== 'undefined') {
                 return encodeURIComponent(document.location.pathname);

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -286,9 +286,7 @@ export default {
 
         returnUrl () {
             if (this.$route) {
-                const { name } = this.$route;
-                const { href } = this.$router.resolve({ name });
-                return encodeURIComponent(href);
+                return encodeURIComponent(this.$route.path);
             }
             if (typeof document !== 'undefined') {
                 return encodeURIComponent(document.location.pathname);
@@ -299,7 +297,6 @@ export default {
         returnLoginUrl () {
             return `${this.accountLogin.url}?returnurl=${this.returnUrl}`;
         },
-
         returnLogoutUrl () {
             return `${this.accountLogout.url}?returnurl=${this.returnUrl}`;
         },


### PR DESCRIPTION
This means the return URL in the query string on the homepage will be rendered as `returnurl=%2F` (encoded `/`) rather than `returnurl=homepage` when using Vue Router. I tested the existing behaviour in QA1 and it didn't work.