### PR TITLE
f-footer@v2.0.0 – v2 release and small package.json update

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0
+------------------------------
+*February 19, 2020*
+
+### Changed
+- Moving `f-footer` Vue component to be `v2.0.0`.
+  If we need to update the old `f-footer` package, those changes can be released on the legacy `v1.x.x` release branch via the [legacy `f-footer` repo](https://github.com/justeat/f-footer).
+- Separated out `lint` and `lint:fix` into two tasks (so CircleCI build can run lint task without fixing)
+
+
 v2.0.0-beta.36
 ------------------------------
 *February 4, 2020*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "v2.0.0-beta.36",
+  "version": "2.0.0",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"
@@ -27,7 +27,8 @@
     "prepublishOnly": "yarn lint && yarn test && yarn build",
     "build": "vue-cli-service build --target lib --name f-footer ./src/index.js",
     "demo": "vue serve --open ./src/components/Demo.vue",
-    "lint": "vue-cli-service lint --fix",
+    "lint": "vue-cli-service lint",
+    "lint:fix": "yarn lint --fix",
     "test": "vue-cli-service test:unit"
   },
   "browserslist": [


### PR DESCRIPTION
### Changed
- Moving `f-footer` Vue component to be `v2.0.0`.
  If we need to update the old `f-footer` package, those changes can be released on the legacy `v1.x.x` release branch via the [legacy `f-footer` repo](https://github.com/justeat/f-footer).
- Separated out `lint` and `lint:fix` into two tasks (so CircleCI build can run lint task without fixing)