### PR TITLE
f-content-cards@1.4.0 🦆 Mocks out xhr requests for braze data

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.4.0
 ------------------------------
-*July 22, 2020*
+*July 24, 2020*
 
 ### Added
 - `xhr-mock` and `faker` as dev dependencies
-- Faked card data for braze SDK responses
+- Predictable faked card data for braze SDK responses
 
 ### Changed
 - Story can multi-select different card types and then 'refresh'

--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.4.0
+------------------------------
+*July 22, 2020*
+
+### Added
+- `xhr-mock` and `faker` as dev dependencies
+- Faked card data for braze SDK responses
+
+### Changed
+- Story can multi-select different card types and then 'refresh'
+
+
 v1.3.0
 ------------------------------
 *July 23, 2020*

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -51,6 +51,7 @@
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
     "@vue/test-utils": "1.0.3",
+    "crypto-js": "^4.0.0",
     "faker": "^4.1.0",
     "node-sass-magic-importer": "5.3.2",
     "xhr-mock": "^2.5.1"

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"
@@ -51,6 +51,8 @@
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
     "@vue/test-utils": "1.0.3",
-    "node-sass-magic-importer": "5.3.2"
+    "faker": "^4.1.0",
+    "node-sass-magic-importer": "5.3.2",
+    "xhr-mock": "^2.5.1"
   }
 }

--- a/packages/f-content-cards/stories/ContentCards.stories.js
+++ b/packages/f-content-cards/stories/ContentCards.stories.js
@@ -59,12 +59,6 @@ export function ContentCardscomponent () {
             ContentCards
         },
 
-        data () {
-            return {
-                mocksPrimed: false
-            };
-        },
-
         props: {
             apiKey: {
                 default: text('API Key', '00000000-0000-0000-0000-000000000000')
@@ -86,28 +80,24 @@ export function ContentCardscomponent () {
         },
 
         /**
-         * Ensures that mocks are set up before enabling the content cards component
-         * @return {Promise<void>}
+         * Ensures that card mocks are set up
          */
-        async beforeCreate () {
+        beforeCreate () {
             resetBrazeData();
             mock.teardown();
             mock.setup();
             mock.post(/\/api\/v3\/content_cards\/sync\/?/, {
                 status: 201,
-                body: JSON.stringify(await cards())
+                body: JSON.stringify(cards())
             });
             mock.post(/\/api\/v3\/data\/?/, {
                 status: 201,
                 body: JSON.stringify(data())
             });
             mock.use(proxy);
-
-            this.mocksPrimed = true;
         },
 
         template: `<content-cards
-            v-if="mocksPrimed"
             :userId="userId"
             :apiKey="apiKey"
             :title="title"

--- a/packages/f-content-cards/stories/ContentCards.stories.js
+++ b/packages/f-content-cards/stories/ContentCards.stories.js
@@ -59,6 +59,12 @@ export function ContentCardscomponent () {
             ContentCards
         },
 
+        data () {
+            return {
+                mocksPrimed: false
+            };
+        },
+
         props: {
             apiKey: {
                 default: text('API Key', '00000000-0000-0000-0000-000000000000')
@@ -79,22 +85,33 @@ export function ContentCardscomponent () {
             }
         },
 
-        beforeCreate: () => {
+        /**
+         * Ensures that mocks are set up before enabling the content cards component
+         * @return {Promise<void>}
+         */
+        async beforeCreate () {
             resetBrazeData();
             mock.teardown();
             mock.setup();
             mock.post(/\/api\/v3\/content_cards\/sync\/?/, {
                 status: 201,
-                body: JSON.stringify(cards())
+                body: JSON.stringify(await cards())
             });
             mock.post(/\/api\/v3\/data\/?/, {
                 status: 201,
                 body: JSON.stringify(data())
             });
             mock.use(proxy);
+
+            this.mocksPrimed = true;
         },
 
-        template: '<content-cards :userId="userId" :apiKey="apiKey" :title="title" :enabledCardTypes="enabledCardTypes" />'
+        template: `<content-cards
+            v-if="mocksPrimed"
+            :userId="userId"
+            :apiKey="apiKey"
+            :title="title"
+            :enabledCardTypes="enabledCardTypes" />`
     };
 }
 

--- a/packages/f-content-cards/stories/mockData/cards.js
+++ b/packages/f-content-cards/stories/mockData/cards.js
@@ -2,33 +2,13 @@ import faker from 'faker';
 
 /* eslint-disable camelcase */
 const cardTypes = {
-    Terms_And_Conditions_Card: {
-        label: 'Terms and Conditions',
-        fields: ['line3', 'line4']
-    },
-    Terms_And_Conditions_Card_2: {
-        label: 'Terms and Conditions 2',
-        fields: []
+    Anniversary_Card_1: {
+        label: 'Anniversary 1',
+        fields: ['button_1', 'line_3', 'background_image_1', 'voucher_code']
     },
     Header_Card: {
         label: 'Header',
         fields: ['background_color']
-    },
-    Voucher_Card_1: {
-        label: 'Voucher',
-        fields: ['button_1', 'line_3', 'voucher_code', 'image_1', 'icon_1']
-    },
-    Recommendation_Card_1: {
-        label: 'Recommendation',
-        fields: ['line_3', 'image_1']
-    },
-    Promotion_Card_1: {
-        label: 'Promotion 1',
-        fields: ['image_1', 'button_1', 'line_3', 'line_4', 'line_5', 'line_6', 'offer_auth_required']
-    },
-    Promotion_Card_2: {
-        label: 'Promotion 2',
-        fields: ['icon_1', 'button_1', 'line_3', 'image_1']
     },
     Home_Promotion_Card_1: {
         label: 'Home Promotion 1',
@@ -42,44 +22,73 @@ const cardTypes = {
         label: 'Post Order 1',
         fields: ['button_1', 'headline', 'image_1', 'icon_1']
     },
-    Anniversary_Card_1: {
-        label: 'Anniversary 1',
-        fields: ['button_1', 'line_3', 'background_image_1', 'voucher_code']
+    Promotion_Card_1: {
+        label: 'Promotion 1',
+        fields: ['image_1', 'button_1', 'line_3', 'line_4', 'line_5', 'line_6', 'offer_auth_required']
+    },
+    Promotion_Card_2: {
+        label: 'Promotion 2',
+        fields: ['icon_1', 'button_1', 'line_3', 'image_1']
+    },
+    Recommendation_Card_1: {
+        label: 'Recommendation',
+        fields: ['line_3', 'image_1']
     },
     Restaurant_FTC_Offer_Card: {
         label: 'Restaurant FTC Offer',
         fields: ['subtitle', 'banner', 'footer', 'restaurant_id', 'restaurant_logo_url', 'restaurant_image_url', 'offer_auth_required']
+    },
+    Terms_And_Conditions_Card: {
+        label: 'Terms and Conditions',
+        fields: ['line3', 'line4']
+    },
+    Terms_And_Conditions_Card_2: {
+        label: 'Terms and Conditions 2',
+        fields: []
+    },
+    Voucher_Card_1: {
+        label: 'Voucher',
+        fields: ['button_1', 'line_3', 'voucher_code', 'image_1', 'icon_1']
     }
 };
+/* eslint-enable camelcase */
 
+const randomSentence = faker.lorem.sentence.bind(faker.lorem, undefined, undefined);
+const randomColour = faker.internet.color.bind(faker.internet, undefined, undefined, undefined);
+
+/* eslint-disable camelcase */
+/**
+ * A POJO map of fieldname to generator function that will predictably generate the correct type
+ * @type {Object}
+ */
 const fieldTypeToFaker = {
-    background_color: faker.internet.color.bind(faker.internet),
-    background_image_1: () => 'https://picsum.photos/seed/background_image_1/384/216?blur=3',
-    banner: faker.lorem.sentence.bind(faker.lorem),
+    background_color: randomColour,
+    background_image_1: type => `https://picsum.photos/seed/${type}_background_image_1/384/216?blur=3`,
+    banner: randomSentence,
     brand_name: faker.commerce.product.bind(faker.commerce),
-    button_1: faker.lorem.words.bind(faker.lorem),
-    content_container_background: faker.internet.color.bind(faker.internet),
+    button_1: faker.lorem.words.bind(faker.lorem, undefined),
+    content_container_background: randomColour,
     display_times_json: () => ({
         Any: [
             { Start: '00:00', End: '23:59' }
         ]
     }),
-    footer: faker.lorem.sentence.bind(faker.lorem),
-    headline: faker.lorem.sentence.bind(faker.lorem),
-    icon_1: () => 'https://picsum.photos/seed/icon_1/48/48',
-    image_1: () => 'https://picsum.photos/seed/image_1/384/216?blur=3',
-    line3: faker.lorem.sentence.bind(faker.lorem),
-    line4: faker.lorem.sentence.bind(faker.lorem),
-    line_3: faker.lorem.sentence.bind(faker.lorem),
-    line_4: faker.lorem.sentence.bind(faker.lorem),
-    line_5: faker.lorem.sentence.bind(faker.lorem),
-    line_6: faker.lorem.sentence.bind(faker.lorem),
+    footer: randomSentence,
+    headline: randomSentence,
+    icon_1: type => `https://picsum.photos/seed/${type}_icon_1/48/48`,
+    image_1: type => `https://picsum.photos/seed/${type}_image_1/384/216?blur=3`,
+    line3: randomSentence,
+    line4: randomSentence,
+    line_3: randomSentence,
+    line_4: randomSentence,
+    line_5: randomSentence,
+    line_6: randomSentence,
     offer_auth_required: faker.random.boolean.bind(faker.random),
     restaurant_id: faker.random.number.bind(faker.random, { min: 100, max: 999999 }),
-    restaurant_image_url: () => 'https://picsum.photos/seed/restaurant_image_url/384/216?blur=3',
-    restaurant_logo_url: () => 'https://picsum.photos/seed/restaurant_logo_url/48/48',
-    subtitle: faker.lorem.sentence.bind(faker.lorem),
-    voucher_code: faker.lorem.slug.bind(faker.lorem)
+    restaurant_image_url: type => `https://picsum.photos/seed/${type}_restaurant_image_url/384/216?blur=3`,
+    restaurant_logo_url: type => `https://picsum.photos/seed/${type}_restaurant_logo_url/48/48`,
+    subtitle: randomSentence,
+    voucher_code: faker.lorem.slug.bind(faker.lorem, undefined)
 };
 /* eslint-enable camelcase */
 
@@ -99,7 +108,25 @@ function timeRange10HoursAroundNow () {
     };
 }
 
-function randomCardOfType (type) {
+const encoder = new TextEncoder();
+
+/**
+ * Predictably generates a number from a given string by performing a sha-1 hash
+ * and extracting the first four bytes as a 32 bit integer
+ * @param type
+ * @return {Promise<number>}
+ */
+async function seedFromType (type) {
+    // const arrayBuffer = new ArrayBuffer(type.length * 4);
+    // const typeBuffer = new Uint8Array(arrayBuffer);
+    const typeBuffer = encoder.encode(type);
+    const typeHash = await crypto.subtle.digest('SHA-1', typeBuffer);
+    const uInt32HashView = new Uint32Array(typeHash);
+    return uInt32HashView[0];
+}
+
+async function seededRandomCardOfType (type) {
+    faker.seed(await seedFromType(type));
     const { nowMinus5Hours, nowPlus5Hours } = timeRange10HoursAroundNow();
 
     const e = {
@@ -115,7 +142,7 @@ function randomCardOfType (type) {
                 return;
             }
 
-            e[field] = fieldTypeToFaker[field]();
+            e[field] = fieldTypeToFaker[field](type);
         });
 
     const id = btoa([`5d79109d167e923a83d3d7db_$_cc=${faker.random.uuid()}`, 'mv=5d79109d167e923a83d3d7dd', 'pi=cmp'].join('&'));
@@ -144,27 +171,27 @@ function randomCardOfType (type) {
 }
 
 /**
- * Generates a set of faked cards wrapped in data format expected by the braze SDK
+ * Generates a set of predictable faked cards wrapped in data format expected by the braze SDK
  *
  * @return {Object}
  */
-export default () => {
+export default async () => {
     const { nowMinus5Hours } = timeRange10HoursAroundNow();
 
     return {
         cards: [
-            randomCardOfType('Terms_And_Conditions_Card'),
-            randomCardOfType('Terms_And_Conditions_Card_2'),
-            randomCardOfType('Header_Card'),
-            randomCardOfType('Voucher_Card_1'),
-            randomCardOfType('Recommendation_Card_1'),
-            randomCardOfType('Promotion_Card_1'),
-            randomCardOfType('Promotion_Card_2'),
-            randomCardOfType('Home_Promotion_Card_1'),
-            randomCardOfType('Home_Promotion_Card_2'),
-            randomCardOfType('Post_Order_Card_1'),
-            randomCardOfType('Anniversary_Card_1'),
-            randomCardOfType('Restaurant_FTC_Offer_Card')
+            await seededRandomCardOfType('Terms_And_Conditions_Card'),
+            await seededRandomCardOfType('Terms_And_Conditions_Card_2'),
+            await seededRandomCardOfType('Header_Card'),
+            await seededRandomCardOfType('Voucher_Card_1'),
+            await seededRandomCardOfType('Recommendation_Card_1'),
+            await seededRandomCardOfType('Promotion_Card_1'),
+            await seededRandomCardOfType('Promotion_Card_2'),
+            await seededRandomCardOfType('Home_Promotion_Card_1'),
+            await seededRandomCardOfType('Home_Promotion_Card_2'),
+            await seededRandomCardOfType('Post_Order_Card_1'),
+            await seededRandomCardOfType('Anniversary_Card_1'),
+            await seededRandomCardOfType('Restaurant_FTC_Offer_Card')
         ],
         /* eslint-disable camelcase */
         last_full_sync_at: nowMinus5Hours,

--- a/packages/f-content-cards/stories/mockData/cards.js
+++ b/packages/f-content-cards/stories/mockData/cards.js
@@ -98,8 +98,8 @@ const fieldTypeToFaker = {
  *
  * @type {any}
  */
-export const labelledMultiSelectAllowedValues = Object.fromEntries(Object.keys(cardTypes)
-    .map(key => [key, cardTypes[key].label]));
+export const labelledMultiSelectAllowedValues = Object.fromEntries(Object.entries(cardTypes)
+    .map(([key, { label }]) => [key, label]));
 
 function timeRange10HoursAroundNow () {
     const now = Math.floor(Date.now() / 1000);

--- a/packages/f-content-cards/stories/mockData/cards.js
+++ b/packages/f-content-cards/stories/mockData/cards.js
@@ -1,4 +1,5 @@
 import faker from 'faker';
+import sha1 from 'crypto-js/sha1';
 
 /* eslint-disable camelcase */
 const cardTypes = {
@@ -108,25 +109,19 @@ function timeRange10HoursAroundNow () {
     };
 }
 
-const encoder = new TextEncoder();
-
 /**
  * Predictably generates a number from a given string by performing a sha-1 hash
  * and extracting the first four bytes as a 32 bit integer
  * @param type
- * @return {Promise<number>}
+ * @return {number}
  */
-async function seedFromType (type) {
-    // const arrayBuffer = new ArrayBuffer(type.length * 4);
-    // const typeBuffer = new Uint8Array(arrayBuffer);
-    const typeBuffer = encoder.encode(type);
-    const typeHash = await crypto.subtle.digest('SHA-1', typeBuffer);
-    const uInt32HashView = new Uint32Array(typeHash);
-    return uInt32HashView[0];
+function seedFromType (type) {
+    const cryptoHash = sha1(type);
+    return cryptoHash.words[0];
 }
 
-async function seededRandomCardOfType (type) {
-    faker.seed(await seedFromType(type));
+function seededRandomCardOfType (type) {
+    faker.seed(seedFromType(type));
     const { nowMinus5Hours, nowPlus5Hours } = timeRange10HoursAroundNow();
 
     const e = {
@@ -175,23 +170,23 @@ async function seededRandomCardOfType (type) {
  *
  * @return {Object}
  */
-export default async () => {
+export default () => {
     const { nowMinus5Hours } = timeRange10HoursAroundNow();
 
     return {
         cards: [
-            await seededRandomCardOfType('Terms_And_Conditions_Card'),
-            await seededRandomCardOfType('Terms_And_Conditions_Card_2'),
-            await seededRandomCardOfType('Header_Card'),
-            await seededRandomCardOfType('Voucher_Card_1'),
-            await seededRandomCardOfType('Recommendation_Card_1'),
-            await seededRandomCardOfType('Promotion_Card_1'),
-            await seededRandomCardOfType('Promotion_Card_2'),
-            await seededRandomCardOfType('Home_Promotion_Card_1'),
-            await seededRandomCardOfType('Home_Promotion_Card_2'),
-            await seededRandomCardOfType('Post_Order_Card_1'),
-            await seededRandomCardOfType('Anniversary_Card_1'),
-            await seededRandomCardOfType('Restaurant_FTC_Offer_Card')
+            seededRandomCardOfType('Terms_And_Conditions_Card'),
+            seededRandomCardOfType('Terms_And_Conditions_Card_2'),
+            seededRandomCardOfType('Header_Card'),
+            seededRandomCardOfType('Voucher_Card_1'),
+            seededRandomCardOfType('Recommendation_Card_1'),
+            seededRandomCardOfType('Promotion_Card_1'),
+            seededRandomCardOfType('Promotion_Card_2'),
+            seededRandomCardOfType('Home_Promotion_Card_1'),
+            seededRandomCardOfType('Home_Promotion_Card_2'),
+            seededRandomCardOfType('Post_Order_Card_1'),
+            seededRandomCardOfType('Anniversary_Card_1'),
+            seededRandomCardOfType('Restaurant_FTC_Offer_Card')
         ],
         /* eslint-disable camelcase */
         last_full_sync_at: nowMinus5Hours,

--- a/packages/f-content-cards/stories/mockData/cards.js
+++ b/packages/f-content-cards/stories/mockData/cards.js
@@ -1,0 +1,175 @@
+import faker from 'faker';
+
+/* eslint-disable camelcase */
+const cardTypes = {
+    Terms_And_Conditions_Card: {
+        label: 'Terms and Conditions',
+        fields: ['line3', 'line4']
+    },
+    Terms_And_Conditions_Card_2: {
+        label: 'Terms and Conditions 2',
+        fields: []
+    },
+    Header_Card: {
+        label: 'Header',
+        fields: ['background_color']
+    },
+    Voucher_Card_1: {
+        label: 'Voucher',
+        fields: ['button_1', 'line_3', 'voucher_code', 'image_1', 'icon_1']
+    },
+    Recommendation_Card_1: {
+        label: 'Recommendation',
+        fields: ['line_3', 'image_1']
+    },
+    Promotion_Card_1: {
+        label: 'Promotion 1',
+        fields: ['image_1', 'button_1', 'line_3', 'line_4', 'line_5', 'line_6', 'offer_auth_required']
+    },
+    Promotion_Card_2: {
+        label: 'Promotion 2',
+        fields: ['icon_1', 'button_1', 'line_3', 'image_1']
+    },
+    Home_Promotion_Card_1: {
+        label: 'Home Promotion 1',
+        fields: ['icon_1', 'button_1', 'background_color', 'content_container_background', 'display_times_json', 'brand_name']
+    },
+    Home_Promotion_Card_2: {
+        label: 'Home Promotion 2',
+        fields: ['button_1', 'background_color', 'display_times_json', 'brand_name']
+    },
+    Post_Order_Card_1: {
+        label: 'Post Order 1',
+        fields: ['button_1', 'headline', 'image_1', 'icon_1']
+    },
+    Anniversary_Card_1: {
+        label: 'Anniversary 1',
+        fields: ['button_1', 'line_3', 'background_image_1', 'voucher_code']
+    },
+    Restaurant_FTC_Offer_Card: {
+        label: 'Restaurant FTC Offer',
+        fields: ['subtitle', 'banner', 'footer', 'restaurant_id', 'restaurant_logo_url', 'restaurant_image_url', 'offer_auth_required']
+    }
+};
+
+const fieldTypeToFaker = {
+    background_color: faker.internet.color.bind(faker.internet),
+    background_image_1: () => 'https://picsum.photos/seed/background_image_1/384/216?blur=3',
+    banner: faker.lorem.sentence.bind(faker.lorem),
+    brand_name: faker.commerce.product.bind(faker.commerce),
+    button_1: faker.lorem.words.bind(faker.lorem),
+    content_container_background: faker.internet.color.bind(faker.internet),
+    display_times_json: () => ({
+        Any: [
+            { Start: '00:00', End: '23:59' }
+        ]
+    }),
+    footer: faker.lorem.sentence.bind(faker.lorem),
+    headline: faker.lorem.sentence.bind(faker.lorem),
+    icon_1: () => 'https://picsum.photos/seed/icon_1/48/48',
+    image_1: () => 'https://picsum.photos/seed/image_1/384/216?blur=3',
+    line3: faker.lorem.sentence.bind(faker.lorem),
+    line4: faker.lorem.sentence.bind(faker.lorem),
+    line_3: faker.lorem.sentence.bind(faker.lorem),
+    line_4: faker.lorem.sentence.bind(faker.lorem),
+    line_5: faker.lorem.sentence.bind(faker.lorem),
+    line_6: faker.lorem.sentence.bind(faker.lorem),
+    offer_auth_required: faker.random.boolean.bind(faker.random),
+    restaurant_id: faker.random.number.bind(faker.random, { min: 100, max: 999999 }),
+    restaurant_image_url: () => 'https://picsum.photos/seed/restaurant_image_url/384/216?blur=3',
+    restaurant_logo_url: () => 'https://picsum.photos/seed/restaurant_logo_url/48/48',
+    subtitle: faker.lorem.sentence.bind(faker.lorem),
+    voucher_code: faker.lorem.slug.bind(faker.lorem)
+};
+/* eslint-enable camelcase */
+
+/**
+ * A set of key types to label as expected by the 'options' knob in storybook
+ *
+ * @type {any}
+ */
+export const labelledMultiSelectAllowedValues = Object.fromEntries(Object.keys(cardTypes)
+    .map(key => [key, cardTypes[key].label]));
+
+function timeRange10HoursAroundNow () {
+    const now = Math.floor(Date.now() / 1000);
+    return {
+        nowPlus5Hours: now + 60 * 60 * 5,
+        nowMinus5Hours: now - 60 * 60 * 5
+    };
+}
+
+function randomCardOfType (type) {
+    const { nowMinus5Hours, nowPlus5Hours } = timeRange10HoursAroundNow();
+
+    const e = {
+        /* eslint-disable camelcase */
+        custom_card_type: type
+        /* eslint-enable camelcase */
+    }; // extra fields
+
+    cardTypes[type].fields
+        .forEach(field => {
+            if (!fieldTypeToFaker[field]) {
+                console.log(`Invalid field: ${field}`);
+                return;
+            }
+
+            e[field] = fieldTypeToFaker[field]();
+        });
+
+    const id = btoa([`5d79109d167e923a83d3d7db_$_cc=${faker.random.uuid()}`, 'mv=5d79109d167e923a83d3d7dd', 'pi=cmp'].join('&'));
+    const tt = faker.lorem.sentence();
+    const ds = faker.lorem.sentence();
+    const dm = faker.internet.domainName();
+
+    return {
+        id,
+        v: false,
+        cl: false,
+        p: true,
+        db: false,
+        ca: nowMinus5Hours,
+        ea: nowPlus5Hours,
+        e,
+        tp: 'short_news',
+        ar: 1,
+        i: null,
+        u: null,
+        uw: null,
+        tt,
+        ds,
+        dm
+    };
+}
+
+/**
+ * Generates a set of faked cards wrapped in data format expected by the braze SDK
+ *
+ * @return {Object}
+ */
+export default () => {
+    const { nowMinus5Hours } = timeRange10HoursAroundNow();
+
+    return {
+        cards: [
+            randomCardOfType('Terms_And_Conditions_Card'),
+            randomCardOfType('Terms_And_Conditions_Card_2'),
+            randomCardOfType('Header_Card'),
+            randomCardOfType('Voucher_Card_1'),
+            randomCardOfType('Recommendation_Card_1'),
+            randomCardOfType('Promotion_Card_1'),
+            randomCardOfType('Promotion_Card_2'),
+            randomCardOfType('Home_Promotion_Card_1'),
+            randomCardOfType('Home_Promotion_Card_2'),
+            randomCardOfType('Post_Order_Card_1'),
+            randomCardOfType('Anniversary_Card_1'),
+            randomCardOfType('Restaurant_FTC_Offer_Card')
+        ],
+        /* eslint-disable camelcase */
+        last_full_sync_at: nowMinus5Hours,
+        last_card_updated_at: nowMinus5Hours,
+        full_sync: true
+        /* eslint-enable camelcase */
+    };
+};

--- a/packages/f-content-cards/stories/mockData/data.js
+++ b/packages/f-content-cards/stories/mockData/data.js
@@ -1,0 +1,57 @@
+/**
+ * Returns some configuration as expected by the braze SDK
+ *
+ * @return {{
+ *   triggers: [],
+ *   config: {
+ *     messaging_session_timeout: number,
+ *     content_cards: {
+ *       enabled: boolean
+ *     },
+ *     purchases_blacklist: string[],
+ *     attributes_blacklist: string[],
+ *     vapid_public_key: string,
+ *     events_blacklist: string[],
+ *     time: number
+ *   }
+ * }}
+ */
+export default () => {
+    const now = Math.floor(Date.now() / 1000);
+
+    /* eslint-disable camelcase */
+    return {
+        triggers: [],
+        config: {
+            time: now,
+            attributes_blacklist: [
+                'control_details',
+                'contrpl_log',
+                'currency',
+                'delivery_method',
+                'exclusions',
+                'order_count',
+                'order_id_local',
+                'order_key',
+                'payment_method_type',
+                'platform',
+                'postcode',
+                'price',
+                'product_id',
+                'purchase_count_yesterday',
+                'restaurant_name',
+                'time',
+                'voucher_code',
+                'voucher_redeemed'
+            ],
+            events_blacklist: ['order_page'],
+            purchases_blacklist: ['Chinese', 'Curry'],
+            messaging_session_timeout: 21600,
+            vapid_public_key: 'FOOBARBAZ',
+            content_cards: {
+                enabled: true
+            }
+        }
+    };
+    /* eslint-enable camelcase */
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -8716,6 +8716,11 @@ eyeglass@^1.1.2:
     node-sass-utils "^1.1.2"
     semver "^5.0.3"
 
+faker@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
+  integrity sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=
+
 fast-async@^6.3.0:
   version "6.3.8"
   resolved "https://registry.yarnpkg.com/fast-async/-/fast-async-6.3.8.tgz#031b9e1d5a84608b117b3e7c999ad477ed2b08a2"
@@ -9667,7 +9672,7 @@ global-prefix@^3.0.0:
     kind-of "^6.0.2"
     which "^1.3.1"
 
-global@^4.3.2, global@^4.4.0:
+global@^4.3.0, global@^4.3.2, global@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
   integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
@@ -20061,6 +20066,14 @@ xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
   integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
+
+xhr-mock@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/xhr-mock/-/xhr-mock-2.5.1.tgz#c591498a8269cc1ce5fefac20d590357affd348b"
+  integrity sha512-UKOjItqjFgPUwQGPmRAzNBn8eTfIhcGjBVGvKYAWxUQPQsXNGD6KEckGTiHwyaAUp9C9igQlnN1Mp79KWCg7CQ==
+  dependencies:
+    global "^4.3.0"
+    url "^0.11.0"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6772,6 +6772,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-js@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
+  integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
+
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"


### PR DESCRIPTION
Adds the capability to check the visual appearance of content cards within the final component wrapper, with faked data.

### Added
- `xhr-mock`, `crypto-js` and `faker` as dev dependencies
- Predictable faked card data for braze SDK responses

### Changed
- Story can multi-select different card types and then 'refresh'

### Example of mocked data (copied from Percy 😼)

![image](https://user-images.githubusercontent.com/6674452/88381662-b301fc00-cd9e-11ea-8705-52b53d30fff3.png)
