### PR TITLE
f-registration@v0.5.0 – Added validation and error messages

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -4,9 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (to be added to next release)
+v0.5.0
 ------------------------------
 *May 26, 2020*
+
+### Added
+- `Vuelidate` package added for validation of form inputs. Validation currently set-up to show to form submission.
+- Error messages for error states and styling for error messages (needs to be in the form rather than on the input because of the way CSS Modules works – the plan will be to move this styling to a more generic `f-form` component down the line).
+- `name` attributes added to each form field component.
+- Added base `typography` file to the demo component so that it shows how the component will look with the global fozzie typographic styles applied (global styles like this will be made available as a separate include that is imported into each component in the future).
 
 ### Changed
 - Stubbed `.css` file module imports as was causing build error.

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Form Field Component",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist"
@@ -38,8 +38,10 @@
   ],
   "dependencies": {
     "@justeat/f-card": "0.2.0",
-    "@justeat/f-form-field": "0.3.0",
-    "@justeat/f-services": "1.0.0"
+    "@justeat/f-form-field": "0.4.0",
+    "@justeat/f-services": "1.0.0",
+    "@justeat/f-vue-icons": "1.0.0-beta.5",
+    "vuelidate": "0.7.5"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1"

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@justeat/f-card": "0.2.0",
-    "@justeat/f-form-field": "0.4.0",
+    "@justeat/f-form-field": "0.5.0",
     "@justeat/f-services": "1.0.0",
     "@justeat/f-vue-icons": "1.0.0-beta.5",
     "vuelidate": "0.7.5"

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -8,31 +8,82 @@
         <form
             type="post"
             :class="$style['o-form']"
+            @submit="checkValidation"
         >
             <form-field
+                v-model="firstName"
+                name="firstName"
                 data-test-id="input-first-name"
                 label-text="First name"
                 input-type="text"
-                label-style="inline" />
-
+                label-style="inline">
+                <template #error>
+                    <p
+                        v-if="($v.firstName.$invalid && !$v.firstName.required) && $v.firstName.$dirty"
+                        :class="$style['o-form-error']">
+                        <warning-icon :class="$style['o-form-error-icon']" />
+                        Please enter your first name
+                    </p>
+                </template>
+            </form-field>
 
             <form-field
+                v-model="lastName"
+                name="lastName"
                 data-test-id="input-last-name"
                 label-text="Last name"
                 input-type="text"
-                label-style="inline" />
+                label-style="inline">
+                <template #error>
+                    <p
+                        v-if="($v.lastName.$invalid && !$v.lastName.required) && $v.lastName.$dirty"
+                        :class="$style['o-form-error']">
+                        <warning-icon :class="$style['o-form-error-icon']" />
+                        Please enter your last name
+                    </p>
+                </template>
+            </form-field>
 
             <form-field
+                v-model="email"
+                name="email"
                 data-test-id="input-email"
                 label-text="Email"
                 input-type="email"
-                label-style="inline" />
+                label-style="inline">
+                <!-- For when we want to add validation on blur of input - @blur="$v.email.$touch" -->
+                <template #error>
+                    <p
+                        v-if="($v.email.$invalid && !$v.email.required) && $v.email.$dirty"
+                        :class="$style['o-form-error']">
+                        <warning-icon :class="$style['o-form-error-icon']" />
+                        Please enter your email address
+                    </p>
+                    <p
+                        v-else-if="($v.email.$invalid && !$v.email.email) && $v.email.$dirty"
+                        :class="$style['o-form-error']">
+                        <warning-icon :class="$style['o-form-error-icon']" />
+                        Please enter a valid email address
+                    </p>
+                </template>
+            </form-field>
 
             <form-field
+                v-model="password"
+                name="password"
                 data-test-id="input-password"
                 label-text="Password"
                 input-type="password"
-                label-style="inline" />
+                label-style="inline">
+                <template #error>
+                    <p
+                        v-if="($v.password.$invalid && !$v.password.required) && $v.password.$dirty"
+                        :class="$style['o-form-error']">
+                        <warning-icon :class="$style['o-form-error-icon']" />
+                        Please enter a password
+                    </p>
+                </template>
+            </form-field>
 
             <form-button
                 data-test-id="create-account-submit-button"
@@ -46,6 +97,9 @@
 
 <script>
 import { globalisationServices } from '@justeat/f-services';
+import { validationMixin } from 'vuelidate';
+import { required, email } from 'vuelidate/lib/validators';
+import { WarningIcon } from '@justeat/f-vue-icons';
 import Card from '@justeat/f-card';
 import '@justeat/f-card/dist/f-card.css';
 import FormField from '@justeat/f-form-field';
@@ -59,8 +113,11 @@ export default {
     components: {
         Card,
         FormButton,
-        FormField
+        FormField,
+        WarningIcon
     },
+
+    mixins: [validationMixin],
 
     props: {
         locale: {
@@ -84,8 +141,37 @@ export default {
 
         return {
             copy: { ...localeConfig },
-            theme
+            theme,
+            firstName: null,
+            lastName: null,
+            email: null,
+            password: null
         };
+    },
+    validations: {
+        firstName: {
+            required
+        },
+        lastName: {
+            required
+        },
+        email: {
+            required,
+            email
+        },
+        password: {
+            required
+        }
+    },
+    methods: {
+        checkValidation (event) {
+            this.$v.$touch();
+            if (this.$v.$invalid) {
+                event.preventDefault();
+                return false;
+            }
+            return true;
+        }
     }
 };
 </script>
@@ -96,6 +182,23 @@ export default {
 
 .o-form {
     @include font-size(base--scaleUp);
+}
+
+    .o-form-error {
+        display: flex;
+        align-items: center;
+        color: $red;
+        @include font-size(base);
+        margin-top: spacing();
+    }
+        .o-form-error-icon {
+            width: 16px;
+            height: 16px;
+            margin-right: spacing(x0.5);
+        }
+
+* + .o-form {
+    margin-top: spacing(x2);
 }
 
 </style>

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -19,7 +19,7 @@
                 label-style="inline">
                 <template #error>
                     <p
-                        v-if="($v.firstName.$invalid && !$v.firstName.required) && $v.firstName.$dirty"
+                        v-if="shouldShowFirstNameRequiredError"
                         :class="$style['o-form-error']">
                         <warning-icon :class="$style['o-form-error-icon']" />
                         Please enter your first name
@@ -36,7 +36,7 @@
                 label-style="inline">
                 <template #error>
                     <p
-                        v-if="($v.lastName.$invalid && !$v.lastName.required) && $v.lastName.$dirty"
+                        v-if="shouldShowLastNameRequiredError"
                         :class="$style['o-form-error']">
                         <warning-icon :class="$style['o-form-error-icon']" />
                         Please enter your last name
@@ -54,13 +54,13 @@
                 <!-- For when we want to add validation on blur of input - @blur="$v.email.$touch" -->
                 <template #error>
                     <p
-                        v-if="($v.email.$invalid && !$v.email.required) && $v.email.$dirty"
+                        v-if="shouldShowEmailRequiredError"
                         :class="$style['o-form-error']">
                         <warning-icon :class="$style['o-form-error-icon']" />
                         Please enter your email address
                     </p>
                     <p
-                        v-else-if="($v.email.$invalid && !$v.email.email) && $v.email.$dirty"
+                        v-else-if="shouldShowEmailInvalidError"
                         :class="$style['o-form-error']">
                         <warning-icon :class="$style['o-form-error-icon']" />
                         Please enter a valid email address
@@ -77,7 +77,7 @@
                 label-style="inline">
                 <template #error>
                     <p
-                        v-if="($v.password.$invalid && !$v.password.required) && $v.password.$dirty"
+                        v-if="shouldShowPasswordRequiredError"
                         :class="$style['o-form-error']">
                         <warning-icon :class="$style['o-form-error-icon']" />
                         Please enter a password
@@ -148,6 +148,30 @@ export default {
             password: null
         };
     },
+
+    computed: {
+        // Returns true if required validation conditions are not met and if the field has been `touched` by a user
+        shouldShowFirstNameRequiredError () {
+            return (this.$v.firstName.$invalid && !this.$v.firstName.required) && this.$v.firstName.$dirty;
+        },
+        // Returns true if required validation conditions are not met and if the field has been `touched` by a user
+        shouldShowLastNameRequiredError () {
+            return (this.$v.lastName.$invalid && !this.$v.lastName.required) && this.$v.lastName.$dirty;
+        },
+        // Returns true if required validation conditions are not met and if the field has been `touched` by a user
+        shouldShowEmailRequiredError () {
+            return (this.$v.email.$invalid && !this.$v.email.required) && this.$v.email.$dirty;
+        },
+        // Returns true if email validation conditions are not met and if the field has been `touched` by a user
+        shouldShowEmailInvalidError () {
+            return (this.$v.email.$invalid && !this.$v.email.email) && this.$v.email.$dirty;
+        },
+        // Returns true if email validation conditions are not met and if the field has been `touched` by a user
+        shouldShowPasswordRequiredError () {
+            return (this.$v.password.$invalid && !this.$v.password.required) && this.$v.password.$dirty;
+        }
+    },
+
     validations: {
         firstName: {
             required
@@ -163,6 +187,7 @@ export default {
             required
         }
     },
+
     methods: {
         checkValidation (event) {
             this.$v.$touch();

--- a/packages/f-registration/src/demo/Index.vue
+++ b/packages/f-registration/src/demo/Index.vue
@@ -24,7 +24,7 @@ export default {
 <style lang="scss">
 @import url('https://fonts.googleapis.com/css?family=Ubuntu:300,500&display=swap');
 @import url('https://fonts.googleapis.com/css?family=Hind+Vadodara:300,500&display=swap');
-
+@import '~@justeat/fozzie/src/scss/base/typography';
 
 body {
     margin: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -17949,6 +17949,11 @@ vue@2.6.11:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
   integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
 
+vuelidate@0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/vuelidate/-/vuelidate-0.7.5.tgz#ff48c75ae9d24ea24c24e9ea08065eda0a0cba0a"
+  integrity sha512-GAAG8QAFVp7BFeQlNaThpTbimq3+HypBPNwdkCkHZZeVaD5zmXXfhp357dcUJXHXTZjSln0PvP6wiwLZXkFTwg==
+
 w3c-hr-time@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"


### PR DESCRIPTION
### Added
- `Vuelidate` package added for validation of form inputs. Validation currently set-up to show to form submission.
- Error messages for error states and styling for error messages (needs to be in the form rather than on the input because of the way CSS Modules works – the plan will be to move this styling to a more generic `f-form` component down the line).
- `name` attributes added to each form field component.
- Added base `typography` file to the demo component so that it shows how the component will look with the global fozzie typographic styles applied (global styles like this will be made available as a separate include that is imported into each component in the future).

### Changed
- Stubbed `.css` file module imports as was causing build error.

N.b. Unit tests and README info coming in future PR as these components are productionised

---

## UI Review Checks

<img width="561" alt="Screen Shot 2020-05-26 at 17 31 57" src="https://user-images.githubusercontent.com/805184/82926254-d3683280-9f76-11ea-8c91-80b22689826b.png">

- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Mobile (iPhone Xs)
