### PR TITLE
f-header@2.0.0-beta.30 - Set homepage as fallback return URL

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.30
+------------------------------
+*November 15, 2019*
+
+### Changed
+- Set homepage as fallback return URL
+
+
 v2.0.0-beta.29
 ------------------------------
 *November 14, 2019*

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.29",
+  "version": "v2.0.0-beta.30",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -291,7 +291,7 @@ export default {
             if (typeof document !== 'undefined') {
                 return encodeURIComponent(document.location.pathname);
             }
-            return '';
+            return encodeURIComponent('/');
         },
 
         returnLoginUrl () {


### PR DESCRIPTION
Currently, when the return URL is generated during SSR it comes back as blank (because `document` is not defined, so an empty string is returned instead), which isn't handled very well by some sites, so this sets the fallback as the homepage instead. If you use Vue Router for your routing then that is still used to work out the return URL preferentially.