### PR TITLE
f-header@2.0.2: Run yarn on prepublish

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,11 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (roll into next release)
+v2.0.2
 ------------------------------
-*February 25, 2020*
+*March 3, 2020*
 
 ### Changed
+- Run `yarn` on prepublish
 - `jest` config updates. `moduleNameMapper` removed, `jsx` removed from checks (as we don't use) and `transformIgnorePatterns` updated.
 
 

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -25,7 +25,7 @@
     "fozzie"
   ],
   "scripts": {
-    "prepublishOnly": "yarn lint && yarn test && yarn build",
+    "prepublishOnly": "yarn && yarn lint && yarn test && yarn build",
     "build": "vue-cli-service build --target lib --name f-header ./src/index.js",
     "demo": "vue serve --open ./src/components/Demo.vue",
     "lint": "vue-cli-service lint",


### PR DESCRIPTION
### Changed
- Run `yarn` on prepublish to ensure dependency changes are picked up. (Refer to #149 for details).