### PR TITLE
f-metadata@2.3.3: Update appboy-web-sdk

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -4,9 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-2.3.1
+2.3.3
 ------------------------------
-*April  3, 2020*
+*May 6, 2020*
+
+### Changed
+- `appboy-web-sdk` version from `2.4.1` to `2.5.2`
+
+
+2.3.2
+------------------------------
+*May 4, 2020*
 
 ### Fixed
 - Cache issue with Braze by setting `sessionTimeoutInSeconds` to `0`.

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "main": "src/index.js",
   "files": [
     "dist"
@@ -36,7 +36,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "appboy-web-sdk": "2.4.1"
+    "appboy-web-sdk": "2.5.2"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4172,10 +4172,10 @@ app-root-dir@^1.0.2:
   resolved "https://registry.yarnpkg.com/app-root-dir/-/app-root-dir-1.0.2.tgz#38187ec2dea7577fff033ffcb12172692ff6e118"
   integrity sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=
 
-appboy-web-sdk@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/appboy-web-sdk/-/appboy-web-sdk-2.4.1.tgz#cdfa4074b83a4ea011f52d16b1d04dcad7f57eb8"
-  integrity sha512-xwNXrsSkENRnfq2IOkWcc7ODfxnxDHQ+Flxwf50+D5rggBSIs9e4rA29+7lJ/eEhgfIPFPux9FCt2HedMsJuzg==
+appboy-web-sdk@2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/appboy-web-sdk/-/appboy-web-sdk-2.5.2.tgz#e01ad9fbd744bc48da5bc91a3b3e71493f1a52bd"
+  integrity sha512-Gh5yAgEH/N7Wc3A0Pm8wZNb7uTygdHCB2BiJlI/0HZbJ1iWiA5SjGplTjovPZtrJK22AGcqRp9XVtea3EBYC9w==
 
 append-transform@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Update `appboy-web-sdk` from version `2.4.1` to `2.5.2`.

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]