### PR TITLE
f-content-cards@0.10.1: Fix cropped image defect

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.10.1
+------------------------------
+*July 10, 2020*
+
+### Fixed
+- A defect where the main content card image was applied as a background image with cover sizing which caused the image to be cropped dependent on it's aspect ratio/sizing.
+
+
 v0.10.0
 ------------------------------
 *July 2, 2020*

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -551,11 +551,16 @@ export default {
         }
 
         .c-contentCard-bgImg {
-            min-height: 250px;
+            overflow: hidden;
             border-radius: $contentCardRadius;
 
             @include media ('<mid') {
                 border-radius: $contentCardRadius $contentCardRadius 0 0;
+            }
+
+            img {
+                display: block;
+                max-width: 100%;
             }
         }
     }

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -557,11 +557,11 @@ export default {
             @include media ('<mid') {
                 border-radius: $contentCardRadius $contentCardRadius 0 0;
             }
+        }
 
-            img {
-                display: block;
-                max-width: 100%;
-            }
+        .c-contentCard-img {
+            display: block;
+            max-width: 100%;
         }
     }
 

--- a/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -7,7 +7,7 @@
         @click="onClickContentCard"
     >
         <div
-            :style="{ 'background-image': `url(${image})` }"
+            :style="{ 'background-image': isPostOrderCard ? `url(${image})` : '' }"
             :class="[{ 'c-contentCard-bgImg': !!image }]">
             <img
                 v-if="isPostOrderCard"

--- a/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -7,8 +7,13 @@
         @click="onClickContentCard"
     >
         <div
-            :style="{ backgroundImage: `url('${image}')` }"
-            :class="[{ 'c-contentCard-bgImg': !!image }]" />
+            :style="{ 'background-image': `url(${image})` }"
+            :class="[{ 'c-contentCard-bgImg': !!image }]">
+            <img
+                v-if="isPostOrderCard"
+                :src="image"
+                :alt="title">
+        </div>
         <div class="c-contentCard-info">
             <img
                 v-if="icon"
@@ -107,6 +112,10 @@ export default {
 
         isAnniversaryCard () {
             return this.type === 'Anniversary_Card_1';
+        },
+
+        isPostOrderCard () {
+            return this.type === 'Post_Order_Card_1';
         }
     },
 

--- a/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -11,6 +11,7 @@
             :class="[{ 'c-contentCard-bgImg': !!image }]">
             <img
                 v-if="!isBackgroundImage"
+                class="c-contentCard-img"
                 :src="image"
                 :alt="title">
         </div>

--- a/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -7,10 +7,10 @@
         @click="onClickContentCard"
     >
         <div
-            :style="{ 'background-image': !isPostOrderCard ? `url(${image})` : '' }"
+            :style="{ 'background-image': isBackgroundImage ? `url(${image})` : '' }"
             :class="[{ 'c-contentCard-bgImg': !!image }]">
             <img
-                v-if="isPostOrderCard"
+                v-if="!isBackgroundImage"
                 :src="image"
                 :alt="title">
         </div>
@@ -114,8 +114,8 @@ export default {
             return this.type === 'Anniversary_Card_1';
         },
 
-        isPostOrderCard () {
-            return this.type === 'Post_Order_Card_1';
+        isBackgroundImage () {
+            return this.type !== 'Post_Order_Card_1';
         }
     },
 

--- a/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -7,7 +7,7 @@
         @click="onClickContentCard"
     >
         <div
-            :style="{ 'background-image': isPostOrderCard ? `url(${image})` : '' }"
+            :style="{ 'background-image': !isPostOrderCard ? `url(${image})` : '' }"
             :class="[{ 'c-contentCard-bgImg': !!image }]">
             <img
                 v-if="isPostOrderCard"


### PR DESCRIPTION
Fixes a defect where the main content card image was applied as a background image with cover sizing which caused the image to be cropped dependent on it's aspect ratio/sizing. This was fine when the image was solely for presentational purposes but the Spotify content card image contains advertising text.

This change applies the main content card image as an element for `Post_Order_Card_1` to ensure the image is always fully displayed.

**Previous Implementation**

<img width="600" alt="Screenshot 2020-07-10 at 13 58 26" src="https://user-images.githubusercontent.com/6689773/87161343-4d9d0e00-c2bc-11ea-8140-e2256ee31004.png">

**Proposed Implementation**

<img width="600" alt="Screenshot 2020-07-10 at 14 54 14" src="https://user-images.githubusercontent.com/6689773/87162000-3c083600-c2bd-11ea-9205-949dc1dbceff.png">
