### PR TITLE
f-content-cards@0.8.0: Fix mobile styling defects

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -15,6 +15,7 @@ v0.8.0
 ### Changed
 - Mobile styling to fix defects with margins on both the title and content card
 
+
 v0.7.0
 ------------------------------
 *June 25th, 2020*
@@ -25,12 +26,14 @@ v0.7.0
 ### Removed
 - `vue-lazyload` while intermittent issues loading images are investigated and rectified.
 
+
 v0.6.0
 ------------------------------
 *June 24th, 2020*
 
 ### Added
 - `@justeat/f-metadata` as a dependency
+
 
 v0.5.0
 ------------------------------
@@ -40,6 +43,7 @@ v0.5.0
 - Add responsive styling to `Post_Order_Card_1` template
 - Expose prop for filtering content cards
 
+
 v0.4.0
 ------------------------------
 *June 16th, 2020*
@@ -47,12 +51,14 @@ v0.4.0
 ### Added
 - Add styling to `Post_Order_Card_1` template
 
+
 v0.3.0
 ------------------------------
 *June 16th, 2020*
 
 ### Added
 - Post Order Content Card
+
 
 v0.2.0
 ------------------------------
@@ -63,6 +69,7 @@ v0.2.0
 - Unit Tests
 - Content card service
 - Storybook entry
+
 
 v0.1.0
 ------------------------------

--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.8.0
+------------------------------
+*June 25th, 2020*
+
+### Added
+
+- `@justeat/f-metadata` to `transformIgnorePatterns` in jest config to avoid failures.
+
+### Changed
+- Mobile styling to fix defects with margins on both the title and content card
+
 v0.7.0
 ------------------------------
 *June 25th, 2020*

--- a/packages/f-content-cards/jest.config.js
+++ b/packages/f-content-cards/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
     },
 
     transformIgnorePatterns: [
-        'node_modules/(?!(lodash-es)/)'
+        'node_modules/(?!(lodash-es|@justeat/f-metadata)/)'
     ],
 
     moduleNameMapper: {

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -413,6 +413,10 @@ export default {
             @include font-size(large);
 
             margin-bottom: spacing(x2);
+
+            @include media ('<mid') {
+                margin: spacing(x2);
+            }
         }
 
         .c-contentCard-thumbnail {
@@ -481,10 +485,6 @@ export default {
                 top: spacing(x2);
                 left: spacing(x2);
             }
-        }
-
-        .c-postOrderCard-title {
-            margin: spacing(x2);
         }
 
         .c-contentCard-info {

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -483,12 +483,16 @@ export default {
             }
         }
 
+        .c-postOrderCard-title {
+            margin: spacing(x2);
+        }
+
         .c-contentCard-info {
             padding: 0 0 0 spacing(x9);
 
             @include media('<mid') {
                 position: relative;
-                padding: spacing(x3) spacing(x3) spacing(x3) spacing(x9);
+                padding: spacing(x2) spacing(x2) spacing(x2) spacing(x9);
                 border-radius: $contentCardRadius;
             }
         }

--- a/packages/f-content-cards/stories/PostOrderCard.stories.js
+++ b/packages/f-content-cards/stories/PostOrderCard.stories.js
@@ -19,7 +19,7 @@ export const ContentCardscomponent = () => ({
             default: text('Card Description', 'Whether you want to treat Mum to her Friday night favourite, or surprise your mate with a ‘KFC on me’, show them you care – the tasty way.')
         },
         image: {
-            default: text('Card Image', '')
+            default: text('Card Image', 'https://appboy-images.com/appboy/communication/marketing/content_cards_message_variations/images/5edf97b6141af454f8197e93/f43c54c99f2deca37600fa16331d7080c51717ef/original.png?1591711674')
         },
         icon: {
             default: text('Card Icon', 'https://appboy-images.com/appboy/communication/assets/image_assets/images/5ed7aac3967e180c25132d24/original.png?1591192259')

--- a/packages/f-content-cards/stories/PostOrderCard.stories.js
+++ b/packages/f-content-cards/stories/PostOrderCard.stories.js
@@ -19,7 +19,7 @@ export const ContentCardscomponent = () => ({
             default: text('Card Description', 'Whether you want to treat Mum to her Friday night favourite, or surprise your mate with a ‘KFC on me’, show them you care – the tasty way.')
         },
         image: {
-            default: text('Card Image', 'https://appboy-images.com/appboy/communication/marketing/content_cards_message_variations/images/5edf97b6141af454f8197e93/f43c54c99f2deca37600fa16331d7080c51717ef/original.png?1591711674')
+            default: text('Card Image', '')
         },
         icon: {
             default: text('Card Icon', 'https://appboy-images.com/appboy/communication/assets/image_assets/images/5ed7aac3967e180c25132d24/original.png?1591192259')


### PR DESCRIPTION
Fixes margins on both the title and the content card on mobile view and updates jest config to ignore `@justeat/f-metadata`

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Internet Explorer 11
- [x] Mobile (iPhone XS - iOS 13.3)
