### PR TITLE
f-metadata@2.5.0: Add interceptor for in-app message click events

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+2.4.1
+------------------------------
+*May 21, 2020*
+
+### Changed
+- Add `interceptInAppMessageClickEvents` callback method
+
+
 2.4.0
 ------------------------------
 *May 13, 2020*

--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -3,9 +3,9 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-2.4.1
+2.5.0
 ------------------------------
-*May 21, 2020*
+*May 27, 2020*
 
 ### Changed
 - Add `interceptInAppMessageClickEvents` callback method

--- a/packages/f-metadata/README.md
+++ b/packages/f-metadata/README.md
@@ -91,6 +91,10 @@ The callback to be invoked when in-app messages have been retrieved.
 
 > **Please note:** This callback is fired before in-app messages are triggered.
 
+### `config.callbacks.interceptInAppMessageClickEvents`
+
+The callback to be invoked when in-app messages have been clicked.
+
 ## Migration to v2
 
 Version 2 exposes the appboy instance as opposed to content cards as part of the refresh callback, this makes it easier to access properties on the instance such as `getUnviewedCardCount` and is a step closer to an isomorphic solution.

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "main": "src/index.js",
   "files": [
     "dist"

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "main": "src/index.js",
   "files": [
     "dist"

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -35,8 +35,16 @@ const initialiseBraze = (options = {}) => new Promise((resolve, reject) => {
             appboy.initialize(apiKey, { enableLogging, sessionTimeoutInSeconds });
 
             appboy.subscribeToInAppMessage(message => {
-                interceptInAppMessages(message);
-                appboy.subscribeToClickedEvent(interceptInAppMessageClickEvents);
+                if (message instanceof appboy.ab.InAppMessage) {
+                    /**
+                     * Always subscribe click action to second button
+                     * as this is always "success" as opposed to "dismiss"
+                     * as confirmed with CRM (AS)
+                     */
+                    const { buttons: { 1: button } } = message;
+                    interceptInAppMessages(message);
+                    button.subscribeToClickedEvent(() => interceptInAppMessageClickEvents(message));
+                }
                 appboy.display.showInAppMessage(message);
             });
             appboy.subscribeToContentCardsUpdates(handleContentCards);

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -17,7 +17,11 @@ const initialiseBraze = (options = {}) => new Promise((resolve, reject) => {
         disableComponent = false,
         callbacks = {}
     } = options;
-    const { handleContentCards = noop, interceptInAppMessages = noop } = callbacks;
+    const {
+        handleContentCards = noop,
+        interceptInAppMessageClickEvents = noop,
+        interceptInAppMessages = noop
+    } = callbacks;
 
     if (disableComponent || !apiKey || !userId) {
         handleContentCards(null);
@@ -32,6 +36,7 @@ const initialiseBraze = (options = {}) => new Promise((resolve, reject) => {
 
             appboy.subscribeToInAppMessage(message => {
                 interceptInAppMessages(message);
+                appboy.subscribeToClickedEvent(interceptInAppMessageClickEvents);
                 appboy.display.showInAppMessage(message);
             });
             appboy.subscribeToContentCardsUpdates(handleContentCards);

--- a/packages/f-metadata/tests/index.test.js
+++ b/packages/f-metadata/tests/index.test.js
@@ -10,7 +10,8 @@ jest.mock('appboy-web-sdk', () => ({
     changeUser: jest.fn(),
     requestContentCardsRefresh: jest.fn(),
     subscribeToContentCardsUpdates: jest.fn(),
-    subscribeToInAppMessage: jest.fn()
+    subscribeToInAppMessage: jest.fn(),
+    subscribeToClickedEvent: jest.fn()
 }));
 
 const apiKey = '__API_KEY__';
@@ -18,12 +19,14 @@ const userId = '__USER_ID__';
 const inAppMessage = '__IN_APP_MESSAGE__';
 const handleContentCards = jest.fn();
 const interceptInAppMessages = jest.fn();
+const interceptInAppMessageClickEvents = jest.fn();
 const enableLogging = true;
 const disableComponent = false;
 
 const callbacks = {
     handleContentCards,
-    interceptInAppMessages
+    interceptInAppMessages,
+    interceptInAppMessageClickEvents
 };
 
 const settings = {
@@ -119,6 +122,16 @@ describe('f-metadata', () => {
             appboy.subscribeToInAppMessage.mock.calls[0][0](inAppMessage);
             expect(interceptInAppMessages).toHaveBeenCalledWith(inAppMessage);
             expect(appboy.display.showInAppMessage).toHaveBeenCalledWith(inAppMessage);
+        });
+
+        it('should call `subscribeToClickedEvent` when in-app messages are displayed', async () => {
+            // Assemble & Act
+            await initialiseBraze(settings);
+
+            // Assert
+            appboy.subscribeToInAppMessage.mock.calls[0][0](inAppMessage);
+            appboy.subscribeToClickedEvent.mock.calls[0][0]();
+            expect(interceptInAppMessageClickEvents).toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
Exposes the callback method `interceptInAppMessageClickEvents` to track click events externally.

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- **N/A** This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)
