### PR TITLE
fozzie-components@v0.5.1 – Remove isSettings env check #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.5.1
+------------------------------
+*February 24, 2020*
+
+### Removed
+- `isSettings` check from package babel configs. This is a custom `ENV` variable used in `f-searchbox` and isn't used anywhere else.
+
 
 v1.5.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.4.1",
+  "version": "1.5.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/f-footer/babel.config.js
+++ b/packages/f-footer/babel.config.js
@@ -1,14 +1,13 @@
 module.exports = api => {
     // Use isTest to determine what presets and plugins to use with jest
     const isTest = api.env('test');
-    const isSettings = api.env('settings');
     const presets = [];
     const plugins = [
         '@babel/plugin-proposal-optional-chaining'
     ];
     const builtIns = (api.env('development') ? 'entry' : false);
 
-    if (!isTest && !isSettings) {
+    if (!isTest) {
         api.cache(true);
         presets.push(['@vue/app', { useBuiltIns: builtIns }]);
     }

--- a/packages/f-header/babel.config.js
+++ b/packages/f-header/babel.config.js
@@ -1,14 +1,13 @@
 module.exports = api => {
     // Use isTest to determine what presets and plugins to use with jest
     const isTest = api.env('test');
-    const isSettings = api.env('settings');
     const presets = [];
     const plugins = [
         '@babel/plugin-proposal-optional-chaining'
     ];
     const builtIns = (api.env('development') ? 'entry' : false);
 
-    if (!isTest && !isSettings) {
+    if (!isTest) {
         api.cache(true);
         presets.push(['@vue/app', { useBuiltIns: builtIns }]);
     }

--- a/packages/f-metadata/babel.config.js
+++ b/packages/f-metadata/babel.config.js
@@ -1,13 +1,12 @@
 module.exports = api => {
     // Use isTest to determine what presets and plugins to use with jest
     const isTest = api.env('test');
-    const isSettings = api.env('settings');
     const presets = [];
     const plugins = [
         '@babel/plugin-proposal-optional-chaining'
     ];
 
-    if (!isTest && !isSettings) {
+    if (!isTest) {
         api.cache(true);
     }
 

--- a/packages/f-services/babel.config.js
+++ b/packages/f-services/babel.config.js
@@ -1,13 +1,12 @@
 module.exports = api => {
     // Use isTest to determine what presets and plugins to use with jest
     const isTest = api.env('test');
-    const isSettings = api.env('settings');
     const presets = [];
     const plugins = [
         '@babel/plugin-proposal-optional-chaining'
     ];
 
-    if (!isTest && !isSettings) {
+    if (!isTest) {
         api.cache(true);
     }
 

--- a/packages/f-vue-icons/babel.config.js
+++ b/packages/f-vue-icons/babel.config.js
@@ -1,11 +1,10 @@
 module.exports = api => {
     // Use isTest to determine what presets and plugins to use with jest
     const isTest = api.env('test');
-    const isSettings = api.env('settings');
     const presets = [];
     const plugins = [];
 
-    if (!isTest && !isSettings) {
+    if (!isTest) {
         api.cache(true);
         presets.push(['@vue/app']);
     }


### PR DESCRIPTION
### Removed
- `isSettings` check from package babel configs. This is a custom `ENV` variable used in `f-searchbox` and isn't used anywhere else.