### PR TITLE
f-form-field@v0.5.0

### DIFF
--- a/packages/f-form-field/CHANGELOG.md
+++ b/packages/f-form-field/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.5.0
+------------------------------
+*May 29, 2020*
+
+### Changed
+- Added a `data-test-id` attribute to the input element.
+
+
 v0.4.0
 ------------------------------
 *May 26, 2020*

--- a/packages/f-form-field/CHANGELOG.md
+++ b/packages/f-form-field/CHANGELOG.md
@@ -8,8 +8,8 @@ v0.5.0
 ------------------------------
 *May 29, 2020*
 
-### Changed
-- Added a `data-test-id` attribute to the input element.
+### Added
+- `data-test-id` attribute to the input element.
 
 
 v0.4.0

--- a/packages/f-form-field/package.json
+++ b/packages/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-form-field/src/components/FormField.vue
+++ b/packages/f-form-field/src/components/FormField.vue
@@ -16,6 +16,7 @@
                 v-bind="$attrs"
                 :type="normalisedInputType"
                 placeholder=" "
+                :data-test-id="testId"
                 :class="[$style['o-form-field'], $style['c-formField-input']]"
                 @input="updateValue"
                 v-on="listeners"
@@ -65,6 +66,10 @@ export default {
         value: {
             type: [String, Number],
             default: ''
+        },
+        dataTestId: {
+            type: String,
+            default: ''
         }
     },
     computed: {
@@ -98,6 +103,9 @@ export default {
         },
         uniqueId () {
             return `formField-${(this.$attrs.name ? this.$attrs.name : this._uid)}`;
+        },
+        testId () {
+            return this.dataTestId || this.$attrs.name || false;
         }
     },
     methods: {

--- a/packages/f-form-field/src/components/tests/FormField.test.js
+++ b/packages/f-form-field/src/components/tests/FormField.test.js
@@ -67,6 +67,30 @@ describe('FormField', () => {
                 // Assert
                 expect(formInput.attributes('type')).toBe(definedType);
             });
+
+            it('should set the value of attribute data-test-id on input element if dataTestId is specified', () => {
+                // Arrange
+                const dataTestId = 'my-test-id';
+                const propsData = {
+                    dataTestId
+                };
+
+                // Act
+                const wrapper = shallowMount(FormField, { propsData });
+                const formInput = wrapper.find('input'); // change to .c-formField when CSS Modules is working
+
+                // Assert
+                expect(formInput.attributes('data-test-id')).toBe(dataTestId);
+            });
+
+            it('should not add the attribute data-test-id on input element if dataTestId is not specified', () => {
+                // Arrange & Act
+                const wrapper = shallowMount(FormField, { });
+                const formInput = wrapper.find('input'); // change to .c-formField when CSS Modules is working
+
+                // Assert
+                expect(formInput.attributes('data-test-id')).toBe(undefined);
+            });
         });
     });
 });

--- a/packages/f-form-field/src/components/tests/FormField.test.js
+++ b/packages/f-form-field/src/components/tests/FormField.test.js
@@ -83,6 +83,21 @@ describe('FormField', () => {
                 expect(formInput.attributes('data-test-id')).toBe(dataTestId);
             });
 
+            it('should set the value of attribute data-test-id on input element if name is specified', () => {
+                // Arrange
+                const name = 'my-input';
+                const attrs = {
+                    name
+                };
+
+                // Act
+                const wrapper = shallowMount(FormField, { attrs });
+                const formInput = wrapper.find('input'); // change to .c-formField when CSS Modules is working
+
+                // Assert
+                expect(formInput.attributes('data-test-id')).toBe(name);
+            });
+
             it('should not add the attribute data-test-id on input element if dataTestId is not specified', () => {
                 // Arrange & Act
                 const wrapper = shallowMount(FormField, { });

--- a/packages/f-form-field/src/demo/Index.vue
+++ b/packages/f-form-field/src/demo/Index.vue
@@ -9,7 +9,8 @@
         <form-field
             locale="en-GB"
             label-text="First Name"
-            label-style="inline" />
+            label-style="inline"
+            data-test-id="a-constant-test-id" />
     </div>
 </template>
 


### PR DESCRIPTION
- Added a `data-test-id` attribute to the input element.

- [X] README and/or UI Documentation has been [created|updated]
- [X] Unit tests have been [created|updated]
- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

![image](https://user-images.githubusercontent.com/1670343/83271907-62b55600-a1c2-11ea-8d34-5cbcc8810ae3.png)

## Browsers Tested

- [X] Chrome (latest)
- [X] Internet Explorer 11