### PR TITLE
f-footer@2.1.0 - Fix country selector closing on-click for mobile

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -13,8 +13,6 @@ v2.1.0
 - Moved v-click-outside handler from button to parent element to prevent the country selector from closing on-click.
 
 
-*March 05, 2020*
-
 ### Changed
 - Update courier footer link URLs for IE (Ireland)
 - `jest` config updates. `jsx` removed from transforms (as we don't use) and `transformIgnorePatterns` updated, `common.scss` added to globals loaded in, and `moduleNameMapper` updated to load in scss imports from `common.scss`.

--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -13,8 +13,6 @@ v2.1.0
 - Moved v-click-outside handler from button to parent element to prevent the country selector from closing on-click.
 
 
-Latest (roll into next release)
-------------------------------
 *March 05, 2020*
 
 ### Changed

--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -13,6 +13,10 @@ v2.1.0
 - Moved v-click-outside handler from button to parent element to prevent the country selector from closing on-click.
 
 
+v2.0.1
+------------------------------
+*March 5, 2020*
+
 ### Changed
 - Update courier footer link URLs for IE (Ireland)
 - `jest` config updates. `jsx` removed from transforms (as we don't use) and `transformIgnorePatterns` updated, `common.scss` added to globals loaded in, and `moduleNameMapper` updated to load in scss imports from `common.scss`.

--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,9 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (roll into next release)
+v2.1.0
 ------------------------------
-*February 25, 2020*
+*March 5, 2020*
+
+### Fixed
+- Moved v-click-outside handler from button to parent element to prevent the country selector from closing on-click.
 
 ### Changed
 - `jest` config updates. `jsx` removed from transforms (as we don't use) and `transformIgnorePatterns` updated, `common.scss` added to globals loaded in, and `moduleNameMapper` updated to load in scss imports from `common.scss`.

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/src/components/CountrySelector.vue
+++ b/packages/f-footer/src/components/CountrySelector.vue
@@ -2,10 +2,10 @@
     <div :class="$style['c-countrySelectorContainer']">
         <div
             :class="$style['c-countrySelector']"
+            v-click-outside="hideCountryList"
             @keyup.esc="hideCountryList">
             <button
                 id="countrySelector-button"
-                v-click-outside="hideCountryList"
                 :aria-expanded="showCountryList ? 'true' : 'false'"
                 :aria-label="changeCountryText"
                 :class="[


### PR DESCRIPTION
Moved v-click-outside handler from button to parent element to prevent the country selector from closing on-click

---

## UI Review Checks

- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [x] Mobile (iPhone and Android on chrome)
