### PR TITLE
f-registration@0.9.1 - Patch bump to include new colours

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -4,9 +4,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (roll into next release)
+v0.9.1
 ------------------------------
-*July 23, 2020*
+*July 28, 2020*
 
 ### Changed
 - Vue CLI minor package updates.

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Form Field Component",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist"


### PR DESCRIPTION
### Changed
- Vue CLI minor package updates.
- Small update to colours from updating to `fozzie-colour-palette` in the mono-repo root.