### PR TITLE
v2.0.1: Update tenant file Ireland with new link URL.

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.1
+------------------------------
+*March 05, 2020*
+
+### Changed
+- Update courier footer link URLs for IE (Ireland)
+
+
 Latest (roll into next release)
 ------------------------------
 *February 25, 2020*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/src/tenants/en-IE.js
+++ b/packages/f-footer/src/tenants/en-IE.js
@@ -152,7 +152,7 @@ export default {
                 },
                 {
                     title: 'Become a courier',
-                    url: 'https://www.fountain.com/just-eat/apply/dublin-courier?preview=true',
+                    url: 'https://couriers.just-eat.ie/application',
                     gtm: 'click_about_couriers'
                 }
             ]
@@ -167,7 +167,7 @@ export default {
                 },
                 {
                     title: 'Courier portal',
-                    url: 'https://couriers.just-eat.ie/account/login',
+                    url: 'https://couriers.just-eat.ie/application',
                     gtm: 'click_about_courier_portal'
                 }
             ]


### PR DESCRIPTION
Minor update to the link URL for the courier links in the footer for Ireland.