### PR TITLE
f-footer@2.0.0-beta.36: Default footer links to open

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.36
+------------------------------
+*February 4, 2020*
+
+### Changed
+- Default to open state for footer, and then collapse for mobile on mounted. This means the footer links will still be shown if Javascript fails or is disabled.
+
+
 v2.0.0-beta.35
 ------------------------------
 *January 23, 2020*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "v2.0.0-beta.35",
+  "version": "v2.0.0-beta.36",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/src/components/LinkList.vue
+++ b/packages/f-footer/src/components/LinkList.vue
@@ -70,7 +70,7 @@ export default {
 
     data () {
         return {
-            panelCollapsed: true,
+            panelCollapsed: false,
             currentScreenWidth: 0
         };
     },
@@ -93,8 +93,8 @@ export default {
         this.currentScreenWidth = sharedServices.getWindowWidth();
         sharedServices.addEvent('resize', this.onResize, 100);
 
-        if (!this.isBelowWide) {
-            this.panelCollapsed = false;
+        if (this.isBelowWide) {
+            this.panelCollapsed = true;
         }
     },
 


### PR DESCRIPTION
... then collapse for mobile in mounted hook.

Now the footer links will still be shown if Javascript execution on the page fails, or if it has been disabled.

This shouldn't really negatively affect mobile users as the majority of the footer is below the fold anyway.