### PR TITLE
f-metadata@v2.3.1 – Fixing test babel issue

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+2.3.1
+------------------------------
+*April  3, 2020*
+
+### Fixed
+- Failing test (locally) due to dynamic imports not being supported when running `jest` without the `dynamic-import-node` plugin.
+- Small linting fix and abstracted out code coverage to separate `test:coverage` script in package.json.
+
+
 2.3.0
 ------------------------------
 *March  2, 2020*

--- a/packages/f-metadata/babel.config.js
+++ b/packages/f-metadata/babel.config.js
@@ -6,7 +6,9 @@ module.exports = api => {
         '@babel/plugin-proposal-optional-chaining'
     ];
 
-    if (!isTest) {
+    if (isTest) {
+        plugins.push('dynamic-import-node'); // to support dynamic imports (and webpack dynamic imports) when running unit tests
+    } else {
         api.cache(true);
     }
 

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "main": "src/index.js",
   "files": [
     "dist"
@@ -29,7 +29,8 @@
     "build": "yarn lint:fix",
     "lint": "vue-cli-service lint",
     "lint:fix": "yarn lint --fix",
-    "test": "vue-cli-service test:unit --coverage"
+    "test": "vue-cli-service test:unit",
+    "test:coverage": "vue-cli-service test:unit --coverage"
   },
   "browserslist": [
     "extends @justeat/browserslist-config-fozzie"

--- a/packages/f-metadata/tests/index.test.js
+++ b/packages/f-metadata/tests/index.test.js
@@ -74,12 +74,13 @@ describe('f-metadata', () => {
     it('should noop the callback if no function is provided', () => {
         // Assemble & Act
         expect.assertions(1);
-        initialiseBraze({ ...settings, callbacks: {} }).then(instance => {
-            appboy.subscribeToContentCardsUpdates.mock.calls[0][0]();
+        initialiseBraze({ ...settings, callbacks: {} })
+            .then(instance => {
+                appboy.subscribeToContentCardsUpdates.mock.calls[0][0]();
 
-            // Assert
-            expect(instance).toBeDefined();
-        });
+                // Assert
+                expect(instance).toBeDefined();
+            });
     });
 
     it('should fire a datalayer event when change user is called', () => {


### PR DESCRIPTION
### Fixed
- Failing test (locally) due to dynamic imports not being supported when running `jest` without the `dynamic-import-node` plugin.
- Small linting fix and abstracted out code coverage to separate `test:coverage` script in package.json.