### PR TITLE
f-metadata@2.8.0

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v2.8.0
 ------------------------------
-*June 24, 2020*
+*June 26, 2020*
 
 ### Added
 - Methods for logging card click and view events, with the view to presenting a consistent

--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.8.0
+------------------------------
+*June 24, 2020*
+
+### Added
+- Methods for logging card click and view events, with the view to presenting a consistent
+  interface for sending information back to braze:
+  - `logCardClick()`
+  - `logCardImpressions()`
+
+
 v2.7.0
 ------------------------------
 *June 24, 2020*

--- a/packages/f-metadata/README.md
+++ b/packages/f-metadata/README.md
@@ -41,12 +41,14 @@ const initialiseBraze = require('@justeat/f-metadata');
 
 ### Initialisation
 
-The package comes with one method for initialising Braze. All other functionality, such as handling content cards or intercepting in-app messages is done with callbacks passed through config.
+The package comes with one method for initialising Braze. A couple of other methods are provided for logging click and view events of cards back to braze.
+
+All other functionality, such as handling content cards or intercepting in-app messages is done with callbacks passed through config.
 
 **Basic Example**
 
 ```js
-import initialiseBraze from '@justeat/f-metadata'
+import initialiseBraze, { logCardClick, logCardImpressions } from '@justeat/f-metadata'
 
 const config = {
   apiKey = '1234-1234-1234',
@@ -59,7 +61,27 @@ const config = {
   }
 };
 
-initialiseBraze(config);
+const brazePromise = initialiseBraze(config);
+
+// The below assumes card data is being rendered into elements with class "brazeCard", that they
+// have card data as returned by braze attached to a "data-content-card" attribute, and that all
+// elements accessible via that css selector are visible
+
+brazePromise.then(() => {
+  const brazeCards = document.querySelectorAll('.brazeCard');
+
+  let brazeCardsData = [];
+
+  brazeCards.forEach(brazeCard => {
+    brazeCardsData.push(brazeCard.dataset.contentCard);
+
+    brazeCard.addEventListener('click', clickEvent => {
+      logCardClick(brazeCard.dataset.contentCard);
+    });
+  });
+
+  logCardImpressions(brazeCardsData);
+});
 ```
 
 ### Config Object

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "main": "src/index.js",
   "files": [
     "src"

--- a/packages/f-metadata/src/_tests/index.node.test.js
+++ b/packages/f-metadata/src/_tests/index.node.test.js
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 import appboy from 'appboy-web-sdk';
-import initialiseBraze from '../index';
+import { initialise } from '../index';
 
 jest.mock('appboy-web-sdk', () => ({
     initialize: jest.fn()
@@ -17,7 +17,7 @@ describe('f-metadata › node', () => {
         // Arrange & Act
         expect.assertions(2);
         try {
-            await initialiseBraze();
+            await initialise();
         } catch (error) {
             // Assert
             expect(appboy.initialize).not.toHaveBeenCalled();

--- a/packages/f-metadata/src/_tests/index.test.js
+++ b/packages/f-metadata/src/_tests/index.test.js
@@ -1,5 +1,4 @@
 import appboySDK from 'appboy-web-sdk';
-import initialiseBraze, { sessionTimeoutInSeconds } from '../index';
 import configureBraze from '../configureBraze';
 import isAppboyInitialised from '../utils/isAppboyInitialised';
 
@@ -16,7 +15,10 @@ jest.mock('appboy-web-sdk', () => ({
     changeUser: jest.fn(),
     ab: {
         InAppMessage: Object
-    }
+    },
+    logCardClick: jest.fn(),
+    logCardImpressions: jest.fn(),
+    requestImmediateDataFlush: jest.fn()
 }));
 
 const apiKey = '__API_KEY__';
@@ -31,9 +33,16 @@ const settings = {
     disableComponent
 };
 
+let initialiseBraze,
+    sessionTimeoutInSeconds;
+
 describe('f-metadata', () => {
     beforeEach(() => {
         jest.resetAllMocks();
+        jest.isolateModules(() => {
+            // eslint-disable-next-line global-require
+            ({ initialise: initialiseBraze, sessionTimeoutInSeconds } = require('../index'));
+        });
     });
 
     it('should resolve as null if disableComponent is provided', async () => {
@@ -96,5 +105,104 @@ describe('f-metadata', () => {
 
         // Assert
         expect(push).toHaveBeenCalledWith({ event: 'appboyReady' });
+    });
+
+    it('should reject with an error when the configuration fails', async () => {
+        // Arrange
+        configureBraze.mockImplementation(() => { throw new Error('foo'); });
+
+        // Act
+        const appBoy = initialiseBraze(settings);
+
+        // Assert
+        await expect(appBoy).rejects.toThrow('An error occurred while loading the component: Error: foo');
+    });
+
+    describe('when called twice', () => {
+        it('should return different promises that resolve to the same value', async () => {
+            // Arrange
+            const appBoy1 = initialiseBraze(settings);
+
+            // Act
+            const appBoy2 = initialiseBraze(settings);
+
+            // Assert
+            expect(appBoy1).not.toBe(appBoy2);
+            await expect(appBoy1).resolves.toBe(await appBoy2);
+        });
+
+        it('should call configureBraze each time it is called', async () => {
+            // Arrange
+            await initialiseBraze(settings);
+
+            // Act
+            await initialiseBraze(settings);
+
+            // Assert
+            expect(configureBraze).toHaveBeenCalledTimes(2);
+        });
+    });
+});
+
+describe('when f-metadata is initialized', () => {
+    let logCardClick,
+        logCardImpressions;
+
+    beforeAll(async () => {
+        // Arrange
+        jest.isolateModules(() => {
+            // eslint-disable-next-line global-require
+            ({ initialise: initialiseBraze, logCardClick, logCardImpressions } = require('../index'));
+        });
+
+        await initialiseBraze(settings);
+    });
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    describe('logCardClick', () => {
+        it('should call logCardClick within appboy SDK and flush', async () => {
+            // Act
+            await logCardClick();
+
+            // Assert
+            expect(appboySDK.logCardClick).toHaveBeenCalled();
+            expect(appboySDK.requestImmediateDataFlush).toHaveBeenCalled();
+        });
+
+        it('should pass through the first parameter verbatim to logCardClick', async () => {
+            // Arrange
+            const param = { foo: 'bar' };
+
+            // Act
+            await logCardClick(param);
+
+            // Assert
+            expect(appboySDK.logCardClick).toHaveBeenCalledWith(param, true);
+        });
+    });
+
+    describe('logCardImpressions', () => {
+        it('should call logCardImpressions within appboy SDK and flush', async () => {
+            // Act
+            await logCardImpressions();
+
+            // Assert
+            expect(appboySDK.logCardImpressions).toHaveBeenCalled();
+            expect(appboySDK.requestImmediateDataFlush).toHaveBeenCalled();
+        });
+
+        it('should pass through the first parameter verbatim to logCardImpressions', async () => {
+            // Arrange
+            const param = { foo: 'bar' };
+
+            // Act
+            await logCardImpressions(param);
+
+            // Assert
+            expect(appboySDK.logCardImpressions).toHaveBeenCalledWith(param, true);
+        });
     });
 });

--- a/packages/f-metadata/src/configureBraze.js
+++ b/packages/f-metadata/src/configureBraze.js
@@ -11,6 +11,7 @@ const configureBraze = (options = {}) => {
         handleContentCards = noop
     } = callbacks;
 
+    // Note that the below subscriptions return an ID that could later be used to unsubscribe
     appboy.subscribeToInAppMessage(message => {
         if (message instanceof appboy.ab.InAppMessage) {
             /**

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -30,6 +30,9 @@ export const initialise = async (options = {}) => {
 
     window.dataLayer = window.dataLayer || [];
 
+    // Note that appBoyPromise will not be set if this is the first time running this method -
+    // this is a guard against initialise() being called more than once, and attempting to
+    // reboot the entire appboy sdk.
     if (appBoyPromise) {
         await appBoyPromise;
         configureBraze(options);
@@ -85,13 +88,13 @@ const logEvent = async (type, payload) => {
 };
 
 /**
- * @param {Object} card Content card for which to log a click event
+ * @param {Object} card - Content card for which to log a click event
  * @returns {Promise<boolean|*>}
  */
 export const logCardClick = card => logEvent('logCardClick', card);
 
 /**
- * @param {Object[]} cards List of content cards for which to log view impressions
+ * @param {Object[]} cards - List of content cards for which to log view impressions
  * @returns {Promise<boolean|*>}
  */
 export const logCardImpressions = cards => logEvent('logCardImpressions', cards);

--- a/packages/f-metadata/src/index.js
+++ b/packages/f-metadata/src/index.js
@@ -2,7 +2,6 @@ import configureBraze from './configureBraze';
 import noop from './utils/noop';
 import isAppboyInitialised from './utils/isAppboyInitialised';
 
-
 /**
  * sessionTimeoutInSeconds
  * Set session timeout to 0 in order to avoid caching issues with Braze
@@ -10,7 +9,14 @@ import isAppboyInitialised from './utils/isAppboyInitialised';
  */
 export const sessionTimeoutInSeconds = 0;
 
-const initialise = async (options = {}) => {
+/**
+ * appBoyPromise
+ * Promise that resolves to appboy when it has been set, for use by dependent utility functions
+ * @type {Promise<Object>|null}
+ */
+let appBoyPromise;
+
+export const initialise = async (options = {}) => {
     if (typeof window === 'undefined') throw new Error('window is not defined');
 
     const {
@@ -24,15 +30,23 @@ const initialise = async (options = {}) => {
 
     window.dataLayer = window.dataLayer || [];
 
+    if (appBoyPromise) {
+        await appBoyPromise;
+        configureBraze(options);
+        return appBoyPromise;
+    }
+
     const isInitialised = await isAppboyInitialised(window.appboy);
 
     if (isInitialised) {
         configureBraze(options);
+        appBoyPromise = Promise.resolve(window.appboy);
         return window.appboy;
     }
 
     if (disableComponent || !apiKey || !userId) {
         handleContentCards(null);
+        appBoyPromise = Promise.resolve();
         return null;
     }
 
@@ -45,6 +59,7 @@ const initialise = async (options = {}) => {
         window.appboy = appboy;
 
         configureBraze(options);
+        appBoyPromise = Promise.resolve(window.appboy);
 
         appboy.changeUser(userId, () => {
             window.dataLayer.push({
@@ -57,5 +72,28 @@ const initialise = async (options = {}) => {
         throw new Error(`An error occurred while loading the component: ${error}`);
     }
 };
+
+const logEvent = async (type, payload) => {
+    if (!appBoyPromise) return false;
+
+    const appboy = await appBoyPromise;
+
+    const output = appboy[type](payload, true);
+    appboy.requestImmediateDataFlush();
+
+    return output;
+};
+
+/**
+ * @param {Object} card Content card for which to log a click event
+ * @returns {Promise<boolean|*>}
+ */
+export const logCardClick = card => logEvent('logCardClick', card);
+
+/**
+ * @param {Object[]} cards List of content cards for which to log view impressions
+ * @returns {Promise<boolean|*>}
+ */
+export const logCardImpressions = cards => logEvent('logCardImpressions', cards);
 
 export default initialise;


### PR DESCRIPTION
### Added

- Methods for logging card click and view events, with the view to presenting a consistent
  interface for sending information back to braze:
  - `logCardClick()`
  - `logCardImpressions()`