### PR TITLE
f-header@2.0.0-beta.31 - Fix header state issues

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v2.0.0-beta.31
 ------------------------------
-*November 29, 2019*
+*December 3, 2019*
 
 ### Fixed
 - DOM inconsistency caused by SSR issue when trying to calculate screen width on server

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.31
+------------------------------
+*November 29, 2019*
+
+### Fixed
+- DOM inconsistency caused by SSR issue when trying to calculate screen width on server
+- Opaque header when tabbing out of nav with narrow viewport
+
+
 v2.0.0-beta.30
 ------------------------------
 *November 15, 2019*

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.30",
+  "version": "v2.0.0-beta.31",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -337,8 +337,11 @@ export default {
         handleMobileNavState () {
             if (this.isBelowMid) {
                 this.$emit('onMobileNavToggle', this.navIsOpen);
-                document.documentElement.classList.toggle('is-navInView', this.navIsOpen);
-                document.documentElement.classList.toggle('is-navInView--noPad', this.navIsOpen && this.isTransparent);
+
+                if (typeof document !== 'undefined') {
+                    document.documentElement.classList.toggle('is-navInView', this.navIsOpen);
+                    document.documentElement.classList.toggle('is-navInView--noPad', this.navIsOpen && this.isTransparent);
+                }
             }
         },
 


### PR DESCRIPTION
Some of the existing issues were:

- SSR warning due to the screen width being used on the server, which failed. Defaulting now to null which works.
- Being able to force the header into an opaque state even when the mobile nav was closed by tabbing all the way through it.
- Being able to close the mobile nav by mousing off it.