### PR TITLE
f-footer@3.3.1 - Use latest f-vue-icons

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.3.1
+------------------------------
+*July 10, 2020*
+
+### Updated
+- Patch to include latest `f-vue-icons`.
+
+
 v3.3.0
 ------------------------------
 *July 9, 2020*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@justeat/f-services": "0.13.0",
-    "@justeat/f-vue-icons": "1.0.0-beta.10",
+    "@justeat/f-vue-icons": "1.0.0-beta.11",
     "v-click-outside": "2.1.3"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,6 +2315,13 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.0.0-beta.10.tgz#11aa923bd4823043fa086f098a2b1e0aba57b84b"
   integrity sha512-BHkiiiZQGlRe6mb42mf0e2UFpB5zINoFf7pSGGpM7okStVDKtaCSUN7URlt/RNsMWdppeA2bhGJcfLriWk02bQ==
 
+"@justeat/f-vue-icons@1.0.0-beta.11":
+  version "1.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.0.0-beta.11.tgz#2c8c1525e22c731a680a2a2bcae3ba1db4f959f8"
+  integrity sha512-wQGUfNzFy0Q111S/uYeeU1AFll5Py9F1QaNl6laQXHa1DCv1XI2u779OLHICDsn5LEW+TMvwDeQVtyYUPbIu8w==
+  dependencies:
+    babel-helper-vue-jsx-merge-props "2.0.3"
+
 "@justeat/f-vue-icons@1.0.0-beta.5":
   version "1.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.0.0-beta.5.tgz#b38372e2c4eca1cf51478fe2e1553d5c50a8ff38"
@@ -5346,7 +5353,7 @@ babel-helper-to-multiple-sequence-expressions@^0.5.0:
   resolved "https://registry.yarnpkg.com/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz#a3f924e3561882d42fcf48907aa98f7979a4588d"
   integrity sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA==
 
-babel-helper-vue-jsx-merge-props@^2.0.3:
+babel-helper-vue-jsx-merge-props@2.0.3, babel-helper-vue-jsx-merge-props@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-2.0.3.tgz#22aebd3b33902328e513293a8e4992b384f9f1b6"
   integrity sha512-gsLiKK7Qrb7zYJNgiXKpXblxbV5ffSwR0f5whkPAaBAR4fhi6bwRZxX9wBlIc5M/v8CCkXUbXZL4N/nSE97cqg==


### PR DESCRIPTION
### Updated
- Patch to include latest `f-vue-icons`.