### PR TITLE
f-vue-icons@0.16.1-updated-class-toggle

### DIFF
--- a/packages/f-vue-icons/CHANGELOG.md
+++ b/packages/f-vue-icons/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.16.1
+------------------------------
+*November 25, 2019*
+
+### Changed
+- Class on `DeliveryIcon` for toggle
+
+
 v0.16.0
 ------------------------------
 *August 22, 2019*

--- a/packages/f-vue-icons/package.json
+++ b/packages/f-vue-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-vue-icons",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "main": "dist/f-vue-icons.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-vue-icons/src/components/DeliveryIcon/DeliveryIcon.vue
+++ b/packages/f-vue-icons/src/components/DeliveryIcon/DeliveryIcon.vue
@@ -1,7 +1,9 @@
 <template>
     <delivery-icon
-        :class="['c-icon c-icon--delivery', {
+        :class="['c-icon--delivery', {
             'c-icon--delivery--small': isSmall,
+            'c-icon': !isGreen,
+            'c-icon--green': isGreen,
             ...iconClasses
         }]" />
 </template>
@@ -19,6 +21,10 @@ export default {
 
     props: {
         isSmall: {
+            type: Boolean,
+            default: false
+        },
+        isGreen: {
             type: Boolean,
             default: false
         }


### PR DESCRIPTION
## Changelog

### Added
- Prop and class for green `DeliveryIcon`