### PR TITLE
f-content-cards@1.12.0 🎂 Fixes up anniversary card style

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.12.0
+------------------------------
+*August 21, 2020*
+
+### Changed
+- Updated anniversary card to match new styling requirements
+
+
 v1.10.0
 ------------------------------
 *August 18, 2020*

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "1.10.0",
+  "version": "1.12.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -23,17 +23,17 @@
                 :src="icon"
                 :alt="title"
                 :class="$style['c-contentCard-thumbnail']">
-            <h3 :class="$style['c-contentCard-title']">
+            <h3 :class="[$style['c-contentCard-title'], titleSubStyle]">
                 {{ title }}
             </h3>
-            <h4 :class="$style['c-contentCard-subTitle']">
+            <h4 :class="[$style['c-contentCard-subTitle'], subtitleSubStyle]">
                 {{ subtitle }}
             </h4>
             <template v-for="(textItem, textIndex) in description">
                 <p
                     :key="textIndex"
                     :data-test-id="testIdForItemWithIndex(textIndex)"
-                    :class="$style['c-contentCard-text']">
+                    :class="[$style['c-contentCard-text'], textSubStyle]">
                     {{ textItem }}
                 </p>
             </template>
@@ -71,6 +71,10 @@ export default {
             type: Boolean,
             default: true
         },
+        emboldenText: {
+            type: Boolean,
+            default: false
+        },
         isolateHeroImage: {
             type: Boolean,
             default: false
@@ -105,6 +109,18 @@ export default {
             type,
             target
         };
+    },
+
+    computed: {
+        titleSubStyle () {
+            return this.emboldenText ? this.$style['c-emboldenedText--title'] : '';
+        },
+        subtitleSubStyle () {
+            return this.emboldenText ? this.$style['c-emboldenedText--subtitle'] : '';
+        },
+        textSubStyle () {
+            return this.emboldenText ? this.$style['c-emboldenedText--text'] : '';
+        }
     },
 
     inject: [
@@ -161,13 +177,14 @@ export default {
         }
 
         /**
-         * 1. Magic number to align isolated image with top of content card
+         * 1. Magic numbers to correctly size the hero image
          */
         &.c-contentCard--isolateHeroImage {
             position: relative;
-            margin: 84px 0 spacing(x3); // 1
 
             .c-contentCard-info {
+                padding-top: spacing(x10) + spacing(x6);
+                padding-bottom: spacing(x2);
                 border-radius: $border-radius;
             }
 
@@ -175,13 +192,15 @@ export default {
                 position: absolute;
                 left: 0;
                 right: 0;
-                top: -83px;
+                top: spacing(x2);
                 z-index: zIndex(mid);
-                width: 109px;
-                height: 96px;
+                width: 114px; // 1
+                height: 114px; // 1
                 margin: 0 auto;
                 min-height: inherit;
-                background: transparent no-repeat;
+                background: transparent no-repeat center;
+                background-size: contain;
+                border-radius: 0;
             }
         }
     }
@@ -194,10 +213,6 @@ export default {
         background-color: $grey--lighter;
         background-position: center;
         border-radius: $border-radius $border-radius 0 0;
-
-        .c-contentCard-info--inset & {
-            height: 188px;
-        }
     }
 
     .c-contentCard-title {
@@ -235,10 +250,6 @@ export default {
         box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
         height: 100%;
         border-radius: 0 0 $border-radius $border-radius;
-
-        .has-offer & {
-            padding-bottom: 0;
-        }
     }
 
     .c-contentCard-footer {
@@ -338,5 +349,20 @@ export default {
                 border-radius: $post-order-card-radius;
             }
         }
+    }
+
+    .c-emboldenedText--title {
+        font-weight: bold;
+    }
+
+    .c-emboldenedText--subtitle {
+        @include font-size(base);
+        margin-top: spacing(x2);
+    }
+
+    .c-emboldenedText--text {
+        @include font-size(base);
+        font-weight: bold;
+        margin-top: 0;
     }
 </style>

--- a/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -26,11 +26,11 @@
             <h3
                 :class="[$style['c-contentCard-title'], {
                     [$style['c-contentCard-title-legacy']]: !boldTitle,
-                    titleSubStyle
+                    [$style['c-emboldenedText--title']]: emboldenText
                 }]">
                 {{ title }}
             </h3>
-            <h4 :class="[$style['c-contentCard-subTitle'], subtitleSubStyle]">
+            <h4 :class="[$style['c-contentCard-subTitle'], { [$style['c-emboldenedText--subtitle']]: emboldenText }]">
                 {{ subtitle }}
             </h4>
             <slot
@@ -40,7 +40,7 @@
                 <p
                     :key="textIndex"
                     :data-test-id="testIdForItemWithIndex(textIndex)"
-                    :class="[$style['c-contentCard-text'], textSubStyle]">
+                    :class="[$style['c-contentCard-text'], { [$style['c-emboldenedText--text']]: emboldenText }]">
                     {{ textItem }}
                 </p>
             </template>
@@ -126,18 +126,6 @@ export default {
 
         url () {
             return this.card.url;
-        },
-
-        titleSubStyle () {
-            return this.emboldenText ? this.$style['c-emboldenedText--title'] : '';
-        },
-
-        subtitleSubStyle () {
-            return this.emboldenText ? this.$style['c-emboldenedText--subtitle'] : '';
-        },
-
-        textSubStyle () {
-            return this.emboldenText ? this.$style['c-emboldenedText--text'] : '';
         }
     },
 

--- a/packages/f-content-cards/src/components/cardTemplates/VoucherCard.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/VoucherCard.vue
@@ -2,7 +2,8 @@
     <card-container
         :card="card"
         :cta-enabled="false"
-        :isolate-hero-image="isAnniversaryCard">
+        :isolate-hero-image="isAnniversaryCard"
+        :embolden-text="isAnniversaryCard">
         <button
             type="button"
             :class="$style['c-contentCard-voucher']"
@@ -73,8 +74,8 @@ export default {
         font-family: $font-family-base;
         border: solid $color-border;
         border-width: 1px 0 0;
-        padding-top: spacing(x1.5);
-        margin-top: spacing(x3);
+        padding-top: spacing(x2);
+        margin-top: spacing();
         cursor: pointer;
         background: transparent;
     }


### PR DESCRIPTION
> NOTE: #289 Should be merged first.

### Changed
- Updated anniversary card to match new styling requirements

---

## UI Review Checks

![image](https://user-images.githubusercontent.com/6674452/90894946-438d2580-e3b9-11ea-9038-fb133c7eb014.png)

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
