### PR TITLE
f-services@1.0.1 - Change index.js syntax so that Storybook is compatible.

### DIFF
--- a/packages/f-services/CHANGELOG.md
+++ b/packages/f-services/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+1.0.1
+------------------------------
+*May 6, 2020*
+
+### Changed
+- Syntax in `index.js` so that newer versions of f-services are compatible with Storybook
 
 1.0.0
 ------------------------------

--- a/packages/f-services/package.json
+++ b/packages/f-services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-services",
   "description": "Fozzie Services - Shared Services for Components and projects",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/f-services.umd.js",
   "module": "dist/f-services.esm.js",
   "source": "src/index.js",

--- a/packages/f-services/src/index.js
+++ b/packages/f-services/src/index.js
@@ -1,9 +1,8 @@
-/**
- * @overview Fozzie's collection of shared javascript modules
- *
- * @module f-services
- */
-
-export { default as axiosServices } from './axios';
-export { default as globalisationServices } from './globalisation';
-export { default as windowServices } from './window';
+import axiosServices from './axios';
+import globalisationServices from './globalisation';
+import windowServices from './window';
+export {
+    axiosServices,
+    globalisationServices,
+    windowServices
+};

--- a/packages/f-services/src/index.js
+++ b/packages/f-services/src/index.js
@@ -1,3 +1,9 @@
+/**
+ * @overview Fozzie's collection of shared javascript modules
+ *
+ * @module f-services
+ */
+
 import axiosServices from './axios';
 import globalisationServices from './globalisation';
 import windowServices from './window';


### PR DESCRIPTION
- As of f-services 1.0.0, the `getLocale` function doesn't work with Storybook. This PR will fix that issue, thanks to @xander-marjoram :)