### PR TITLE
f-form-field@v0.4.0 – emits value and allows for passed-in error messages

### DIFF
--- a/packages/f-form-field/CHANGELOG.md
+++ b/packages/f-form-field/CHANGELOG.md
@@ -4,6 +4,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.4.0
+------------------------------
+*May 26, 2020*
+
+### Added
+- Component now emits an event when its value is updated. This is so that validation applied to the consuming form component knows when to run on the field.
+- Unique ID applied to form input so that clashes between fields doesn't occur.
+- Named slot for error message markup to be passed through from a consuming form.
+
+### Changed
+- Wrapper element added around the input field, to accommodate error message placement.
+- `for` attribute moved from inside the `FormLabel` component and is now applied in the `FormField` component, so that it can make use of passed in `$attrs`.
+
+
 v0.3.0
 ------------------------------
 *May 18, 2020*

--- a/packages/f-form-field/package.json
+++ b/packages/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-form-field/src/components/FormField.vue
+++ b/packages/f-form-field/src/components/FormField.vue
@@ -2,22 +2,32 @@
     <div
         :data-theme-formfield="theme"
         :class="$style['c-formField']">
-        <form-label
-            v-if="normalisedLabelStyle === 'default'"
-            :label-style="normalisedLabelStyle">
-            {{ labelText }}
-        </form-label>
-        <input
-            id="formfield"
-            :type="normalisedInputType"
-            placeholder=" "
-            :class="[$style['o-form-field'], $style['c-formField-input']]"
-        >
-        <form-label
-            v-if="normalisedLabelStyle === 'inline'"
-            :label-style="normalisedLabelStyle">
-            {{ labelText }}
-        </form-label>
+        <div
+            :class="$style['c-formField-inputWrapper']">
+            <form-label
+                v-if="normalisedLabelStyle === 'default'"
+                :label-style="normalisedLabelStyle"
+                :for="uniqueId">
+                {{ labelText }}
+            </form-label>
+            <input
+                :id="`${uniqueId}`"
+                :value="value"
+                v-bind="$attrs"
+                :type="normalisedInputType"
+                placeholder=" "
+                :class="[$style['o-form-field'], $style['c-formField-input']]"
+                @input="updateValue"
+                v-on="listeners"
+            >
+            <form-label
+                v-if="normalisedLabelStyle === 'inline'"
+                :label-style="normalisedLabelStyle"
+                :for="uniqueId">
+                {{ labelText }}
+            </form-label>
+        </div>
+        <slot name="error" />
     </div>
 </template>
 
@@ -32,6 +42,7 @@ export default {
     components: {
         FormLabel
     },
+    inheritAttrs: false,
     props: {
         locale: {
             type: String,
@@ -50,6 +61,10 @@ export default {
             type: String,
             default: 'default',
             validator: value => (VALID_LABEL_STYLES.indexOf(value) !== -1) // The prop value must match one of the valid input types
+        },
+        value: {
+            type: [String, Number],
+            default: ''
         }
     },
     computed: {
@@ -74,6 +89,20 @@ export default {
         },
         theme () {
             return globalisationServices.getTheme(this.formFieldLocale);
+        },
+        listeners () {
+            return {
+                ...this.$listeners,
+                input: this.updateValue
+            };
+        },
+        uniqueId () {
+            return `formField-${(this.$attrs.name ? this.$attrs.name : this._uid)}`;
+        }
+    },
+    methods: {
+        updateValue (event) {
+            this.$emit('input', event.target.value);
         }
     }
 };
@@ -88,12 +117,13 @@ $form-input-borderColour                  : $grey--lightest;
 $form-input-borderColour--focus           : $grey--dark;
 
 .c-formField {
-    position: relative;
-
     & + & {
         margin-top: spacing(x2);
     }
 }
+    .c-formField-inputWrapper {
+        position: relative;
+    }
 
     .c-formField-input {
         width: 100%;
@@ -108,5 +138,6 @@ $form-input-borderColour--focus           : $grey--dark;
         border-radius: $form-input-borderRadius;
         background-clip: padding-box;
     }
+
 
 </style>

--- a/packages/f-form-field/src/components/FormLabel.vue
+++ b/packages/f-form-field/src/components/FormLabel.vue
@@ -1,7 +1,6 @@
 <template>
     <label
         v-if="hasLabelText"
-        for="formfield"
         :class="[
             $style['o-form-label'],
             $style['c-formField-label'],

--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (to be added to next release)
+------------------------------
+*May 26, 2020*
+
+### Changed
+- Stubbed `.css` file module imports as was causing build error.
+
+
 v0.4.0
 ------------------------------
 *May 18, 2020*

--- a/packages/f-registration/jest.config.js
+++ b/packages/f-registration/jest.config.js
@@ -15,9 +15,22 @@ module.exports = {
         'node_modules/(?!(lodash-es)/)'
     ],
 
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+        '^~include-media/(.*)$': '<rootDir>../../node_modules/include-media/$1',
+        '^~@justeat/(.*)$': '<rootDir>../../node_modules/@justeat/$1',
+        '\\.(css|scss)$': 'jest-transform-stub'
+    },
+
     snapshotSerializers: [
         'jest-serializer-vue'
     ],
 
-    testURL: 'http://localhost/'
+    testURL: 'http://localhost/',
+
+    globals: {
+        'vue-jest': {
+            hideStyleWarn: true // We hide style warnings given the first time we run the tests it complains about some styles. The second time the tests are run, the warning disappears. https://github.com/vuejs/vue-jest/issues/178#issuecomment-529175129
+        }
+    }
 };


### PR DESCRIPTION
### Added
- Component now emits an event when its value is updated. This is so that validation applied to the consuming form component knows when to run on the field.
- Unique ID applied to form input so that clashes between fields doesn't occur.
- Named slot for ertror message markup to be passed through from a consuming form.

### Changed
- Wrapper element added around the input field, to accommodate error message placement.
- `for` attribute moved from inside the `FormLabel` component and is now applied in the `FormField` component, so that it can make use of passed in `$attrs`.
- #trivial `f-registration` test fix

N.b. README and unit tests coming in future PR (as relies on a separate issue in Jest being fixed for CSS Module classes to be enabled.

---

## UI Review Checks

<img width="336" alt="Screen Shot 2020-05-26 at 14 17 03" src="https://user-images.githubusercontent.com/805184/82905302-9f334880-9f5b-11ea-81b3-a79d8f8790f9.png">


- [x] Storybook Documentation has been updated

## Browsers Tested

- [x] Chrome (latest)
- [x] Mobile (iPhone Xs)
