### PR TITLE
f-footer@v2.0.0-beta.34 – Removing dependency reference from package.json

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.34
+------------------------------
+*January 10, 2020*
+
+### Removed
+- `vue` dependency in component `package.json` as was causing conflicts when imported and the version didn't match the consuming application version.
+
+
 v2.0.0-beta.33
 ------------------------------
 *December 30, 2019*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "v2.0.0-beta.33",
+  "version": "v2.0.0-beta.34",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"
@@ -37,8 +37,7 @@
     "@justeat/f-services": "0.13.0",
     "@justeat/f-vue-icons": "1.0.0-beta.4",
     "lodash-es": "4.17.15",
-    "v-click-outside": "2.1.3",
-    "vue": "2.6.10"
+    "v-click-outside": "2.1.3"
   },
   "peerDependencies": {
     "@justeat/f-trak": "0.6.0"


### PR DESCRIPTION
### Removed
- `vue` dependency in component `package.json` as was causing conflicts when imported and the version didn't match the consuming application version.