### PR TITLE
f-header@v2.0.1 - Super small package.json update

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.1
+------------------------------
+*February 19, 2020*
+
+### Added
+- `@justeat/browserslist-config-fozzie` added to `peerDependencies`
+
+### Changed
+- Separated out `lint` and `lint:fix` into two tasks (so CircleCI build can run lint task without fixing)
+
+
 v2.0.0
 ------------------------------
 *February 13, 2020*

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"
@@ -28,7 +28,8 @@
     "prepublishOnly": "yarn lint && yarn test && yarn build",
     "build": "vue-cli-service build --target lib --name f-header ./src/index.js",
     "demo": "vue serve --open ./src/components/Demo.vue",
-    "lint": "vue-cli-service lint --fix",
+    "lint": "vue-cli-service lint",
+    "lint:fix": "yarn lint --fix",
     "test": "vue-cli-service test:unit"
   },
   "browserslist": [
@@ -41,7 +42,8 @@
     "lodash-es": "4.17.15"
   },
   "peerDependencies": {
-    "@justeat/f-trak": "0.6.0"
+    "@justeat/f-trak": "0.6.0",
+    "@justeat/browserslist-config-fozzie": ">=1.1.1"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "3.9.2",


### PR DESCRIPTION
### Added
- `@justeat/browserslist-config-fozzie` added to `peerDependencies`

### Changed
- Separated out `lint` and `lint:fix` into two tasks (so CircleCI build can run lint task without fixing)