### PR TITLE
f-metadata@v1.0.0 - Dynamic bundling, content card support and adding userID

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -4,19 +4,33 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.0.0
+------------------------------
+*November 15, 2019*
+
+### Added
+- Support for handling content cards through SDK methods
+- User ID to `initialiseBraze` function
+- Support for GTM with Braze
+
+### Changed
+- Changing Braze to be a dynamic import
+- Don't bundle `f-metadata`, leave that to the consuming component.
+
+
 v0.3.0
 ------------------------------
-*October 04, 2019*
+*October 4, 2019*
 
- ### Added
+### Added
 - Babel config (as wasn't transpiling ES functionality)
 
 
 v0.2.0
 ------------------------------
-*October 02, 2019*
+*October 2, 2019*
 
- ### Added
+### Added
 - `disable` toggle added to disable Braze
 
 
@@ -24,6 +38,6 @@ v0.1.0
 ------------------------------
 *September 19, 2019*
 
- ### Added
+### Added
 - Created package
 - Enabling initialisation of Braze

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "0.3.0",
-  "main": "dist/f-metadata.umd.min.js",
+  "version": "1.0.0",
+  "main": "src/index.js",
   "files": [
     "dist"
   ],
@@ -25,7 +25,7 @@
     "fozzie"
   ],
   "scripts": {
-    "build": "yarn lint && vue-cli-service build --target lib --formats umd-min --name f-metadata ./src/index.js",
+    "build": "yarn lint",
     "lint": "vue-cli-service lint --fix"
   },
   "browserslist": [

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -1,10 +1,40 @@
-const initialiseBraze = (apiKey, enableLogging = false, disableComponent = false) => {
+const initialiseBraze = (options = {
+    apiKey: null,
+    userId: null,
+    enableLogging: false,
+    disableComponent: false,
+    callbacks: {
+        handleContentCards: null
+    }
+}) => {
     if (typeof window !== 'undefined') {
-        if (!disableComponent) {
-            const appboy = require('appboy-web-sdk'); // eslint-disable-line
-            appboy.initialize(apiKey, { enableLogging });
-            appboy.display.automaticallyShowNewInAppMessages();
-            appboy.openSession();
+        window.dataLayer = window.dataLayer || [];
+
+        if (!options.disableComponent) {
+            import(/* webpackChunkName: "appboy-web-sdk" */ 'appboy-web-sdk')
+                .then(({ default: appboy }) => {
+                    if (options.apiKey && options.apiKey.length && options.userId && options.userId.length) {
+                        appboy.initialize(options.apiKey, { enableLogging: options.enableLogging });
+
+                        appboy.display.automaticallyShowNewInAppMessages();
+
+                        appboy.changeUser(options.userId, () => {
+                            window.dataLayer.push({
+                                event: 'appboyReady'
+                            });
+                        });
+
+                        window.appboy = appboy;
+                        appboy.openSession();
+
+                        appboy.requestContentCardsRefresh();
+                        const contentCards = appboy.getCachedContentCards();
+                        if (contentCards && contentCards.cards.length) {
+                            options.callbacks.handleContentCards(contentCards.cards);
+                        }
+                    }
+                })
+                .catch(error => `An error occurred while loading the component: ${error}`);
         }
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,6 +1108,23 @@
   dependencies:
     qwery "4.0.0"
 
+"@justeat/f-footer@file:packages/f-footer":
+  version "2.0.0-beta.26"
+  dependencies:
+    "@justeat/f-services" "0.11.0"
+    "@justeat/f-vue-icons" "1.0.0-beta.4"
+    lodash-es "4.17.15"
+    v-click-outside "2.1.3"
+    vue "2.6.10"
+
+"@justeat/f-header@file:packages/f-header":
+  version "2.0.0-beta.24"
+  dependencies:
+    "@justeat/f-services" "0.11.0"
+    "@justeat/f-vue-icons" "1.0.0-beta.4"
+    axios "0.19.0"
+    lodash-es "4.17.15"
+
 "@justeat/f-icons@1.29.0":
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-1.29.0.tgz#87adc2ac052cb8cade9090e87eefcf0cfdfdae1b"
@@ -1129,6 +1146,18 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-logger/-/f-logger-0.7.1.tgz#06e728d3c65733cab7c9bbfc813b401fa68ba82b"
   integrity sha512-qi1wDK5ijmQ6nE+2bIv68AuWVxCvogzVoXvHd4D0oZCw4PQmVfw9i25m/fw6AiipL6yxkiIGM4LfBlnm+FncDA==
 
+"@justeat/f-metadata@file:packages/f-metadata":
+  version "1.0.0-beta.1"
+  dependencies:
+    appboy-web-sdk "2.4.0"
+
+"@justeat/f-services@file:packages/f-services":
+  version "0.11.0"
+  dependencies:
+    "@babel/polyfill" "7.6.0"
+    lodash-es "4.17.15"
+    window-or-global "1.0.1"
+
 "@justeat/f-utils@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.2.0.tgz#b2333b5ddf20b4157af25091e6bc54706358100c"
@@ -1146,6 +1175,12 @@
   dependencies:
     "@justeat/f-icons" "2.0.0-beta.6"
     babel-helper-vue-jsx-merge-props "^2.0.3"
+
+"@justeat/f-vue-icons@file:packages/f-vue-icons":
+  version "0.16.0"
+  dependencies:
+    "@justeat/f-icons" "1.29.0"
+    vue "2.6.10"
 
 "@justeat/fozzie-colour-palette@2.3.0":
   version "2.3.0"


### PR DESCRIPTION
### Added
- Support for handling content cards through SDK methods
- User ID to `initialiseBraze` function
- Support for GTM with Braze

### Changed
- Changing Braze to be a dynamic import
- Don't bundle `f-metadata`, leave that to the consuming component.