### PR TITLE
f-header@2.0.0-beta.39: Temporary feature flag

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0-beta.39
+------------------------------
+*February 12, 2020*
+
+### Changed
+- Add temporary feature flag to 'For You' updates
+
+
 v2.0.0-beta.38
 ------------------------------
 *February 12, 2020*

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "v2.0.0-beta.38",
+  "version": "v2.0.0-beta.39",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -21,6 +21,7 @@
                 :show-delivery-enquiry="showDeliveryEnquiryWithContent"
                 :offers-copy="copy.offers"
                 :show-offers-link="showOffersLink"
+                :show-for-you-copy="showForYouCopy"
                 :error-log="errorLog"
                 :user-info-prop="userInfoProp"
                 :user-info-url="userInfoUrl"
@@ -63,6 +64,11 @@ export default {
         },
 
         showOffersLink: {
+            type: Boolean,
+            default: false
+        },
+
+        showForYouCopy: {
             type: Boolean,
             default: false
         },

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -38,9 +38,12 @@
             }'
             :href="offersCopy.url"
             class="c-nav-featureLink u-showBelowMid">
-            <gift-icon class="c-nav-icon c-nav-icon--offers" />
+            <component
+                :is="showForYouCopy ? 'gift-icon' : 'offer-icon'"
+                class="c-nav-icon c-nav-icon--offers"
+            />
             <span class="is-visuallyHidden">
-                {{ offersCopy.text }}
+                {{ showForYouCopy ? offersCopy.text : 'Offers' }}
             </span>
         </a>
 
@@ -60,8 +63,11 @@
                         }'
                         :href="offersCopy.url"
                         class="c-nav-list-link u-showAboveMid">
-                        <gift-icon class="c-nav-icon c-nav-icon--offers" />
-                        {{ offersCopy.text }}
+                        <component
+                            :is="showForYouCopy ? 'gift-icon' : 'offer-icon'"
+                            class="c-nav-icon c-nav-icon--offers"
+                        />
+                        {{ showForYouCopy ? offersCopy.text : 'Offers' }}
                     </a>
                 </li>
                 <li
@@ -209,6 +215,7 @@
 import {
     DeliveryIcon,
     GiftIcon,
+    OfferIcon,
     ProfileIcon
 } from '@justeat/f-vue-icons';
 import sharedServices from '@justeat/f-services';
@@ -218,6 +225,7 @@ export default {
     components: {
         DeliveryIcon,
         GiftIcon,
+        OfferIcon,
         ProfileIcon
     },
 
@@ -263,6 +271,11 @@ export default {
         },
 
         showOffersLink: {
+            type: Boolean,
+            default: false
+        },
+
+        showForYouCopy: {
             type: Boolean,
             default: false
         },


### PR DESCRIPTION
The 'For You' updates will not go live until the offers inbox experiment has finished. This PR introduces a rudimentary and temporary feature flag to avoid the 'For You' content changes hitting production if the header component is updated between now and the 17/02.