### PR TITLE
f-metadata@2.3.4: Change callback order

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -4,12 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (roll into next release)
+2.3.4
 ------------------------------
 *May 12, 2020*
 
 ### Changed
 - Updating `@vue/cli-plugin-unit-test` to v4.3.1.
+- Ordering of callbacks to ensure they're initialised before used
 
 
 2.3.3

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "main": "src/index.js",
   "files": [
     "dist"

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -31,6 +31,7 @@ const initialiseBraze = (options = {}) => new Promise((resolve, reject) => {
             appboy.initialize(apiKey, { enableLogging, sessionTimeoutInSeconds });
 
             appboy.display.automaticallyShowNewInAppMessages();
+            appboy.subscribeToContentCardsUpdates(handleContentCards);
 
             appboy.openSession();
             window.appboy = appboy;
@@ -42,8 +43,6 @@ const initialiseBraze = (options = {}) => new Promise((resolve, reject) => {
             });
 
             appboy.requestContentCardsRefresh();
-
-            appboy.subscribeToContentCardsUpdates(handleContentCards);
 
             resolve(appboy);
         })


### PR DESCRIPTION
Change callback order to ensure it's initialised before use

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
