### PR TITLE
f-registration@0.11.0 - Add validation for first and last name

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.11.0
+------------------------------
+*August 5, 2020*
+
+### Added
+- Validation on First name and Last name regarding max length and invalid characters
+
+
 v0.10.0
 ------------------------------
 *August 3, 2020*

--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.11.0
 ------------------------------
-*August 5, 2020*
+*August 6, 2020*
 
 ### Added
 - Validation on First name and Last name regarding max length and invalid characters

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Form Field Component",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -36,7 +36,19 @@
                         v-if="shouldShowFirstNameRequiredError"
                         :class="$style['o-form-error']">
                         <warning-icon :class="$style['o-form-error-icon']" />
-                        Please enter your first name
+                        Please include your first name
+                    </p>
+                    <p
+                        v-if="shouldShowFirstNameMaxLengthError"
+                        :class="$style['o-form-error']">
+                        <warning-icon :class="$style['o-form-error-icon']" />
+                        First name exceeds 50 chars
+                    </p>
+                    <p
+                        v-if="shouldShowFirstNameInvalidCharError"
+                        :class="$style['o-form-error']">
+                        <warning-icon :class="$style['o-form-error-icon']" />
+                        Name should only contain letters, hyphens or apostrophes
                     </p>
                 </template>
             </form-field>
@@ -53,7 +65,13 @@
                         v-if="shouldShowLastNameRequiredError"
                         :class="$style['o-form-error']">
                         <warning-icon :class="$style['o-form-error-icon']" />
-                        Please enter your last name
+                        Please include your last name
+                    </p>
+                    <p
+                        v-if="shouldShowLastNameMaxLengthError"
+                        :class="$style['o-form-error']">
+                        <warning-icon :class="$style['o-form-error-icon']" />
+                        Last name exceeds 50 chars
                     </p>
                 </template>
             </form-field>
@@ -119,7 +137,7 @@
 <script>
 import { globalisationServices } from '@justeat/f-services';
 import { validationMixin } from 'vuelidate';
-import { required, email } from 'vuelidate/lib/validators';
+import { required, email, maxLength } from 'vuelidate/lib/validators';
 import { WarningIcon } from '@justeat/f-vue-icons';
 import Card from '@justeat/f-card';
 import '@justeat/f-card/dist/f-card.css';
@@ -129,6 +147,14 @@ import FormButton from './Button.vue';
 import tenantConfigs from '../tenants';
 import RegistrationServiceApi from '../services/RegistrationServiceApi';
 import EventNames from '../event-names';
+
+// Returns true if there are no invalid chars in value. Valid chars are: a-z, A-Z, apostrophe, hyphen
+const validCharsInName = value => {
+    if (typeof value === 'undefined' || value === null || value === '') {
+        return true;
+    }
+    return /^[a-zA-Z'-]*$/.test(value);
+};
 
 export default {
     name: 'Registration',
@@ -190,7 +216,13 @@ export default {
     computed: {
         // Returns true if required validation conditions are not met and if the field has been `touched` by a user
         shouldShowFirstNameRequiredError () {
-            return (this.$v.firstName.$invalid && !this.$v.firstName.required) && this.$v.firstName.$dirty;
+            return this.$v.firstName.$invalid && !this.$v.firstName.required && this.$v.firstName.$dirty;
+        },
+        shouldShowFirstNameMaxLengthError () {
+            return this.$v.firstName.$invalid && !this.$v.firstName.maxLength && this.$v.firstName.$dirty;
+        },
+        shouldShowFirstNameInvalidCharError () {
+            return this.$v.firstName.$invalid && !this.$v.firstName.validCharsInName && this.$v.firstName.$dirty;
         },
         // Returns true if required validation conditions are not met and if the field has been `touched` by a user
         shouldShowLastNameRequiredError () {
@@ -215,10 +247,13 @@ export default {
 
     validations: {
         firstName: {
-            required
+            required,
+            maxLength: maxLength(50),
+            validCharsInName
         },
         lastName: {
-            required
+            required,
+            maxLength: maxLength(50)
         },
         email: {
             required,

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -48,7 +48,7 @@
                         v-if="shouldShowFirstNameInvalidCharError"
                         :class="$style['o-form-error']">
                         <warning-icon :class="$style['o-form-error-icon']" />
-                        Name should only contain letters, hyphens or apostrophes
+                        First name should only contain letters, hyphens or apostrophes
                     </p>
                 </template>
             </form-field>
@@ -72,6 +72,12 @@
                         :class="$style['o-form-error']">
                         <warning-icon :class="$style['o-form-error-icon']" />
                         Last name exceeds 50 chars
+                    </p>
+                    <p
+                        v-if="shouldShowLastNameInvalidCharError"
+                        :class="$style['o-form-error']">
+                        <warning-icon :class="$style['o-form-error-icon']" />
+                        Last name should only contain letters, hyphens or apostrophes
                     </p>
                 </template>
             </form-field>
@@ -214,7 +220,8 @@ export default {
     },
 
     computed: {
-        // Returns true if required validation conditions are not met and if the field has been `touched` by a user
+        // Validation methods return true if the validation conditions
+        // have not been met and the field has been `touched` by a user.
         shouldShowFirstNameRequiredError () {
             return this.$v.firstName.$invalid && !this.$v.firstName.required && this.$v.firstName.$dirty;
         },
@@ -224,19 +231,21 @@ export default {
         shouldShowFirstNameInvalidCharError () {
             return this.$v.firstName.$invalid && !this.$v.firstName.validCharsInName && this.$v.firstName.$dirty;
         },
-        // Returns true if required validation conditions are not met and if the field has been `touched` by a user
         shouldShowLastNameRequiredError () {
-            return (this.$v.lastName.$invalid && !this.$v.lastName.required) && this.$v.lastName.$dirty;
+            return this.$v.lastName.$invalid && !this.$v.lastName.required && this.$v.lastName.$dirty;
         },
-        // Returns true if required validation conditions are not met and if the field has been `touched` by a user
+        shouldShowLastNameMaxLengthError () {
+            return this.$v.lastName.$invalid && !this.$v.lastName.maxLength && this.$v.lastName.$dirty;
+        },
+        shouldShowLastNameInvalidCharError () {
+            return this.$v.lastName.$invalid && !this.$v.lastName.validCharsInName && this.$v.lastName.$dirty;
+        },
         shouldShowEmailRequiredError () {
             return (this.$v.email.$invalid && !this.$v.email.required) && this.$v.email.$dirty;
         },
-        // Returns true if email validation conditions are not met and if the field has been `touched` by a user
         shouldShowEmailInvalidError () {
             return (this.$v.email.$invalid && !this.$v.email.email) && this.$v.email.$dirty;
         },
-        // Returns true if email validation conditions are not met and if the field has been `touched` by a user
         shouldShowPasswordRequiredError () {
             return (this.$v.password.$invalid && !this.$v.password.required) && this.$v.password.$dirty;
         },
@@ -253,7 +262,8 @@ export default {
         },
         lastName: {
             required,
-            maxLength: maxLength(50)
+            maxLength: maxLength(50),
+            validCharsInName
         },
         email: {
             required,

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -42,7 +42,7 @@
                         v-if="shouldShowFirstNameMaxLengthError"
                         :class="$style['o-form-error']">
                         <warning-icon :class="$style['o-form-error-icon']" />
-                        First name exceeds 50 chars
+                        First name exceeds 50 characters
                     </p>
                     <p
                         v-if="shouldShowFirstNameInvalidCharError"
@@ -71,7 +71,7 @@
                         v-if="shouldShowLastNameMaxLengthError"
                         :class="$style['o-form-error']">
                         <warning-icon :class="$style['o-form-error-icon']" />
-                        Last name exceeds 50 chars
+                        Last name exceeds 50 characters
                     </p>
                     <p
                         v-if="shouldShowLastNameInvalidCharError"
@@ -154,7 +154,12 @@ import tenantConfigs from '../tenants';
 import RegistrationServiceApi from '../services/RegistrationServiceApi';
 import EventNames from '../event-names';
 
-// Returns true if there are no invalid chars in value. Valid chars are: a-z, A-Z, apostrophe, hyphen
+/**
+ * Returns Tests for existence of valid chars only. Valid chars are: '', a-z, A-Z, apostrophe, hyphen
+ *
+ * @param {string} value The string to test.
+ * @return {boolean} True if there are no invalid chars in value, false otherwise.
+ */
 const validCharsInName = value => {
     if (typeof value === 'undefined' || value === null || value === '') {
         return true;
@@ -220,8 +225,11 @@ export default {
     },
 
     computed: {
-        // Validation methods return true if the validation conditions
-        // have not been met and the field has been `touched` by a user.
+        /*
+         * Validation methods return true if the validation conditions
+         * have not been met and the field has been `touched` by a user.
+         */
+
         shouldShowFirstNameRequiredError () {
             return this.$v.firstName.$invalid && !this.$v.firstName.required && this.$v.firstName.$dirty;
         },

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -155,17 +155,12 @@ import RegistrationServiceApi from '../services/RegistrationServiceApi';
 import EventNames from '../event-names';
 
 /**
- * Returns Tests for existence of valid chars only. Valid chars are: '', a-z, A-Z, apostrophe, hyphen
+ * Tests for existence of valid chars only in a string.
  *
  * @param {string} value The string to test.
  * @return {boolean} True if there are no invalid chars in value, false otherwise.
  */
-const validCharsInName = value => {
-    if (typeof value === 'undefined' || value === null || value === '') {
-        return true;
-    }
-    return /^[a-zA-Z'-]*$/.test(value);
-};
+const meetsCharacterValidationRules = value => /^[\u0060\u00C0-\u00F6\u00F8-\u017Fa-zA-Z-' ]*$/.test(value);
 
 export default {
     name: 'Registration',
@@ -228,34 +223,36 @@ export default {
         /*
          * Validation methods return true if the validation conditions
          * have not been met and the field has been `touched` by a user.
+         * The $dirty boolean changes to true when the user has focused/lost
+         * focus on the input field.
          */
 
         shouldShowFirstNameRequiredError () {
-            return this.$v.firstName.$invalid && !this.$v.firstName.required && this.$v.firstName.$dirty;
+            return !this.$v.firstName.required && this.$v.firstName.$dirty;
         },
         shouldShowFirstNameMaxLengthError () {
-            return this.$v.firstName.$invalid && !this.$v.firstName.maxLength && this.$v.firstName.$dirty;
+            return !this.$v.firstName.maxLength && this.$v.firstName.$dirty;
         },
         shouldShowFirstNameInvalidCharError () {
-            return this.$v.firstName.$invalid && !this.$v.firstName.validCharsInName && this.$v.firstName.$dirty;
+            return !this.$v.firstName.meetsCharacterValidationRules && this.$v.firstName.$dirty;
         },
         shouldShowLastNameRequiredError () {
-            return this.$v.lastName.$invalid && !this.$v.lastName.required && this.$v.lastName.$dirty;
+            return !this.$v.lastName.required && this.$v.lastName.$dirty;
         },
         shouldShowLastNameMaxLengthError () {
-            return this.$v.lastName.$invalid && !this.$v.lastName.maxLength && this.$v.lastName.$dirty;
+            return !this.$v.lastName.maxLength && this.$v.lastName.$dirty;
         },
         shouldShowLastNameInvalidCharError () {
-            return this.$v.lastName.$invalid && !this.$v.lastName.validCharsInName && this.$v.lastName.$dirty;
+            return !this.$v.lastName.meetsCharacterValidationRules && this.$v.lastName.$dirty;
         },
         shouldShowEmailRequiredError () {
-            return (this.$v.email.$invalid && !this.$v.email.required) && this.$v.email.$dirty;
+            return !this.$v.email.required && this.$v.email.$dirty;
         },
         shouldShowEmailInvalidError () {
-            return (this.$v.email.$invalid && !this.$v.email.email) && this.$v.email.$dirty;
+            return !this.$v.email.email && this.$v.email.$dirty;
         },
         shouldShowPasswordRequiredError () {
-            return (this.$v.password.$invalid && !this.$v.password.required) && this.$v.password.$dirty;
+            return !this.$v.password.required && this.$v.password.$dirty;
         },
         shouldShowLoginLink () {
             return this.loginSettings && this.loginSettings.linkText && this.loginSettings.url;
@@ -266,12 +263,12 @@ export default {
         firstName: {
             required,
             maxLength: maxLength(50),
-            validCharsInName
+            meetsCharacterValidationRules
         },
         lastName: {
             required,
             maxLength: maxLength(50),
-            validCharsInName
+            meetsCharacterValidationRules
         },
         email: {
             required,

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -230,6 +230,70 @@ describe('Registration', () => {
             }
         });
 
+        it('should show error message and emit failure event when the first name field is populated with too long an input', async () => {
+            // Arrange
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                const longValue = 'abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij';
+                wrapper.find('[data-test-id="input-first-name"]').setValue(longValue);
+
+                // Act
+                await wrapper.vm.onFormSubmit();
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowFirstNameRequiredError).toBe(false);
+                expect(wrapper.vm.shouldShowFirstNameMaxLengthError).toBe(true);
+                expect(wrapper.vm.shouldShowFirstNameInvalidCharError).toBe(false);
+                expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+            } finally {
+                wrapper.destroy();
+            }
+        });
+
+        it('should show error message and emit failure event when the last name field is not populated', async () => {
+            // Arrange
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                wrapper.find('[data-test-id="input-first-name"]').setValue('Adam');
+
+                // Act
+                await wrapper.vm.onFormSubmit();
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowLastNameRequiredError).toBe(true);
+                expect(wrapper.vm.shouldShowLastNameMaxLengthError).toBe(false);
+                expect(wrapper.vm.shouldShowLastNameInvalidCharError).toBe(false);
+                expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+            } finally {
+                wrapper.destroy();
+            }
+        });
+
+        it('should show error message and emit failure event when the last name field is populated with invalid input', async () => {
+            // Arrange
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                wrapper.find('[data-test-id="input-last-name"]').setValue('wh4t @ w3!rd |\\|ame');
+
+                // Act
+                await wrapper.vm.onFormSubmit();
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowLastNameRequiredError).toBe(false);
+                expect(wrapper.vm.shouldShowLastNameMaxLengthError).toBe(false);
+                expect(wrapper.vm.shouldShowLastNameInvalidCharError).toBe(true);
+                expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+            } finally {
+                wrapper.destroy();
+            }
+        });
+
         it('should show error message and emit failure event when the last name field is populated with too long an input', async () => {
             // Arrange
             const wrapper = mountComponentAndAttachToDocument();
@@ -247,6 +311,34 @@ describe('Registration', () => {
                 expect(wrapper.vm.shouldShowLastNameMaxLengthError).toBe(true);
                 expect(wrapper.vm.shouldShowLastNameInvalidCharError).toBe(false);
                 expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+            } finally {
+                wrapper.destroy();
+            }
+        });
+
+        it('should show not error messages and emit success event when the name fields are populated correctly', async () => {
+            // Arrange
+            RegistrationServiceApi.createAccount.mockImplementation(async () => Promise.resolve());
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                wrapper.find('[data-test-id="input-first-name"]').setValue('James');
+                wrapper.find('[data-test-id="input-last-name"]').setValue('O\'Neil-Wight');
+                wrapper.find('[data-test-id="input-email"]').setValue('ashton.adamms+jetest@just-eat.com');
+                wrapper.find('[data-test-id="input-password"]').setValue('Secure123');
+
+                // Act
+                await wrapper.vm.onFormSubmit();
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowFirstNameRequiredError).toBe(false);
+                expect(wrapper.vm.shouldShowFirstNameMaxLengthError).toBe(false);
+                expect(wrapper.vm.shouldShowFirstNameInvalidCharError).toBe(false);
+                expect(wrapper.vm.shouldShowLastNameRequiredError).toBe(false);
+                expect(wrapper.vm.shouldShowLastNameMaxLengthError).toBe(false);
+                expect(wrapper.vm.shouldShowLastNameInvalidCharError).toBe(false);
+                expect(wrapper.emitted(EventNames.CreateAccountSuccess).length).toBe(1);
             } finally {
                 wrapper.destroy();
             }

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -229,5 +229,27 @@ describe('Registration', () => {
                 wrapper.destroy();
             }
         });
+
+        it('should show error message and emit failure event when the last name field is populated with too long an input', async () => {
+            // Arrange
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                const longValue = 'abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij';
+                wrapper.find('[data-test-id="input-last-name"]').setValue(longValue);
+
+                // Act
+                await wrapper.vm.onFormSubmit();
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowLastNameRequiredError).toBe(false);
+                expect(wrapper.vm.shouldShowLastNameMaxLengthError).toBe(true);
+                expect(wrapper.vm.shouldShowLastNameInvalidCharError).toBe(false);
+                expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+            } finally {
+                wrapper.destroy();
+            }
+        });
     });
 });

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -189,5 +189,45 @@ describe('Registration', () => {
                 wrapper.destroy();
             }
         });
+
+        it('should show error message and emit failure event when the first name field is not populated', async () => {
+            // Arrange
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                // Act
+                await wrapper.vm.onFormSubmit();
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowFirstNameRequiredError).toBe(true);
+                expect(wrapper.vm.shouldShowFirstNameMaxLengthError).toBe(false);
+                expect(wrapper.vm.shouldShowFirstNameInvalidCharError).toBe(false);
+                expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+            } finally {
+                wrapper.destroy();
+            }
+        });
+
+        it('should show error message and emit failure event when the first name field is populated with invalid input', async () => {
+            // Arrange
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                wrapper.find('[data-test-id="input-first-name"]').setValue('wh4t @ w3!rd |\\|ame');
+
+                // Act
+                await wrapper.vm.onFormSubmit();
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowFirstNameRequiredError).toBe(false);
+                expect(wrapper.vm.shouldShowFirstNameMaxLengthError).toBe(false);
+                expect(wrapper.vm.shouldShowFirstNameInvalidCharError).toBe(true);
+                expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+            } finally {
+                wrapper.destroy();
+            }
+        });
     });
 });


### PR DESCRIPTION
Improved validation for first name and last name.

The validation rules are to be aligned with [current production](https://www.just-eat.co.uk/account/register) so that we can compare drop-off rates when deployed before relaxing the validation later on.

- [X] README and/or UI Documentation has been [created|updated]
- [X] Unit tests have been [created|updated]

## Browsers Tested

- [X] Chrome (latest)
- [X] Edge
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)
