### PR TITLE
f-footer@2.0.0-beta.32 - Fix SSR of footer loading in expanded state

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.32
+------------------------------
+*December 16, 2019*
+
+### Fixed
+- Accordions load in collapsed state
+
+
 v2.0.0-beta.31
 ------------------------------
 *November 19, 2019*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "v2.0.0-beta.31",
+  "version": "v2.0.0-beta.32",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/src/components/LinkList.vue
+++ b/packages/f-footer/src/components/LinkList.vue
@@ -71,7 +71,7 @@ export default {
     data () {
         return {
             panelCollapsed: true,
-            currentScreenWidth: sharedServices.getWindowWidth()
+            currentScreenWidth: 0
         };
     },
 
@@ -90,6 +90,7 @@ export default {
     },
 
     mounted () {
+        this.currentScreenWidth = sharedServices.getWindowWidth();
         sharedServices.addEvent('resize', this.onResize, 100);
     },
 


### PR DESCRIPTION
`sharedServices.getWindowWidth()` was being called during server-side render, this caused the `isBelowWide` check to fail in the LinkList component on the server.

Presumably this wasn't showing as a DOM mismatch error in the console (like we've seen before) because it's only a single class that is missing, rather than different elements being added to the DOM tree.