### PR TITLE
fozzie-components@v2.0.0 – JustEatBasis typography updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,14 @@ v1.29.0
 - Move `@pact-foundation/pact` to devDependencies.
 
 
+v2.0.0
+------------------------------
+*September 9, 2020*
+
+### Changed
+- Updating components to use `JustEatBasis` and subsequent breaking changes to update font variables to hook into new design token variables in fozzie.
+
+
 v1.28.0
 ------------------------------
 *September 9, 2020*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.34.0",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",
@@ -26,9 +26,9 @@
     "@justeat/browserslist-config-fozzie": "1.1.1",
     "@justeat/eslint-config-fozzie": "3.4.1",
     "@justeat/f-build-config": "0.3.0",
-    "@justeat/f-utils": "0.3.0",
-    "@justeat/fozzie": "3.0.0-beta.8",
-    "@justeat/fozzie-colour-palette": "3.0.0-beta.4",
+    "@justeat/f-utils": "1.0.0-beta.0",
+    "@justeat/fozzie": "4.0.0-beta.0",
+    "@justeat/fozzie-colour-palette": "3.0.0-beta.6",
     "@storybook/storybook-deployer": "2.8.6",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",

--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -31,6 +31,17 @@ v1.14.0
 - `Home_Promotion_Card_1` template and type to allowed content card types
 
 
+v2.0.0-beta.1
+------------------------------
+*August 28, 2020*
+
+### Added
+- Check for `console.error` being thrown in `utils` tests.
+
+### Fixed
+- Couple of old font references updated.
+
+
 v2.0.0-beta.0
 ------------------------------
 *August 27, 2020*

--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0
+------------------------------
+*September 23, 2020*
+
+### Changed
+- Moving component out of beta now font changes have been released.
+
+
 v1.15.0
 ------------------------------
 *September 15, 2020*
@@ -21,6 +29,15 @@ v1.14.0
 
 ### Added
 - `Home_Promotion_Card_1` template and type to allowed content card types
+
+
+v2.0.0-beta.0
+------------------------------
+*August 27, 2020*
+
+### Changed
+- Now uses new `JustEatBasis` font and updated type variables.
+
 
 
 v1.13.0

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,11 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-<<<<<<< HEAD
-  "version": "1.15.0",
-=======
-  "version": "2.0.0-beta.0",
->>>>>>> 1a5a4c6... fozzie-components@v2.0.0 – JustEatBasis typography updates
+  "version": "2.0.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
+<<<<<<< HEAD
   "version": "1.15.0",
+=======
+  "version": "2.0.0-beta.0",
+>>>>>>> 1a5a4c6... fozzie-components@v2.0.0 – JustEatBasis typography updates
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -241,7 +241,7 @@ export default {
     }
 
     .c-contentCard-subTitle {
-        @include font-size(base--scaleUp);
+        @include font-size(body-l);
         margin-top: spacing();
     }
 
@@ -308,7 +308,7 @@ export default {
         }
 
         .c-contentCard-subTitle {
-            @include font-size(base);
+            @include font-size(body-s);
 
             text-align: left;
             margin: 0;

--- a/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -367,12 +367,12 @@ export default {
     }
 
     .c-emboldenedText--subtitle {
-        @include font-size(base);
+        @include font-size(body-s);
         margin-top: spacing(x2);
     }
 
     .c-emboldenedText--text {
-        @include font-size(base);
+        @include font-size(body-s);
         font-weight: bold;
         margin-top: 0;
     }

--- a/packages/f-content-cards/src/components/cardTemplates/FirstTimeCustomerCard.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/FirstTimeCustomerCard.vue
@@ -84,7 +84,7 @@ $banner-bgColour-legacy : #cd381f;
 }
 
 .c-restaurantCard-footer {
-    @include font-size(small);
+    @include font-size(caption);
     font-weight: bold;
     margin-top: 0;
     margin-bottom: -#{spacing()};
@@ -103,7 +103,7 @@ $banner-bgColour-legacy : #cd381f;
 }
 
 .c-restaurantCard-footer-legacy {
-    @include font-size(base);
+    @include font-size(body-s);
     font-weight: normal;
     margin-bottom: 0;
 }

--- a/packages/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
@@ -103,7 +103,7 @@ export default {
         }
 
         .c-postOrderCard-title {
-            @include font-size(large);
+            @include font-size(heading-m);
 
             margin-bottom: spacing(x2);
 

--- a/packages/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
@@ -89,21 +89,21 @@ export default {
   }
 
   .c-contentCards-tnc-card-primaryHeader {
-    @include font-size(mid);
+    @include font-size(heading-s);
     color: $grey--darkest;
 
     @include media('>=narrow') {
-      @include font-size(jumbo);
+      @include font-size(heading-xl);
     }
   }
 
   .c-contentCards-tnc-card-secondaryHeader {
-    @include font-size(base);
+    @include font-size(body-s);
     color: $grey--dark;
     margin-top: spacing(x2);
 
     @include media('>=narrow') {
-      @include font-size(mid);
+      @include font-size(heading-s);
     }
   }
 </style>

--- a/packages/f-content-cards/src/components/cardTemplates/utils/_tests/index.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/utils/_tests/index.test.js
@@ -32,7 +32,15 @@ describe('contentCards › utils › normaliseCardType', () => {
             []
         ];
 
+        console.error = jest.fn();
+
         // Act & Assert
-        await Promise.all(tests.map(input => expect(normaliseCardType(input)).toBe(null)));
+
+        await Promise.all(tests.map(input => {
+            expect(normaliseCardType(input)).toBe(null);
+            expect(console.error).toHaveBeenCalledTimes(1); // checks that an error is thrown
+            console.error.mockClear();
+            return true;
+        }));
     });
 });

--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.0.0-beta.0
+------------------------------
+*August 27, 2020*
+
+### Changed
+- Uses `JustEatBasis` font and new fozzie font size declarations.
+
+
 v3.4.0
 ------------------------------
 *July 23, 2020*

--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.0.0-beta.1
+------------------------------
+*September 3, 2020*
+
+### Changed
+- Updating footer headings to new JustEatBasis font.
+
+
 v4.0.0-beta.0
 ------------------------------
 *August 27, 2020*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "3.4.0",
+  "version": "4.0.0-beta.0",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-beta.1",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-footer/src/assets/scss/common.scss
+++ b/packages/f-footer/src/assets/scss/common.scss
@@ -20,15 +20,6 @@ $theme: 'je' !default;
  $footer-chevronColor    : $grey--darkest !default;
  $footer-socialIconColor : $grey--darkest !default;
 
- /**
- * Global variables which need to be included for Menulog theming
-* TODO: remove these when type is normalised to new JET font
- */
- $font-family-headings--ml   : 'Aspira', 'Times New Roman', Times, serif;
- $font-weight-headings--ml   : 800;
-
-
-
 @mixin theme($type) {
     [data-theme-footer="#{$type}"] & {
         @content;

--- a/packages/f-footer/src/components/ButtonList.vue
+++ b/packages/f-footer/src/components/ButtonList.vue
@@ -36,6 +36,9 @@ export default {
 </script>
 
 <style lang="scss" module>
+
+$buttonList-font-size: 'subheading-s';
+
 .c-buttonList {
     align-items: center;
     display: flex;
@@ -47,7 +50,7 @@ export default {
     border-radius: 4px;
     color: $color-link-default;
     display: inline-block;
-    font-family: $font-family-headings;
+    @include font-size($buttonList-font-size, false);
     font-weight: $font-weight-headings;
     min-width: 226px;
     margin-right: spacing(x2);
@@ -56,12 +59,6 @@ export default {
     text-align: center;
     text-decoration: none;
     vertical-align: middle;
-    @include font-size(18, false);
-
-    @include theme(ml) {
-       font-family: $font-family-headings--ml;
-       font-weight:  $font-weight-headings--ml;
-    }
 
     &:last-child {
         margin-right: 0;

--- a/packages/f-footer/src/components/CountrySelector.vue
+++ b/packages/f-footer/src/components/CountrySelector.vue
@@ -137,6 +137,8 @@ export default {
 <style lang="scss" module>
 @import '../assets/scss/icons.scss';
 
+$countrySelector-btn-font-size: 'body-s';
+
 .c-countrySelector {
     width: 190px;
     position: relative;
@@ -186,14 +188,14 @@ export default {
 }
 
 .c-countrySelector-button {
-    width: 100%;
-    padding: spacing(x2);
-    display: flex;
     align-items: center;
     background-color: $footer-bgColor;
     border: none;
     cursor: pointer;
-    @include font-size(base);
+    display: flex;
+    @include font-size($countrySelector-btn-font-size);
+    padding: spacing(x2);
+    width: 100%;
 }
 
 .c-countrySelector-list {

--- a/packages/f-footer/src/components/FeedbackBlock.vue
+++ b/packages/f-footer/src/components/FeedbackBlock.vue
@@ -46,6 +46,8 @@ export default {
 
 <style lang="scss" module>
 
+$feedback-btn-font-size: 'body-s';
+
 .c-feedback {
     @include media('<wide') {
         order: 1;
@@ -63,7 +65,7 @@ export default {
     margin: 0;
     color: $color-link-default;
     font-weight: 500;
-    @include font-size(base);
+    @include font-size($feedback-btn-font-size);
     text-decoration: underline;
 
     &:hover {

--- a/packages/f-footer/src/components/Footer.vue
+++ b/packages/f-footer/src/components/Footer.vue
@@ -111,6 +111,9 @@ export default {
 </script>
 
 <style lang="scss">
+
+$footer-heading-font-size: 'heading-s';
+
 .c-footer {
     background-color: $footer-bgColor;
     color: $footer-textColor;
@@ -127,16 +130,10 @@ export default {
 }
 
 .c-footer-heading {
-    @include font-size(mid);
+    @include font-size($footer-heading-font-size);
+    font-weight: $font-weight-headings;
     padding: spacing(x2);
     padding-left: 0;
-    font-family: $font-family-headings;
-    font-weight: $font-weight-headings;
-
-    @include theme(ml) {
-        font-family: $font-family-headings--ml;
-        font-weight: $font-weight-headings--ml;
-    }
 }
 
 .c-footer-heading--shortBelowWide {
@@ -151,19 +148,13 @@ export default {
     border-style: none;
     color: $color-headings;
     display: flex;
-    font-family: $font-family-headings;
     font-weight: $font-weight-headings;
     justify-content: space-between;
     margin: 0;
     padding: spacing(x2);
     text-align: left;
     width: 100%;
-    @include font-size(mid);
-
-    @include theme(ml) {
-        font-family: $font-family-headings--ml;
-        font-weight: $font-weight-headings--ml;
-    }
+    @include font-size($footer-heading-font-size);
 
     @include media('<wide') {
         cursor: pointer;

--- a/packages/f-footer/src/components/Footer.vue
+++ b/packages/f-footer/src/components/Footer.vue
@@ -131,6 +131,7 @@ $footer-heading-font-size: 'heading-s';
 
 .c-footer-heading {
     @include font-size($footer-heading-font-size);
+    font-family: $font-family-base;
     font-weight: $font-weight-headings;
     padding: spacing(x2);
     padding-left: 0;

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -30,7 +30,7 @@ v4.0.0-beta.1
 
 v4.0.0-beta.0
 ------------------------------
-*August 26, 2020*
+*August 27, 2020*
 
 ### Changed
 - Uses `JustEatBasis` font and new fozzie font size declarations.

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -3,12 +3,38 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v4.0.0
+------------------------------
+*September 14, 2020*
+
+### Changed
+- Moving header components out of `beta` state as now released.
+
+
 v3.9.0
 ------------------------------
 *September 14, 2020*
 
 ### Changed
 - Directory of component UI test specs
+
+
+v4.0.0-beta.1
+------------------------------
+*August 28, 2020*
+
+### Changed
+- Rebase latest master onto beta release.
+
+
+v4.0.0-beta.0
+------------------------------
+*August 26, 2020*
+
+### Changed
+- Uses `JustEatBasis` font and new fozzie font size declarations.
+
 
 v3.8.0
 ------------------------------
@@ -24,6 +50,7 @@ v3.7.0
 
 ### Added
 - Added new prop on header & navigation to allow hiding of login / user icon in navigation.
+
 
 v3.6.0
 ------------------------------

--- a/packages/f-header/README.md
+++ b/packages/f-header/README.md
@@ -55,23 +55,32 @@
 
     ```
 
-3. Properties which component accepts:
 
-    `locale` - If there is a vue-i18n plugin in the project, the header component can be called without locale property, otherwise it accepts it in format like 'en-GB'
+### Props
 
-    `isTransparent` - Boolean property with `false` as a default value, defines whether the header has transparent or white background.
+`f-header` has a number of props that allow you to customise its functionality.
 
-    `showDeliveryEnquiry` - Boolean property with `false` as a default value, defines if it is necessary to show the "Deliver with Just Eat" link in the header.
+The props that can be defined are as follows:
 
-    `errorLog` - Function passed in for logging errors with the `fetchUserInfo` method. It has empty function as a default value
+| Prop                      | Type          | Default | Description |
+| :---                      |     :---:     |  :---:  | :---        |
+| locale                    | `String`      | `en-GB` | Sets the locale of the component (which determines what theme and translations to use.<br><br>If the application consuming the `f-card` component is using the vue `i18n` module, then the locale from that module will be used when this prop isn't defined. When this prop is defined, it takes precedence over the locale defined by the `i18n` module.<br><br>If not defined and the `i18n` module isn't present, the default locale used is `en-GB`.|
+| errorLog                  | `Function`     | `-`    | Function passed in for logging errors with the `fetchUserInfo` method. |
+| headerBackgroundTheme     | `Boolean`     | `white` | Sets the background theme for the header component.<br><br>When set to `white` the header will be white with the default logo colour.<br>When set to `transparent` the header will be transparent with a white logo.<br>When set to `highlight` the header will use the primary brand colour as the background colour with a white logo. |
+| isOrderCountSupported     | `Boolean`     | `true` | ?? |
+| orderCountUrl             | `Boolean`     | `false` | ?? |
+| showDeliveryEnquiry       | `Boolean`     | `false` | Defines if it is necessary to show the "Deliver with Just Eat" link in the header. |
+| showOffersLink            | `Boolean`     | `false` | Defines whether the offers link should be shown in the navigation. |
+| showLoginInfo             | `Boolean`     | `true` | Defines whether the login & user info icon should be shown in the navigation. |
+| userInfoProp              | `Object`     | `{}`     | Optional object conaining user details. If not provided `userInfoProp` is set via XHR call to `/api/account/details` |
+| userInfoUrl               | `Boolean`     | `false` | URL to call to retrieve the userInfo (when `userInfoProp` isn't set). |
 
-    `userInfoProp` - Optional object conaining user details. If not provided `userInfoProp` is set via XHR call to `/api/account/details`
 
     `showLoginInfo` - Optional Boolean property with `true` as a default value, defines whether the login / user info icon should be shown in the navigation.
 
 ## Demo and local development
 
-Running the command below from the component folder e.g. `./packages/f-header` will start a development server and allow to preview the component usually on http://localhost:8080/ 
+Running the command below from the component folder e.g. `./packages/f-header` will start a development server and allow to preview the component usually on http://localhost:8080/
 
 ```bash
 # Local preview
@@ -81,7 +90,7 @@ yarn demo
 # Logged in user - http://localhost:8080/?testuser
 ```
 
-In addition using a `?testuser` parameter will simulate a logged in state. 
+In addition using a `?testuser` parameter will simulate a logged in state.
 
 
 ## Documentation to be completed once module is in stable state.

--- a/packages/f-header/README.md
+++ b/packages/f-header/README.md
@@ -64,16 +64,16 @@ The props that can be defined are as follows:
 
 | Prop                      | Type          | Default | Description |
 | :---                      |     :---:     |  :---:  | :---        |
-| locale                    | `String`      | `en-GB` | Sets the locale of the component (which determines what theme and translations to use.<br><br>If the application consuming the `f-card` component is using the vue `i18n` module, then the locale from that module will be used when this prop isn't defined. When this prop is defined, it takes precedence over the locale defined by the `i18n` module.<br><br>If not defined and the `i18n` module isn't present, the default locale used is `en-GB`.|
-| errorLog                  | `Function`     | `-`    | Function passed in for logging errors with the `fetchUserInfo` method. |
-| headerBackgroundTheme     | `Boolean`     | `white` | Sets the background theme for the header component.<br><br>When set to `white` the header will be white with the default logo colour.<br>When set to `transparent` the header will be transparent with a white logo.<br>When set to `highlight` the header will use the primary brand colour as the background colour with a white logo. |
+| locale                    | `String`      | `en-GB` | Sets the locale of the component (which determines what theme and translations to use.<br><br>If the application consuming the `f-header` component is using the vue `i18n` module, then the locale from that module will be used when this prop isn't defined. When this prop is defined, it takes precedence over the locale defined by the `i18n` module.<br><br>If not defined and the `i18n` module isn't present, the default locale used is `en-GB`.|
+| errorLog                  | `Function`    | `-`    | Function passed in for logging errors with the `fetchUserInfo` method. |
+| headerBackgroundTheme     | `String`      | `white` | Sets the background theme for the header component.<br><br>When set to `white` the header will be white with the default logo colour.<br>When set to `transparent` the header will be transparent with a white logo.<br>When set to `highlight` the header will use the primary brand colour as the background colour with a white logo. |
 | isOrderCountSupported     | `Boolean`     | `true` | ?? |
-| orderCountUrl             | `Boolean`     | `false` | ?? |
+| orderCountUrl             | `String`      | `false` | ?? |
 | showDeliveryEnquiry       | `Boolean`     | `false` | Defines if it is necessary to show the "Deliver with Just Eat" link in the header. |
 | showOffersLink            | `Boolean`     | `false` | Defines whether the offers link should be shown in the navigation. |
 | showLoginInfo             | `Boolean`     | `true` | Defines whether the login & user info icon should be shown in the navigation. |
-| userInfoProp              | `Object`     | `{}`     | Optional object conaining user details. If not provided `userInfoProp` is set via XHR call to `/api/account/details` |
-| userInfoUrl               | `Boolean`     | `false` | URL to call to retrieve the userInfo (when `userInfoProp` isn't set). |
+| userInfoProp              | `Object`      | `{}`     | Optional object conaining user details. If not provided `userInfoProp` is set via XHR call to `/api/account/details` |
+| userInfoUrl               | `String`      | `false` | URL to call to retrieve the userInfo (when `userInfoProp` isn't set). |
 
 
     `showLoginInfo` - Optional Boolean property with `true` as a default value, defines whether the login / user info icon should be shown in the navigation.

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "3.9.0",
+  "version": "4.0.0",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -55,12 +55,27 @@ export default {
             default: ''
         },
 
-        showDeliveryEnquiry: {
-            type: Boolean,
+        errorLog: {
+            type: [Function, Boolean],
             default: false
         },
 
-        showOffersLink: {
+        headerBackgroundTheme: {
+            type: String,
+            default: 'white'
+        },
+
+        isOrderCountSupported: {
+            type: Boolean,
+            default: true
+        },
+
+        orderCountUrl: {
+            type: String,
+            default: '/api/analytics/ordercount'
+        },
+
+        showDeliveryEnquiry: {
             type: Boolean,
             default: false
         },
@@ -70,8 +85,8 @@ export default {
             default: true
         },
 
-        errorLog: {
-            type: [Function, Boolean],
+        showOffersLink: {
+            type: Boolean,
             default: false
         },
 
@@ -83,21 +98,6 @@ export default {
         userInfoUrl: {
             type: String,
             default: '/api/account/details'
-        },
-
-        orderCountUrl: {
-            type: String,
-            default: '/api/analytics/ordercount'
-        },
-
-        isOrderCountSupported: {
-            type: Boolean,
-            default: true
-        },
-
-        headerBackgroundTheme: {
-            type: String,
-            default: 'white'
         }
     },
     data () {
@@ -267,7 +267,7 @@ export default {
         text-align: center;
         border-radius: 8px;
         position: absolute;
-        @include font-size(small, false);
+        @include font-size(caption, false);
         color: $header-buttonCount-color;
         background: $header-buttonCount-bg;
         border: 1px solid $header-buttonCount-borderColor;

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -528,8 +528,8 @@ export default {
  *
  */
 
-$nav-text-size                     : 'base--scaleUp';
-$nav-text-font                     : $font-family-headings;
+$nav-text-size                     : 'body-l';
+$nav-text-size--narrow             : 'body-s';
 $nav-text-color                    : $color-link-default;
 $nav-text-color--hover             : $color-link-hover;
 $nav-text-color--narrow            : $grey--dark;
@@ -682,13 +682,12 @@ $nav-popover-padding               : spacing(x2);
             margin: 0;
             font-family: $nav-text-subFont;
             color: $nav-text-color--narrow;
-            @include font-size('base');
+            @include font-size($nav-text-size--narrow);
             font-weight: 300;
             text-decoration: none;
             border-bottom: 1px solid $grey--light;
 
             @include media('>=mid') {
-                font-family: $nav-text-font;
                 @include font-size($nav-text-size);
                 font-weight: $nav-text-weight;
                 color: $nav-text-color;

--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -3,15 +3,22 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.29.0
+------------------------------
+### Changed
+- Uses `JustEatBasis` font and new fozzie font size declarations.
+
+
 v0.28.0
 ------------------------------
 ### Removed
 - Contract tests + scripts
 
-
 v0.27.0
 ------------------------------
 *September 23, 2020*
+
 ### Changed
 - Use the latest version of F-Card to apply top and bottom margins to the registration component
 
@@ -82,6 +89,7 @@ v0.21.0
 
 ### Added
 - `registrationSource` and `marketingPreferences` to account creation post request body.
+
 
 v0.20.0
 ------------------------------

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-registration/src/components/Button.vue
+++ b/packages/f-registration/src/components/Button.vue
@@ -43,7 +43,7 @@ $btn-default-bgColor                : $grey--lighter;
 $btn-default-text-colour            : $grey--dark;
 $btn-default-weight                 : 500;
 $btn-default-height                 : 2.6;
-$btn-default-font-size              : base--scaleUp;
+$btn-default-font-size              : body-l;
 $btn-default-font-family            : $font-family-base;
 $btn-default-bgColor--hover         : $grey--light;
 $btn-default-borderRadius           : 2px;

--- a/packages/f-registration/src/components/Button.vue
+++ b/packages/f-registration/src/components/Button.vue
@@ -44,7 +44,7 @@ $btn-default-text-colour            : $grey--dark;
 $btn-default-weight                 : 500;
 $btn-default-height                 : 2.6;
 $btn-default-font-size              : base--scaleUp;
-$btn-default-font-family            : $font-family-headings;
+$btn-default-font-family            : $font-family-base;
 $btn-default-bgColor--hover         : $grey--light;
 $btn-default-borderRadius           : 2px;
 $btn-default-hozPadding             : 1em;

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -408,14 +408,14 @@ export default {
 // Form styling
 
 .o-form {
-    @include font-size(base--scaleUp);
+    @include font-size(body-l);
 }
 
 .o-form-error {
     display: flex;
     align-items: center;
     color: $red;
-    @include font-size(base);
+    @include font-size(body-s);
     margin-top: spacing();
 }
 

--- a/packages/f-registration/test/specs/component/f-registration.component.spec.js
+++ b/packages/f-registration/test/specs/component/f-registration.component.spec.js
@@ -1,13 +1,12 @@
 import RegistrationComponent from '../../../test-utils/component-objects/f-registration.component';
 
-describe('f-header component tests', () => {
+describe('f-registration component tests', () => {
     beforeEach(() => {
         // Arrange
         browser.url('http://localhost:8081');
-    })
+    });
 
     it.only('should display errors if mandatory fields are empty', () => {
-
         // Arrange
         const userInfo = {
             firstName: '',
@@ -27,7 +26,6 @@ describe('f-header component tests', () => {
     });
 
     it('should show and be able to click the legal documentation', () => {
-
         // Act
         RegistrationComponent.waitForRegistrationForm();
 

--- a/packages/f-user-message/CHANGELOG.md
+++ b/packages/f-user-message/CHANGELOG.md
@@ -4,6 +4,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.0.0-beta.1
+------------------------------
+*September 3, 2020*
+
+### Changed
+- Rebasing `v0.3.0` changes into the beta branch.
+
+
+v1.0.0-beta.0
+------------------------------
+*August 27, 2020*
+
+### Changed
+- Uses `JustEatBasis` font and new fozzie font size declarations.
+
+
 v0.3.1
 ------------------------------
 *September 8, 2020*

--- a/packages/f-user-message/package.json
+++ b/packages/f-user-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-user-message",
   "description": "Fozzie User Message – Globalised User Message Component",
-  "version": "0.3.1",
+  "version": "1.0.0-beta.1",
   "main": "dist/f-user-message.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-user-message/src/components/UserMessage.vue
+++ b/packages/f-user-message/src/components/UserMessage.vue
@@ -97,7 +97,7 @@ export default {
     margin: 0 0 0 spacing(x2);
     font-family: $font-family-base;
     font-weight: $font-weight-base;
-    @include font-size(base);
+    @include font-size(body-s);
 
     @include media('>=mid') {
         padding-left: 0;

--- a/packages/generator-component/CHANGELOG.md
+++ b/packages/generator-component/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.0.0
+------------------------------
+*August 27, 2020*
+
+### Changed
+- Updating `font-size` variable.
+
+
 v0.2.1
 ------------------------------
 *September 8, 2020*

--- a/packages/generator-component/generators/app/templates/src/components/Skeleton.vue
+++ b/packages/generator-component/generators/app/templates/src/components/Skeleton.vue
@@ -42,7 +42,7 @@ export default {
     margin: auto;
     border: 1px solid $red;
     font-family: $font-family-base;
-    @include font-size(large);
+    @include font-size(heading-m);
 }
 
 </style>

--- a/packages/generator-component/package.json
+++ b/packages/generator-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/generator-component",
   "description": "Generator Component – A generator for Fozzie components",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "files": [
     "generators"
   ],

--- a/packages/storybook/config/storybook/preview-body.html
+++ b/packages/storybook/config/storybook/preview-body.html
@@ -1,0 +1,29 @@
+<script>
+(function () {
+    var fontUrls = 'url("https://d30v2pzvrfyzpo.cloudfront.net/fonts/JustEatBasis-Bold-optimised.woff2") format("woff2"), url("https://d30v2pzvrfyzpo.cloudfront.net/fonts/JustEatBasis-Bold-optimised.woff") format("woff")';
+
+    if('fonts' in document ) {
+        var bold = new FontFace('JustEatBasis', fontUrls, { weight: '600' });
+
+        Promise.all([bold.load()])
+            .then(function (fonts) {
+                fonts.forEach(function (font) {
+                    document.fonts.add(font);
+                });
+            })
+            .then(function () {
+                document.documentElement.classList.add('webfonts-loaded');
+            });
+    }
+
+    // This next block is for IE11 and old Edge support, which don't support the new Font loading API
+    if(!('fonts' in document) && 'head' in document) {
+        // Awkwardly dump the second stage @font-face blocks in the head
+        var style = document.createElement('style');
+        // Note: Edge supports WOFF2
+        style.innerHTML = '@font-face { font-family: JustEatBasis; font-weight: 600; src: ' + fontUrls + '; }';
+        document.head.appendChild(style);
+        document.documentElement.classList.add('webfonts-loaded');
+    }
+})();
+</script>

--- a/packages/storybook/config/storybook/preview-head.html
+++ b/packages/storybook/config/storybook/preview-head.html
@@ -1,0 +1,16 @@
+<link rel="preload" href="https://d30v2pzvrfyzpo.cloudfront.net/fonts/JustEatBasis-Regular-optimised.woff2" as="font"
+    type="font/woff2" crossorigin>
+
+<style>
+    @font-face {
+        font-family: JustEatBasis;
+        src: url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JustEatBasis-Regular-optimised.woff2') format("woff2"),
+            url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JustEatBasis-Regular-optimised.woff') format("woff");
+        font-weight: 400;
+        font-display: swap;
+    }
+
+    body {
+        font-feature-settings: "tnum"; /* Enable tabular numbers */
+    }
+</style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1734,10 +1734,10 @@
     lodash-es "4.17.15"
     window-or-global "1.0.1"
 
-"@justeat/f-utils@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.3.0.tgz#1f18ba13ad7061e21c2112387234a77ba45fb5d3"
-  integrity sha512-hqRiGA2lP++Z1oqawsv1V2Duf3YShaAbJ3S5JEPTpTMP5RjH36Xpc8nRbIVFBmwnZCu7L9iF7AebYTUX8XhiZA==
+"@justeat/f-utils@1.0.0-beta.0":
+  version "1.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-1.0.0-beta.0.tgz#4d0765efda51ed78b5cd6a377fcea02b343dc1ff"
+  integrity sha512-CkvBhv9pJMY/qqbYAu1c2buLcyfGfR8LbGGmIUh8LdTf+P1UvPi5868N+7W5pKStNRD2WOOK5Oo6TBRLMgt1Pg==
 
 "@justeat/f-vue-icons@1.0.0":
   version "1.0.0"
@@ -1761,20 +1761,20 @@
     "@justeat/f-icons" "2.0.0-beta.9"
     babel-helper-vue-jsx-merge-props "^2.0.3"
 
-"@justeat/fozzie-colour-palette@3.0.0-beta.4":
-  version "3.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.4.tgz#cd36b52d9ae346f5101d3a5914bc91d086177461"
-  integrity sha512-LOcUh6H66CzNAakHTvy9QDRwzLGGBP+evZwOJDj2oV6lbYhWLN2Sb7ldnooFdgSBNwwuTSOm8tW0o/8KLMqnsQ==
+"@justeat/fozzie-colour-palette@3.0.0-beta.6":
+  version "3.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.6.tgz#3d66dd63b48dacf649f003a3b3c7c39ecf7d94b7"
+  integrity sha512-DbUvzLpVr2Q9/6QTF58/fomb1YOdn8ytGE+PLo9prNlpc24ZaFEDPfHzK63nyAvmmw1VboRNRzOpffArdW4FNQ==
 
-"@justeat/fozzie@3.0.0-beta.8":
-  version "3.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-3.0.0-beta.8.tgz#b3bc41145f4fa54a09ecedf54db08b61e0c46066"
-  integrity sha512-5Y/Kg668DWK/1ilb6WddOQ0nwfWc57m8MqpHAAxIsaQQbTO5ANRcZsmBWmBAt+rEKzG2sUmP5BaqZe/kwc1ENA==
+"@justeat/fozzie@4.0.0-beta.0":
+  version "4.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-4.0.0-beta.0.tgz#66d7ee71a90bdff3bc4b67994305d888fe8f7c64"
+  integrity sha512-/uElS2zDFD8A7DiA5bxbBmjKbUGI00u4bApJVUwCRaGBgqScEwrI9ya1cYt5/KlTD5YtFef3iOd7QppilSb5mQ==
   dependencies:
     "@justeat/f-dom" "1.1.0"
     "@justeat/f-logger" "0.8.1"
-    "@justeat/f-utils" "0.3.0"
-    "@justeat/fozzie-colour-palette" "3.0.0-beta.4"
+    "@justeat/f-utils" "1.0.0-beta.0"
+    "@justeat/fozzie-colour-palette" "3.0.0-beta.6"
     fontfaceobserver "2.1.0"
     include-media "1.4.9"
     kickoff-grid.css "1.2.0"


### PR DESCRIPTION
PR for v2.0.0 of fozzie components – updating fonts to new JustEatBasis.

This PR should only be merged once we have a release date confirmed for the font changes – in the meantime though, the components changes will be released as beta versions so that the new versions of the header/footer etc can be released and pulled in to the vertical codebases. These will then move to full non-beta releases once we roll this out and don't need to support the old versions.

---

## UI Review Checks

- [x] README and/or UI Documentation has been updated
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Internet Explorer 11
- [x] Mobile (Please list device/browser – Ideally one iPhone model and one Android)