### PR TITLE
fozzie-components@v1.17.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,18 +4,25 @@
 #
 version: 2.1
 
-commands: 
-  set_deploy_key: 
+commands:
+  set_deploy_key:
     description: Sets the ssh key for project access
-    steps: 
-      - add_ssh_keys: 
-          fingerprints: 
+    steps:
+      - add_ssh_keys:
+          fingerprints:
             - "8b:4c:f2:d1:a1:1e:d6:f9:1e:e9:e0:40:a0:31:32:af"
 
   install_node_dependencies:
     description: Installs the node dependencies
     steps:
       - run: yarn install --frozen-lockfile
+
+  build_packages:
+    description: Locally builds all packages in the monorepo
+    steps:
+      - run: # Check UI packages all build as expected
+          name: Build Packages
+          command: yarn build
 
 executors:
   node:
@@ -29,6 +36,9 @@ jobs:
 
   build:
     executor: node
+    environment:
+      # required to prevent ENOMEM errors
+      LERNA_ARGS: --concurrency 1
     steps: # a collection of executable commands
       - checkout # special step to check out source code to working directory
       - restore_cache:
@@ -36,17 +46,15 @@ jobs:
           keys:
               - yarn-packages-{{ checksum "yarn.lock" }}
       - install_node_dependencies
-      - save_cache: 
+      - save_cache:
           name: Save Yarn Package Cache
           key: yarn-packages-{{ checksum "yarn.lock" }}
-          paths: 
+          paths:
             - ~/.cache/yarn
       - run: # Run PR Checks
           name: Run PR Checks
           command: yarn danger ci
-      - run: # Check UI packages all build as expected
-          name: Build Packages
-          command: yarn build
+      - build_packages
       - run: # Lint packages
           name: Run Lint Tasks on Packages
           command: yarn lint
@@ -56,10 +64,18 @@ jobs:
 
   deploy-storybook:
     executor: node
+    environment:
+      # required to prevent ENOMEM errors
+      LERNA_ARGS: --concurrency 1
     steps:
       - set_deploy_key
       - checkout
+      - restore_cache:
+      name: Restore Yarn Package Cache
+      keys:
+        - yarn-packages-{{ checksum "yarn.lock" }}
       - install_node_dependencies
+      - build_packages
       - run:
           name: Deploy
           command: yarn storybook:deploy --packages packages
@@ -72,11 +88,11 @@ workflows:
       - build:
           filters:
             branches:
-              ignore: 'gh-pages' 
+              ignore: 'gh-pages'
 
-  deploy-storybook: 
+  deploy-storybook:
     jobs:
       - deploy-storybook:
-          filters: 
-            branches: 
+          filters:
+            branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,9 +71,9 @@ jobs:
       - set_deploy_key
       - checkout
       - restore_cache:
-      name: Restore Yarn Package Cache
-      keys:
-        - yarn-packages-{{ checksum "yarn.lock" }}
+          name: Restore Yarn Package Cache
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
       - install_node_dependencies
       - build_packages
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.17.0
+------------------------------
+*June 24, 2020*
+
+### Changed
+- CircleCI params to restrict build concurrency to 1 to solve memory issues
+- StoryBook CircleCI build to build packages first to ensure dependencies are available
+
+
 v1.16.0
 ------------------------------
 *June 8, 2020*

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
   "version": "1.16.0",
   "private": true,
   "scripts": {
-    "build": "lerna run build --stream",
-    "lint": "lerna run lint --stream",
+    "build": "lerna run $LERNA_ARGS build --stream",
+    "lint": "lerna run $LERNA_ARGS lint --stream",
     "lint:fix": "lerna run lint -- --fix",
     "prepublishOnly": "lerna run prepublishOnly --stream",
     "release": "lerna publish",
     "storybook:build": "lerna run storybook:build",
     "storybook:serve": "lerna run storybook:serve",
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
-    "test": "lerna run test --stream"
+    "test": "lerna run $LERNA_ARGS test --stream"
   },
   "dependencies": {
     "core-js": "^3.6.4"


### PR DESCRIPTION
Noticed [ENOMEM issues](https://app.circleci.com/pipelines/github/justeat/fozzie-components/594/workflows/027184a8-fcf2-4ae3-8faf-2f7ab5add25d/jobs/635/steps) when running circleCI builds that seems to be caused by the sheer amount of packages running in parallel. This PR reduces this to 1 at a time when running on circleci.

In addition, the storybok-deploy job [appeared to be failing](https://app.circleci.com/pipelines/github/justeat/fozzie-components/595/workflows/dbc79b77-8e97-4896-8c59-d676e8ed6246/jobs/634) because of an internal dependency that was not satisfied due to the package not having been built in that context - that step is factored out from the build job and added as a step for that job here.
