### PR TITLE
fozzie-components@v1.10.0 – Storybook scripts added to mono-repo root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.10.0
+------------------------------
+*April 27, 2020*
+
+### Added
+- NPM Scripts at the root of the mono repo to run the Storybook docs through `yarn storybook:build` and `yarn storybook:serve`.
+
+
 v1.9.0
 ------------------------------
 *April 23, 2020*
@@ -11,6 +19,7 @@ v1.9.0
 - `@storybook/storybook-deployer` dependency to easily deploy storybook using the `storybook:deploy` script
 - Updated Circle CI config.yml to include new `deploy` workflow + other tweaks to existing `build` workflow
 - Added link to hosted Storybook in fozzie-component docs.
+
 
 v1.9.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "scripts": {
     "build": "lerna run build --stream",
@@ -8,6 +8,8 @@
     "lint:fix": "lerna run lint -- --fix",
     "prepublishOnly": "lerna run prepublishOnly --stream",
     "release": "lerna publish",
+    "storybook:build": "lerna run storybook:build",
+    "storybook:serve": "lerna run storybook:serve",
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "test": "lerna run test --stream"
   },


### PR DESCRIPTION
### Added
- NPM Scripts at the root of the mono repo to run the Storybook docs through `yarn storybook:build` and `yarn storybook:serve`.