### PR TITLE
fozzie-components@v1.5.0 - Minor package, CI and README updates #trivial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,18 @@ jobs:
             key: yarn-packages-{{ checksum "yarn.lock" }}
             paths:
                 - ~/.cache/yarn
-        - run: # Run Tests
-            name: Run Unit Tests
-            command: yarn test
         - run: # Run PR Checks
             name: Run PR Checks
             command: yarn danger ci
+        - run: # Lint packages
+            name: Run Lint Tasks on Packages
+            command: yarn lint
+        - run: # Run Tests
+            name: Run Unit Tests
+            command: yarn test
+        - run: # Check UI packages all build as expected
+            name: Build Packages
+            command: yarn build
+
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.5.0
+------------------------------
+*February 24, 2020*
+
+### Changed
+- Updated packages to have consistent lint rules
+- CircleCI Badge on README replaces TravisCI badge
+- Node version (`package.json`) updated to be `>=10.0.0` across all packages, as that's what we test against.
+- CircleCI Build now runs lint and build checks on all packages
+- `f-services` patch release (deleted some redundant/unneeded packages)
+
+
 v1.4.1
 ------------------------------
 *February 10, 2020*

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/f-footer/README.md
+++ b/packages/f-footer/README.md
@@ -9,7 +9,7 @@
 ---
 
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-footer.svg)](https://badge.fury.io/js/%40justeat%2Ff-footer)
-[![Build Status](https://travis-ci.org/justeat/f-footer.svg)](https://travis-ci.org/justeat/f-footer)
+[![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg&circle-token=4c77c1990b98c8e06e01b497bc80f376346f609d)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-footer/badge.svg)](https://coveralls.io/github/justeat/f-footer)
 [![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-footer/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-footer?targetFile=package.json)
 

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/f-header/README.md
+++ b/packages/f-header/README.md
@@ -9,7 +9,7 @@
 ---
 
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-header.svg)](https://badge.fury.io/js/%40justeat%2Ff-header)
-[![Build Status](https://travis-ci.org/justeat/f-header.svg)](https://travis-ci.org/justeat/f-header)
+[![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg&circle-token=4c77c1990b98c8e06e01b497bc80f376346f609d)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-header/badge.svg)](https://coveralls.io/github/justeat/f-header)
 [![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-header/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-header?targetFile=package.json)
 

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -19,7 +19,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/f-metadata/README.md
+++ b/packages/f-metadata/README.md
@@ -9,7 +9,7 @@
 ---
 
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-metadata.svg)](https://badge.fury.io/js/%40justeat%2Ff-metadata)
-[![Build Status](https://travis-ci.org/justeat/f-metadata.svg)](https://travis-ci.org/justeat/f-metadata)
+[![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg&circle-token=4c77c1990b98c8e06e01b497bc80f376346f609d)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-metadata/badge.svg)](https://coveralls.io/github/justeat/f-metadata)
 [![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-metadata/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-metadata?targetFile=package.json)
 
@@ -39,7 +39,7 @@
     `enableLogging` - If set to `true`, it allows Braze logging in the console. Default set to `false`.
 
     `disableComponent` - If set to `true`, it does not initialise Braze when called. Default set to `false`.
-    
+
 ## Migration to v2
 
 Version 2 exposes the appboy instance as opposed to content cards as part of the refresh callback, this makes it easier to access properties on the instance such as `getUnviewedCardCount` and is a step closer to an isomorphic solution.

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -19,16 +19,16 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "keywords": [
     "fozzie"
   ],
   "scripts": {
     "prepublishOnly": "yarn test",
-    "build": "yarn lint",
+    "build": "yarn lint:fix",
     "lint": "vue-cli-service lint",
-    "lint:fix": "vue-cli-service lint --fix",
+    "lint:fix": "yarn lint --fix",
     "test": "vue-cli-service test:unit --coverage"
   },
   "browserslist": [

--- a/packages/f-services/CHANGELOG.md
+++ b/packages/f-services/CHANGELOG.md
@@ -3,11 +3,19 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+0.13.2
+------------------------------
+*february 24, 2020*
+
+### Changed
+- Unneeded dependencies removed (as in root monorepo dependencies or not used)
+
+
 0.13.1
 ------------------------------
 *January 22, 2020*
 
- ### Changed
+### Changed
 - Refactor JSDoc to conform to syntax rules
 - Refactor `getLocale` function to reduce complexity
 - Refactor `addEvent` function to reduce complexity
@@ -20,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *November 8, 2019*
 
- ### Changed
+### Changed
 - Making sure that necessary 3rd party dependencies are bundled as part of the package
 
 
@@ -28,7 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *November 8, 2019*
 
- ### Changed
+### Changed
 - Switched over to rollup for bundling as webpack was giving strange results when importing as a library
 
 
@@ -36,7 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *October 4, 2019*
 
- ### Added
+### Added
 - `window-or-global` package for SSR issue`
 
 
@@ -44,10 +52,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *October 2, 2019*
 
- ### Added
+### Added
 - Tests for new services that have been added
 
- ### Changed
+### Changed
 - `webpack.config.js` and packages for a better build
 - Name of the export in the `index.js` to `sharedServices` for consistency
 
@@ -56,7 +64,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *October 1, 2019*
 
- ### Added
+### Added
 - `lodash-es` throttle for the `addEvent` service
 
 
@@ -64,7 +72,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *September 30, 2019*
 
- ### Added
+### Added
 - `getWindowWidth` method for returning the current width of the window
 - `getWindowHeight` method for returning the current height of the window
 - `addEvent` method for listening to a given event and applying a given function at a given time
@@ -75,7 +83,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *September 27, 2019*
 
- ### Removed
+### Removed
 - `transformLocale` as it is not needed any more
 
 
@@ -83,7 +91,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *September 26, 2019*
 
- ### Changed
+### Changed
 - Webpack config to add babel polyfill
 
 
@@ -91,7 +99,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *September 26, 2019*
 
- ### Added
+### Added
 - `transformLocale` method for changing the case format of the locale
 
 
@@ -99,7 +107,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *September 25, 2019*
 
- ### Added
+### Added
 - String manipulation on locale in `getLocale` method
 
 
@@ -107,7 +115,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *September 24, 2019*
 
- ### Added
+### Added
 - Added fallback for other method in shared service
 
 
@@ -115,7 +123,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *September 24, 2019*
 
- ### Added
+### Added
 - Fallback for locale in shared logic
 
 
@@ -123,6 +131,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ------------------------------
 *September 24, 2019*
 
- ### Added
+### Added
 - Created service package for shared logic
 - Tests for the methods inside

--- a/packages/f-services/package.json
+++ b/packages/f-services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-services",
   "description": "Fozzie Services - Shared Services for Components and projects",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "main": "dist/f-services.umd.js",
   "module": "dist/f-services.esm.js",
   "source": "src/index.js",
@@ -21,28 +21,26 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "keywords": [
     "fozzie"
   ],
   "scripts": {
-    "prepublishOnly": "yarn test && yarn build",
-    "build": "yarn lint && rollup --config",
-    "lint": "vue-cli-service lint --fix",
+    "prepublishOnly": "yarn lint && yarn test && yarn build",
+    "build": "rollup --config",
+    "lint": "vue-cli-service lint",
+    "lint:fix": "yarn lint --fix",
     "test": "vue-cli-service test:unit"
   },
   "browserslist": [
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@babel/polyfill": "7.7.0",
     "lodash-es": "4.17.15",
     "window-or-global": "1.0.1"
   },
   "devDependencies": {
-    "@babel/core": "7.7.2",
-    "@babel/preset-env": "7.7.1",
     "@vue/cli-plugin-eslint": "4.0.5",
     "@vue/cli-plugin-unit-jest": "4.0.5",
     "rollup": "1.26.3",

--- a/packages/f-vue-icons/README.md
+++ b/packages/f-vue-icons/README.md
@@ -9,7 +9,7 @@
 ---
 
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-vue-icons.svg)](https://badge.fury.io/js/%40justeat%2Ff-vue-icons)
-[![Build Status](https://travis-ci.org/justeat/f-vue-icons.svg)](https://travis-ci.org/justeat/f-vue-icons)
+[![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg&circle-token=4c77c1990b98c8e06e01b497bc80f376346f609d)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-vue-icons/badge.svg)](https://coveralls.io/github/justeat/f-vue-icons)
 [![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-vue-icons/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-vue-icons?targetFile=package.json)
 

--- a/packages/f-vue-icons/package.json
+++ b/packages/f-vue-icons/package.json
@@ -18,15 +18,16 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "keywords": [
     "fozzie"
   ],
   "scripts": {
-    "prepublishOnly": "yarn test && yarn build",
-    "build": "yarn lint && vue-cli-service build --target lib --formats umd-min --name f-vue-icons ./src/index.js",
-    "lint": "vue-cli-service lint --fix",
+    "prepublishOnly": "yarn lint && yarn test && yarn build",
+    "build": "vue-cli-service build --target lib --formats umd-min --name f-vue-icons ./src/index.js",
+    "lint": "vue-cli-service lint",
+    "lint:fix": "yarn lint --fix",
     "test": "vue-cli-service test:unit"
   },
   "browserslist": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@7.7.2", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.6.4":
+"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.6.4":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.7.2.tgz#ea5b99693bcfc058116f42fa1dd54da412b29d91"
   dependencies:


### PR DESCRIPTION
### Changed
- Updated packages to have consistent lint rules
- CircleCI Badge on README replaces TravisCI badge
- Node version (`package.json`) updated to be `>=10.0.0` across all packages, as that's what we test against.
- CircleCI Build now runs lint and build checks on all packages
- `f-services` patch release (deleted some redundant/unneeded packages)

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
