### PR TITLE
f-metadata@2.3.0: Change callback and return early

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+2.3.0
+------------------------------
+*March  2, 2020*
+
+### Changed
+- Callback with `null` if `apiKey` or `userId` is not defined.
+- Return before SDK import if dependencies are not available.
+
+
 2.2.0
 ------------------------------
 *February  20, 2020*

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "main": "src/index.js",
   "files": [
     "dist"

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -20,27 +20,27 @@ const initialiseBraze = (options = {}) => new Promise((resolve, reject) => {
     window.dataLayer = window.dataLayer || [];
 
     return import(/* webpackChunkName: "appboy-web-sdk" */ 'appboy-web-sdk')
-            .then(({ default: appboy }) => {
-                appboy.initialize(apiKey, { enableLogging });
+        .then(({ default: appboy }) => {
+            appboy.initialize(apiKey, { enableLogging });
 
-                appboy.display.automaticallyShowNewInAppMessages();
+            appboy.display.automaticallyShowNewInAppMessages();
 
-                appboy.openSession();
-                window.appboy = appboy;
+            appboy.openSession();
+            window.appboy = appboy;
 
-                appboy.changeUser(userId, () => {
-                    window.dataLayer.push({
-                        event: 'appboyReady'
-                    });
+            appboy.changeUser(userId, () => {
+                window.dataLayer.push({
+                    event: 'appboyReady'
                 });
+            });
 
-                appboy.requestContentCardsRefresh();
+            appboy.requestContentCardsRefresh();
 
-                appboy.subscribeToContentCardsUpdates(handleContentCards);
+            appboy.subscribeToContentCardsUpdates(handleContentCards);
 
-                return resolve(appboy);
-            })
-            .catch(error => reject(new Error(`An error occurred while loading the component: ${error}`)));
+            return resolve(appboy);
+        })
+        .catch(error => reject(new Error(`An error occurred while loading the component: ${error}`)));
 });
 
 export default initialiseBraze;

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -12,13 +12,15 @@ const initialiseBraze = (options = {}) => new Promise((resolve, reject) => {
     } = options;
     const { handleContentCards = noop } = callbacks;
 
-    if (disableComponent) return resolve(null);
+    if (disableComponent || !apiKey || !userId) {
+        handleContentCards(null);
+        return resolve(null);
+    }
 
     window.dataLayer = window.dataLayer || [];
 
     return import(/* webpackChunkName: "appboy-web-sdk" */ 'appboy-web-sdk')
-        .then(({ default: appboy }) => {
-            if (apiKey && apiKey.length && userId && userId.length) {
+            .then(({ default: appboy }) => {
                 appboy.initialize(apiKey, { enableLogging });
 
                 appboy.display.automaticallyShowNewInAppMessages();
@@ -36,10 +38,9 @@ const initialiseBraze = (options = {}) => new Promise((resolve, reject) => {
 
                 appboy.subscribeToContentCardsUpdates(handleContentCards);
 
-                resolve(appboy);
-            }
-        })
-        .catch(error => reject(new Error(`An error occurred while loading the component: ${error}`)));
+                return resolve(appboy);
+            })
+            .catch(error => reject(new Error(`An error occurred while loading the component: ${error}`)));
 });
 
 export default initialiseBraze;

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -38,7 +38,7 @@ const initialiseBraze = (options = {}) => new Promise((resolve, reject) => {
 
             appboy.subscribeToContentCardsUpdates(handleContentCards);
 
-            return resolve(appboy);
+            resolve(appboy);
         })
         .catch(error => reject(new Error(`An error occurred while loading the component: ${error}`)));
 });


### PR DESCRIPTION
### Changed
- Callback with `null` if `apiKey` or `userId` is not defined.
- Return before SDK import if dependencies are not available.

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
