### PR TITLE
f-metadata@2.1.0: Remove card length check

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+2.1.0
+------------------------------
+*February  18, 2020*
+
+### Changed
+- Call `handleContentCards` with an empty array if no content cards are available, enabling any side effects once Braze is called.
+
+
 2.0.0
 ------------------------------
 *February  10, 2020*

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "src/index.js",
   "files": [
     "dist"

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -30,7 +30,6 @@ const initialiseBraze = (options = {}) => {
                         appboy.requestContentCardsRefresh();
 
                         appboy.subscribeToContentCardsUpdates(contentCards => contentCards
-                            && contentCards.cards.length
                             && handleContentCards
                             && handleContentCards(contentCards));
                     }


### PR DESCRIPTION
Call `handleCards` callback regardless of success to trigger any side effects.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
