### PR TITLE
f-registration@0.10.0 - Handle 409 response to show custom error message

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.10.0
+------------------------------
+*August 3, 2020*
+
+### Fixed
+- Update expected structure of the axios error object to show custom 409 error message
+
+
 v0.9.2
 ------------------------------
 *July 31, 2020*

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Form Field Component",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -248,12 +248,16 @@ export default {
                 await RegistrationServiceApi.createAccount(this.createAccountUrl, this.tenant, registrationData);
                 this.$emit(EventNames.CreateAccountSuccess);
             } catch (error) {
-                const thrownErrors = error.Errors || error;
+                let thrownErrors = error;
+                if (error && error.response && error.response.data && error.response.data.errors) {
+                    thrownErrors = error.response.data.errors;
+                }
+
                 if (Array.isArray(thrownErrors)) {
-                    if (thrownErrors.some(thrownError => thrownError.ErrorCode === '409')) {
+                    if (thrownErrors.some(thrownError => thrownError.errorCode === '409')) {
                         this.shouldShowEmailAlreadyExistsError = true;
                     } else {
-                        this.genericErrorMessage = thrownErrors[0].Description || 'Something went wrong, please try again later';
+                        this.genericErrorMessage = thrownErrors[0].description || 'Something went wrong, please try again later';
                     }
                 } else {
                     this.genericErrorMessage = error;

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -135,7 +135,7 @@ describe('Registration', () => {
 
         it('should show error message and emit failure event when service responds with a 409', async () => {
             // Arrange
-            const err = { FaultId: '123', TraceId: '123', Errors: [{ Description: 'The specified email already exists', ErrorCode: '409' }] };
+            const err = { response: { data: { faultId: '123', traceId: '123', errors: [{ description: 'The specified email already exists', errorCode: '409' }] } } };
             RegistrationServiceApi.createAccount.mockImplementation(async () => { throw err; });
             const wrapper = mountComponentAndAttachToDocument();
             Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
@@ -154,7 +154,7 @@ describe('Registration', () => {
 
         it('should populate generic error message and emit failure event when service responds with a 400', async () => {
             // Arrange
-            const err = { FaultId: '123', TraceId: '123', Errors: [{ Description: 'The Password field is required', ErrorCode: '400' }] };
+            const err = { response: { data: { faultId: '123', traceId: '123', errors: [{ description: 'The Password field is required', errorCode: '400' }] } } };
             RegistrationServiceApi.createAccount.mockImplementation(async () => { throw err; });
             const wrapper = mountComponentAndAttachToDocument();
             Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
@@ -173,7 +173,7 @@ describe('Registration', () => {
 
         it('should show default error message and emit failure event when service with an error with no description', async () => {
             // Arrange
-            const err = { Errors: [{ ErrorCode: 'XXX' }] };
+            const err = { response: { data: { errors: [{ errorCode: 'XXX' }] } } };
             RegistrationServiceApi.createAccount.mockImplementation(async () => { throw err; });
             const wrapper = mountComponentAndAttachToDocument();
             Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });


### PR DESCRIPTION
Update the expected structure of the axios error response object, and update the logic so that we can show a custom error message for 409 response (an account with this email address already exists).

---

## UI Review Checks
- [x] Unit tests have been [created|updated]

## Browsers Tested
- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)