### PR TITLE
f-user-message@0.3.0 Top margin removed

### DIFF
--- a/packages/f-user-message/CHANGELOG.md
+++ b/packages/f-user-message/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.3.0
+------------------------------
+*August 28, 2020*
+
+### Changed
+- Removed component top margin. This should be set in the host app, if required
+- Updated packages. Reduced bundle size
 
 v0.2.0
 ------------------------------
@@ -12,6 +19,8 @@ v0.2.0
 - Small update to colours from updating to `fozzie-colour-palette` in the mono-repo root.
 - Vue CLI minor package updates.
 
+v0.1.1
+------------------------------
 *May 12, 2020*
 
 ### Changed

--- a/packages/f-user-message/package.json
+++ b/packages/f-user-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-user-message",
   "description": "Fozzie User Message – Globalised User Message Component",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/f-user-message.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-user-message/package.json
+++ b/packages/f-user-message/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@justeat/f-services": "0.13.2",
-    "@justeat/f-vue-icons": "0.18.0",
+    "@justeat/f-vue-icons": "^1.2.0",
     "axios": "0.19.2",
     "lodash-es": "4.17.15"
   },

--- a/packages/f-user-message/package.json
+++ b/packages/f-user-message/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@justeat/f-services": "0.13.2",
-    "@justeat/f-vue-icons": "^1.2.0",
+    "@justeat/f-vue-icons": "1.2.0",
     "axios": "0.19.2",
     "lodash-es": "4.17.15"
   },

--- a/packages/f-user-message/src/components/UserMessage.vue
+++ b/packages/f-user-message/src/components/UserMessage.vue
@@ -65,7 +65,6 @@ export default {
     color: $white;
     background-color: $orange;
     max-width: 100%;
-    margin-top: spacing(x2);
 }
 
 .c-userMessage-container {


### PR DESCRIPTION
_Removed component top margin. This should be set in the host app, if required_
_Issue #160  Updated dependencies and removed unused ones. Reduced bundle size_

Before: 
<img width="492" alt="Screenshot 2020-07-16 at 17 02 25" src="https://user-images.githubusercontent.com/26770126/87695454-6d827500-c787-11ea-9112-384951a0bad5.png">
After: 
<img width="489" alt="Screenshot 2020-07-16 at 17 09 42" src="https://user-images.githubusercontent.com/26770126/87695461-6fe4cf00-c787-11ea-9a5c-2bdfb6658307.png">

It pushes the page content down, below header, creating an unwanted gap. See screenshot below. 

---

## UI Review Checks

![Screenshot 2020-07-16 at 15 32 12](https://user-images.githubusercontent.com/26770126/87683940-8edc6480-c779-11ea-904c-06d13f8404f3.png)

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Internet Explorer 11
- [x] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
