### PR TITLE
f-header@2.2.1 - Change export to CommonJS syntax

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.2.1
+------------------------------
+*May 1, 2020*
+
+### Changed
+- exports in `f-header.page.js` to CommonJS syntax
+
 v2.2.0
 ------------------------------
 *April 29, 2020*

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-header/page-objects/f-header.page.js
+++ b/packages/f-header/page-objects/f-header.page.js
@@ -4,20 +4,20 @@ const deliveryEnquiryLink = () => $('[data-test-id="delivery-link"]');
 const helpLink = () => $('[data-test-id="help-link"]');
 const headerLogo = () => $('[data-test-id="header-logo"]');
 
-export const clickLoginLink = () => {
+exports.clickLoginLink = () => {
     loginLink().click();
 }
 
-export const clickOffersLink = () => {
+exports.clickOffersLink = () => {
     offersLink().click();
 }
 
-export const clickDeliveryEnquiryLink = () => {
+exports.clickDeliveryEnquiryLink = () => {
     deliveryEnquiryLink().click();
 }
 
-export const clickHelpLink = () => {
+exports.clickHelpLink = () => {
     helpLink().click();
 }
 
-export const logoIsDisplayed = () => headerLogo().isDisplayed();
+exports.logoIsDisplayed = () => headerLogo().isDisplayed();


### PR DESCRIPTION
Was having issues importing the new f-header page object into Magikarp, so changing the syntax from ES6 > CommonJS