### PR TITLE
fozzie-component@v1.15.0 – Turning off ESLint autofix of all components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.15.0
+------------------------------
+*June 4, 2020*
+
+### Changed
+- ESLint autofix turned off across all packages for default lint tasks so that tests don't pass due to `--fix` being applied (as they should fail when this happens to prompt engineers to autofix).
+
+
 v1.14.0
 ------------------------------
 *June 3, 2020*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.13.0",
+  "version": "1.15.0",
   "private": true,
   "scripts": {
     "build": "lerna run build --stream",

--- a/packages/f-card/CHANGELOG.md
+++ b/packages/f-card/CHANGELOG.md
@@ -11,7 +11,7 @@ Latest (roll into next release)
 ### Changed
 - Updating `vue-test-utils` to v1.
 - Structure of Storybook stories changed to CSF (Component Story Format) – the new recommended way to write stories.
-
+- ESLint autofix turned off (so that tests don't pass due to --fix being applied, but then publish subsequently fails)
 
 v0.2.0
 ------------------------------

--- a/packages/f-card/package.json
+++ b/packages/f-card/package.json
@@ -28,7 +28,7 @@
     "prepublishOnly": "yarn lint && yarn test && yarn build",
     "build": "vue-cli-service build --target lib --name f-card ./src/index.js",
     "demo": "vue serve --open ./src/demo/Index.vue",
-    "lint": "vue-cli-service lint",
+    "lint": "vue-cli-service lint --no-fix",
     "lint:fix": "yarn lint --fix",
     "test": "vue-cli-service test:unit"
   },

--- a/packages/f-card/stories/card.stories.js
+++ b/packages/f-card/stories/card.stories.js
@@ -4,7 +4,7 @@ import {
 import Card from '../src/components/Card.vue';
 
 export default {
-    title: 'Components',
+    title: 'Components/Atoms',
     decorators: [withKnobs]
 };
 

--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (roll into next release)
+------------------------------
+*June 4, 2020*
+
+### Changed
+- ESLint autofix turned off (so that tests don't pass due to `--fix` being applied, but then publish subsequently fails)
+- Jest config updated to hide style warnings (as we don't need them to be shown for the tests).
+
+
 v2.3.0
 ------------------------------
 *June 3, 2020*

--- a/packages/f-footer/jest.config.js
+++ b/packages/f-footer/jest.config.js
@@ -29,11 +29,7 @@ module.exports = {
 
     globals: {
         'vue-jest': {
-            resources: {
-                scss: [
-                    './src/assets/scss/common.scss'
-                ]
-            }
+            hideStyleWarn: true // We hide style warnings given the first time we run the tests it complains about some styles. The second time the tests are run, the warning disappears. https://github.com/vuejs/vue-jest/issues/178#issuecomment-529175129
         }
     }
 };

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -27,7 +27,7 @@
     "prepublishOnly": "yarn lint && yarn test && yarn build",
     "build": "vue-cli-service build --target lib --name f-footer ./src/index.js",
     "demo": "vue serve --open ./src/demo/Index.vue",
-    "lint": "vue-cli-service lint",
+    "lint": "vue-cli-service lint --no-fix",
     "lint:fix": "yarn lint --fix",
     "test": "vue-cli-service test:unit"
   },

--- a/packages/f-footer/stories/footer.stories.js
+++ b/packages/f-footer/stories/footer.stories.js
@@ -2,7 +2,7 @@ import { select, boolean } from '@storybook/addon-knobs';
 import VueFooter from '../src/components/Footer.vue';
 
 export default {
-    title: 'Shared'
+    title: 'Components/Organisms'
 };
 
 export const FooterComponent = () => ({

--- a/packages/f-form-field/CHANGELOG.md
+++ b/packages/f-form-field/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (roll into next release)
+------------------------------
+*June 4, 2020*
+
+### Changed
+- ESLint autofix turned off (so that tests don't pass due to `--fix` being applied, but then publish subsequently fails)
+
+
 v0.5.0
 ------------------------------
 *May 29, 2020*

--- a/packages/f-form-field/stories/FormField.stories.js
+++ b/packages/f-form-field/stories/FormField.stories.js
@@ -5,7 +5,7 @@ import FormField from '../src/components/FormField.vue';
 import { VALID_INPUT_TYPES, VALID_LABEL_STYLES } from '../src/constants';
 
 export default {
-    title: 'Components',
+    title: 'Components/Atoms',
     decorators: [withKnobs]
 };
 

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -9,6 +9,7 @@ Latest (roll into next release)
 *May 12, 2020*
 
 - Structure of Storybook stories changed to CSF (Component Story Format) – the new recommended way to write stories.
+- ESLint autofix turned off (so that tests don't pass due to `--fix` being applied, but then publish subsequently fails)
 
 
 v2.4.0

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "yarn && yarn lint && yarn test && yarn build",
     "build": "vue-cli-service build --target lib --name f-header ./src/index.js",
     "demo": "vue serve --open ./src/components/Demo.vue",
-    "lint": "vue-cli-service lint",
+    "lint": "vue-cli-service lint --no-fix",
     "lint:fix": "yarn lint --fix",
     "test": "vue-cli-service test:unit"
   },

--- a/packages/f-header/stories/header.stories.js
+++ b/packages/f-header/stories/header.stories.js
@@ -16,7 +16,7 @@ const userInfo = {
 };
 
 export default {
-    title: 'Shared',
+    title: 'Components/Organisms',
     decorators: [withKnobs]
 };
 

--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (roll into next release)
+------------------------------
+*June 4, 2020*
+
+### Changed
+- ESLint autofix turned off (so that tests don't pass due to `--fix` being applied, but then publish subsequently fails)
+
+
 2.5.0
 ------------------------------
 *May 27, 2020*

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "prepublishOnly": "yarn test",
     "build": "yarn lint:fix",
-    "lint": "vue-cli-service lint",
+    "lint": "vue-cli-service lint --no-fix",
     "lint:fix": "yarn lint --fix",
     "test": "vue-cli-service test:unit",
     "test:coverage": "vue-cli-service test:unit --coverage"

--- a/packages/f-services/CHANGELOG.md
+++ b/packages/f-services/CHANGELOG.md
@@ -10,6 +10,7 @@ Latest (roll into next release)
 
 ### Changed
 - `@vue/cli-plugin-unit-test` to v4.3.1.
+- ESLint autofix turned off (so that tests don't pass due to `--fix` being applied, but then publish subsequently fails)
 
 
 1.0.1

--- a/packages/f-services/package.json
+++ b/packages/f-services/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "prepublishOnly": "yarn lint && yarn test && yarn build",
     "build": "rollup --config",
-    "lint": "vue-cli-service lint",
+    "lint": "vue-cli-service lint --no-fix",
     "lint:fix": "yarn lint --fix",
     "test": "vue-cli-service test:unit"
   },

--- a/packages/f-user-message/CHANGELOG.md
+++ b/packages/f-user-message/CHANGELOG.md
@@ -10,6 +10,7 @@ Latest (roll into next release)
 
 ### Changed
 - Updating `vue-test-utils` to v1 and `@vue/cli-plugin-unit-test` to v4.3.1.
+- ESLint autofix turned off (so that tests don't pass due to `--fix` being applied, but then publish subsequently fails)
 
 ### Removed
 - `testMatch` from jest config, as not needed.

--- a/packages/f-user-message/package.json
+++ b/packages/f-user-message/package.json
@@ -28,7 +28,7 @@
     "prepublishOnly": "yarn lint && yarn test && yarn build",
     "build": "vue-cli-service build --target lib --name f-user-message ./src/index.js",
     "demo": "vue serve --open ./src/demo/index.vue",
-    "lint": "vue-cli-service lint",
+    "lint": "vue-cli-service lint --no-fix",
     "lint:fix": "yarn lint --fix",
     "test": "vue-cli-service test:unit"
   },

--- a/packages/f-vue-icons/CHANGELOG.md
+++ b/packages/f-vue-icons/CHANGELOG.md
@@ -3,12 +3,22 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (roll into next release)
+------------------------------
+*June 4, 2020*
+
+### Changed
+- ESLint autofix turned off (so that tests don't pass due to `--fix` being applied, but then publish subsequently fails)
+
+
 v0.20.1
 ------------------------------
 *June 3, 2020*
 
 ### Fixed
 - Add `.vue` extentions to imports for icons in v0.20.0
+
 
 v0.20.0
 ------------------------------
@@ -23,6 +33,7 @@ v0.20.0
 
 ### Removed
 - `testMatch` from jest config, as not needed.
+
 
 v0.19.0
 ------------------------------

--- a/packages/f-vue-icons/package.json
+++ b/packages/f-vue-icons/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "prepublishOnly": "yarn lint && yarn test && yarn build",
     "build": "vue-cli-service build --target lib --formats umd-min --name f-vue-icons ./src/index.js",
-    "lint": "vue-cli-service lint",
+    "lint": "vue-cli-service lint --no-fix",
     "lint:fix": "yarn lint --fix",
     "test": "vue-cli-service test:unit"
   },


### PR DESCRIPTION
### Changed
- ESLint autofix turned off across all packages for default lint tasks so that tests don't pass due to `--fix` being applied (as they should fail when this happens to prompt engineers to autofix).