### PR TITLE
f-footer@v2.2.0 - Add rel noopener attributes

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Latest (roll into next release)
 ------------------------------
-*May 12, 2020*
+*June 2, 2020*
 
 ### Changed
+- Include rel="noopener" attr in ButtonList items
+- Include target attr/property in LinksList items
+- Add rel: 'noopener' to en-GB link item with target: '_blank' property
 - Updating `vue-test-utils` to v1 and `@vue/cli-plugin-unit-test` to v4.3.1.
 - Use `node current` in unit test Babel config, so that it supports `async > await` properly.
 - Structure of Storybook stories changed to CSF (Component Story Format) – the new recommended way to write stories.

--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (roll into next release)
+v2.2.0
 ------------------------------
 *June 2, 2020*
 

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/src/components/ButtonList.vue
+++ b/packages/f-footer/src/components/ButtonList.vue
@@ -16,7 +16,8 @@
                     "label": "${button.gtm}"
                 }`'
                 :class="$style['c-buttonList-button']"
-                target="_blank">
+                target="_blank"
+                rel="noopener">
                 {{ button.title }}
             </a>
         </div>

--- a/packages/f-footer/src/components/Demo.vue
+++ b/packages/f-footer/src/components/Demo.vue
@@ -7,7 +7,7 @@
             name="viewport"
             content="width=device-width, initial-scale=1">
         <vue-footer
-            locale="en-AU" />
+            locale="en-GB" />
     </div>
 </template>
 

--- a/packages/f-footer/src/components/LinkList.vue
+++ b/packages/f-footer/src/components/LinkList.vue
@@ -38,6 +38,7 @@
                 <a
                     :href="link.url"
                     :rel="link.rel"
+                    :target="link.target"
                     :class="$style['c-footer-list-link']"
                     :data-trak='`{
                         "trakEvent": "click",

--- a/packages/f-footer/src/tenants/en-GB.js
+++ b/packages/f-footer/src/tenants/en-GB.js
@@ -184,6 +184,7 @@ export default {
                     url: 'https://www.justeatplc.com/download_file/view/435/1',
                     text: 'Modern Slavery Statement',
                     target: '_blank',
+                    rel: 'noopener',
                     gtm: 'click_about_modern_slavery_statement'
                 }
             ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1319,6 +1319,13 @@
   dependencies:
     qwery "4.0.0"
 
+"@justeat/f-form-field@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-0.3.0.tgz#5ef23b4a6a5bc2e18a5695dc521a92344d092a4c"
+  integrity sha512-JZIPcptn2q2eoTtmSnLDXt8Dtt2KbGTY8TGqihPkjbiSYDr8tug2G+0sRV4/fcAp9MFTf4VSjMC1HgukVkdSwg==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+
 "@justeat/f-icons@1.32.0":
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-1.32.0.tgz#d3f68ab1a59fd14069e184a6f6dff4a5d42c4e70"


### PR DESCRIPTION
---

Lighthouse audits mark us down for using external links, but not adding restrictions to the anchors. Described here - https://web.dev/external-anchors-use-rel-noopener/?utm_source=lighthouse&utm_medium=devtools

---

## UI Review Checks

![image](https://user-images.githubusercontent.com/1398088/83532542-4aa54580-a4e6-11ea-9583-67313cf21026.png)

- [x] README and/or UI Documentation has been [created|updated]

## Browsers Tested

- [x] Chrome (latest)
- [x] Opera (latest)
