### PR TITLE
f-footer@v2.0.0-beta.35 — Updating props to prevent stray attributes in rendered markup.

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.35
+------------------------------
+*January 23, 2020*
+
+### Added
+- Icon props mixin so that the app store and base providor icon components can share the props.
+- Icon props mixin contains all possible props which can be passed to the icons to prevent stray attributed in the rendered HTML markup.
+
+### Changed
+- Removed `required` from props which already have a default value.
+
+
 v2.0.0-beta.34
 ------------------------------
 *January 10, 2020*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "v2.0.0-beta.34",
+  "version": "v2.0.0-beta.35",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/src/components/AppStoreIcon.vue
+++ b/packages/f-footer/src/components/AppStoreIcon.vue
@@ -15,6 +15,7 @@ import {
     AppIosItIcon as IosIconItIt,
     AppIosNoIcon as IosIconNbNo
 } from '@justeat/f-vue-icons';
+import iconPropsMixin from '../mixins/iconProps.mixin';
 
 export default {
     components: {
@@ -36,18 +37,9 @@ export default {
         IosIconNbNo
     },
 
-    props: {
-        name: {
-            type: String,
-            required: true
-        },
-
-        locale: {
-            type: String,
-            required: false,
-            default: 'en-GB'
-        }
-    },
+    mixins: [
+        iconPropsMixin
+    ],
 
     computed: {
         iconComponent () {

--- a/packages/f-footer/src/components/BaseProviderIcon.vue
+++ b/packages/f-footer/src/components/BaseProviderIcon.vue
@@ -22,6 +22,7 @@ import {
     PaymentVisaIcon as VisaIcon,
     PaymentVisaVerifiedIcon as VisaVerifiedIcon
 } from '@justeat/f-vue-icons';
+import iconPropsMixin from '../mixins/iconProps.mixin';
 
 export default {
     components: {
@@ -43,12 +44,9 @@ export default {
         VisaVerifiedIcon
     },
 
-    props: {
-        name: {
-            type: String,
-            required: true
-        }
-    },
+    mixins: [
+        iconPropsMixin
+    ],
 
     computed: {
         iconType () {

--- a/packages/f-footer/src/components/Footer.vue
+++ b/packages/f-footer/src/components/Footer.vue
@@ -84,13 +84,11 @@ export default {
     props: {
         locale: {
             type: String,
-            required: false,
             default: ''
         },
 
         showCourierLinks: {
             type: Boolean,
-            required: false,
             default: true
         }
     },

--- a/packages/f-footer/src/components/IconList.vue
+++ b/packages/f-footer/src/components/IconList.vue
@@ -5,7 +5,7 @@
             [$style['c-iconList--payments']]: isPayments,
             [$style['c-iconList--social']]: isSocial
         }]"
-        data-test-id='footerBrands-column'>
+        data-test-id="footerBrands-column">
         <h2
             v-if="title"
             class="c-footer-heading c-footer-heading--shortBelowWide">
@@ -62,31 +62,26 @@ export default {
 
         title: {
             type: String,
-            required: false,
             default: ''
         },
 
         isApps: {
             type: Boolean,
-            required: false,
             default: false
         },
 
         isPayments: {
             type: Boolean,
-            required: false,
             default: false
         },
 
         isSocial: {
             type: Boolean,
-            required: false,
             default: false
         },
 
         locale: {
             type: String,
-            required: false,
             default: 'en-GB'
         }
     },

--- a/packages/f-footer/src/mixins/iconProps.mixin.js
+++ b/packages/f-footer/src/mixins/iconProps.mixin.js
@@ -1,0 +1,28 @@
+export default {
+    props: {
+        url: {
+            type: String,
+            default: ''
+        },
+
+        name: {
+            type: String,
+            default: ''
+        },
+
+        alt: {
+            type: String,
+            default: ''
+        },
+
+        gtm: {
+            type: String,
+            default: ''
+        },
+
+        locale: {
+            type: String,
+            default: 'en-GB'
+        }
+    }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,6 +1129,15 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-logger/-/f-logger-0.7.1.tgz#06e728d3c65733cab7c9bbfc813b401fa68ba82b"
   integrity sha512-qi1wDK5ijmQ6nE+2bIv68AuWVxCvogzVoXvHd4D0oZCw4PQmVfw9i25m/fw6AiipL6yxkiIGM4LfBlnm+FncDA==
 
+"@justeat/f-services@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.13.0.tgz#b0fc67948e94800ba176addb9d92cce444d28c8e"
+  integrity sha512-iHfmZho2yvP8Bz2UrE9DYh2yMEf7jzINXkL6mtsM8CuSpJAjP4gVI9oQVMzEku7pOWDz6pZaTZT5mVu6Q6o8BQ==
+  dependencies:
+    "@babel/polyfill" "7.7.0"
+    lodash-es "4.17.15"
+    window-or-global "1.0.1"
+
 "@justeat/f-utils@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.2.0.tgz#b2333b5ddf20b4157af25091e6bc54706358100c"


### PR DESCRIPTION
### Added
- Icon props mixin so that the app store and base providor icon components can share the props.
- Icon props mixin contains all possible props which can be passed to the icons to prevent stray attributed in the rendered HTML markup.

### Changed
- Removed `required` from props which already have a default value.