### PR TITLE
f-header@v2.5.0 – Updating ML to new JET theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.15.0
 ------------------------------
+*June 8, 2020*
+
+### Changed
+- Updated `fozzie` and `fozzie-colour-palette` dependencies to pull in updated JET theme variables for ML.
+
+
+v1.15.0
+------------------------------
 *June 4, 2020*
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "scripts": {
     "build": "lerna run build --stream",
@@ -24,8 +24,8 @@
     "@justeat/eslint-config-fozzie": "3.4.1",
     "@justeat/f-build-config": "0.3.0",
     "@justeat/f-utils": "0.3.0",
-    "@justeat/fozzie": "3.0.0-beta.0",
-    "@justeat/fozzie-colour-palette": "3.0.0-beta.0",
+    "@justeat/fozzie": "3.0.0-beta.4",
+    "@justeat/fozzie-colour-palette": "3.0.0-beta.1",
     "@storybook/storybook-deployer": "2.8.5",
     "@vue/cli-plugin-babel": "4.2.3",
     "@vue/cli-plugin-eslint": "3.9.2",

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,10 +4,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (roll into next release)
+v2.5.0
 ------------------------------
-*May 12, 2020*
+*June 8, 2020*
 
+- New Menulog JET updates (logo and colours).
 - Structure of Storybook stories changed to CSF (Component Story Format) – the new recommended way to write stories.
 - ESLint autofix turned off (so that tests don't pass due to `--fix` being applied, but then publish subsequently fails)
 

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist",
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@justeat/f-services": "0.13.0",
-    "@justeat/f-vue-icons": "1.0.0-beta.5",
+    "@justeat/f-vue-icons": "1.0.0-beta.6",
     "axios": "0.19.0",
     "lodash-es": "4.17.15"
   },

--- a/packages/f-header/src/assets/scss/common.scss
+++ b/packages/f-header/src/assets/scss/common.scss
@@ -29,10 +29,23 @@ $header-buttonCount-bg              : $blue;
 $header-buttonCount-color           : $white;
 $header-buttonCount-borderColor     : $white;
 
-
 $header--transparent-gradient-color : $black;
 $header--transparent-gradient       : 115px;
 $header--transparent-opacity        : 0.7;
+
+// TODO: Temporary JET ML colours – can delete in phase 2 of JET branding
+$orange-largeText             : #f36d00;
+$orange-largeText--dark       : #e96800; // used for hover of base $orange-largeText
+$orange-largeText--darkest    : #cb5b00; // used for focus/active of base $orange-largeText
+$orange--offWhite             : #ffe6cc;
+$violet                       : #4950b9;
+$violet--dark                 : #464cb1; // used for hover of base $violet
+$violet--darkest              : #3d439b; // used for focus/active of base $violet
+$violet--offWhite             : #f1effb;
+$violet--offWhite--dark       : #e7e5f1; // used for hover of base $violet--offWhite
+$violet--offWhite--darkest    : #cac8d2; // used for hover of base $violet--offWhite
+// TODO: End of ML specific JET colours to be deleted
+
 
 /**
  * Global variables which need to be changed depending on the theme (TODO: move to separate component)

--- a/packages/f-header/src/components/Logo.vue
+++ b/packages/f-header/src/components/Logo.vue
@@ -76,7 +76,7 @@ export default {
 
 
         @include theme(ml) {
-            padding-top: 12px;
+            padding-top: 8px;
         }
 
         @include media('>=mid') {
@@ -85,7 +85,7 @@ export default {
             padding-top: 24px;
 
             @include theme(ml) {
-                padding-top: 10px;
+                padding-top: 16px;
             }
         }
     }
@@ -102,13 +102,13 @@ export default {
 
         // Menulog logo, as it has multiple fill values built in. We just hide the outline on transparent mode.
         @include theme(ml) {
-            width: 118px;
-            height: 40px;
+            width: 120px;
+            height: 32px;
             margin-left: -10.5px; //half of hamburger menu width
 
             @include media('>=mid') {
-                width: 180px;
-                height: 61px;
+                width: 149px;
+                height: 41px;
                 margin-left: 0;
             }
 

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -558,13 +558,13 @@ $nav-popover-padding               : spacing(x2);
 
 
 // Menulog theme overrides
-$nav-text-color--ml                : $green;
-$nav-text-color--hover--ml         : $green--dark;
-$nav-toggleIcon-color--ml          : $brand--green;
-$nav-icon-color--ml                : $brand--green;
+$nav-text-color--ml                : $violet;
+$nav-text-color--hover--ml         : $violet--dark;
+$nav-toggleIcon-color--ml          : $orange-largeText;
+$nav-icon-color--ml                : $orange-largeText;
 
-$nav-trigger-focus-color--ml       : $green;
-$nav-trigger-focus-bg--ml          : $green--offWhite;
+$nav-trigger-focus-color--ml       : $orange-largeText;
+$nav-trigger-focus-bg--ml          : $orange--offWhite;
 
 
 @mixin nav-container-visible () {

--- a/packages/f-header/src/components/SkipToMain.vue
+++ b/packages/f-header/src/components/SkipToMain.vue
@@ -53,7 +53,7 @@ export default {
             padding: 4px;
 
             @include theme(ml) {
-                color: $green;
+                color: $violet;
             }
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,6 +1327,14 @@
     "@justeat/f-utils" "0.3.0"
     include-media "1.4.9"
 
+"@justeat/f-icons@2.0.0-beta.11":
+  version "2.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-2.0.0-beta.11.tgz#c2653fb72147b96de8ba9eb13d95142716f568fb"
+  integrity sha512-PHOHGujgn0xaOmV3X3nt8BMkNHf6rMmz1AVlZd3ACGiLObXOcPWitiV8ehCXAwGV5EBI0HIGBlQtU10wwJuGLQ==
+  dependencies:
+    classnames "2.2.5"
+    core-js "3.1.3"
+
 "@justeat/f-icons@2.0.0-beta.6":
   version "2.0.0-beta.6"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-2.0.0-beta.6.tgz#e3a08a25621332305abe79867a8005695958bce2"
@@ -1404,20 +1412,28 @@
     "@justeat/f-icons" "2.0.0-beta.9"
     babel-helper-vue-jsx-merge-props "^2.0.3"
 
-"@justeat/fozzie-colour-palette@3.0.0-beta.0":
-  version "3.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.0.tgz#12c88c3c1e9d81544c05773bea6eb12c75ac2447"
-  integrity sha512-QnPiHnYmOpLN+gswv9hOezegrsRpzqroamrVeh5JjEJXFSsUwCb+LnkrpQjlqoCfKNw3gL9WTFldptd+Om8syg==
+"@justeat/f-vue-icons@1.0.0-beta.6":
+  version "1.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.0.0-beta.6.tgz#14ace81da24675f4d8f83799b608c9e471a7578b"
+  integrity sha512-F3Wur/iPug6g8gwdYWxvTUSlKtePs4hTvyX+ugnVZthGPVKZELYhuIyKz4IyEILdFIoUQnLE6ZcFy9687sf5qA==
+  dependencies:
+    "@justeat/f-icons" "2.0.0-beta.11"
+    babel-helper-vue-jsx-merge-props "2.0.3"
 
-"@justeat/fozzie@3.0.0-beta.0":
-  version "3.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-3.0.0-beta.0.tgz#bc21127077bfcb47f912fa826ca04451e6e38d88"
-  integrity sha512-C1VTPBTfz28oC5VS0MIZ5HNk+e2ndNPnd+0H8jrdWPuJLNlmboxGSHrYxa5oGK5wBJfsbAX5YVeb7Vi43InCwA==
+"@justeat/fozzie-colour-palette@3.0.0-beta.1":
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.1.tgz#c4f7594b338f8f73470875174872c92ccdfd8f21"
+  integrity sha512-QlxDWTBfjS1n2W5wycqRNLSR+sX54qupAjl1WiVl0lW3dbPQAHnmi8wxcyrbMOlYw8PqeOUZffuSmHLR4exwlw==
+
+"@justeat/fozzie@3.0.0-beta.4":
+  version "3.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-3.0.0-beta.4.tgz#242f30f63764157bfcb7eeff31c4916dbd844c18"
+  integrity sha512-1e/DtutYld1RE+AMUTUu7nvM0xnAqeTTviLVT75VnCiYu4v/DsVkOS5ZzIdlO2E6daoNUOwfatkys2MAXoFNMQ==
   dependencies:
     "@justeat/f-dom" "1.1.0"
     "@justeat/f-logger" "0.8.1"
     "@justeat/f-utils" "0.3.0"
-    "@justeat/fozzie-colour-palette" "3.0.0-beta.0"
+    "@justeat/fozzie-colour-palette" "3.0.0-beta.1"
     fontfaceobserver "2.1.0"
     include-media "1.4.9"
     kickoff-grid.css "1.2.0"
@@ -4505,7 +4521,7 @@ babel-helper-to-multiple-sequence-expressions@^0.5.0:
   resolved "https://registry.yarnpkg.com/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz#a3f924e3561882d42fcf48907aa98f7979a4588d"
   integrity sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA==
 
-babel-helper-vue-jsx-merge-props@^2.0.3:
+babel-helper-vue-jsx-merge-props@2.0.3, babel-helper-vue-jsx-merge-props@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-2.0.3.tgz#22aebd3b33902328e513293a8e4992b384f9f1b6"
   integrity sha512-gsLiKK7Qrb7zYJNgiXKpXblxbV5ffSwR0f5whkPAaBAR4fhi6bwRZxX9wBlIc5M/v8CCkXUbXZL4N/nSE97cqg==


### PR DESCRIPTION
## f-header@v2.5.0

- New Menulog JET updates (logo and colours).
- Structure of Storybook stories changed to CSF (Component Story Format) – the new recommended way to write stories.
- ESLint autofix turned off (so that tests don't pass due to `--fix` being applied, but then publish subsequently fails)

## fozzie-components@v1.16.0

### Changed
- Updated `fozzie` and `fozzie-colour-palette` dependencies to pull in updated JET theme variables for ML.

---

## UI Review Checks

### Wide screens

<img width="780" alt="Screen Shot 2020-06-08 at 17 28 36" src="https://user-images.githubusercontent.com/805184/84056022-8be99980-a9ad-11ea-9221-bf2c3824a673.png">

### Narrow screens

<img width="331" alt="Screen Shot 2020-06-08 at 17 28 46" src="https://user-images.githubusercontent.com/805184/84056026-8d1ac680-a9ad-11ea-8637-e25c1a6c9970.png">

---

- [x] README and/or UI Documentation has been updated
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Mobile (iPhone)
