### PR TITLE
f-form-field@v0.1.0 – Component structure and core functionality 

### DIFF
--- a/packages/f-form-field/.eslintignore
+++ b/packages/f-form-field/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/f-form-field/CHANGELOG.md
+++ b/packages/f-form-field/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+v0.1.0
+------------------------------
+*May 1, 2020*
+
+### Added
+- Component structure and basic configuration (created using `generator-component`).
+- Component markup and core functionality.
+- Storybook config.

--- a/packages/f-form-field/LICENSE
+++ b/packages/f-form-field/LICENSE
@@ -1,0 +1,17 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+Copyright 2020 Just Eat Holding Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/f-form-field/README.md
+++ b/packages/f-form-field/README.md
@@ -1,0 +1,77 @@
+
+<div align="center">
+  <h1>f-form-field</h1>
+
+  <img width="125" alt="Fozzie Bear" src="../../bear.png" />
+
+  <p>Fozzie Form Field Component</p>
+</div>
+
+---
+
+[![npm version](https://badge.fury.io/js/%40justeat%2Ff-form-field.svg)](https://badge.fury.io/js/%40justeat%2Ff-form-field)
+[![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg&circle-token=4c77c1990b98c8e06e01b497bc80f376346f609d)](https://circleci.com/gh/justeat/workflows/fozzie-components)
+[![Coverage Status](https://coveralls.io/repos/github/justeat/f-form-field/badge.svg)](https://coveralls.io/github/justeat/f-form-field)
+[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-form-field/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-form-field?targetFile=package.json)
+
+
+## Usage
+
+1.  Install the module using NPM or Yarn:
+
+    ```bash
+    yarn add @justeat/f-form-field
+    ```
+
+    ```bash
+    npm install @justeat/f-form-field
+    ```
+
+2.  Import the component
+
+    You can import it in your Vue SFC like this (please note that styles have to be imported separately):
+
+    ```
+    import FormField from '@justeat/f-form-field';
+    import '@justeat/f-form-field/dist/f-form-field.css';
+
+    export default {
+        components: {
+            FormField
+        }
+    }
+    ```
+
+    If you are using Webpack, you can import the component dynamically to separate the header bundle from the main `bundle.client.js`:
+
+    ```
+    import '@justeat/f-form-field/dist/f-form-field.css';
+
+    export default {
+        components: {
+            ...
+            FormField: () => import(/* webpackChunkName: "form-field" */ '@justeat/f-form-field')
+        }
+    }
+
+    ```
+
+## Development
+
+Running below `yarn` commands from the component folder, starts a development
+server displaying a preview example of the component implementation.
+
+```bash
+# cd /packages/f-form-field
+yarn install
+
+# followed by
+yarn demo
+```
+
+### Storybook
+
+This component is also available to demo through our Storybook instance which can be served locally by running `yarn storybook:serve` from the mono-repo root.
+
+
+## Documentation to be completed once module is in stable state.

--- a/packages/f-form-field/babel.config.js
+++ b/packages/f-form-field/babel.config.js
@@ -1,0 +1,24 @@
+module.exports = api => {
+    // Use `isTest` to determine what presets and plugins to use with jest
+    const isTest = api.env('test');
+    const presets = [];
+    const plugins = [
+        '@babel/plugin-proposal-optional-chaining' // https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining
+    ];
+    const builtIns = (api.env('development') ? 'entry' : false);
+
+    if (!isTest) {
+        api.cache(true); // Caches the computed babel config function – https://babeljs.io/docs/en/config-files#apicache
+        presets.push(['@vue/app', { useBuiltIns: builtIns }]);
+    }
+
+    // Alias for @babel/preset-env
+    // Hooks into browserslist to provide smart Babel transforms
+    // https://babeljs.io/docs/en/babel-preset-env
+    presets.push('@babel/env');
+
+    return {
+        presets,
+        plugins
+    };
+};

--- a/packages/f-form-field/jest.config.js
+++ b/packages/f-form-field/jest.config.js
@@ -1,0 +1,39 @@
+module.exports = {
+    moduleFileExtensions: [
+        'js',
+        'json',
+        'vue'
+    ],
+
+    transform: {
+        '^.+\\.js$': 'babel-jest',
+        '^.+\\.vue$': 'vue-jest',
+        '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub'
+    },
+
+    transformIgnorePatterns: [
+        'node_modules/(?!(lodash-es)/)'
+    ],
+
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+        '^~include-media/(.*)$': '<rootDir>../../node_modules/include-media/$1',
+        '^~@justeat/(.*)$': '<rootDir>../../node_modules/@justeat/$1'
+    },
+
+    snapshotSerializers: [
+        'jest-serializer-vue'
+    ],
+
+    globals: {
+        'vue-jest': {
+            hideStyleWarn: true // We hide style warnings given the first time we run the tests it complains about some styles. The second time the tests are run, the warning disappears. https://github.com/vuejs/vue-jest/issues/178#issuecomment-529175129
+        }
+    },
+
+    testMatch: [
+        '**/*.{spec|test}.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)'
+    ],
+
+    testURL: 'http://localhost/'
+};

--- a/packages/f-form-field/package.json
+++ b/packages/f-form-field/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@justeat/f-form-field",
+  "description": "Fozzie Form Field – Fozzie Form Field Component",
+  "version": "0.1.0",
+  "main": "dist/f-form-field.umd.min.js",
+  "files": [
+    "dist"
+  ],
+  "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/f-form-field",
+  "contributors": [
+    "Github contributors <https://github.com/justeat/fozzie-components/graphs/contributors>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:justeat/fozzie-components.git"
+  },
+  "bugs": {
+    "url": "https://github.com/justeat/fozzie-components/issues"
+  },
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "keywords": [
+    "fozzie"
+  ],
+  "scripts": {
+    "prepublishOnly": "yarn lint && yarn test && yarn build",
+    "build": "vue-cli-service build --target lib --name f-form-field ./src/index.js",
+    "demo": "vue serve --open ./src/demo/Index.vue",
+    "lint": "vue-cli-service lint",
+    "lint:fix": "yarn lint --fix",
+    "test": "vue-cli-service test:unit"
+  },
+  "browserslist": [
+    "extends @justeat/browserslist-config-fozzie"
+  ],
+  "dependencies": {
+    "@justeat/f-services": "1.0.0"
+  },
+  "peerDependencies": {
+    "@justeat/browserslist-config-fozzie": ">=1.1.1"
+  },
+  "devDependencies": {
+    "@vue/cli-plugin-babel": "4.2.3",
+    "@vue/cli-plugin-eslint": "3.9.2",
+    "@vue/cli-plugin-unit-jest": "3.9.0",
+    "@vue/test-utils": "1.0.0-beta.29",
+    "node-sass-magic-importer": "5.3.2"
+  }
+}

--- a/packages/f-form-field/src/assets/scss/common.scss
+++ b/packages/f-form-field/src/assets/scss/common.scss
@@ -1,0 +1,22 @@
+// Set $theme variable so that fozzie doesn't complain when vars are imported below
+// n.b. This variables isn't actually used (unless there are theme specific vars from fozzie)
+// Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
+$theme: 'je' !default;
+
+@import '~@justeat/f-utils/src/scss/functions/index';
+@import '~@justeat/f-utils/src/scss/mixins/index';
+@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
+@import '~@justeat/fozzie/src/scss/settings/variables';
+@import '~@justeat/fozzie/src/scss/base/reset';
+@import '~@justeat/fozzie-colour-palette/src/scss/';
+
+/**
+ * Component Variables
+ */
+// $formField-background-color: $brand--red;
+
+@mixin theme($type) {
+    [data-theme="#{$type}"] & {
+        @content;
+    }
+}

--- a/packages/f-form-field/src/components/FormField.vue
+++ b/packages/f-form-field/src/components/FormField.vue
@@ -1,0 +1,108 @@
+<template>
+    <div
+        :data-theme-formfield="theme"
+        :class="$style['c-formField']">
+        <form-label
+            v-if="normalisedLabelStyle === 'default'"
+            :label-style="normalisedLabelStyle">
+            {{ labelText }}
+        </form-label>
+        <input
+            id="formfield"
+            :type="normalisedInputType"
+            placeholder=" "
+            :class="[$style['o-form-field'], $style['c-formField-input']]"
+        >
+        <form-label
+            v-if="normalisedLabelStyle === 'inline'"
+            :label-style="normalisedLabelStyle">
+            {{ labelText }}
+        </form-label>
+    </div>
+</template>
+
+<script>
+import { globalisationServices } from '@justeat/f-services';
+import FormLabel from './FormLabel.vue';
+import tenantConfigs from '../tenants';
+import { VALID_INPUT_TYPES, DEFAULT_INPUT_TYPE, VALID_LABEL_STYLES } from '../constants';
+
+export default {
+    name: 'FormField',
+    components: {
+        FormLabel
+    },
+    props: {
+        locale: {
+            type: String,
+            default: ''
+        },
+        labelText: {
+            type: String,
+            default: ''
+        },
+        inputType: {
+            type: String,
+            default: DEFAULT_INPUT_TYPE,
+            validator: value => (VALID_INPUT_TYPES.indexOf(value) !== -1) // The prop value must match one of the valid input types
+        },
+        labelStyle: {
+            type: String,
+            default: 'default',
+            validator: value => (VALID_LABEL_STYLES.indexOf(value) !== -1) // The prop value must match one of the valid input types
+        }
+    },
+    computed: {
+        normalisedInputType () {
+            if (VALID_INPUT_TYPES.includes(this.inputType)) {
+                return this.inputType;
+            }
+            return DEFAULT_INPUT_TYPE;
+        },
+        normalisedLabelStyle () {
+            if (VALID_LABEL_STYLES.includes(this.labelStyle)) {
+                return this.labelStyle;
+            }
+            return '';
+        },
+        formFieldLocale () {
+            return globalisationServices.getLocale(tenantConfigs, this.locale, this.$i18n);
+        },
+        copy () {
+            const localeConfig = tenantConfigs[this.formFieldLocale];
+            return { ...localeConfig };
+        },
+        theme () {
+            return globalisationServices.getTheme(this.formFieldLocale);
+        }
+    }
+};
+</script>
+
+<style lang="scss" module>
+$form-input-colour                        : $grey--dark;
+$form-input-bg                            : $white;
+$form-input-borderRadius                  : 3px;
+$form-input-borderWidth                   : 1px;
+$form-input-borderColour                  : $grey--lightest;
+$form-input-borderColour--focus           : $grey--dark;
+
+.c-formField {
+    position: relative;
+}
+
+    .c-formField-input {
+        width: 100%;
+        height: 2.5rem;
+        padding: 0.5rem;
+        @include font-size();
+        font-family: $font-family-base;
+        color: $form-input-colour;
+        font-weight: $font-weight-base;
+        background-color: $form-input-bg;
+        border: $form-input-borderWidth solid $form-input-borderColour;
+        border-radius: $form-input-borderRadius;
+        background-clip: padding-box;
+    }
+
+</style>

--- a/packages/f-form-field/src/components/FormLabel.vue
+++ b/packages/f-form-field/src/components/FormLabel.vue
@@ -1,0 +1,71 @@
+<template>
+    <label
+        v-if="hasLabelText"
+        for="formfield"
+        :class="[
+            $style['o-form-label'],
+            $style['c-formField-label'],
+            (labelStyle === 'inline' ? $style['c-formField-label--inline'] : '')
+        ]">
+        <slot />
+    </label>
+</template>
+
+<script>
+import { VALID_LABEL_STYLES } from '../constants';
+
+export default {
+    name: 'FormLabel',
+    components: {},
+    props: {
+        labelStyle: {
+            type: String,
+            default: 'default',
+            validator: value => (VALID_LABEL_STYLES.indexOf(value) !== -1)
+        }
+    },
+    computed: {
+        hasLabelText () {
+            return this.$slots.default && !!this.$slots.default[0].text.length;
+        }
+    }
+};
+</script>
+
+<style lang="scss" module>
+
+$form-label-colour: $grey--mid; // Text colour of form labels
+
+.c-formField-label {
+    display: block;
+    color: $form-label-colour;
+    margin-bottom: spacing();
+}
+
+.c-formField-label--inline {
+    position: absolute;
+    top: 50%;
+    left: 0.5rem;
+    transform: translateY(-50%);
+    margin-bottom: 0;
+    cursor: text; // make the cursor the same as the default input hover cursor
+}
+
+input {
+    &:focus {
+        // select the .c-formField-label--inline element if it's preceded by an input
+        & + .c-formField-label--inline {
+            opacity: 0;
+            z-index: -1;
+        }
+    }
+
+    // select the .c-formField-label--inline element
+    // if it's preceded by an input whose placeholder isn't being shown (i.e. the input has a value)
+    &:not(:placeholder-shown) + .c-formField-label--inline {
+        opacity: 0;
+        z-index: -1;
+    }
+}
+
+</style>

--- a/packages/f-form-field/src/components/tests/FormField.test.js
+++ b/packages/f-form-field/src/components/tests/FormField.test.js
@@ -1,0 +1,10 @@
+import { shallowMount } from '@vue/test-utils';
+import FormField from '../FormField.vue';
+
+describe('FormField', () => {
+    it('should be defined', () => {
+        const propsData = {};
+        const wrapper = shallowMount(FormField, { propsData });
+        expect(wrapper.exists()).toBe(true);
+    });
+});

--- a/packages/f-form-field/src/constants.js
+++ b/packages/f-form-field/src/constants.js
@@ -1,0 +1,4 @@
+export const VALID_INPUT_TYPES = ['text', 'email', 'password', 'radio', 'checkbox'];
+export const DEFAULT_INPUT_TYPE = 'text';
+
+export const VALID_LABEL_STYLES = ['default', 'inline'];

--- a/packages/f-form-field/src/demo/Index.vue
+++ b/packages/f-form-field/src/demo/Index.vue
@@ -1,0 +1,31 @@
+// Demo component for testing `f-form-field` independently via `vue serve --open src/demo/Index.vue`
+// Fonts were added for beter comparison with the designs.
+
+<template>
+    <div>
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1">
+        <form-field
+            locale="en-GB"
+            label-text="First Name"
+            label-style="inline" />
+    </div>
+</template>
+
+<script>
+import FormField from '@/components/FormField.vue';
+
+export default {
+    components: { FormField }
+};
+</script>
+
+<style>
+@import url('https://fonts.googleapis.com/css?family=Ubuntu:300,500&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Hind+Vadodara:300,500&display=swap');
+
+body {
+    margin: 0;
+}
+</style>

--- a/packages/f-form-field/src/index.js
+++ b/packages/f-form-field/src/index.js
@@ -1,0 +1,35 @@
+/**
+ * @overview Fozzie Form Field Component JS Wrapper
+ *
+ * @module f-form-field
+ */
+
+
+// Import vue component
+import FormField from '@/components/FormField.vue';
+
+// Declare install function executed by Vue.use()
+export function install (Vue) {
+    if (install.installed) return;
+    install.installed = true;
+    Vue.component('FormField', FormField);
+}
+
+// Create module definition for Vue.use()
+const plugin = {
+    install
+};
+
+// Auto-install when vue is found (eg. in browser via <script> tag)
+let GlobalVue = null;
+if (typeof window !== 'undefined') {
+    GlobalVue = window.Vue;
+} else if (typeof global !== 'undefined') {
+    GlobalVue = global.Vue;
+}
+if (GlobalVue) {
+    GlobalVue.use(plugin);
+}
+
+// To allow use as module (npm/webpack/etc.) export component
+export default FormField;

--- a/packages/f-form-field/src/tenants/da-DK.js
+++ b/packages/f-form-field/src/tenants/da-DK.js
@@ -1,0 +1,3 @@
+export default {
+    locale: 'da-DK'
+};

--- a/packages/f-form-field/src/tenants/en-AU.js
+++ b/packages/f-form-field/src/tenants/en-AU.js
@@ -1,0 +1,3 @@
+export default {
+    locale: 'en-AU'
+};

--- a/packages/f-form-field/src/tenants/en-GB.js
+++ b/packages/f-form-field/src/tenants/en-GB.js
@@ -1,0 +1,3 @@
+export default {
+    locale: 'en-GB'
+};

--- a/packages/f-form-field/src/tenants/en-IE.js
+++ b/packages/f-form-field/src/tenants/en-IE.js
@@ -1,0 +1,3 @@
+export default {
+    locale: 'en-IE'
+};

--- a/packages/f-form-field/src/tenants/en-NZ.js
+++ b/packages/f-form-field/src/tenants/en-NZ.js
@@ -1,0 +1,3 @@
+export default {
+    locale: 'en-NZ'
+};

--- a/packages/f-form-field/src/tenants/es-ES.js
+++ b/packages/f-form-field/src/tenants/es-ES.js
@@ -1,0 +1,3 @@
+export default {
+    locale: 'es-ES'
+};

--- a/packages/f-form-field/src/tenants/index.js
+++ b/packages/f-form-field/src/tenants/index.js
@@ -1,0 +1,21 @@
+import uk from './en-GB';
+import au from './en-AU';
+import nz from './en-NZ';
+import dk from './da-DK';
+import es from './es-ES';
+import ie from './en-IE';
+import it from './it-IT';
+import no from './nb-NO';
+
+const tenantConfigs = {
+    'en-GB': uk,
+    'en-AU': au,
+    'en-NZ': nz,
+    'da-DK': dk,
+    'es-ES': es,
+    'en-IE': ie,
+    'it-IT': it,
+    'nb-NO': no
+};
+
+export default tenantConfigs;

--- a/packages/f-form-field/src/tenants/it-IT.js
+++ b/packages/f-form-field/src/tenants/it-IT.js
@@ -1,0 +1,3 @@
+export default {
+    locale: 'it-IT'
+};

--- a/packages/f-form-field/src/tenants/nb-NO.js
+++ b/packages/f-form-field/src/tenants/nb-NO.js
@@ -1,0 +1,3 @@
+export default {
+    locale: 'nb-NO'
+};

--- a/packages/f-form-field/stories/FormField.stories.js
+++ b/packages/f-form-field/stories/FormField.stories.js
@@ -1,0 +1,31 @@
+import { storiesOf } from '@storybook/vue';
+import {
+    withKnobs, boolean, select, text
+} from '@storybook/addon-knobs';
+import FormField from '../src/components/FormField.vue';
+import { VALID_INPUT_TYPES, VALID_LABEL_STYLES } from '../src/constants';
+
+
+storiesOf('Components', module)
+    .addDecorator(withKnobs)
+    .add('f-form-field', () => ({
+        components: { FormField },
+        props: {
+            locale: {
+                default: select('Locale', ['en-GB', 'en-AU'])
+            },
+            labelText: {
+                default: text('Label Text', 'First Name')
+            },
+            inputType: {
+                default: select('Input Type', VALID_INPUT_TYPES)
+            },
+            labelStyle: {
+                default: select('Label Style', VALID_LABEL_STYLES)
+            }
+        },
+        parameters: {
+            notes: 'some documentation here'
+        },
+        template: '<form-field :locale="locale" :labelText="labelText" :inputType="inputType" :labelStyle="labelStyle" />'
+    }));

--- a/packages/f-form-field/vue.config.js
+++ b/packages/f-form-field/vue.config.js
@@ -1,0 +1,17 @@
+const magicImporter = require('node-sass-magic-importer');
+
+// vue.config.js
+module.exports = {
+    chainWebpack: config => {
+        config.module
+            .rule('scss-importer')
+            .test(/\.scss$/)
+            .use('importer')
+            .loader('sass-loader')
+            .options({
+                importer: magicImporter(),
+                // eslint-disable-next-line quotes
+                data: `@import "@/assets/scss/common.scss";`
+            });
+    }
+};


### PR DESCRIPTION
### Added
- Component structure and basic configuration (copied from `f-skeleton-component`).
- Component markup and core functionality.
- Storybook config.

N.b. Full unit tests will be coming in a separate PR. Didn't want this one to get too big to review.

---

## UI Review Checks

- [x] README and/or UI Documentation has been created (will be updated with more detail shortly)
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (testing atm)
