### PR TITLE
f-content-cards@0.7.0: Temporarily remove `vue-lazyload` lib

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.6.0
+v0.7.0
 ------------------------------
 *June 25th, 2020*
 

--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -8,6 +8,13 @@ v0.6.0
 ------------------------------
 *June 24th, 2020*
 
+### Removed
+- `vue-lazyload` while intermittent issues loading images are investigated and rectified.
+
+v0.6.0
+------------------------------
+*June 24th, 2020*
+
 ### Added
 - `@justeat/f-metadata` as a dependency
 

--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.6.0
 ------------------------------
-*June 24th, 2020*
+*June 25th, 2020*
+
+### Changed
+- `@justeat/f-metadata` from a dependency to a devDependency
 
 ### Removed
 - `vue-lazyload` while intermittent issues loading images are investigated and rectified.

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"
@@ -39,7 +39,6 @@
     "@justeat/f-services": "1.0.0",
     "@justeat/f-metadata": "2.7.0",
     "core-js": "3.6.5",
-    "vue-lazyload": "1.3.3",
     "lodash.findindex": "4.6.0",
     "lodash.orderby": "4.6.0"
   },

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -37,7 +37,6 @@
   ],
   "dependencies": {
     "@justeat/f-services": "1.0.0",
-    "@justeat/f-metadata": "2.7.0",
     "core-js": "3.6.5",
     "lodash.findindex": "4.6.0",
     "lodash.orderby": "4.6.0"
@@ -46,6 +45,7 @@
     "@justeat/browserslist-config-fozzie": ">=1.1.1"
   },
   "devDependencies": {
+    "@justeat/f-metadata": "2.7.0",
     "@vue/cli-plugin-babel": "4.2.3",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.3.1",

--- a/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -6,12 +6,12 @@
         data-test-id="contentCard-link"
     >
         <div
-            v-lazy:background-image="image"
+            :style="{ backgroundImage: `url('${image}')` }"
             :class="[{ 'c-contentCard-bgImg': !!image }]" />
         <div class="c-contentCard-info">
             <img
                 v-if="icon"
-                v-lazy="icon"
+                :src="icon"
                 class="c-contentCard-thumbnail">
             <h3 class="c-contentCard-title">
                 {{ title }}

--- a/packages/f-content-cards/src/components/cardTemplates/_tests/CardContainer.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/_tests/CardContainer.test.js
@@ -1,10 +1,7 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils';
-import VueLazyload from 'vue-lazyload';
 import CardContainer from '../CardContainer.vue';
 
 const localVue = createLocalVue();
-
-localVue.use(VueLazyload);
 
 const url = '__URL__';
 const button = '__BUTTON__';

--- a/packages/f-content-cards/src/index.js
+++ b/packages/f-content-cards/src/index.js
@@ -5,7 +5,6 @@
  */
 
 import globalThis from 'core-js/features/global-this';
-import VueLazyload from 'vue-lazyload';
 // Import vue component
 import ContentCards from '@/components/ContentCards.vue';
 
@@ -26,7 +25,6 @@ const GlobalVue = globalThis?.Vue;
 
 if (GlobalVue?.use) {
     GlobalVue.use(plugin);
-    GlobalVue.use(VueLazyload, { observer: true });
 }
 
 // To allow use as module (npm/webpack/etc.) export component


### PR DESCRIPTION
The `vue-lazyload` library is currently causing issues whereby images are intermittently failing. Investigation and mitigation is ongoing but this PR is to remove the lib until we've found a fix or other solution.

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Internet Explorer 11
- [x] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [x] Firefox (latest)
- [x] Opera (latest)
