### PR TITLE
f-registration@0.11.1

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.11.1
+------------------------------
+*August 7, 2020*
+
+### Changed
+- Unit tests cleaned up in Registration.test.js
+
+
 v0.11.0
 ------------------------------
 *August 6, 2020*

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Form Field Component",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -304,7 +304,7 @@ describe('Registration', () => {
             }
         });
 
-        it('should show not error messages and emit success event when all fields are populated correctly', async () => {
+        it('should emit success event when all fields are populated correctly', async () => {
             // Arrange
             RegistrationServiceApi.createAccount.mockImplementation(async () => Promise.resolve());
             const wrapper = mountComponentAndAttachToDocument();

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -201,8 +201,6 @@ describe('Registration', () => {
 
                 // Assert
                 expect(wrapper.vm.shouldShowFirstNameRequiredError).toBe(true);
-                expect(wrapper.vm.shouldShowFirstNameMaxLengthError).toBe(false);
-                expect(wrapper.vm.shouldShowFirstNameInvalidCharError).toBe(false);
                 expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
             } finally {
                 wrapper.destroy();
@@ -221,8 +219,6 @@ describe('Registration', () => {
                 await flushPromises();
 
                 // Assert
-                expect(wrapper.vm.shouldShowFirstNameRequiredError).toBe(false);
-                expect(wrapper.vm.shouldShowFirstNameMaxLengthError).toBe(false);
                 expect(wrapper.vm.shouldShowFirstNameInvalidCharError).toBe(true);
                 expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
             } finally {
@@ -243,9 +239,7 @@ describe('Registration', () => {
                 await flushPromises();
 
                 // Assert
-                expect(wrapper.vm.shouldShowFirstNameRequiredError).toBe(false);
                 expect(wrapper.vm.shouldShowFirstNameMaxLengthError).toBe(true);
-                expect(wrapper.vm.shouldShowFirstNameInvalidCharError).toBe(false);
                 expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
             } finally {
                 wrapper.destroy();
@@ -265,8 +259,6 @@ describe('Registration', () => {
 
                 // Assert
                 expect(wrapper.vm.shouldShowLastNameRequiredError).toBe(true);
-                expect(wrapper.vm.shouldShowLastNameMaxLengthError).toBe(false);
-                expect(wrapper.vm.shouldShowLastNameInvalidCharError).toBe(false);
                 expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
             } finally {
                 wrapper.destroy();
@@ -285,8 +277,6 @@ describe('Registration', () => {
                 await flushPromises();
 
                 // Assert
-                expect(wrapper.vm.shouldShowLastNameRequiredError).toBe(false);
-                expect(wrapper.vm.shouldShowLastNameMaxLengthError).toBe(false);
                 expect(wrapper.vm.shouldShowLastNameInvalidCharError).toBe(true);
                 expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
             } finally {
@@ -307,20 +297,17 @@ describe('Registration', () => {
                 await flushPromises();
 
                 // Assert
-                expect(wrapper.vm.shouldShowLastNameRequiredError).toBe(false);
                 expect(wrapper.vm.shouldShowLastNameMaxLengthError).toBe(true);
-                expect(wrapper.vm.shouldShowLastNameInvalidCharError).toBe(false);
                 expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
             } finally {
                 wrapper.destroy();
             }
         });
 
-        it('should show not error messages and emit success event when the name fields are populated correctly', async () => {
+        it('should show not error messages and emit success event when all fields are populated correctly', async () => {
             // Arrange
             RegistrationServiceApi.createAccount.mockImplementation(async () => Promise.resolve());
             const wrapper = mountComponentAndAttachToDocument();
-            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
             try {
                 wrapper.find('[data-test-id="input-first-name"]').setValue('James');
                 wrapper.find('[data-test-id="input-last-name"]').setValue('O\'Neil-Wight');
@@ -332,12 +319,6 @@ describe('Registration', () => {
                 await flushPromises();
 
                 // Assert
-                expect(wrapper.vm.shouldShowFirstNameRequiredError).toBe(false);
-                expect(wrapper.vm.shouldShowFirstNameMaxLengthError).toBe(false);
-                expect(wrapper.vm.shouldShowFirstNameInvalidCharError).toBe(false);
-                expect(wrapper.vm.shouldShowLastNameRequiredError).toBe(false);
-                expect(wrapper.vm.shouldShowLastNameMaxLengthError).toBe(false);
-                expect(wrapper.vm.shouldShowLastNameInvalidCharError).toBe(false);
                 expect(wrapper.emitted(EventNames.CreateAccountSuccess).length).toBe(1);
             } finally {
                 wrapper.destroy();


### PR DESCRIPTION
Unit tests cleaned up in Registration.test.js

- [X] README and/or UI Documentation has been [created|updated]
- [X] Unit tests have been [created|updated]