### PR TITLE
f-form-field@v0.3.0 – Adding spacing between two adjacent form-fields

### DIFF
--- a/packages/f-form-field/CHANGELOG.md
+++ b/packages/f-form-field/CHANGELOG.md
@@ -4,10 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (roll into next release)
+v0.3.0
 ------------------------------
-*May 12, 2020*
+*May 18, 2020*
 
+### Changed
+- Adding spacing between two adjacent form-fields.
 - Structure of Storybook stories changed to CSF (Component Story Format) – the new recommended way to write stories.
 
 

--- a/packages/f-form-field/package.json
+++ b/packages/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-form-field/src/components/FormField.vue
+++ b/packages/f-form-field/src/components/FormField.vue
@@ -89,6 +89,10 @@ $form-input-borderColour--focus           : $grey--dark;
 
 .c-formField {
     position: relative;
+
+    & + & {
+        margin-top: spacing(x2);
+    }
 }
 
     .c-formField-input {


### PR DESCRIPTION
### Changed
- Adding spacing between two adjacent form-fields.
- Structure of Storybook stories changed to CSF (Component Story Format) – the new recommended way to write stories.

---

## UI Review Checks

- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)