### PR TITLE
f-metadata@2.3.2: Fix appboy caching issue

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+2.3.1
+------------------------------
+*April  3, 2020*
+
+### Fixed
+- Cache issue with Braze by setting `sessionTimeoutInSeconds` to `0`.
+
+
 2.3.1
 ------------------------------
 *April  3, 2020*

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "main": "src/index.js",
   "files": [
     "dist"

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -1,5 +1,12 @@
 const noop = () => {};
 
+/**
+ * sessionTimeoutInSeconds
+ * Set session timeout to 0 in order to avoid caching issues with Braze
+ * @type {number}
+ */
+const sessionTimeoutInSeconds = 0;
+
 const initialiseBraze = (options = {}) => new Promise((resolve, reject) => {
     if (typeof window === 'undefined') return reject(new Error('window is not defined'));
 
@@ -21,7 +28,7 @@ const initialiseBraze = (options = {}) => new Promise((resolve, reject) => {
 
     return import(/* webpackChunkName: "appboy-web-sdk" */ 'appboy-web-sdk')
         .then(({ default: appboy }) => {
-            appboy.initialize(apiKey, { enableLogging });
+            appboy.initialize(apiKey, { enableLogging, sessionTimeoutInSeconds });
 
             appboy.display.automaticallyShowNewInAppMessages();
 

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -5,7 +5,7 @@ const noop = () => {};
  * Set session timeout to 0 in order to avoid caching issues with Braze
  * @type {number}
  */
-const sessionTimeoutInSeconds = 0;
+export const sessionTimeoutInSeconds = 0;
 
 const initialiseBraze = (options = {}) => new Promise((resolve, reject) => {
     if (typeof window === 'undefined') return reject(new Error('window is not defined'));

--- a/packages/f-metadata/tests/index.test.js
+++ b/packages/f-metadata/tests/index.test.js
@@ -1,5 +1,5 @@
 import appboy from 'appboy-web-sdk';
-import initialiseBraze from '../src';
+import initialiseBraze, { sessionTimeoutInSeconds } from '../src';
 
 jest.mock('appboy-web-sdk', () => ({
     initialize: jest.fn(),
@@ -65,7 +65,7 @@ describe('f-metadata', () => {
         // Assemble & Act
         initialiseBraze(settings).then(() => {
             // Assert
-            expect(appboy.initialize).toHaveBeenCalledWith(apiKey, { enableLogging });
+            expect(appboy.initialize).toHaveBeenCalledWith(apiKey, { enableLogging, sessionTimeoutInSeconds });
             expect(appboy.display.automaticallyShowNewInAppMessages).toHaveBeenCalled();
             expect(appboy.openSession).toHaveBeenCalled();
         });


### PR DESCRIPTION
Fixes a cache issue with Braze by setting `sessionTimeoutInSeconds` to `0`.

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
