### PR TITLE
f-header@2.0.0-beta.32 - Offers inbox link

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v2.0.0-beta.31
 ------------------------------
-*November 29, 2019*
+*December 3, 2019*
 
 ### Fixed
 - DOM inconsistency caused by SSR issue when trying to calculate screen width on server

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v2.0.0-beta.32
 ------------------------------
-*December 2, 2019*
+*December 3, 2019*
 
 ### Added
 - Link to offers page

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.31
+------------------------------
+*November 29, 2019*
+
+### Fixed
+- DOM inconsistency caused by SSR issue when trying to calculate screen width on server
+- Opaque header when tabbing out of nav with narrow viewport
+
+
 v2.0.0-beta.30
 ------------------------------
 *November 15, 2019*

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.32
+------------------------------
+*December 2, 2019*
+
+### Added
+- Link to offers page
+- Translations for Offers page link
+
+
 v2.0.0-beta.31
 ------------------------------
 *November 29, 2019*

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.31",
+  "version": "v2.0.0-beta.32",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.30",
+  "version": "v2.0.0-beta.31",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -19,6 +19,8 @@
                 :open-menu-text="copy.openMenuText"
                 :delivery-enquiry="copy.deliveryEnquiry"
                 :show-delivery-enquiry="showDeliveryEnquiryWithContent"
+                :offers-copy="copy.offers"
+                :show-offers-link="showOffersLink"
                 :error-log="errorLog"
                 :user-info-prop="userInfoProp"
                 :user-info-url="userInfoUrl"
@@ -56,6 +58,11 @@ export default {
         },
 
         showDeliveryEnquiry: {
+            type: Boolean,
+            default: false
+        },
+
+        showOffersLink: {
             type: Boolean,
             default: false
         },
@@ -189,14 +196,14 @@ export default {
         position: relative;
         min-height: $header-height--narrow;
 
+        @include media('<wide') {
+            padding-left: #{$layout-margin--mid}px;
+            padding-right: #{$layout-margin--mid}px;
+        }
+
         @include media('>=mid') {
             display: flex;
             min-height: $header-height;
-        }
-
-        @include media('<mid') {
-            padding-left: #{$layout-margin--mid}px;
-            padding-right: #{$layout-margin--mid}px;
         }
 
         @include media('<narrow') {

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -28,7 +28,7 @@
         </label>
 
         <a
-            v-if="showOffers && isBelowMid"
+            v-if="showOffersLink && isBelowMid"
             data-js-test="offers-link-mobile"
             :data-trak='`{
                 "trakEvent": "click",
@@ -48,7 +48,7 @@
             :class="['c-nav-container', { 'is-visible': navIsOpen }]">
             <ul class="c-nav-list">
                 <li
-                    v-if="showOffers && !isBelowMid"
+                    v-if="showOffersLink && !isBelowMid"
                     class="c-nav-list-item">
                     <a
                         data-js-test="offers-link-desktop"
@@ -312,21 +312,9 @@ export default {
             return this.currentScreenWidth < 768;
         },
 
-        currentPath () {
-            return this.$route.path;
-        },
-
-        isHomepage () {
-            return this.currentPath === '/';
-        },
-
-        showOffers () {
-            return this.showOffersLink && this.isHomepage;
-        },
-
         returnUrl () {
             if (this.$route) {
-                return encodeURIComponent(this.currentPath);
+                return encodeURIComponent(this.$route.path);
             }
             if (typeof document !== 'undefined') {
                 return encodeURIComponent(document.location.pathname);

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -507,6 +507,9 @@ $nav-icon-color                    : $blue;
 $nav-icon-color--transparent       : $white;
 $nav-transition-duration           : 250ms;
 
+$nav-featureLinkIcon-width         : 28px;
+$nav-featureLinkIcon-height        : 28px;
+
 $nav-trigger-length                : 56px;
 $nav-trigger-focus-color           : $blue;
 $nav-trigger-focus-bg              : $blue--offWhite;
@@ -733,15 +736,15 @@ $nav-trigger-focus-bg--ml          : $green--offWhite;
 
     .c-nav-featureLink {
         display: block;
-        width: 28px;
-        height: 28px;
+        width: $nav-featureLinkIcon-width;
+        height: $nav-featureLinkIcon-height;
 
         @include media('<mid') {
             position: absolute;
             top: 0;
             right: 0;
-            width: 28px + 2*spacing(x2);
-            height: 28px + 2*spacing(x2);
+            width: spacing(x2) + $nav-featureLinkIcon-width + spacing(x2); // includes padding on both sides
+            height: spacing(x2) + $nav-featureLinkIcon-height + spacing(x2);
             padding: spacing(x2);
         }
 
@@ -787,8 +790,8 @@ $nav-trigger-focus-bg--ml          : $green--offWhite;
     }
 
     .c-nav-icon--offers {
-        width: 28px;
-        height: 28px;
+        width: $nav-featureLinkIcon-width;
+        height: $nav-featureLinkIcon-height;
 
         & path {
             fill: $nav-icon-color;

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -337,8 +337,11 @@ export default {
         handleMobileNavState () {
             if (this.isBelowMid) {
                 this.$emit('onMobileNavToggle', this.navIsOpen);
-                document.documentElement.classList.toggle('is-navInView', this.navIsOpen);
-                document.documentElement.classList.toggle('is-navInView--noPad', this.navIsOpen && this.isTransparent);
+
+                if (typeof document !== 'undefined') {
+                    document.documentElement.classList.toggle('is-navInView', this.navIsOpen);
+                    document.documentElement.classList.toggle('is-navInView--noPad', this.navIsOpen && this.isTransparent);
+                }
             }
         },
 

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -29,6 +29,7 @@
 
         <a
             v-if="showOffers && isBelowMid"
+            data-js-test="offers-link-mobile"
             :data-trak='`{
                 "trakEvent": "click",
                 "category": "engagement",
@@ -50,6 +51,7 @@
                     v-if="showOffers && !isBelowMid"
                     class="c-nav-list-item">
                     <a
+                        data-js-test="offers-link-desktop"
                         :data-trak='`{
                             "trakEvent": "click",
                             "category": "engagement",

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -27,9 +27,41 @@
             <span class="c-nav-toggle-icon" />
         </label>
 
+        <a
+            v-if="showOffers && isBelowMid"
+            :data-trak='`{
+                "trakEvent": "click",
+                "category": "engagement",
+                "action": "header",
+                "label": "${offersCopy.gtm}"
+            }`'
+            :href="offersCopy.url"
+            class="c-nav-featureLink">
+            <offer-icon class="c-nav-icon c-nav-icon--offers" />
+            <span class="is-visuallyHidden">
+                {{ offersCopy.text }}
+            </span>
+        </a>
+
         <div
             :class="['c-nav-container', { 'is-visible': navIsOpen }]">
             <ul class="c-nav-list">
+                <li
+                    v-if="showOffers && !isBelowMid"
+                    class="c-nav-list-item">
+                    <a
+                        :data-trak='`{
+                            "trakEvent": "click",
+                            "category": "engagement",
+                            "action": "header",
+                            "label": "${offersCopy.gtm}"
+                        }`'
+                        :href="offersCopy.url"
+                        class="c-nav-list-link">
+                        <offer-icon class="c-nav-icon c-nav-icon--offers" />
+                        {{ offersCopy.text }}
+                    </a>
+                </li>
                 <li
                     v-if="showDeliveryEnquiry && !isBelowMid"
                     class="c-nav-list-item"
@@ -172,14 +204,19 @@
 </template>
 
 <script>
-import { ProfileIcon, DeliveryIcon } from '@justeat/f-vue-icons';
+import {
+    DeliveryIcon,
+    OfferIcon,
+    ProfileIcon
+} from '@justeat/f-vue-icons';
 import sharedServices from '@justeat/f-services';
 import axios from 'axios';
 
 export default {
     components: {
-        ProfileIcon,
-        DeliveryIcon
+        DeliveryIcon,
+        OfferIcon,
+        ProfileIcon
     },
 
     props: {
@@ -214,6 +251,16 @@ export default {
         },
 
         showDeliveryEnquiry: {
+            type: Boolean,
+            default: false
+        },
+
+        offersCopy: {
+            type: Object,
+            default: () => ({})
+        },
+
+        showOffersLink: {
             type: Boolean,
             default: false
         },
@@ -260,12 +307,24 @@ export default {
 
     computed: {
         isBelowMid () {
-            return this.currentScreenWidth <= 767;
+            return this.currentScreenWidth < 768;
+        },
+
+        currentPath () {
+            return this.$route.path;
+        },
+
+        isHomepage () {
+            return this.currentPath === '/';
+        },
+
+        showOffers () {
+            return this.showOffersLink && this.isHomepage;
         },
 
         returnUrl () {
             if (this.$route) {
-                return encodeURIComponent(this.$route.path);
+                return encodeURIComponent(this.currentPath);
             }
             if (typeof document !== 'undefined') {
                 return encodeURIComponent(document.location.pathname);
@@ -409,7 +468,8 @@ export default {
 </script>
 
 <style lang="scss">
-
+// TODO - Pull in fozzie utilities css instead
+// https://github.com/justeat/fozzie/blob/f7f0184ba3a244c19d6e83c44c35a31b7c2dd2d9/src/scss/trumps/_utilities.scss
 // Hide from both screenreaders and browsers: h5bp.com/u
 .is-hidden,
 .no-js .is-hidden--noJS {
@@ -421,6 +481,18 @@ export default {
 .no-js .is-shown--noJS {
     display: block !important;
     visibility: visible !important;
+}
+
+// Hide only visually, but have it available for screenreaders: h5bp.com/v
+.is-visuallyHidden {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
 }
 
 /**
@@ -666,6 +738,22 @@ $nav-trigger-focus-bg--ml          : $green--offWhite;
         }
     }
 
+    .c-nav-featureLink {
+        display: block;
+        width: 28px;
+        height: 28px;
+
+        @include media('<mid') {
+            position: absolute;
+            top: 0;
+            right: 0;
+            width: 28px + 2*spacing(x2);
+            height: 28px + 2*spacing(x2);
+            padding: spacing(x2);
+        }
+
+    }
+
     // Icons, such as the profile icon
     .c-nav-icon {
         float: left;
@@ -685,6 +773,7 @@ $nav-trigger-focus-bg--ml          : $green--offWhite;
             }
         }
     }
+
     .c-nav-icon--profile {
         width: 20px;
         height: 22px;
@@ -702,6 +791,23 @@ $nav-trigger-focus-bg--ml          : $green--offWhite;
     .c-nav-icon--delivery {
         width: 27px;
         height: 22px;
+    }
+
+    .c-nav-icon--offers {
+        width: 28px;
+        height: 28px;
+
+        & path {
+            fill: $nav-icon-color;
+
+            @include theme(ml) {
+                fill: $nav-icon-color--ml;
+            }
+
+            .c-header--transparent & {
+                fill: $nav-icon-color--transparent;
+            }
+        }
     }
 
 // Nav Popover list

--- a/packages/f-header/src/components/tests/Navigation.test.js
+++ b/packages/f-header/src/components/tests/Navigation.test.js
@@ -170,51 +170,54 @@ describe('Navigation', () => {
         expect(wrapper.find('[data-js-test="login"]').exists()).toBe(true);
     });
 
-    it('should show nav links on mobile when is "navIsOpen" is true', () => {
-        // Arrange
-        const propsData = {
-            ...defaultPropsData,
-            navLinks: {}
-        };
+    describe('nav links', () => {
+        it('should be shown on mobile when is "navIsOpen" is true', () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                navLinks: {}
+            };
 
-        // Act
-        resizeWindow(mobileWidth, mobileHeight);
-        const wrapper = shallowMount(Navigation, { propsData });
-        wrapper.vm.data = {
-            ...defaultData,
-            userInfo: {
-                isAuthenticated: true
-            },
-            navIsOpen: true
-        };
-        wrapper.vm.openNav();
+            // Act
+            resizeWindow(mobileWidth, mobileHeight);
+            const wrapper = shallowMount(Navigation, { propsData });
+            wrapper.vm.data = {
+                ...defaultData,
+                userInfo: {
+                    isAuthenticated: true
+                },
+                navIsOpen: true
+            };
+            wrapper.vm.openNav();
 
-        // Assert
-        expect(wrapper.find('[data-js-test="nav-toggle"]').classes()).toContain('is-open');
+            // Assert
+            expect(wrapper.find('[data-js-test="nav-toggle"]').classes()).toContain('is-open');
+        });
+
+        it('should not be shown on mobile when "navIsOpen" is false', () => {
+            // Arrange
+            const propsData = defaultPropsData;
+
+            // Act
+            resizeWindow(mobileWidth, mobileHeight);
+            const wrapper = shallowMount(Navigation, { propsData });
+            wrapper.vm.data = {
+                ...defaultData,
+                userInfo: {
+                    isAuthenticated: true
+                },
+                navIsOpen: true
+            };
+            wrapper.vm.closeNav();
+
+            // Assert
+            expect(wrapper.find('[data-js-test="nav-toggle"]').classes()).not.toContain('is-open');
+        });
     });
 
-    it('should NOT show nav links on mobile when "navIsOpen" is false', () => {
-        // Arrange
-        const propsData = defaultPropsData;
 
-        // Act
-        resizeWindow(mobileWidth, mobileHeight);
-        const wrapper = shallowMount(Navigation, { propsData });
-        wrapper.vm.data = {
-            ...defaultData,
-            userInfo: {
-                isAuthenticated: true
-            },
-            navIsOpen: true
-        };
-        wrapper.vm.closeNav();
-
-        // Assert
-        expect(wrapper.find('[data-js-test="nav-toggle"]').classes()).not.toContain('is-open');
-    });
-
-    describe('offers', () => {
-        it('showOffersLink prop should be passed through', () => {
+    describe('offers link', () => {
+        it('prop flag should be passed through', () => {
             // Arrange
             const propsData = {
                 ...defaultPropsData,
@@ -224,18 +227,14 @@ describe('Navigation', () => {
             // Act
             const wrapper = shallowMount(Navigation, {
                 propsData,
-                mocks: {
-                    $route: {
-                        path: '/'
-                    }
-                }
+                mocks: { $route: { path: '/' } }
             });
 
             // Assert
             expect(wrapper.vm.showOffersLink).toBe(true);
         });
 
-        it('should show offers link on desktop when "showOffersLink" is true', () => {
+        it('should be shown on desktop when "showOffersLink" is true', () => {
             // Arrange
             const propsData = {
                 ...defaultPropsData,
@@ -245,18 +244,14 @@ describe('Navigation', () => {
             // Act
             const wrapper = shallowMount(Navigation, {
                 propsData,
-                mocks: {
-                    $route: {
-                        path: '/'
-                    }
-                }
+                mocks: { $route: { path: '/' } }
             });
 
             // Assert
             expect(wrapper.find('[data-js-test="offers-link-desktop"]').exists()).toBe(true);
         });
 
-        it('should NOT show offers link on desktop when "showOffersLink" is false', () => {
+        it('should not be shown on desktop when "showOffersLink" is false', () => {
             // Arrange
             const propsData = {
                 ...defaultPropsData,
@@ -266,18 +261,14 @@ describe('Navigation', () => {
             // Act
             const wrapper = shallowMount(Navigation, {
                 propsData,
-                mocks: {
-                    $route: {
-                        path: '/'
-                    }
-                }
+                mocks: { $route: { path: '/' } }
             });
 
             // Assert
             expect(wrapper.find('[data-js-test="offers-link-desktop"]').exists()).toBe(false);
         });
 
-        it('should show offers link on mobile when "showOffersLink" is true', () => {
+        it('should be shown on mobile when "showOffersLink" is true', () => {
             // Arrange
             const propsData = {
                 ...defaultPropsData,
@@ -288,18 +279,14 @@ describe('Navigation', () => {
             // Act
             const wrapper = shallowMount(Navigation, {
                 propsData,
-                mocks: {
-                    $route: {
-                        path: '/'
-                    }
-                }
+                mocks: { $route: { path: '/' } }
             });
 
             // Assert
             expect(wrapper.find('[data-js-test="offers-link-mobile"]').exists()).toBe(true);
         });
 
-        it('should NOT show offers link on mobile when "showOffersLink" is false', () => {
+        it('should not be shown on mobile when "showOffersLink" is false', () => {
             // Arrange
             const propsData = {
                 ...defaultPropsData,
@@ -310,18 +297,14 @@ describe('Navigation', () => {
             // Act
             const wrapper = shallowMount(Navigation, {
                 propsData,
-                mocks: {
-                    $route: {
-                        path: '/'
-                    }
-                }
+                mocks: { $route: { path: '/' } }
             });
 
             // Assert
             expect(wrapper.find('[data-js-test="offers-link-mobile"]').exists()).toBe(false);
         });
 
-        it('should show offers link on mobile with open nav when "showOffersLink" is true', () => {
+        it('should be shown on mobile with open nav when "showOffersLink" is true', () => {
             // Arrange
             const propsData = {
                 ...defaultPropsData,
@@ -332,11 +315,7 @@ describe('Navigation', () => {
             // Act
             const wrapper = shallowMount(Navigation, {
                 propsData,
-                mocks: {
-                    $route: {
-                        path: '/'
-                    }
-                }
+                mocks: { $route: { path: '/' } }
             });
             wrapper.vm.data = {
                 ...defaultData,
@@ -347,7 +326,7 @@ describe('Navigation', () => {
             expect(wrapper.find('[data-js-test="offers-link-mobile"]').exists()).toBe(true);
         });
 
-        it('should NOT show offers link on mobile with open nav when "showOffersLink" is false', () => {
+        it('should not be shown on mobile with open nav when "showOffersLink" is false', () => {
             // Arrange
             const propsData = {
                 ...defaultPropsData,
@@ -358,11 +337,7 @@ describe('Navigation', () => {
             // Act
             const wrapper = shallowMount(Navigation, {
                 propsData,
-                mocks: {
-                    $route: {
-                        path: '/'
-                    }
-                }
+                mocks: { $route: { path: '/' } }
             });
             wrapper.vm.data = {
                 ...defaultData,
@@ -383,11 +358,7 @@ describe('Navigation', () => {
         // Act
         const wrapper = shallowMount(Navigation, {
             propsData,
-            mocks: {
-                $route: {
-                    path: '/'
-                }
-            }
+            mocks: { $route: { path: '/' } }
         });
 
         // Assert
@@ -403,11 +374,7 @@ describe('Navigation', () => {
         // Act
         const wrapper = shallowMount(Navigation, {
             propsData,
-            mocks: {
-                $route: {
-                    path: '/offers'
-                }
-            }
+            mocks: { $route: { path: '/' } }
         });
 
         // Assert

--- a/packages/f-header/src/components/tests/Navigation.test.js
+++ b/packages/f-header/src/components/tests/Navigation.test.js
@@ -225,10 +225,7 @@ describe('Navigation', () => {
             };
 
             // Act
-            const wrapper = shallowMount(Navigation, {
-                propsData,
-                mocks: { $route: { path: '/' } }
-            });
+            const wrapper = shallowMount(Navigation, { propsData });
 
             // Assert
             expect(wrapper.vm.showOffersLink).toBe(true);
@@ -242,10 +239,7 @@ describe('Navigation', () => {
             };
 
             // Act
-            const wrapper = shallowMount(Navigation, {
-                propsData,
-                mocks: { $route: { path: '/' } }
-            });
+            const wrapper = shallowMount(Navigation, { propsData });
 
             // Assert
             expect(wrapper.find('[data-js-test="offers-link-desktop"]').exists()).toBe(true);
@@ -259,10 +253,7 @@ describe('Navigation', () => {
             };
 
             // Act
-            const wrapper = shallowMount(Navigation, {
-                propsData,
-                mocks: { $route: { path: '/' } }
-            });
+            const wrapper = shallowMount(Navigation, { propsData });
 
             // Assert
             expect(wrapper.find('[data-js-test="offers-link-desktop"]').exists()).toBe(false);
@@ -277,10 +268,7 @@ describe('Navigation', () => {
             resizeWindow(mobileWidth, mobileHeight);
 
             // Act
-            const wrapper = shallowMount(Navigation, {
-                propsData,
-                mocks: { $route: { path: '/' } }
-            });
+            const wrapper = shallowMount(Navigation, { propsData });
 
             // Assert
             expect(wrapper.find('[data-js-test="offers-link-mobile"]').exists()).toBe(true);
@@ -295,10 +283,7 @@ describe('Navigation', () => {
             resizeWindow(mobileWidth, mobileHeight);
 
             // Act
-            const wrapper = shallowMount(Navigation, {
-                propsData,
-                mocks: { $route: { path: '/' } }
-            });
+            const wrapper = shallowMount(Navigation, { propsData });
 
             // Assert
             expect(wrapper.find('[data-js-test="offers-link-mobile"]').exists()).toBe(false);
@@ -313,10 +298,7 @@ describe('Navigation', () => {
             resizeWindow(mobileWidth, mobileHeight);
 
             // Act
-            const wrapper = shallowMount(Navigation, {
-                propsData,
-                mocks: { $route: { path: '/' } }
-            });
+            const wrapper = shallowMount(Navigation, { propsData });
             wrapper.vm.data = {
                 ...defaultData,
                 navIsOpen: true
@@ -335,10 +317,7 @@ describe('Navigation', () => {
             resizeWindow(mobileWidth, mobileHeight);
 
             // Act
-            const wrapper = shallowMount(Navigation, {
-                propsData,
-                mocks: { $route: { path: '/' } }
-            });
+            const wrapper = shallowMount(Navigation, { propsData });
             wrapper.vm.data = {
                 ...defaultData,
                 navIsOpen: true
@@ -347,38 +326,6 @@ describe('Navigation', () => {
             // Assert
             expect(wrapper.find('[data-js-test="offers-link-mobile"]').exists()).toBe(false);
         });
-    });
-
-    it('isHomepage is true on the homepage', () => {
-        const propsData = {
-            ...defaultPropsData,
-            showOffersLink: false
-        };
-
-        // Act
-        const wrapper = shallowMount(Navigation, {
-            propsData,
-            mocks: { $route: { path: '/' } }
-        });
-
-        // Assert
-        expect(wrapper.vm.isHomepage).toBe(true);
-    });
-
-    it('isHomepage is false when on another page', () => {
-        const propsData = {
-            ...defaultPropsData,
-            showOffersLink: false
-        };
-
-        // Act
-        const wrapper = shallowMount(Navigation, {
-            propsData,
-            mocks: { $route: { path: '/' } }
-        });
-
-        // Assert
-        expect(wrapper.vm.isHomepage).toBe(false);
     });
 
     describe('isOrderCountOutOfDate', () => {

--- a/packages/f-header/src/components/tests/Navigation.test.js
+++ b/packages/f-header/src/components/tests/Navigation.test.js
@@ -19,20 +19,24 @@ const defaultPropsData = {
     openMenuText: 'Open menu',
     deliveryEnquiry: {},
     showDeliveryEnquiry: false,
-    isOrderCountSupported: true
+    isOrderCountSupported: true,
+    offersCopy: {},
+    showOffersLink: false
 };
 const defaultData = {
     userInfo: {
         isAuthenticated: false,
         friendlyName: 'James Fisher',
         email: 'j.fisher@fakemail.com'
-
     },
     navIsOpen: false,
     localOrderCountExpires: false
 };
-const width = 767;
-const height = 768;
+
+const desktopWidth = 1200;
+const desktopHeight = 1024;
+const mobileWidth = 375;
+const mobileHeight = 667;
 
 const resizeWindow = (x, y) => {
     window.innerWidth = x;
@@ -41,6 +45,10 @@ const resizeWindow = (x, y) => {
 };
 
 describe('Navigation', () => {
+    beforeEach(() => {
+        resizeWindow(desktopWidth, desktopHeight);
+    });
+
     it('should be defined', () => {
         const propsData = defaultPropsData;
         const wrapper = shallowMount(Navigation, { propsData });
@@ -170,7 +178,7 @@ describe('Navigation', () => {
         };
 
         // Act
-        resizeWindow(width, height);
+        resizeWindow(mobileWidth, mobileHeight);
         const wrapper = shallowMount(Navigation, { propsData });
         wrapper.vm.data = {
             ...defaultData,
@@ -190,7 +198,7 @@ describe('Navigation', () => {
         const propsData = defaultPropsData;
 
         // Act
-        resizeWindow(width, height);
+        resizeWindow(mobileWidth, mobileHeight);
         const wrapper = shallowMount(Navigation, { propsData });
         wrapper.vm.data = {
             ...defaultData,
@@ -203,6 +211,207 @@ describe('Navigation', () => {
 
         // Assert
         expect(wrapper.find('[data-js-test="nav-toggle"]').classes()).not.toContain('is-open');
+    });
+
+    describe('offers', () => {
+        it('showOffersLink prop should be passed through', () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showOffersLink: true
+            };
+
+            // Act
+            const wrapper = shallowMount(Navigation, {
+                propsData,
+                mocks: {
+                    $route: {
+                        path: '/'
+                    }
+                }
+            });
+
+            // Assert
+            expect(wrapper.vm.showOffersLink).toBe(true);
+        });
+
+        it('should show offers link on desktop when "showOffersLink" is true', () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showOffersLink: true
+            };
+
+            // Act
+            const wrapper = shallowMount(Navigation, {
+                propsData,
+                mocks: {
+                    $route: {
+                        path: '/'
+                    }
+                }
+            });
+
+            // Assert
+            expect(wrapper.find('[data-js-test="offers-link-desktop"]').exists()).toBe(true);
+        });
+
+        it('should NOT show offers link on desktop when "showOffersLink" is false', () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showOffersLink: false
+            };
+
+            // Act
+            const wrapper = shallowMount(Navigation, {
+                propsData,
+                mocks: {
+                    $route: {
+                        path: '/'
+                    }
+                }
+            });
+
+            // Assert
+            expect(wrapper.find('[data-js-test="offers-link-desktop"]').exists()).toBe(false);
+        });
+
+        it('should show offers link on mobile when "showOffersLink" is true', () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showOffersLink: true
+            };
+            resizeWindow(mobileWidth, mobileHeight);
+
+            // Act
+            const wrapper = shallowMount(Navigation, {
+                propsData,
+                mocks: {
+                    $route: {
+                        path: '/'
+                    }
+                }
+            });
+
+            // Assert
+            expect(wrapper.find('[data-js-test="offers-link-mobile"]').exists()).toBe(true);
+        });
+
+        it('should NOT show offers link on mobile when "showOffersLink" is false', () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showOffersLink: false
+            };
+            resizeWindow(mobileWidth, mobileHeight);
+
+            // Act
+            const wrapper = shallowMount(Navigation, {
+                propsData,
+                mocks: {
+                    $route: {
+                        path: '/'
+                    }
+                }
+            });
+
+            // Assert
+            expect(wrapper.find('[data-js-test="offers-link-mobile"]').exists()).toBe(false);
+        });
+
+        it('should show offers link on mobile with open nav when "showOffersLink" is true', () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showOffersLink: true
+            };
+            resizeWindow(mobileWidth, mobileHeight);
+
+            // Act
+            const wrapper = shallowMount(Navigation, {
+                propsData,
+                mocks: {
+                    $route: {
+                        path: '/'
+                    }
+                }
+            });
+            wrapper.vm.data = {
+                ...defaultData,
+                navIsOpen: true
+            };
+
+            // Assert
+            expect(wrapper.find('[data-js-test="offers-link-mobile"]').exists()).toBe(true);
+        });
+
+        it('should NOT show offers link on mobile with open nav when "showOffersLink" is false', () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showOffersLink: false
+            };
+            resizeWindow(mobileWidth, mobileHeight);
+
+            // Act
+            const wrapper = shallowMount(Navigation, {
+                propsData,
+                mocks: {
+                    $route: {
+                        path: '/'
+                    }
+                }
+            });
+            wrapper.vm.data = {
+                ...defaultData,
+                navIsOpen: true
+            };
+
+            // Assert
+            expect(wrapper.find('[data-js-test="offers-link-mobile"]').exists()).toBe(false);
+        });
+    });
+
+    it('isHomepage is true on the homepage', () => {
+        const propsData = {
+            ...defaultPropsData,
+            showOffersLink: false
+        };
+
+        // Act
+        const wrapper = shallowMount(Navigation, {
+            propsData,
+            mocks: {
+                $route: {
+                    path: '/'
+                }
+            }
+        });
+
+        // Assert
+        expect(wrapper.vm.isHomepage).toBe(true);
+    });
+
+    it('isHomepage is false when on another page', () => {
+        const propsData = {
+            ...defaultPropsData,
+            showOffersLink: false
+        };
+
+        // Act
+        const wrapper = shallowMount(Navigation, {
+            propsData,
+            mocks: {
+                $route: {
+                    path: '/offers'
+                }
+            }
+        });
+
+        // Assert
+        expect(wrapper.vm.isHomepage).toBe(false);
     });
 
     describe('isOrderCountOutOfDate', () => {

--- a/packages/f-header/src/components/tests/__snapshots__/Header.test.js.snap
+++ b/packages/f-header/src/components/tests/__snapshots__/Header.test.js.snap
@@ -5,7 +5,7 @@ exports[`Header should render default component markup 1`] = `
   <skip-to-main-stub text="Skip to main content" transparentbg="true"></skip-to-main-stub>
   <div class="c-header-container">
     <logo-stub theme="je" istransparent="true" companyname="Just Eat" logogtmlabel="click_logo"></logo-stub>
-    <navigation-stub accountlogin="[object Object]" accountlogout="[object Object]" navlinks="[object Object]" help="[object Object]" openmenutext="Open Menu" deliveryenquiry="[object Object]" userinfourl="/api/account/details" ordercounturl="/api/analytics/ordercount" isordercountsupported="true" istransparent="true"></navigation-stub>
+    <navigation-stub accountlogin="[object Object]" accountlogout="[object Object]" navlinks="[object Object]" help="[object Object]" openmenutext="Open Menu" deliveryenquiry="[object Object]" offerscopy="[object Object]" userinfourl="/api/account/details" ordercounturl="/api/analytics/ordercount" isordercountsupported="true" istransparent="true"></navigation-stub>
   </div>
 </header>
 `;

--- a/packages/f-header/src/tenants/da-DK.js
+++ b/packages/f-header/src/tenants/da-DK.js
@@ -55,5 +55,10 @@ export default {
         text: 'Log ud',
         url: '/account/logout',
         gtm: 'click_logout'
+    },
+    offers: {
+        text: '%OFFERS%',
+        url: '/offers',
+        gtm: 'click_offers_inbox'
     }
 };

--- a/packages/f-header/src/tenants/en-AU.js
+++ b/packages/f-header/src/tenants/en-AU.js
@@ -45,5 +45,10 @@ export default {
         text: 'Log out',
         url: '/account/logout',
         gtm: 'click_logout'
+    },
+    offers: {
+        text: 'Offers',
+        url: '/offers',
+        gtm: 'click_offers_inbox'
     }
 };

--- a/packages/f-header/src/tenants/en-GB.js
+++ b/packages/f-header/src/tenants/en-GB.js
@@ -66,5 +66,10 @@ export default {
         text: 'Deliver with Just Eat',
         url: 'https://couriers.just-eat.co.uk/application?utm_medium=referrer&utm_source=just-eat.co.uk&utm_campaign=ex1140-header',
         gtm: 'click_courier_signup'
+    },
+    offers: {
+        text: 'Offers',
+        url: '/offers',
+        gtm: 'click_offers_inbox'
     }
 };

--- a/packages/f-header/src/tenants/en-IE.js
+++ b/packages/f-header/src/tenants/en-IE.js
@@ -55,5 +55,10 @@ export default {
         text: 'Log out',
         url: '/account/logout',
         gtm: 'click_logout'
+    },
+    offers: {
+        text: 'Offers',
+        url: '/offers',
+        gtm: 'click_offers_inbox'
     }
 };

--- a/packages/f-header/src/tenants/en-NZ.js
+++ b/packages/f-header/src/tenants/en-NZ.js
@@ -45,5 +45,10 @@ export default {
         text: 'Log out',
         url: '/account/logout',
         gtm: 'click_logout'
+    },
+    offers: {
+        text: 'Offers',
+        url: '/offers',
+        gtm: 'click_offers_inbox'
     }
 };

--- a/packages/f-header/src/tenants/es-ES.js
+++ b/packages/f-header/src/tenants/es-ES.js
@@ -55,5 +55,10 @@ export default {
         text: 'Salir',
         url: '/account/logout',
         gtm: 'click_logout'
+    },
+    offers: {
+        text: '%OFFERS%',
+        url: '/offers',
+        gtm: 'click_offers_inbox'
     }
 };

--- a/packages/f-header/src/tenants/it-IT.js
+++ b/packages/f-header/src/tenants/it-IT.js
@@ -55,5 +55,10 @@ export default {
         text: 'Esci',
         url: '/account/logout',
         gtm: 'click_logout'
+    },
+    offers: {
+        text: '%OFFERS%',
+        url: '/offers',
+        gtm: 'click_offers_inbox'
     }
 };

--- a/packages/f-header/src/tenants/nb-NO.js
+++ b/packages/f-header/src/tenants/nb-NO.js
@@ -55,5 +55,10 @@ export default {
         text: 'Logg ut',
         url: '/account/logout',
         gtm: 'click_logout'
+    },
+    offers: {
+        text: '%OFFERS%',
+        url: '/offers',
+        gtm: 'click_offers_inbox'
     }
 };


### PR DESCRIPTION
Disabled by default, can be enabled by passing the `showOffersLink` prop into the header.

This will initially only be shown in UK, behind an experiment flag (TBD).