### PR TITLE
v2.0.0-beta.33 – fix f-footer beta collapsed panels 

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.33
+------------------------------
+*December 30, 2019*
+
+### Fixed
+- Only load accordions collapsed in mobile
+- Set `panelCollapsed` depending on device
+- Collapse panels when going from > to < mid.
+
+
 v2.0.0-beta.32
 ------------------------------
 *December 16, 2019*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "v2.0.0-beta.32",
+  "version": "v2.0.0-beta.33",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/src/components/LinkList.vue
+++ b/packages/f-footer/src/components/LinkList.vue
@@ -92,6 +92,10 @@ export default {
     mounted () {
         this.currentScreenWidth = sharedServices.getWindowWidth();
         sharedServices.addEvent('resize', this.onResize, 100);
+
+        if (!this.isBelowWide) {
+            this.panelCollapsed = false;
+        }
     },
 
     destroyed () {
@@ -107,6 +111,10 @@ export default {
 
         onResize () {
             this.currentScreenWidth = sharedServices.getWindowWidth();
+
+            if (this.isBelowWide) {
+                this.panelCollapsed = true;
+            }
         }
     }
 };


### PR DESCRIPTION
### Fixed
- Only load accordions collapsed in mobile
- Set `panelCollapsed` depending on device
- Collapse panels when going from > to < mid.