### PR TITLE
WIP: f-header@2.0.0-beta.38: Add "red dot" indicator to offers icon

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -5,9 +5,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v2.0.0-beta.37
 ------------------------------
-*February 5, 2020*
+*February 10, 2020*
 
-**In Progress**
+### Added
+
+- "red dot" indicator to offers icon when `hasUnreadOffers` prop is set to true and associated unit tests.
 
 v2.0.0-beta.36
 ------------------------------

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -3,13 +3,19 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v2.0.0-beta.37
+v2.0.0-beta.38
 ------------------------------
 *February 10, 2020*
 
 ### Added
 
 - "red dot" indicator to offers icon when `hasUnreadOffers` prop is set to true and associated unit tests.
+
+v2.0.0-beta.37
+------------------------------
+*February 10, 2020*
+
+**Pending:** https://github.com/justeat/fozzie-components/pull/129
 
 v2.0.0-beta.36
 ------------------------------

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.0.0-beta.37
+------------------------------
+*February 5, 2020*
+
+**In Progress**
+
 v2.0.0-beta.36
 ------------------------------
 *February 5, 2020*

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.36",
+  "version": "v2.0.0-beta.37",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.37",
+  "version": "v2.0.0-beta.38",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -21,6 +21,7 @@
                 :show-delivery-enquiry="showDeliveryEnquiryWithContent"
                 :offers-copy="copy.offers"
                 :show-offers-link="showOffersLink"
+                :has-unread-offers="hasUnreadOffers"
                 :error-log="errorLog"
                 :user-info-prop="userInfoProp"
                 :user-info-url="userInfoUrl"
@@ -63,6 +64,11 @@ export default {
         },
 
         showOffersLink: {
+            type: Boolean,
+            default: false
+        },
+
+        hasUnreadOffers: {
             type: Boolean,
             default: false
         },

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -42,7 +42,7 @@
                 <offer-icon class="c-nav-icon c-nav-icon--offers" />
             </span>
             <span class="is-visuallyHidden">
-                {{ offersCopy.text }}
+                {{ offersCopy.text }}<span v-if="hasUnreadOffers">. You have new offers.</span>
             </span>
         </a>
 
@@ -65,7 +65,9 @@
                         <span :class="{ 'c-nav-icon-container--unread-offers': hasUnreadOffers }">
                             <offer-icon class="c-nav-icon c-nav-icon--offers" />
                         </span>
-                        {{ offersCopy.text }}
+                        {{ offersCopy.text }}<span
+                            v-if="hasUnreadOffers"
+                            class="is-visuallyHidden">. You have new offers.</span>
                     </a>
                 </li>
                 <li

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -38,7 +38,9 @@
             }'
             :href="offersCopy.url"
             class="c-nav-featureLink u-showBelowMid">
-            <offer-icon class="c-nav-icon c-nav-icon--offers" />
+            <span :class="{ 'c-nav-icon-container--unread-offers': hasUnreadOffers }">
+                <offer-icon class="c-nav-icon c-nav-icon--offers" />
+            </span>
             <span class="is-visuallyHidden">
                 {{ offersCopy.text }}
             </span>
@@ -60,7 +62,9 @@
                         }'
                         :href="offersCopy.url"
                         class="c-nav-list-link u-showAboveMid">
-                        <offer-icon class="c-nav-icon c-nav-icon--offers" />
+                        <span :class="{ 'c-nav-icon-container--unread-offers': hasUnreadOffers }">
+                            <offer-icon class="c-nav-icon c-nav-icon--offers" />
+                        </span>
                         {{ offersCopy.text }}
                     </a>
                 </li>
@@ -263,6 +267,11 @@ export default {
         },
 
         showOffersLink: {
+            type: Boolean,
+            default: false
+        },
+
+        hasUnreadOffers: {
             type: Boolean,
             default: false
         },
@@ -791,6 +800,7 @@ $nav-trigger-focus-bg--ml          : $green--offWhite;
     }
 
     .c-nav-icon--offers {
+        position: relative;
         width: $nav-featureLinkIcon-width;
         height: $nav-featureLinkIcon-height;
 
@@ -804,6 +814,27 @@ $nav-trigger-focus-bg--ml          : $green--offWhite;
             .c-header--transparent & {
                 fill: $nav-icon-color--transparent;
             }
+        }
+    }
+
+    .c-nav-icon-container--unread-offers {
+        position: relative;
+        margin-right: spacing();
+
+        &:after {
+            content: '';
+            position: absolute;
+            top: 0;
+            right: 0;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: #f74c00;
+            border: 1px solid white;
+        }
+
+        .c-nav-icon {
+            margin-right: 0;
         }
     }
 

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -820,6 +820,7 @@ $nav-trigger-focus-bg--ml          : $green--offWhite;
     }
 
     .c-nav-icon-container--unread-offers {
+        display: inline-block;
         position: relative;
         margin-right: spacing();
 

--- a/packages/f-header/src/components/tests/Navigation.test.js
+++ b/packages/f-header/src/components/tests/Navigation.test.js
@@ -326,6 +326,25 @@ describe('Navigation', () => {
             // Assert
             expect(wrapper.find('[data-js-test="offers-link-mobile"]').exists()).toBe(false);
         });
+
+        it('should flag new offers when "hasUnreadOffers" is true', () => {
+            // Arrange
+            const offersText = '__OFFERS_TEXT__';
+            const propsData = {
+                ...defaultPropsData,
+                offersCopy: {
+                    text: offersText
+                },
+                showOffersLink: true,
+                hasUnreadOffers: true
+            };
+
+            // Act
+            const wrapper = shallowMount(Navigation, { propsData });
+
+            // Assert
+            expect(wrapper.find('[data-js-test="offers-link-desktop"]').text()).toBe(`${offersText}. You have new offers.`);
+        });
     });
 
     describe('isOrderCountOutOfDate', () => {


### PR DESCRIPTION
> **Do not merge**: Awaiting (#129) and further testing.

## Added

- "red dot" indicator to offers icon in `f-header` when `hasUnreadOffers` prop is set to true and associated unit tests.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

* Chrome 79
* Safari 13
* iPhone 11 Max Pro 13.3 - Safari
* iPad Pro (9.7 inch) 13.3 - Safari
* Opera 66
* Firefox 72

[View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)