### PR TITLE
f-header@v2.6.0 – Updated Menulog header colour on transparent background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v1.15.0
+v1.16.0
 ------------------------------
 *June 8, 2020*
 

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,10 +4,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.6.0
+------------------------------
+*June 9, 2020*
+
+### Changed
+- Updated Menulog header to switch to white logo when using transparent background header theme.
+
+
 v2.5.0
 ------------------------------
 *June 8, 2020*
 
+### Changed
 - New Menulog JET updates (logo and colours).
 - Structure of Storybook stories changed to CSF (Component Story Format) – the new recommended way to write stories.
 - ESLint autofix turned off (so that tests don't pass due to `--fix` being applied, but then publish subsequently fails)

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-header/src/components/Logo.vue
+++ b/packages/f-header/src/components/Logo.vue
@@ -59,7 +59,7 @@ export default {
             return `Go to ${this.companyName} homepage`;
         },
         logoColourModifier () {
-            return (this.headerBackgroundTheme === 'transparent' || this.headerBackgroundTheme === 'red') && this.theme === 'je' ? 'c-icon-je--alt' : '';
+            return (this.headerBackgroundTheme === 'transparent' || this.headerBackgroundTheme === 'red') ? 'c-icon--alt' : '';
         }
     }
 };
@@ -124,7 +124,7 @@ export default {
         fill: $header-logo-color;
     }
 
-    .c-icon-je--alt g {
+    .c-icon--alt g {
         fill: $header-logo-color--alt;
     }
 </style>

--- a/packages/f-header/src/components/tests/Logo.test.js
+++ b/packages/f-header/src/components/tests/Logo.test.js
@@ -44,7 +44,7 @@ describe('Logo', () => {
         expect(logo).toBeDefined();
     });
 
-    it('should have "c-icon-je--alt" class if "headerBackgroundTheme" property is "transparent"', () => {
+    it('should have "c-icon--alt" class if "headerBackgroundTheme" property is "transparent"', () => {
         // Arrange
         const propsData = {
             theme: 'je',
@@ -57,12 +57,10 @@ describe('Logo', () => {
         const logo = wrapper.find('[data-js-test="c-icon--je"]');
 
         // Assert
-        // dynamic classes returned as one string in the array
-        // so have to check for 'c-logo-img,c-icon--je,c-icon-je--alt' not just 'c-icon-je--alt'
-        expect(logo.classes('c-icon-je--alt')).toBe(true);
+        expect(logo.classes('c-icon--alt')).toBe(true);
     });
 
-    it('should have "c-icon-je--alt" class if "headerBackgroundTheme" property is "red"', () => {
+    it('should have "c-icon--alt" class if "headerBackgroundTheme" property is "red"', () => {
         // Arrange
         const propsData = {
             theme: 'je',
@@ -75,12 +73,10 @@ describe('Logo', () => {
         const logo = wrapper.find('[data-js-test="c-icon--je"]');
 
         // Assert
-        // dynamic classes returned as one string in the array
-        // so have to check for 'c-logo-img,c-icon--je,c-icon-je--alt' not just 'c-icon-je--alt'
-        expect(logo.classes('c-icon-je--alt')).toBe(true);
+        expect(logo.classes('c-icon--alt')).toBe(true);
     });
 
-    it('shouldn\'t have "c-icon-je--alt" class if if "headerBackgroundTheme" property is not "red", "transparent"', () => {
+    it('shouldn\'t have "c-icon--alt" class if if "headerBackgroundTheme" property is not "red", "transparent"', () => {
         // Arrange
         const propsData = {
             theme: 'je',
@@ -95,7 +91,7 @@ describe('Logo', () => {
         // Assert
         // with dynamically rendered components
         // dynamic classes returned as one string in the array
-        // so have to check for 'c-logo-img,c-icon--je,c-icon-je--alt' not just 'c-icon-je--alt'
-        expect(logo.classes()).not.toContain('c-logo-img,c-icon--je,c-icon-je--alt');
+        // so have to check for 'c-logo-img,c-icon--je,c-icon--alt' not just 'c-icon--alt'
+        expect(logo.classes()).not.toContain('c-logo-img,c-icon--je,c-icon--alt');
     });
 });

--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -3,12 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (rolled into next release)
+------------------------------
+*June 9, 2020*
+
+### Changed
+- Storybook category updated to `Organisms`.
+
+
 v0.6.0
 ------------------------------
 *June 2, 2020*
 
 ### Added
 - Create account API call when clicking create account button
+
 
 v0.5.0
 ------------------------------

--- a/packages/f-registration/stories/Registration.stories.js
+++ b/packages/f-registration/stories/Registration.stories.js
@@ -2,7 +2,7 @@ import { withKnobs, select, text } from '@storybook/addon-knobs';
 import Registration from '../src/components/Registration.vue';
 
 export default {
-    title: 'Components',
+    title: 'Components/Organisms',
     decorators: [withKnobs]
 };
 


### PR DESCRIPTION
### Changed
- Updated Menulog header to switch to white logo when using transparent background header theme.

---

<img width="1065" alt="Screen Shot 2020-06-09 at 16 58 04" src="https://user-images.githubusercontent.com/805184/84171351-a0dc3080-aa72-11ea-9881-091ceb2f20f5.png">
<img width="412" alt="Screen Shot 2020-06-09 at 16 59 35" src="https://user-images.githubusercontent.com/805184/84171355-a2a5f400-aa72-11ea-8b21-3a8a4ceb512b.png">


## UI Review Checks

- [x] README and/or UI Documentation has been updated
- [x] Unit tests have been updated
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)