### PR TITLE
f-content-cards@v1.10.0 🅰 Header/TnC card

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,9 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.10.0
+------------------------------
+*August 18, 2020*
+
+### Added
+- `Terms and Conditions Card` (title) card type, with associated tests and story.
+
+
 v1.9.0
 ------------------------------
-*August 10, 2020*
+*August 11, 2020*
 
 ### Changed
 - Move content card type checks to appropriate components to avoid explicit card type comparisons in `CardContainer`.

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -207,6 +207,9 @@ export default {
                 case 'Promotion_Card_1':
                 case 'Promotion_Card_2':
                     return 'PromotionCard';
+                case 'Terms_And_Conditions_Card':
+                case 'Terms_And_Conditions_Card_2':
+                    return 'TermsAndConditionsCard';
                 default:
                     break;
             }

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -197,6 +197,12 @@ export default {
             this.$emit('has-loaded', true);
         },
 
+        /**
+         * Maps given card type to component name
+         *
+         * @param type
+         * @return {string|boolean}
+         */
         handleCustomCardType (type) {
             switch (type) {
                 case 'Anniversary_Card_1':

--- a/packages/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
@@ -8,16 +8,16 @@
             {{ titleCard.title }}
         </h1>
         <h2
-            :data-test-id="dataTestId('description')"
+            :data-test-id="dataTestId('subtitle')"
             :class="$style['c-contentCards-tnc-card-secondaryHeader']">
-            {{ titleCard.description }}
+            {{ titleCard.subtitle }}
         </h2>
         <p>
             <a
                 :href="titleCard.url"
                 :data-test-id="dataTestId('cta')"
                 class="o-link--noDecoration o-link--bold">
-                {{ titleCard.ctaLabel }}
+                {{ titleCard.ctaText }}
             </a>
         </p>
     </div>
@@ -30,8 +30,8 @@ export default {
             type: Object,
             default: () => ({
                 title: false,
-                description: false,
-                ctaLabel: false,
+                subtitle: false,
+                ctaText: false,
                 url: false
             })
         },
@@ -45,8 +45,8 @@ export default {
     computed: {
         suppliedCardHasAllProperties () {
             return this.card.title &&
-                this.card.description &&
-                this.card.ctaLabel &&
+                this.card.subtitle &&
+                this.card.ctaText &&
                 this.card.url;
         },
 
@@ -55,8 +55,8 @@ export default {
                 ? this.card
                 : {
                     title: this.copy.loggedInTitle,
-                    description: this.copy.loggedInSubtitle,
-                    ctaLabel: this.copy.loggedInTermsText,
+                    subtitle: this.copy.loggedInSubtitle,
+                    ctaText: this.copy.loggedInTermsText,
                     url: this.copy.loggedInTermsUrl
                 };
         }

--- a/packages/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
@@ -1,0 +1,103 @@
+<template>
+    <div
+        :data-test-id="dataTestId('shell')"
+        :class="$style['c-contentCards-tnc-card-shell']">
+        <h1
+            :data-test-id="dataTestId('title')"
+            :class="$style['c-contentCards-tnc-card-primaryHeader']">
+            {{ titleCard.title }}
+        </h1>
+        <h2
+            :data-test-id="dataTestId('description')"
+            :class="$style['c-contentCards-tnc-card-secondaryHeader']">
+            {{ titleCard.description }}
+        </h2>
+        <p>
+            <a
+                :href="titleCard.url"
+                :data-test-id="dataTestId('cta')"
+                class="o-link--noDecoration o-link--bold">
+                {{ titleCard.ctaLabel }}
+            </a>
+        </p>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        card: {
+            type: Object,
+            default: () => ({
+                title: false,
+                description: false,
+                ctaLabel: false,
+                url: false
+            })
+        },
+
+        testId: {
+            type: String,
+            default: undefined
+        }
+    },
+
+    computed: {
+        suppliedCardHasAllProperties () {
+            return this.card.title &&
+                this.card.description &&
+                this.card.ctaLabel &&
+                this.card.url;
+        },
+
+        titleCard () {
+            return this.suppliedCardHasAllProperties
+                ? this.card
+                : {
+                    title: this.copy.loggedInTitle,
+                    description: this.copy.loggedInSubtitle,
+                    ctaLabel: this.copy.loggedInTermsText,
+                    url: this.copy.loggedInTermsUrl
+                };
+        }
+    },
+
+    inject: [
+        // Locale-specific copy configuration
+        'copy'
+    ],
+
+    methods: {
+        dataTestId (suffix) {
+            return this.testId && `${this.testId}-${suffix}`;
+        }
+    }
+};
+</script>
+
+<style lang="scss" module>
+  .c-contentCards-tnc-card-shell {
+    background-color: $white;
+    padding: spacing(x3);
+    text-align: center;
+  }
+
+  .c-contentCards-tnc-card-primaryHeader {
+    @include font-size(mid);
+    color: $grey--darkest;
+
+    @include media('>=narrow') {
+      @include font-size(jumbo);
+    }
+  }
+
+  .c-contentCards-tnc-card-secondaryHeader {
+    @include font-size(base);
+    color: $grey--dark;
+    margin-top: spacing(x2);
+
+    @include media('>=narrow') {
+      @include font-size(mid);
+    }
+  }
+</style>

--- a/packages/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
@@ -68,8 +68,14 @@ export default {
     ],
 
     methods: {
+        /**
+         * Returns an ID based on the given suffix if non-empty test ID supplied as prop
+         * @param suffix
+         * @return {false|string}
+         */
         dataTestId (suffix) {
-            return this.testId && `${this.testId}-${suffix}`;
+            return (this.testId || false)
+                && `${this.testId}-${suffix}`;
         }
     }
 };

--- a/packages/f-content-cards/src/components/cardTemplates/_tests/TermsAndConditionsCard.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/_tests/TermsAndConditionsCard.test.js
@@ -12,12 +12,10 @@ const subtitle = '__SUBTITLE__';
 const title = '__TITLE__';
 
 const card = (overrides = {}) => ({
-    ...{
-        title,
-        subtitle,
-        ctaText,
-        url
-    },
+    title,
+    subtitle,
+    ctaText,
+    url,
     ...overrides
 });
 

--- a/packages/f-content-cards/src/components/cardTemplates/_tests/TermsAndConditionsCard.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/_tests/TermsAndConditionsCard.test.js
@@ -1,0 +1,74 @@
+import {createLocalVue, shallowMount} from '@vue/test-utils';
+import TermsAndConditionsCard from '../TermsAndConditionsCard.vue';
+
+const localVue = createLocalVue();
+
+jest.mock('copy-to-clipboard');
+
+const ctaLabel = '__CTA_LABEL__';
+const url = 'https://foo.com/bar';
+const description = '__DESCRIPTION__';
+const title = '__TITLE__';
+
+const card = (overrides = {}) => ({
+    ...{
+        title,
+        description,
+        ctaLabel,
+        url
+    },
+    ...overrides
+});
+
+function getWrapper (cardOverrides) {
+    return shallowMount(TermsAndConditionsCard, {
+        localVue,
+        propsData: {
+            card: card(cardOverrides),
+            testId: 'tnctest'
+        },
+        provide () {
+            return {
+                copy: {
+                    loggedInTitle: 'loggedInTitle',
+                    loggedInSubtitle: 'loggedInSubtitle',
+                    loggedInTermsText: 'loggedInTermsText',
+                    loggedInTermsUrl: 'loggedInTermsUrl'
+                }
+            };
+        }
+    });
+}
+
+describe('contentCards › TermsAndConditionsCard', () => {
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    describe.each`
+        shouldDisplayProps | undefinedKey
+        ${false}           | ${'title'}
+        ${false}           | ${'description'}
+        ${false}           | ${'ctaLabel'}
+        ${false}           | ${'url'}
+        ${true}            | ${'unrelatedKey'}
+    `('when $undefinedKey is undefined', (shouldDisplayProps, undefinedKey) => {
+        let wrapper;
+
+        beforeEach(() => {
+            // Arrange
+            wrapper = getWrapper({
+                [undefinedKey]: undefined
+            });
+        });
+
+        it(`should ${shouldDisplayProps ? '' : 'not '}display all props as given`, () => {
+            // Assert
+            expect(wrapper.find('[data-test-id="tnctest-title"]').text()).toBe(shouldDisplayProps ? title : 'loggedInTitle');
+            expect(wrapper.find('[data-test-id="tnctest-description"]').text()).toBe(shouldDisplayProps ? description : 'loggedInSubtitle');
+            expect(wrapper.find('[data-test-id="tnctest-cta"]').text()).toBe(shouldDisplayProps ? ctaLabel : 'loggedInTermsText');
+            expect(wrapper.find('[data-test-id="tnctest-cta"]').attributes('href')).toBe(shouldDisplayProps ? url : 'loggedInTermsUrl');
+        });
+    });
+});

--- a/packages/f-content-cards/src/components/cardTemplates/_tests/TermsAndConditionsCard.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/_tests/TermsAndConditionsCard.test.js
@@ -1,20 +1,21 @@
-import {createLocalVue, shallowMount} from '@vue/test-utils';
+/* eslint indent: ["error", 4, {ignoredNodes: ["TemplateLiteral > *"]}] */
+import { createLocalVue, shallowMount } from '@vue/test-utils';
 import TermsAndConditionsCard from '../TermsAndConditionsCard.vue';
 
 const localVue = createLocalVue();
 
 jest.mock('copy-to-clipboard');
 
-const ctaLabel = '__CTA_LABEL__';
+const ctaText = '__CTA_TEXT__';
 const url = 'https://foo.com/bar';
-const description = '__DESCRIPTION__';
+const subtitle = '__SUBTITLE__';
 const title = '__TITLE__';
 
 const card = (overrides = {}) => ({
     ...{
         title,
-        description,
-        ctaLabel,
+        subtitle,
+        ctaText,
         url
     },
     ...overrides
@@ -41,7 +42,6 @@ function getWrapper (cardOverrides) {
 }
 
 describe('contentCards › TermsAndConditionsCard', () => {
-
     beforeEach(() => {
         jest.resetAllMocks();
     });
@@ -49,15 +49,15 @@ describe('contentCards › TermsAndConditionsCard', () => {
     describe.each`
         shouldDisplayProps | undefinedKey
         ${false}           | ${'title'}
-        ${false}           | ${'description'}
-        ${false}           | ${'ctaLabel'}
+        ${false}           | ${'subtitle'}
+        ${false}           | ${'ctaText'}
         ${false}           | ${'url'}
         ${true}            | ${'unrelatedKey'}
     `('when $undefinedKey is undefined', (shouldDisplayProps, undefinedKey) => {
         let wrapper;
 
         beforeEach(() => {
-            // Arrange
+            // Arrange & Act
             wrapper = getWrapper({
                 [undefinedKey]: undefined
             });
@@ -66,8 +66,8 @@ describe('contentCards › TermsAndConditionsCard', () => {
         it(`should ${shouldDisplayProps ? '' : 'not '}display all props as given`, () => {
             // Assert
             expect(wrapper.find('[data-test-id="tnctest-title"]').text()).toBe(shouldDisplayProps ? title : 'loggedInTitle');
-            expect(wrapper.find('[data-test-id="tnctest-description"]').text()).toBe(shouldDisplayProps ? description : 'loggedInSubtitle');
-            expect(wrapper.find('[data-test-id="tnctest-cta"]').text()).toBe(shouldDisplayProps ? ctaLabel : 'loggedInTermsText');
+            expect(wrapper.find('[data-test-id="tnctest-subtitle"]').text()).toBe(shouldDisplayProps ? subtitle : 'loggedInSubtitle');
+            expect(wrapper.find('[data-test-id="tnctest-cta"]').text()).toBe(shouldDisplayProps ? ctaText : 'loggedInTermsText');
             expect(wrapper.find('[data-test-id="tnctest-cta"]').attributes('href')).toBe(shouldDisplayProps ? url : 'loggedInTermsUrl');
         });
     });

--- a/packages/f-content-cards/src/components/cardTemplates/index.js
+++ b/packages/f-content-cards/src/components/cardTemplates/index.js
@@ -2,10 +2,12 @@ import PromotionCard from './PromotionCard.vue';
 import PostOrderCard from './PostOrderCard.vue';
 import SkeletonLoader from './SkeletonLoader.vue';
 import VoucherCard from './VoucherCard.vue';
+import TermsAndConditionsCard from './TermsAndConditionsCard.vue';
 
 export default {
     PromotionCard,
     PostOrderCard,
     SkeletonLoader,
-    VoucherCard
+    VoucherCard,
+    TermsAndConditionsCard
 };

--- a/packages/f-content-cards/src/tenants/da-DK.js
+++ b/packages/f-content-cards/src/tenants/da-DK.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'da-DK',
-    copyCodeLabel: 'Kopier kode'
+    copyCodeLabel: 'Kopier kode',
+    loggedInTitle: 'Du fortjener noget godt',
+    loggedInSubtitle: 'Disse tilbud er skræddersyet til dig, så vent ikke for længe.',
+    loggedInTermsText: 'Læs vilkår og betingelser her',
+    loggedInTermsUrl: '/termsandconditions#ii.just-eat-voucher-terms-conditions'
 };

--- a/packages/f-content-cards/src/tenants/en-AU.js
+++ b/packages/f-content-cards/src/tenants/en-AU.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'en-AU',
-    copyCodeLabel: 'Copy Code'
+    copyCodeLabel: 'Copy Code',
+    loggedInTitle: 'You deserve a treat',
+    loggedInSubtitle: 'These deals are personalised to you so they’re too good to miss.',
+    loggedInTermsText: 'Full terms and conditions here',
+    loggedInTermsUrl: '/termsandconditions#ii.just-eat-voucher-terms-conditions'
 };

--- a/packages/f-content-cards/src/tenants/en-GB.js
+++ b/packages/f-content-cards/src/tenants/en-GB.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'en-GB',
-    copyCodeLabel: 'Copy Code'
+    copyCodeLabel: 'Copy Code',
+    loggedInTitle: 'You deserve a treat',
+    loggedInSubtitle: 'These deals are personalised to you so they’re too good to miss.',
+    loggedInTermsText: 'Full terms and conditions here',
+    loggedInTermsUrl: '/termsandconditions#ii.just-eat-voucher-terms-conditions'
 };

--- a/packages/f-content-cards/src/tenants/en-IE.js
+++ b/packages/f-content-cards/src/tenants/en-IE.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'en-IE',
-    copyCodeLabel: 'Copy Code'
+    copyCodeLabel: 'Copy Code',
+    loggedInTitle: 'You deserve a treat',
+    loggedInSubtitle: 'These deals are personalised to you so they’re too good to miss.',
+    loggedInTermsText: 'Full terms and conditions here',
+    loggedInTermsUrl: '/termsandconditions#ii.just-eat-voucher-terms-conditions'
 };

--- a/packages/f-content-cards/src/tenants/en-NZ.js
+++ b/packages/f-content-cards/src/tenants/en-NZ.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'en-NZ',
-    copyCodeLabel: 'Copy Code'
+    copyCodeLabel: 'Copy Code',
+    loggedInTitle: 'You deserve a treat',
+    loggedInSubtitle: 'These deals are personalised to you so they’re too good to miss.',
+    loggedInTermsText: 'Full terms and conditions here',
+    loggedInTermsUrl: '/termsandconditions#ii.just-eat-voucher-terms-conditions'
 };

--- a/packages/f-content-cards/src/tenants/es-ES.js
+++ b/packages/f-content-cards/src/tenants/es-ES.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'es-ES',
-    copyCodeLabel: 'Copia el código'
+    copyCodeLabel: 'Copia el código',
+    loggedInTitle: 'Te mereces un capricho',
+    loggedInSubtitle: 'Estas ofertas son personalizadas para ti, demasiado buenas para perdérselas.',
+    loggedInTermsText: 'Términos y condiciones aquí',
+    loggedInTermsUrl: '/info/terminos-y-condiciones#ii.terminos-y-condiciones-de-los-cupones-promocionales-just-eat'
 };

--- a/packages/f-content-cards/src/tenants/it-IT.js
+++ b/packages/f-content-cards/src/tenants/it-IT.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'it-IT',
-    copyCodeLabel: 'Copia il codice'
+    copyCodeLabel: 'Copia il codice',
+    loggedInTitle: 'Te lo sei meritato',
+    loggedInSubtitle: 'Queste offerte sono fatte su misura per te, non lasciartele sfuggire.',
+    loggedInTermsText: 'Termini e condizioni qui',
+    loggedInTermsUrl: '/informazioni/termini-e-condizioni'
 };

--- a/packages/f-content-cards/src/tenants/nb-NO.js
+++ b/packages/f-content-cards/src/tenants/nb-NO.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'nb-NO',
-    copyCodeLabel: 'Kopier kode'
+    copyCodeLabel: 'Kopier kode',
+    loggedInTitle: 'Du fortjener en treat',
+    loggedInSubtitle: 'Dette er et tilbud kun til deg, så ikke vent for lenge.',
+    loggedInTermsText: 'Les vilkår og betingelser her',
+    loggedInTermsUrl: '/termsandconditions#ii.just-eat-voucher-terms-conditions'
 };

--- a/packages/f-content-cards/stories/TermsAndConditionsCard.stories.js
+++ b/packages/f-content-cards/stories/TermsAndConditionsCard.stories.js
@@ -26,8 +26,8 @@ export const TermsAndConditionsCardcomponent = () => ({
         cardTitle: {
             default: text('Card Title', 'T&amp;C Example Title')
         },
-        description: {
-            default: text('Card Description', 'Example description')
+        subtitle: {
+            default: text('Card Subtitle', 'Example subtitle')
         },
         url: {
             default: text('Card URL', '/termsandconditions#ii.just-eat-voucher-terms-conditions')
@@ -52,7 +52,7 @@ export const TermsAndConditionsCardcomponent = () => ({
         };
     },
 
-    template: '<terms-and-conditions-card :card="{title:cardTitle,description,url,ctaLabel:label}" />'
+    template: '<terms-and-conditions-card :card="{title:cardTitle,subtitle,url,ctaText:label}" />'
 });
 
 TermsAndConditionsCardcomponent.story = {

--- a/packages/f-content-cards/stories/TermsAndConditionsCard.stories.js
+++ b/packages/f-content-cards/stories/TermsAndConditionsCard.stories.js
@@ -1,0 +1,47 @@
+import { text, withKnobs } from '@storybook/addon-knobs';
+import { withA11y } from '@storybook/addon-a11y';
+import TermsAndConditionsCard from '../src/components/cardTemplates/TermsAndConditionsCard.vue';
+
+export default {
+    title: 'Components/Atoms/f-content-cards',
+    decorators: [withKnobs, withA11y]
+};
+
+
+export const TermsAndConditionsCardcomponent = () => ({
+    components: {
+        TermsAndConditionsCard
+    },
+
+    props: {
+        cardTitle: {
+            default: text('Card Title', 'T&amp;C Example Title')
+        },
+        description: {
+            default: text('Card Description', 'Example description')
+        },
+        url: {
+            default: text('Card URL', '/termsandconditions#ii.just-eat-voucher-terms-conditions')
+        },
+        label: {
+            default: text('Call to Action Label', 'See the terms and conditions')
+        }
+    },
+
+    provide () {
+        return {
+            copy: {
+                loggedInTitle: 'Copy logged in title',
+                loggedInSubtitle: 'Copy logged in subtitle',
+                loggedInTermsText: 'Copy linked text',
+                loggedInTermsUrl: '/copy/terms/url'
+            }
+        };
+    },
+
+    template: '<terms-and-conditions-card :card="{title:cardTitle,description,url,ctaLabel:label}" />'
+});
+
+TermsAndConditionsCardcomponent.story = {
+    name: 'terms-and-conditions-card'
+};

--- a/packages/f-content-cards/stories/TermsAndConditionsCard.stories.js
+++ b/packages/f-content-cards/stories/TermsAndConditionsCard.stories.js
@@ -7,7 +7,16 @@ export default {
     decorators: [withKnobs, withA11y]
 };
 
-
+/**
+ * Definition for story for Terms and Conditions card component
+ *
+ * @return {{
+ *  template: string,
+ *  components: {Object}
+ *  props: {Object}
+ *  provide: {Function}
+ * }}
+ */
 export const TermsAndConditionsCardcomponent = () => ({
     components: {
         TermsAndConditionsCard
@@ -28,6 +37,10 @@ export const TermsAndConditionsCardcomponent = () => ({
         }
     },
 
+    /**
+     * Stubbed copy for injecting when supplied card information is not complete
+     * @return {{copy: {loggedInSubtitle: string, loggedInTitle: string, loggedInTermsUrl: string, loggedInTermsText: string}}}
+     */
     provide () {
         return {
             copy: {


### PR DESCRIPTION
### Added
- `Terms and Conditions Card` card type, with associated tests and story.

## UI Review Checks

![image](https://user-images.githubusercontent.com/6674452/90005496-34a6c480-dc8f-11ea-8cf8-86a56e324544.png)

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been created
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)
