### PR TITLE
f-content-cards@0.8.2: Add fallback to imageUrl for conditional class

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.8.2
+------------------------------
+*June 30th, 2020*
+
+### Changed
+- Conditional logic for `c-postOrderCard--condensed` to match card container.
+
+
 v0.8.1
 ------------------------------
 *June 26th, 2020*

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
@@ -3,6 +3,7 @@
         <h2
             v-if="title"
             class="c-postOrderCard-title"
+            data-test-id="contentCard-postOrderCard-title"
         >
             {{ title }}
         </h2>
@@ -47,6 +48,7 @@ export default {
     data () {
         const {
             extras = {},
+            imageUrl,
             linkText
         } = this.card;
         const {
@@ -55,10 +57,11 @@ export default {
             image_1: image,
             icon_1: icon
         } = extras;
+
         return {
             ctaText: button || linkText,
             icon,
-            image,
+            image: image || imageUrl,
             type
         };
     }

--- a/packages/f-content-cards/src/components/cardTemplates/_tests/PostOrderCard.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/_tests/PostOrderCard.test.js
@@ -1,6 +1,9 @@
 import { shallowMount } from '@vue/test-utils';
 import PostOrderCard from '../PostOrderCard.vue';
 
+const imageUrl = '__IMAGE_URL__';
+const image = '__IMAGE_1__';
+const icon = '__ICON_1__';
 const button = '__BUTTON__';
 const linkText = '__LINK_TEXT__';
 const customCardType = 'Post_Order_Card_1';
@@ -8,6 +11,7 @@ const customCardType = 'Post_Order_Card_1';
 const card = {
     linkText,
     extras: {
+        icon_1: icon, // eslint-disable-line camelcase
         button_1: button, // eslint-disable-line camelcase
         custom_card_type: customCardType // eslint-disable-line camelcase
     }
@@ -48,6 +52,61 @@ describe('contentCards › PostOrderCard', () => {
         const wrapper = shallowMount(PostOrderCard);
 
         // Assert
-        expect(wrapper.find('h2').exists()).toBe(false);
+        expect(wrapper.find('[data-test-id="contentCard-postOrderCard-title"]').exists()).toBe(false);
+    });
+
+    describe('condensed', () => {
+        it('should apply the condensed class when no background image is available', () => {
+            // Arrange & Act
+            const wrapper = shallowMount(PostOrderCard, {
+                propsData: {
+                    card: {
+                        extras: {
+                            icon_1: icon, // eslint-disable-line camelcase
+                            custom_card_type: customCardType // eslint-disable-line camelcase
+                        }
+                    }
+                }
+            });
+
+            // Assert
+            expect(wrapper.find('.c-postOrderCard--condensed').exists()).toBe(true);
+        });
+
+        it('should NOT apply the condensed class when imageUrl is provided', () => {
+            // Arrange & Act
+            const wrapper = shallowMount(PostOrderCard, {
+                propsData: {
+                    card: {
+                        imageUrl,
+                        extras: {
+                            icon_1: icon, // eslint-disable-line camelcase
+                            custom_card_type: customCardType // eslint-disable-line camelcase
+                        }
+                    }
+                }
+            });
+
+            // Assert
+            expect(wrapper.find('.c-postOrderCard--condensed').exists()).toBe(false);
+        });
+
+        it('should NOT apply the condensed class when extras.image_1 is provided', () => {
+            // Arrange & Act
+            const wrapper = shallowMount(PostOrderCard, {
+                propsData: {
+                    card: {
+                        extras: {
+                            icon_1: icon, // eslint-disable-line camelcase
+                            image_1: image, // eslint-disable-line camelcase
+                            custom_card_type: customCardType // eslint-disable-line camelcase
+                        }
+                    }
+                }
+            });
+
+            // Assert
+            expect(wrapper.find('.c-postOrderCard--condensed').exists()).toBe(false);
+        });
     });
 });


### PR DESCRIPTION
Fixes defect where background image was not displayed if set as `imageUrl` as opposed to `extras.image_1`. Updates fallback to `imageUrl` in the condition for the class `c-postOrderCard--condensed`.

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- **N/A** This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)
