### PR TITLE
f-metadata@2.8.1 - Fix Braze error

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -3,12 +3,22 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v2.7.1
+------------------------------
+*June 29, 2020*
+
+### Fixed
+- Only subscribe to button click event when the button exists.
+
+
 v2.7.0
 ------------------------------
 *June 24, 2020*
 
 ### Changed
 - Promises to async/await
+
 
 v2.6.0
 ------------------------------

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "src/index.js",
   "files": [
     "src"

--- a/packages/f-metadata/src/_tests/configureBraze.test.js
+++ b/packages/f-metadata/src/_tests/configureBraze.test.js
@@ -120,7 +120,7 @@ describe('f-metadata', () => {
                     }
                 ]
             };
-            const { buttons: { 0: otherButton } } = messageWithSingleButton;
+            const { buttons: { 0: singleButton } } = messageWithSingleButton;
 
             // Act
             await configureBraze(settings);
@@ -129,7 +129,7 @@ describe('f-metadata', () => {
             inAppMessageCallback(messageWithSingleButton);
 
             // Assert
-            expect(otherButton.subscribeToClickedEvent).not.toHaveBeenCalled();
+            expect(singleButton.subscribeToClickedEvent).not.toHaveBeenCalled();
         });
 
         it('should pass other messages straight to handleInAppMessage without adding click handlers', async () => {

--- a/packages/f-metadata/src/_tests/configureBraze.test.js
+++ b/packages/f-metadata/src/_tests/configureBraze.test.js
@@ -111,6 +111,27 @@ describe('f-metadata', () => {
             expect(successButton.subscribeToClickedEvent).toHaveBeenCalled();
         });
 
+        it('should not assign `subscribeToClickedEvent` if there are fewer than two buttons', async () => {
+            // Arrange
+            const messageWithSingleButton = {
+                buttons: [
+                    {
+                        subscribeToClickedEvent: jest.fn()
+                    }
+                ]
+            };
+            const { buttons: { 0: otherButton } } = messageWithSingleButton;
+
+            // Act
+            await configureBraze(settings);
+
+            const [[inAppMessageCallback]] = subscribeToInAppMessage.mock.calls;
+            inAppMessageCallback(messageWithSingleButton);
+
+            // Assert
+            expect(otherButton.subscribeToClickedEvent).not.toHaveBeenCalled();
+        });
+
         it('should pass other messages straight to handleInAppMessage without adding click handlers', async () => {
             // Arrange
             const message = '__MESSAGE__';

--- a/packages/f-metadata/src/configureBraze.js
+++ b/packages/f-metadata/src/configureBraze.js
@@ -18,10 +18,13 @@ const configureBraze = (options = {}) => {
              * as this is always "success" as opposed to "dismiss"
              * as confirmed with CRM (AS)
              */
-            const { buttons: { 1: button } } = message;
             interceptInAppMessages(message);
-            button.subscribeToClickedEvent(() => interceptInAppMessageClickEvents(message));
+            if (message.buttons && message.buttons.length >= 2) {
+                const button = message.buttons[1]; // eslint-disable-line prefer-destructuring
+                button.subscribeToClickedEvent(() => interceptInAppMessageClickEvents(message));
+            }
         }
+
         appboy.display.showInAppMessage(message);
     });
     appboy.subscribeToContentCardsUpdates(handleContentCards);


### PR DESCRIPTION
### Fixed
- Only subscribe to button click event when the button exists.

## Browsers Tested
- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)