### PR TITLE
f-metadata@v2.0.0: Expose appboy instance instead of cards

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 *February  10, 2020*
 
 ### Changed
-
 - Callback methods are now called with the whole appboy instance ensuring functionality is available on the appboy instance whenever a refresh is called. This also means that the callback will always return an object even when no content cards are available. Further instructions and upgrade instructions can be found in the [README](README.md).
+
 
 1.0.4
 ------------------------------
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Ensure that `handleContentCards` callback has been set before attempting to call it.
+
 
 1.0.3
 ------------------------------

--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *February  10, 2020*
 
-### Deprecated
+### Changed
 
 - Callback methods are now called with the whole appboy instance ensuring functionality is available on the appboy instance whenever a refresh is called. This also means that the callback will always return an object even when no content cards are available. Further instructions and upgrade instructions can be found in the [README](README.md).
 

--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+2.0.0
+------------------------------
+*February  10, 2020*
+
+### Deprecated
+
+- Callback methods are now called with the whole appboy instance ensuring functionality is available on the appboy instance whenever a refresh is called. This also means that the callback will always return an object even when no content cards are available. Further instructions and upgrade instructions can be found in the [README](README.md).
+
 1.0.3
 ------------------------------
 *January  29, 2020*

--- a/packages/f-metadata/README.md
+++ b/packages/f-metadata/README.md
@@ -39,4 +39,26 @@
     `enableLogging` - If set to `true`, it allows Braze logging in the console. Default set to `false`.
 
     `disableComponent` - If set to `true`, it does not initialise Braze when called. Default set to `false`.
+    
+## Migration to v2
+
+Version 2 exposes the appboy instance as opposed to content cards as part of the refresh callback, this makes it easier to access properties on the instance such as unreadCardCount and is a step closer to an isomorphic solution.
+
+### Accessing Cards
+
+Cards are now accessible on `myCallbackMethod.cards`.
+
+**For example**
+
+```js
+// v1 implementation
+const myCallback = cards => console.log(cards); // [...cards]
+appboy.requestImmediateRefresh();
+// [...cards]
+
+// v2 implementation
+const myCallback = cardsInstance => console.log(cardsInstance); // {cards: [...cards]}
+appboy.requestImmediateRefresh();
+// { cards: [...cards]}
+```
 

--- a/packages/f-metadata/README.md
+++ b/packages/f-metadata/README.md
@@ -42,7 +42,7 @@
     
 ## Migration to v2
 
-Version 2 exposes the appboy instance as opposed to content cards as part of the refresh callback, this makes it easier to access properties on the instance such as unreadCardCount and is a step closer to an isomorphic solution.
+Version 2 exposes the appboy instance as opposed to content cards as part of the refresh callback, this makes it easier to access properties on the instance such as `getUnviewedCardCount` and is a step closer to an isomorphic solution.
 
 ### Accessing Cards
 

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "main": "src/index.js",
   "files": [
     "dist"

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -1,39 +1,35 @@
-const initialiseBraze = (options = {
-    apiKey: null,
-    userId: null,
-    enableLogging: false,
-    disableComponent: false,
-    callbacks: {
-        handleContentCards: null
-    }
-}) => {
+const initialiseBraze = (options = {}) => {
     if (typeof window !== 'undefined') {
         window.dataLayer = window.dataLayer || [];
+        const {
+            apiKey = null,
+            userId = null,
+            enableLogging = false,
+            disableComponent = false,
+            callbacks = {}
+        } = options;
+        const { handleContentCards = null } = callbacks;
 
-        if (!options.disableComponent) {
+        if (!disableComponent) {
             import(/* webpackChunkName: "appboy-web-sdk" */ 'appboy-web-sdk')
                 .then(({ default: appboy }) => {
-                    if (options.apiKey && options.apiKey.length && options.userId && options.userId.length) {
-                        appboy.initialize(options.apiKey, { enableLogging: options.enableLogging });
+                    if (apiKey && apiKey.length && userId && userId.length) {
+                        appboy.initialize(apiKey, { enableLogging });
 
                         appboy.display.automaticallyShowNewInAppMessages();
 
                         appboy.openSession();
                         window.appboy = appboy;
 
-                        appboy.changeUser(options.userId, () => {
+                        appboy.changeUser(userId, () => {
                             window.dataLayer.push({
                                 event: 'appboyReady'
                             });
                         });
-    
+
                         appboy.requestContentCardsRefresh();
-                        
-                        appboy.subscribeToContentCardsUpdates(contentCards => {
-                            if (contentCards && contentCards.cards.length) {
-                                options.callbacks.handleContentCards(contentCards.cards);
-                            }
-                        });
+
+                        if (handleContentCards) appboy.subscribeToContentCardsUpdates(callbacks.handleContentCards);
                     }
                 })
                 .catch(error => `An error occurred while loading the component: ${error}`);

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -29,13 +29,10 @@ const initialiseBraze = (options = {}) => {
 
                         appboy.requestContentCardsRefresh();
 
-                        appboy.subscribeToContentCardsUpdates(contentCards => {
-                            if (contentCards
-                                && contentCards.cards.length
-                                && options.callbacks.handleContentCards) {
-                                options.callbacks.handleContentCards(contentCards);
-                            }
-                        });
+                        appboy.subscribeToContentCardsUpdates(contentCards => contentCards
+                            && contentCards.cards.length
+                            && handleContentCards
+                            && handleContentCards(contentCards));
                     }
                 })
                 .catch(error => `An error occurred while loading the component: ${error}`);


### PR DESCRIPTION
### Changed

- Contains a breaking change whereby callback methods are now called with the whole appboy instance ensuring we expose class methods such as `getUnviewedCardCount`. This also means that the callback will always return an object even when no content cards are available. More information on migrations can be found in the README.

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- **N/A** This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
