### PR TITLE
f-content-cards@0.8.1 

### DIFF
--- a/packages/f-content-cards/.eslintrc.js
+++ b/packages/f-content-cards/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    rules: {
+        'import/no-extraneous-dependencies': ["error", {
+            "devDependencies": true
+        }]
+    }
+};

--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,9 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (roll into next release)
+v0.8.1
 ------------------------------
-*June 25, 2020*
+*June 26th, 2020*
+
+### Added
+- `.eslintrc.js` to allow `@justeat/f-metadata` to be updated without breaking the build
 
 ### Changed
 - Updating colour variables to use new versions set in `fozzie-colour-palette`.

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"


### PR DESCRIPTION
🩹 Adds .eslintrc.js with devDependencies exception

### Added

- `.eslintrc.js` to allow `@justeat/f-metadata` to be updated without breaking the build