### PR TITLE
f-content-cards@1.3.0: [DNMY] Open external links in a new tab

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.14.0
+------------------------------
+*July 16, 2020*
+
+### Changed
+- Open external links in `_blank` and internal links in `_self`
+
+
 v0.10.1
 ------------------------------
 *July 10, 2020*

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "0.10.1",
+  "version": "0.14.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -2,6 +2,8 @@
     <component
         :is="ctaUrl && ctaEnabled ? 'a' : 'div'"
         :href="ctaEnabled && ctaUrl"
+        :target="target.attribute"
+        :rel="target.rel"
         :class="['c-contentCard', { 'c-contentCard--isolateHeroImage': isAnniversaryCard }]"
         :data-test-id="testId"
         @click="onClickContentCard"
@@ -117,6 +119,25 @@ export default {
 
         isBackgroundImage () {
             return this.type !== 'Post_Order_Card_1';
+        },
+
+        target () {
+            try {
+                const url = new URL(this.ctaUrl);
+                const internalDomains = ['just-eat', 'justeat', 'menulog'];
+                const openInNewWindow = !internalDomains.some(partial => url.hostname.indexOf(partial) > -1);
+
+                return openInNewWindow ? {
+                    attribute: '_blank',
+                    rel: 'noopener noreferrer'
+                } : {
+                    attribute: '_self'
+                };
+            } catch (err) {
+                return {
+                    attribute: '_self'
+                };
+            }
         }
     },
 

--- a/packages/f-content-cards/src/components/cardTemplates/_tests/CardContainer.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/_tests/CardContainer.test.js
@@ -111,4 +111,49 @@ describe('ContentCard', () => {
         // Assert
         expect(provide.emitCardClick).toHaveBeenCalled();
     });
+
+    describe('target', () => {
+        it('should open in _self for internal routes', async () => {
+            const urls = [
+                'https://www.just-eat.co.uk/test-url',
+                'https://www.justeat.com/test-url',
+                'https://www.just-eat.es/test-url',
+                'https://www.menulog.co.nz/test-url'
+            ];
+
+            await Promise.all(urls.map(testUrl => {
+                const wrapper = shallowMount(CardContainer, {
+                    localVue,
+                    propsData: {
+                        card: {
+                            ...card,
+                            url: testUrl
+                        },
+                        testId
+                    },
+                    provide
+                });
+                return expect(wrapper.find('a').attributes('target')).toBe('_self');
+            }));
+        });
+
+        it('should open in _blank for external routes', () => {
+            const testUrl = 'https://www.helloworld.com/';
+
+            const wrapper = shallowMount(CardContainer, {
+                localVue,
+                propsData: {
+                    card: {
+                        ...card,
+                        url: testUrl
+                    },
+                    testId
+                },
+                provide
+            });
+            const link = wrapper.find('a');
+            expect(link.attributes('target')).toBe('_blank');
+            expect(link.attributes('rel')).toBe('noopener noreferrer');
+        });
+    });
 });


### PR DESCRIPTION
Currently, external links open in the same tab, which is less than ideal in terms of keeping users engaged on the just eat platform.

This change checks for internal/external URL's and changes content card links to `_self` or `_blank` as appropriate.

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
