### PR TITLE
fozzie-components@v1.8.1 – Updating CI task order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,15 +28,15 @@ jobs:
         - run: # Run PR Checks
             name: Run PR Checks
             command: yarn danger ci
+        - run: # Check UI packages all build as expected
+            name: Build Packages
+            command: yarn build
         - run: # Lint packages
             name: Run Lint Tasks on Packages
             command: yarn lint
         - run: # Run Tests
             name: Run Unit Tests
             command: yarn test
-        - run: # Check UI packages all build as expected
-            name: Build Packages
-            command: yarn build
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.8.1
+------------------------------
+*April 9, 2020*
+
+### Fixed
+- Running build CI step before unit tests and linting tests, as some linting checks rely on the compiled `dist` asset to check against (when checking `import` for instance).
+
+
 v1.8.0
 ------------------------------
 *April 3, 2020*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "private": true,
   "scripts": {
     "build": "lerna run build --stream",


### PR DESCRIPTION
### Fixed
- Running build CI step before unit tests and linting tests, as some linting checks rely on the compiled `dist` asset to check against (when checking `import` for instance).