### PR TITLE
fozzie-components@v1.3.0 – Adding CircleCI config to run unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+# version: 2.1 # use CircleCI 2.1
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2.1
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:12.14.1 # For latest available images check – https://circleci.com/docs/2.0/docker-image-tags.json
+
+    working_directory: ~/repo
+
+    steps: # a collection of executable commands
+        - checkout # special step to check out source code to working directory
+        - restore_cache:
+            name: Restore Yarn Package Cache
+            keys:
+                - yarn-packages-{{ checksum "yarn.lock" }}
+        - run:
+            name: Install Dependencies
+            command: yarn install --frozen-lockfile
+        - save_cache:
+            name: Save Yarn Package Cache
+            key: yarn-packages-{{ checksum "yarn.lock" }}
+            paths:
+                - ~/.cache/yarn
+        - run: # run tests
+            name: Run Unit Tests
+            command: yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v1.2.1
+v1.3.0
 ------------------------------
-*January 30, 2019*
+*February 5, 2020*
 
 ### Added
-- Link to Fozzie docs.
+- CircleCI base config for PR checks. Config currently will run unit tests across all `fozzie-components` packages
+
+
+v1.2.1
+------------------------------
+*January 30, 2020*
+
+### Added
+- Link to Fozzie docs
+
 
 v1.2.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2621,9 +2621,10 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-appboy-web-sdk@2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/appboy-web-sdk/-/appboy-web-sdk-2.3.4.tgz#a7dceed96168118168e3780d3ddd0176e46fe924"
+appboy-web-sdk@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/appboy-web-sdk/-/appboy-web-sdk-2.4.1.tgz#cdfa4074b83a4ea011f52d16b1d04dcad7f57eb8"
+  integrity sha512-xwNXrsSkENRnfq2IOkWcc7ODfxnxDHQ+Flxwf50+D5rggBSIs9e4rA29+7lJ/eEhgfIPFPux9FCt2HedMsJuzg==
 
 append-transform@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
### Added
- CircleCI base config for PR checks. Config currently will run unit tests across all `fozzie-components` packages