### PR TITLE
f-user-message@v0.3.0 - Removing top margin from component

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,11 +44,11 @@ jobs:
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-              - yarn-packages-{{ checksum "yarn.lock" }}
+              - yarn-packages-v1-{{ checksum "yarn.lock" }}
       - install_node_dependencies
       - save_cache:
           name: Save Yarn Package Cache
-          key: yarn-packages-{{ checksum "yarn.lock" }}
+          key: yarn-packages-v1-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
       - run: # Run PR Checks
@@ -76,7 +76,7 @@ jobs:
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            - yarn-packages-{{ checksum "yarn.lock" }}
+            - yarn-packages-v1-{{ checksum "yarn.lock" }}
       - install_node_dependencies
       - build_packages
       - run:

--- a/packages/f-user-message/CHANGELOG.md
+++ b/packages/f-user-message/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.3.0
+------------------------------
+*July 31, 2020*
+
+### Changed
+- Removed component top margin. This should be set in the host app, if required.
+- Updated packages. Reduced bundle size.
+
+
 v0.2.0
 ------------------------------
 *July 23, 2020*
@@ -12,6 +21,9 @@ v0.2.0
 - Small update to colours from updating to `fozzie-colour-palette` in the mono-repo root.
 - Vue CLI minor package updates.
 
+
+v0.1.1
+------------------------------
 *May 12, 2020*
 
 ### Changed

--- a/packages/f-user-message/package.json
+++ b/packages/f-user-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-user-message",
   "description": "Fozzie User Message – Globalised User Message Component",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/f-user-message.umd.min.js",
   "files": [
     "dist"
@@ -37,9 +37,8 @@
   ],
   "dependencies": {
     "@justeat/f-services": "0.13.2",
-    "@justeat/f-vue-icons": "0.18.0",
-    "axios": "0.19.2",
-    "lodash-es": "4.17.15"
+    "@justeat/f-vue-icons": "1.2.0",
+    "axios": "0.19.2"
   },
   "peerDependencies": {
     "@justeat/eslint-config-fozzie": "3.3.1",

--- a/packages/f-user-message/src/components/UserMessage.vue
+++ b/packages/f-user-message/src/components/UserMessage.vue
@@ -61,11 +61,11 @@ export default {
 </script>
 
 <style lang="scss" module>
+
 .c-userMessage {
     color: $white;
     background-color: $orange;
     max-width: 100%;
-    margin-top: spacing(x2);
 }
 
 .c-userMessage-container {
@@ -104,4 +104,5 @@ export default {
         padding-left: 0;
     }
 }
+
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,14 +1476,6 @@
   dependencies:
     "@justeat/f-services" "1.0.0"
 
-"@justeat/f-icons@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-1.32.0.tgz#d3f68ab1a59fd14069e184a6f6dff4a5d42c4e70"
-  integrity sha512-2Y9IRarHS5Uyv3iy/g3e4O6dqs7LaxfBNfudGnFkotB1O8HTffOFTwc5dBtSunkleHmCr5MMDAhaEJoAeSNL/A==
-  dependencies:
-    "@justeat/f-utils" "0.3.0"
-    include-media "1.4.9"
-
 "@justeat/f-icons@2.0.0-beta.9":
   version "2.0.0-beta.9"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-2.0.0-beta.9.tgz#af5c16c8562fd62d4c456c18f0773f68c796c625"
@@ -1533,14 +1525,6 @@
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.3.0.tgz#1f18ba13ad7061e21c2112387234a77ba45fb5d3"
   integrity sha512-hqRiGA2lP++Z1oqawsv1V2Duf3YShaAbJ3S5JEPTpTMP5RjH36Xpc8nRbIVFBmwnZCu7L9iF7AebYTUX8XhiZA==
-
-"@justeat/f-vue-icons@0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-0.18.0.tgz#6438c33985a5a9c7d70b82dc9ef07300fa00b6f1"
-  integrity sha512-PSWTq+RtHgUisyGH+6OUoygx8cIFOUumbYzfMR72D18/vc3TxUGiwC3R4psCf/acLmxYGALXHW1sjku9AFbUnw==
-  dependencies:
-    "@justeat/f-icons" "1.32.0"
-    vue "2.6.10"
 
 "@justeat/f-vue-icons@1.0.0":
   version "1.0.0"
@@ -19464,11 +19448,6 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
-
-vue@2.6.10:
-  version "2.6.10"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
-  integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==
 
 vuelidate@0.7.5:
   version "0.7.5"


### PR DESCRIPTION
_Removed component top margin. This should be set in the host app, if required_
_Issue #160  Updated dependencies and removed unused ones. Reduced bundle size_

Before: 
<img width="492" alt="Screenshot 2020-07-16 at 17 02 25" src="https://user-images.githubusercontent.com/26770126/87695454-6d827500-c787-11ea-9112-384951a0bad5.png">
After: 
<img width="489" alt="Screenshot 2020-07-16 at 17 09 42" src="https://user-images.githubusercontent.com/26770126/87695461-6fe4cf00-c787-11ea-9a5c-2bdfb6658307.png">

It pushes the page content down, below header, creating an unwanted gap. See screenshot below. 

---

## UI Review Checks

![Screenshot 2020-07-16 at 15 32 12](https://user-images.githubusercontent.com/26770126/87683940-8edc6480-c779-11ea-904c-06d13f8404f3.png)

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Internet Explorer 11
- [x] Mobile