### PR TITLE
Fixed Appboy ready event issue for GTM

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+1.0.1
+------------------------------
+*November 18, 2019*
+
+### Fixed
+- GTM event loading issues
 
 v1.0.0
 ------------------------------

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.js",
   "files": [
     "dist"

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -18,14 +18,14 @@ const initialiseBraze = (options = {
 
                         appboy.display.automaticallyShowNewInAppMessages();
 
+                        appboy.openSession();
+                        window.appboy = appboy;
+
                         appboy.changeUser(options.userId, () => {
                             window.dataLayer.push({
                                 event: 'appboyReady'
                             });
                         });
-
-                        window.appboy = appboy;
-                        appboy.openSession();
 
                         appboy.requestContentCardsRefresh();
                         const contentCards = appboy.getCachedContentCards();


### PR DESCRIPTION
Moved `ChangeUser` after `openSession` to allow appboy to load before `appboyready` event is being sent to GTM