### PR TITLE
f-content-cards@0.10.0

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.10.0
+------------------------------
+*July 7th, 2020*
+
+### Added
+- ContentCards component accepts `pushToDataLayer` callback as a prop for feeding back
+  analytics regarding content cards
+- ContentCards component accepts `testId` parameter as a prop, which indicates the test
+  id attribute of the component root element. If this is missing, all child components
+  will also be rendered without test id attributes.
+
+### Changed
+- Updated @justeat/f-metadata version
+
+
 v0.9.0
 ------------------------------
 *July 2nd, 2020*

--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -17,6 +17,7 @@ v0.10.0
 
 ### Changed
 - Updated @justeat/f-metadata version
+- Updated README
 
 
 v0.9.0

--- a/packages/f-content-cards/README.md
+++ b/packages/f-content-cards/README.md
@@ -153,6 +153,25 @@ An array of custom content card types to display.
 
 > If no array is passed the component will default to showing all supported content card types.
 
+### `pushToDataLayer`
+
+**Type:** function
+**Required:** false
+
+A callback for feeding back analytics regarding content cards to the consuming application
+
+> If no function is passed then this will be replaced with a noop function
+
+### `testId`
+
+**Type:** string
+**Required:** false
+
+Indicates the test id attribute of the component root element.
+
+> If this is missing or nully, all child components will also be rendered without test id
+> attributes.
+
 ## Development
 
 Start by cloning the repository and installing the required dependencies:

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -42,10 +42,11 @@
     "lodash.orderby": "4.6.0"
   },
   "peerDependencies": {
-    "@justeat/browserslist-config-fozzie": ">=1.1.1"
+    "@justeat/browserslist-config-fozzie": ">=1.1.1",
+    "vue": "2.x"
   },
   "devDependencies": {
-    "@justeat/f-metadata": "2.7.0",
+    "@justeat/f-metadata": "2.8.1",
     "@vue/cli-plugin-babel": "4.2.3",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.3.1",

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -125,6 +125,7 @@ export default {
                 }
             });
         },
+
         contentCards (appboy) {
             if (!appboy) return;
             const { cards, titleCard } = new ContentCards(appboy, {

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -19,22 +19,33 @@ import initialiseBraze, { logCardClick, logCardImpressions } from '@justeat/f-me
 import ContentCards from '../services/contentCard.service';
 import cardTemplates from './cardTemplates';
 
-const createBrazeEvent = (contentAction, payload) => {
+/**
+ * Generates card-specific analytics data suitable for sending back to GTM via f-trak
+ *
+ * @param contentAction
+ * @param card
+ * @returns {{contentCTA, customVoucherCode, contentId: *, contentAction: *, contentPosition, contentTitle: *, contentType: string}}
+ */
+const createBrazeCardEvent = (contentAction, card) => {
     const {
-        message,
-        messageAlignment,
-        dg: type,
-        buttons = {}
-    } = payload;
-    const { 1: primaryCTA = {} } = buttons;
+        id: contentId,
+        title: contentTitle,
+        extras = {}
+    } = card;
+    const {
+        order: contentPosition,
+        button_1: contentCTA,
+        voucher_code: customVoucherCode
+    } = extras;
 
     return {
+        contentId,
+        contentType: 'contentCard',
+        customVoucherCode,
+        contentTitle,
         contentAction,
-        contentType: 'inAppMessage',
-        contentTitle: message,
-        contentPosition: messageAlignment,
-        contentCTA: primaryCTA.text,
-        variantName: type
+        contentPosition,
+        contentCTA
     };
 };
 
@@ -93,11 +104,11 @@ export default {
         const component = this;
 
         return {
-            emitCardView ({ details }) {
-                component.trackInAppMessageVisibility(details);
+            emitCardView (card) {
+                component.trackCardVisibility(card);
             },
-            emitCardClick ({ card, details }) {
-                component.trackInAppMessageClick(details);
+            emitCardClick (card) {
+                component.trackCardClick(card);
                 logCardClick(card);
             }
         };
@@ -154,13 +165,13 @@ export default {
             return this.testId && `ContentCard-${index}`;
         },
 
-        trackInAppMessageClick (details) {
-            const event = createBrazeEvent('click', details);
+        trackCardClick (card) {
+            const event = createBrazeCardEvent('click', card);
             this.pushBrazeEvent(event);
         },
 
-        trackInAppMessageVisibility (details) {
-            const event = createBrazeEvent('view', details);
+        trackCardVisibility (card) {
+            const event = createBrazeCardEvent('view', card);
             this.pushBrazeEvent(event);
         }
     }

--- a/packages/f-content-cards/src/components/_tests/ContentCards.test.js
+++ b/packages/f-content-cards/src/components/_tests/ContentCards.test.js
@@ -13,6 +13,9 @@ const url = '__URL__';
 const button = '__BUTTON__';
 const line1 = '__LINE_1__';
 const description = '__DESCRIPTION__';
+const title = '__TITLE__';
+const voucherCode = '__VOUCHERCODE__';
+const order = '__ORDER__';
 const id = btoa('ABC123');
 
 const createCard = type => ({
@@ -20,10 +23,13 @@ const createCard = type => ({
     url,
     button,
     description,
+    title,
     extras: {
+        order,
         button_1: button, // eslint-disable-line camelcase
         custom_card_type: type, // eslint-disable-line camelcase
-        line_1: line1 // eslint-disable-line camelcase
+        line_1: line1, // eslint-disable-line camelcase
+        voucher_code: voucherCode // eslint-disable-line camelcase
     }
 });
 
@@ -121,7 +127,7 @@ describe('ContentCards', () => {
 
         it('should provide a view handler', async () => {
             const { instance, cardViewHandler } = await arrange();
-            const cardViewDetails = { details: { message: 'bar' }, card: 'bar' };
+            const cardViewDetails = createCard('Post_Order_Card_1');
 
             // Act
             instance.find('[data-promotion-card="true"]').vm.emitCardView(cardViewDetails);
@@ -133,17 +139,7 @@ describe('ContentCards', () => {
         describe('the view handler', () => {
             it('should push a correctly-formed tracking event to the data layer', async () => {
                 const { instance } = await arrange();
-                const cardViewDetails = {
-                    details: {
-                        message: 'bar',
-                        messageAlignment: 'bang',
-                        dg: 'baz',
-                        buttons: [{}, {
-                            text: 'Call to Arms!'
-                        }]
-                    },
-                    card: 'bar'
-                };
+                const cardViewDetails = createCard('Post_Order_Card_1');
 
                 // Act
                 instance.find('[data-promotion-card="true"]').vm.emitCardView(cardViewDetails);
@@ -153,12 +149,13 @@ describe('ContentCards', () => {
                     event: 'BrazeContent',
                     custom: {
                         braze: {
+                            contentId: id,
                             contentAction: 'view',
-                            contentType: 'inAppMessage',
-                            contentTitle: 'bar',
-                            contentPosition: 'bang',
-                            contentCTA: 'Call to Arms!',
-                            variantName: 'baz'
+                            contentType: 'contentCard',
+                            contentTitle: title,
+                            contentPosition: order,
+                            contentCTA: button,
+                            customVoucherCode: voucherCode
                         }
                     }
                 });
@@ -167,7 +164,7 @@ describe('ContentCards', () => {
 
         it('should provide a click handler', async () => {
             const { instance, cardClickHandler } = await arrange();
-            const cardClickDetails = { details: { message: 'foo' }, card: 'foo' };
+            const cardClickDetails = createCard('Post_Order_Card_1');
 
             // Act
             instance.find('[data-promotion-card="true"]').vm.emitCardClick(cardClickDetails);
@@ -179,17 +176,7 @@ describe('ContentCards', () => {
         describe('the click handler', () => {
             it('should push a correctly-formed tracking event to the data layer', async () => {
                 const { instance } = await arrange();
-                const cardClickDetails = {
-                    details: {
-                        message: 'foo',
-                        messageAlignment: 'bar',
-                        dg: 'baz',
-                        buttons: [{}, {
-                            text: 'Call to Arms!'
-                        }]
-                    },
-                    card: 'foo'
-                };
+                const cardClickDetails = createCard('Post_Order_Card_1');
 
                 // Act
                 instance.find('[data-promotion-card="true"]').vm.emitCardClick(cardClickDetails);
@@ -199,12 +186,13 @@ describe('ContentCards', () => {
                     event: 'BrazeContent',
                     custom: {
                         braze: {
+                            contentId: id,
                             contentAction: 'click',
-                            contentType: 'inAppMessage',
-                            contentTitle: 'foo',
-                            contentPosition: 'bar',
-                            contentCTA: 'Call to Arms!',
-                            variantName: 'baz'
+                            contentType: 'contentCard',
+                            contentTitle: title,
+                            contentPosition: order,
+                            contentCTA: button,
+                            customVoucherCode: voucherCode
                         }
                     }
                 });
@@ -212,7 +200,7 @@ describe('ContentCards', () => {
 
             it('should log a card click event with braze', async () => {
                 const { instance } = await arrange();
-                const cardClickDetails = { details: { message: 'foo' }, card: 'foo' };
+                const cardClickDetails = 'foo';
 
                 // Act
                 instance.find('[data-promotion-card="true"]').vm.emitCardClick(cardClickDetails);

--- a/packages/f-content-cards/src/components/_tests/ContentCards.test.js
+++ b/packages/f-content-cards/src/components/_tests/ContentCards.test.js
@@ -1,5 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
-import initialiseBraze from '@justeat/f-metadata';
+import Vue from 'vue';
+import initialiseBraze, { logCardImpressions, logCardClick } from '@justeat/f-metadata';
 import ContentCards from '../ContentCards.vue';
 import cardTemplates from '../cardTemplates';
 
@@ -28,6 +29,10 @@ const createCard = type => ({
 
 const createAppboyInstance = cardTypes => ({
     cards: cardTypes.map(type => createCard(type))
+});
+
+beforeEach(() => {
+    jest.resetAllMocks();
 });
 
 describe('ContentCards', () => {
@@ -65,5 +70,209 @@ describe('ContentCards', () => {
         // Assert
         expect(instance.findAllComponents(cardTemplates.PromotionCard).length).toBe(2);
         expect(instance.findAllComponents(cardTemplates.PostOrderCard).length).toBe(1);
+    });
+
+    it('should call logCardImpressions from f-metadata with data from all displayed cards', async () => {
+        // Arrange
+        const cardTypes = ['Promotion_Card_1', 'Promotion_Card_2', 'Post_Order_Card_1'];
+        const appboy = createAppboyInstance(cardTypes);
+
+        // Act
+        const instance = shallowMount(ContentCards, {
+            propsData: {
+                apiKey,
+                userId
+            }
+        });
+        instance.vm.contentCards(appboy);
+        await instance.vm.$nextTick();
+
+        // Assert
+        expect(logCardImpressions).toHaveBeenCalledWith(appboy.cards);
+    });
+
+    describe('when mounting descendants', () => {
+        const pushToDataLayer = jest.fn();
+
+        const arrange = async () => {
+            const PromotionCard = Vue.extend({
+                template: '<div data-promotion-card="true"></div>',
+                inject: ['emitCardClick', 'emitCardView']
+            });
+            const cardTypes = ['Promotion_Card_1', 'Promotion_Card_2', 'Post_Order_Card_1'];
+            const appboy = createAppboyInstance(cardTypes);
+            const instance = shallowMount(ContentCards, {
+                propsData: {
+                    apiKey,
+                    userId,
+                    pushToDataLayer
+                },
+                stubs: {
+                    PromotionCard
+                }
+            });
+            const cardClickHandler = jest.spyOn(instance.vm._provided, 'emitCardClick');
+            const cardViewHandler = jest.spyOn(instance.vm._provided, 'emitCardView');
+            instance.vm.contentCards(appboy);
+            await instance.vm.$nextTick();
+
+            return { instance, cardClickHandler, cardViewHandler };
+        };
+
+        it('should provide a view handler', async () => {
+            const { instance, cardViewHandler } = await arrange();
+            const cardViewDetails = { details: { message: 'bar' }, card: 'bar' };
+
+            // Act
+            instance.find('[data-promotion-card="true"]').vm.emitCardView(cardViewDetails);
+
+            // Assert
+            expect(cardViewHandler).toHaveBeenCalledWith(cardViewDetails);
+        });
+
+        describe('the view handler', () => {
+            it('should push a correctly-formed tracking event to the data layer', async () => {
+                const { instance } = await arrange();
+                const cardViewDetails = {
+                    details: {
+                        message: 'bar',
+                        messageAlignment: 'bang',
+                        dg: 'baz',
+                        buttons: [{}, {
+                            text: 'Call to Arms!'
+                        }]
+                    },
+                    card: 'bar'
+                };
+
+                // Act
+                instance.find('[data-promotion-card="true"]').vm.emitCardView(cardViewDetails);
+
+                // Assert
+                expect(pushToDataLayer).toHaveBeenCalledWith({
+                    event: 'BrazeContent',
+                    custom: {
+                        braze: {
+                            contentAction: 'view',
+                            contentType: 'inAppMessage',
+                            contentTitle: 'bar',
+                            contentPosition: 'bang',
+                            contentCTA: 'Call to Arms!',
+                            variantName: 'baz'
+                        }
+                    }
+                });
+            });
+        });
+
+        it('should provide a click handler', async () => {
+            const { instance, cardClickHandler } = await arrange();
+            const cardClickDetails = { details: { message: 'foo' }, card: 'foo' };
+
+            // Act
+            instance.find('[data-promotion-card="true"]').vm.emitCardClick(cardClickDetails);
+
+            // Assert
+            expect(cardClickHandler).toHaveBeenCalledWith(cardClickDetails);
+        });
+
+        describe('the click handler', () => {
+            it('should push a correctly-formed tracking event to the data layer', async () => {
+                const { instance } = await arrange();
+                const cardClickDetails = {
+                    details: {
+                        message: 'foo',
+                        messageAlignment: 'bar',
+                        dg: 'baz',
+                        buttons: [{}, {
+                            text: 'Call to Arms!'
+                        }]
+                    },
+                    card: 'foo'
+                };
+
+                // Act
+                instance.find('[data-promotion-card="true"]').vm.emitCardClick(cardClickDetails);
+
+                // Assert
+                expect(pushToDataLayer).toHaveBeenCalledWith({
+                    event: 'BrazeContent',
+                    custom: {
+                        braze: {
+                            contentAction: 'click',
+                            contentType: 'inAppMessage',
+                            contentTitle: 'foo',
+                            contentPosition: 'bar',
+                            contentCTA: 'Call to Arms!',
+                            variantName: 'baz'
+                        }
+                    }
+                });
+            });
+
+            it('should log a card click event with braze', async () => {
+                const { instance } = await arrange();
+                const cardClickDetails = { details: { message: 'foo' }, card: 'foo' };
+
+                // Act
+                instance.find('[data-promotion-card="true"]').vm.emitCardClick(cardClickDetails);
+
+                // Assert
+                expect(logCardClick).toHaveBeenCalledWith('foo');
+            });
+        });
+    });
+
+    describe('when test id prop provided', () => {
+        const testId = 'foo';
+        let instance;
+
+        beforeAll(async () => {
+            // Arrange
+            const cardTypes = ['Promotion_Card_1', 'Promotion_Card_2', 'Post_Order_Card_1'];
+            const appboy = createAppboyInstance(cardTypes);
+
+            // Act
+            instance = shallowMount(ContentCards, {
+                propsData: {
+                    apiKey,
+                    userId,
+                    testId
+                }
+            });
+            instance.vm.contentCards(appboy);
+            await instance.vm.$nextTick();
+        });
+
+        it('should generate test id attribute on content cards container', async () => {
+            // Assert
+            expect(instance.find(`[data-test-id=${testId}]`).exists()).toBeTruthy();
+        });
+
+        it('should generate test id attributes on child content cards components', async () => {
+            // Assert
+            expect(instance.find('[data-test-id="ContentCard-0"]').exists()).toBeTruthy();
+            expect(instance.find('[data-test-id="ContentCard-1"]').exists()).toBeTruthy();
+            expect(instance.find('[data-test-id="ContentCard-2"]').exists()).toBeTruthy();
+        });
+    });
+
+    it('should not generate test id attribute on self or children when no test id provided', async () => {
+        // Arrange
+        const cardTypes = ['Promotion_Card_1', 'Promotion_Card_2', 'Post_Order_Card_1'];
+        const appboy = createAppboyInstance(cardTypes);
+
+        // Act
+        const instance = shallowMount(ContentCards, {
+            propsData: {
+                apiKey,
+                userId
+            }
+        });
+        instance.vm.contentCards(appboy);
+        await instance.vm.$nextTick();
+
+        // Assert
+        expect(instance.find('[data-test-id]').exists()).toBeFalsy();
     });
 });

--- a/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -36,28 +36,6 @@
 </template>
 
 <script>
-const cardDetails = (card, args) => ({
-    canvasName: null,
-    contentAction: null,
-    contentCTA: card.voucherCode ? 'copy_voucher' : card.ctaText,
-    contentCategory: null,
-    contentDeeplink: null,
-    contentId: card.extractedCardId,
-    contentPosition: card.order,
-    contentTitle: card.title,
-    contentType: 'ContentCard',
-    customVoucherCode: card.voucherCode || null,
-    variantName: null,
-    carousel: card.isCarousel
-        ?
-        {
-            listType: 'offers',
-            componentId: card.containerTitle
-        }
-        : null,
-    ...args
-});
-
 export default {
     props: {
         card: {
@@ -143,26 +121,11 @@ export default {
 
     methods: {
         onViewContentCard () {
-            const details = cardDetails(this, {
-                contentAction: 'view'
-            });
-
-            this.emitCardView({
-                card: this.card,
-                details
-            });
+            this.emitCardView(this.card);
         },
 
         onClickContentCard () {
-            const details = cardDetails(this, {
-                contentAction: 'click',
-                contentDeeplink: this.ctaUrl
-            });
-
-            this.emitCardClick({
-                card: this.card,
-                details
-            });
+            this.emitCardClick(this.card);
         },
 
         testIdForItemWithIndex (index) {

--- a/packages/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
@@ -1,5 +1,7 @@
 <template>
-    <div :class="['c-postOrderCard' , { 'c-postOrderCard--condensed': !image && icon }]">
+    <div
+        :data-test-id="testId"
+        :class="['c-postOrderCard' , { 'c-postOrderCard--condensed': !image && icon }]">
         <h2
             v-if="title"
             class="c-postOrderCard-title"
@@ -10,10 +12,11 @@
         <card-container
             :card="card"
             :container-title="containerTitle"
-            :is-carousel="isCarousel">
+            :is-carousel="isCarousel"
+            :data-test-id="containerTestId()">
             <span
                 class="o-link--full o-link--bold u-color-link u-text-left"
-                data-test-id="contentCard-postOrderCard-1">
+                :data-test-id="cardContentTestId()">
                 {{ ctaText }}
             </span>
         </card-container>
@@ -43,6 +46,10 @@ export default {
         title: {
             type: String,
             default: ''
+        },
+        testId: {
+            type: String,
+            default: null
         }
     },
     data () {
@@ -64,6 +71,15 @@ export default {
             image: image || imageUrl,
             type
         };
+    },
+
+    methods: {
+        cardContentTestId () {
+            return this.testId && 'contentCard-postOrderCard-1';
+        },
+        containerTestId () {
+            return this.testId && 'contentCard-link';
+        }
     }
 };
 </script>

--- a/packages/f-content-cards/src/components/cardTemplates/PromotionCard.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/PromotionCard.vue
@@ -2,17 +2,18 @@
     <card-container
         :card="card"
         :container-title="containerTitle"
-        :is-carousel="isCarousel">
+        :is-carousel="isCarousel"
+        :data-test-id="testId">
         <span
             v-if="type === 'Promotion_Card_1'"
             class="o-btn o-btn--secondary"
-            data-test-id="contentCard-promoCard-1">
+            :data-test-id="testIdForPromoCardType(1)">
             {{ ctaText }}
         </span>
         <span
             v-if="type === 'Promotion_Card_2'"
             class="c-contentCard-link o-btnLink"
-            data-test-id="contentCard-promoCard-2">
+            :data-test-id="testIdForPromoCardType(2)">
             {{ ctaText }}
         </span>
     </card-container>
@@ -37,6 +38,10 @@ export default {
         isCarousel: {
             type: Boolean,
             default: false
+        },
+        testId: {
+            type: String,
+            default: null
         }
     },
     data () {
@@ -52,6 +57,12 @@ export default {
             ctaText: button || linkText,
             type
         };
+    },
+
+    methods: {
+        testIdForPromoCardType (type) {
+            return this.testId && `contentCard-promoCard-${type}`;
+        }
     }
 };
 </script>

--- a/packages/f-content-cards/src/components/cardTemplates/_tests/CardContainer.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/_tests/CardContainer.test.js
@@ -22,14 +22,27 @@ const card = {
     }
 };
 
+const testId = 'CardContainer';
+
+const provide = {
+    emitCardView: jest.fn(),
+    emitCardClick: jest.fn()
+};
+
 describe('ContentCard', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
     it('should render a link if ctaUrl is provided', () => {
         // Act
         const wrapper = shallowMount(CardContainer, {
             localVue,
             propsData: {
-                card
-            }
+                card,
+                testId
+            },
+            provide
         });
 
         // Assert
@@ -41,12 +54,14 @@ describe('ContentCard', () => {
         const wrapper = shallowMount(CardContainer, {
             localVue,
             propsData: {
-                card
-            }
+                card,
+                testId
+            },
+            provide
         });
 
         // Assert
-        expect(wrapper.find('[data-test-id="ContentCard-TextItem-0"').text()).toBe(line1);
+        expect(wrapper.find('[data-test-id="ContentCard-TextItem-0"]').text()).toBe(line1);
     });
 
     it('should apply the correct URL', () => {
@@ -54,11 +69,46 @@ describe('ContentCard', () => {
         const wrapper = shallowMount(CardContainer, {
             localVue,
             propsData: {
-                card
-            }
+                card,
+                testId
+            },
+            provide
         });
 
         // Assert
         expect(wrapper.find(`[href="${url}"]`).exists()).toBe(true);
+    });
+
+    it('should call the injected `emitCardView` event when mounted', () => {
+        // Arrange & Act
+        shallowMount(CardContainer, {
+            localVue,
+            propsData: {
+                card,
+                testId
+            },
+            provide
+        });
+
+        // Assert
+        expect(provide.emitCardView).toHaveBeenCalled();
+    });
+
+    it('should call the injected `emitCardClick` event when clicked', () => {
+        // Arrange
+        const wrapper = shallowMount(CardContainer, {
+            localVue,
+            propsData: {
+                card,
+                testId
+            },
+            provide
+        });
+
+        // Act
+        wrapper.find(`[data-test-id="${testId}"]`).trigger('click');
+
+        // Assert
+        expect(provide.emitCardClick).toHaveBeenCalled();
     });
 });

--- a/packages/f-content-cards/src/components/cardTemplates/_tests/PostOrderCard.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/_tests/PostOrderCard.test.js
@@ -22,7 +22,8 @@ describe('contentCards › PostOrderCard', () => {
         // Arrange & Act
         const wrapper = shallowMount(PostOrderCard, {
             propsData: {
-                card
+                card,
+                testId: 'foo'
             }
         });
 
@@ -39,7 +40,8 @@ describe('contentCards › PostOrderCard', () => {
                     extras: {
                         custom_card_type: customCardType // eslint-disable-line camelcase
                     }
-                }
+                },
+                testId: 'foo'
             }
         });
 

--- a/packages/f-content-cards/src/components/cardTemplates/_tests/PromotionCard.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/_tests/PromotionCard.test.js
@@ -15,7 +15,8 @@ describe('contentCards › PromotionCard1', () => {
         // Arrange & Act
         const wrapper = shallowMount(PromotionCard, {
             propsData: {
-                card
+                card,
+                testId: 'foo'
             }
         });
 
@@ -32,7 +33,8 @@ describe('contentCards › PromotionCard1', () => {
                         ...card.extras,
                         custom_card_type: 'Promotion_Card_2' // eslint-disable-line
                     }
-                }
+                },
+                testId: 'foo'
             }
         });
 
@@ -52,7 +54,8 @@ describe('contentCards › PromotionCard1', () => {
                     extras: {
                         custom_card_type: 'Promotion_Card_1' // eslint-disable-line
                     }
-                }
+                },
+                testId: 'foo'
             }
         });
 

--- a/packages/f-content-cards/stories/PostOrderCard.stories.js
+++ b/packages/f-content-cards/stories/PostOrderCard.stories.js
@@ -28,6 +28,12 @@ export const ContentCardscomponent = () => ({
             default: text('Card CTA', 'Purchase now')
         }
     },
+    provide () {
+        return {
+            emitCardView () {},
+            emitCardClick () {}
+        };
+    },
     data () {
         return {
             card: {


### PR DESCRIPTION

### Added
- ContentCards component accepts `pushToDataLayer` callback as a prop for feeding back
  analytics regarding content cards
- ContentCards component accepts `testId` parameter as a prop, which indicates the test
  id attribute of the component root element. If this is missing, all child components
  will also be rendered without test id attributes.

### Changed
- Updated @justeat/f-metadata version
- Updated README

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)