### PR TITLE
f-registration@0.3.0

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -6,7 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Latest (roll into next release)
 ------------------------------
-*May 12, 2020*
+
+
+v0.3.0
+------------------------------
+*May 14, 2020*
+
+### Added
+- Added `data-test-id` for input elements in `f-registration`.
 
 ### Changed
 - Updating `vue-test-utils` to v1 and `@vue/cli-plugin-unit-test` to v4.3.1.

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Form Field Component",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -7,22 +7,27 @@
             :class="$style['o-form']"
         >
             <form-field
+                data-test-id="input-first-name"
                 label-text="First name"
                 input-type="text" />
 
             <form-field
+                data-test-id="input-last-name"
                 label-text="Last name"
                 input-type="text" />
 
             <form-field
+                data-test-id="input-email"
                 label-text="Email"
                 input-type="email" />
 
             <form-field
+                data-test-id="input-password"
                 label-text="Password"
                 input-type="password" />
 
             <form-button
+                data-test-id="create-account-submit-button"
                 button-style="primary"
                 is-full-width>
                 Create Account

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -11,9 +11,9 @@ describe('Registration', () => {
     it('has a button', () => {
         const propsData = {};
         const wrapper = shallowMount(Registration, { propsData });
-        const button = wrapper.find('button[data-test-id="create-account-submit-button"]')
-        expect(button.exists());
-    })
+        const button = wrapper.find("[data-test-id='create-account-submit-button']");
+        expect(button.exists()).toBe(true);
+    });
 
     describe(': props :', () => {
         it('if `value` is specified, should assign the input field a value attribute', () => {

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -8,6 +8,13 @@ describe('Registration', () => {
         expect(wrapper.exists()).toBe(true);
     });
 
+    it('has a button', () => {
+        const propsData = {};
+        const wrapper = shallowMount(Registration, { propsData });
+        const button = wrapper.find('button[data-test-id="create-account-submit-button"]')
+        expect(button.exists());
+    })
+
     describe(': props :', () => {
         it('if `value` is specified, should assign the input field a value attribute', () => {
             const propsData = {};


### PR DESCRIPTION
### Added
- Added `data-test-id` for input elements in `f-registration`.

## UI Review Checks
- [X] README and/or UI Documentation has been [created|updated]
- [X] Unit tests have been [created|updated]
- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [X] Chrome (latest)
- [X] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in: