### PR TITLE
f-registration@0.9.2 - Change `email` to `emailAddress` in POST request

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.9.2
+------------------------------
+*July 31, 2020*
+
+### Fixed
+- Changed property name of POST object from `email` to `emailAddress`.
+
+
 v0.9.1
 ------------------------------
 *July 28, 2020*
@@ -19,16 +27,10 @@ v0.9.0
 
 ### Changed
 - Update registration component to handle AccountWeb API endpoint.
-
-*July 2, 2020*
+- Updating colour variables to use new versions set in `fozzie-colour-palette`.
 
 ### Added
 - Accessibility add-on to Storybook story.
-
-*June 25, 2020*
-
-### Changed
-- Updating colour variables to use new versions set in `fozzie-colour-palette`.
 
 
 v0.7.1

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Form Field Component",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -242,7 +242,7 @@ export default {
                 const registrationData = {
                     firstName: this.firstName,
                     lastName: this.lastName,
-                    email: this.email,
+                    emailAddress: this.email,
                     password: this.password
                 };
                 await RegistrationServiceApi.createAccount(this.createAccountUrl, this.tenant, registrationData);


### PR DESCRIPTION
We were getting the following response:
```
{"faultId":"4f3ebbe4-b1ed-46ab-8759-5c113506592b","traceId":"800005b2-0000-fc00-b63f-84710c7967bb","errors":[{"description":"EmailAddress is required","errorCode":"400"}]}
```

[And looking at AccountAPI, it confirms that `emailAddress` is expected.](https://github.je-labs.com/Account-Vertical/AccountApi/blob/master/src/JE.Account.AccountApi.Contracts/CreateConsumerModel.cs#L8)