### PR TITLE
f-content-cards@1.13.0: Dynamic POCC Heading

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.13.0
 ------------------------------
-*August 26, 2020*
+*September 1, 2020*
 
 ### Changed
 - Pull Post Order Content Card title from Braze

--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.13.0
+------------------------------
+*August 26, 2020*
+
+### Changed
+- Pull Post Order Content Card title from Braze
+- Update PostOrderCard storybook configuration
+- Remove title prop from ContentCards
+
+
 v1.12.0
 ------------------------------
 *August 24, 2020*

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -98,11 +98,6 @@ export default {
             default: null
         },
 
-        title: {
-            type: String,
-            default: ''
-        },
-
         userId: {
             type: String,
             default: ''

--- a/packages/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
@@ -3,11 +3,11 @@
         :data-test-id="testId"
         :class="[$style['c-postOrderCard']]">
         <h2
-            v-if="title"
+            v-if="headline"
             :class="[$style['c-postOrderCard-title']]"
             data-test-id="contentCard-postOrderCard-title"
         >
-            {{ title }}
+            {{ headline }}
         </h2>
         <card-container
             :card="card"
@@ -54,10 +54,6 @@ export default {
             type: Boolean,
             default: false
         },
-        title: {
-            type: String,
-            default: ''
-        },
         testId: {
             type: String,
             default: null
@@ -69,7 +65,8 @@ export default {
             ctaText,
             button,
             type,
-            icon
+            icon,
+            headline
         } = this.card;
 
         return {
@@ -77,7 +74,8 @@ export default {
             ctaText,
             button,
             type,
-            icon
+            icon,
+            headline
         };
     },
 

--- a/packages/f-content-cards/src/components/cardTemplates/_tests/PostOrderCard.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/_tests/PostOrderCard.test.js
@@ -5,12 +5,14 @@ const image = '__IMAGE__';
 const icon = '__ICON__';
 const ctaText = '__CTA_TEXT__';
 const type = 'Post_Order_Card_1';
+const headline = '__HEADLINE__';
 
 const card = {
     ctaText,
     icon,
     image,
-    type
+    type,
+    headline
 };
 
 describe('contentCards › PostOrderCard', () => {
@@ -25,6 +27,7 @@ describe('contentCards › PostOrderCard', () => {
 
         // Assert
         expect(wrapper.find('[data-test-id="contentCard-postOrderCard-1"]').text()).toBe(ctaText);
+        expect(wrapper.find('[data-test-id="contentCard-postOrderCard-title"]').text()).toBe(headline);
     });
 
     it('should hide the heading element if the copy is unavailable', () => {
@@ -34,6 +37,7 @@ describe('contentCards › PostOrderCard', () => {
         // Assert
         expect(wrapper.find('[data-test-id="contentCard-postOrderCard-title"]').exists()).toBe(false);
     });
+
 
     describe('condensed', () => {
         it('should apply the condensed class when no background image is available', () => {

--- a/packages/f-content-cards/src/services/utils/transformCardData.js
+++ b/packages/f-content-cards/src/services/utils/transformCardData.js
@@ -34,7 +34,8 @@ const transformCardData = card => {
         subtitle = subtitleDescription,
         custom_card_type: type,
         updated,
-        voucher_code: voucherCode
+        voucher_code: voucherCode,
+        headline
     } = extras;
 
     const description = Object.keys(extras)
@@ -54,6 +55,7 @@ const transformCardData = card => {
         description,
         extractedCardId,
         footer,
+        headline,
         icon,
         id,
         image,

--- a/packages/f-content-cards/stories/PostOrderCard.stories.js
+++ b/packages/f-content-cards/stories/PostOrderCard.stories.js
@@ -6,7 +6,6 @@ export default {
         headline: { control: { type: 'text' } },
         cardTitle: { control: { type: 'text' } },
         subtitle: { control: { type: 'text' } },
-        description: { control: { type: 'text' } },
         image: { control: { type: 'text' } },
         icon: { control: { type: 'text' } },
         ctaText: { control: { type: 'text' } },
@@ -47,7 +46,7 @@ export const PostOrderCardComponent = (args, { argTypes }) => ({
         };
     },
 
-    template: '<post-order-card :card="{title: cardTitle, ctaText, headline, image, icon, description: [description], url}" :tenant="tenant" />'
+    template: '<post-order-card :card="{title: cardTitle, ctaText, headline, image, icon, subtitle, url}" :tenant="tenant" />'
 });
 
 PostOrderCardComponent.storyName = 'post-order-card';
@@ -55,7 +54,7 @@ PostOrderCardComponent.storyName = 'post-order-card';
 PostOrderCardComponent.args = {
     headline: 'Promotional Offer',
     cardTitle: 'Treat them with a Just Eat gift card',
-    description: 'Whether you want to treat Mum to her Friday night favourite, or surprise your mate with a ‘KFC on me’, show them you care – the tasty way.',
+    subtitle: 'Whether you want to treat Mum to her Friday night favourite, or surprise your mate with a ‘KFC on me’, show them you care – the tasty way.',
     ctaText: 'Purchase now',
     image: 'https://picsum.photos/seed/FirstTimeCustomerCard_image/384/216?blur=3',
     icon: 'https://picsum.photos/seed/FirstTimeCustomerCard_icon/48/48',

--- a/packages/f-content-cards/stories/PostOrderCard.stories.js
+++ b/packages/f-content-cards/stories/PostOrderCard.stories.js
@@ -1,72 +1,65 @@
-import { withKnobs, text } from '@storybook/addon-knobs';
-import { withA11y } from '@storybook/addon-a11y';
 import PostOrderCard from '../src/components/cardTemplates/PostOrderCard.vue';
-import jeIcon from './images/je-icon.png';
-import jeBackground from './images/je-marketing.png';
 
 export default {
     title: 'Components/Atoms/f-content-cards',
-    decorators: [withKnobs, withA11y]
+    argTypes: {
+        headline: { control: { type: 'text' } },
+        cardTitle: { control: { type: 'text' } },
+        subtitle: { control: { type: 'text' } },
+        description: { control: { type: 'text' } },
+        image: { control: { type: 'text' } },
+        icon: { control: { type: 'text' } },
+        ctaText: { control: { type: 'text' } },
+        url: { control: { type: 'text' } },
+        tenant: { control: { type: 'radio', options: ['uk', 'au', 'nz'] } }
+    }
 };
 
-export const PostOrderCardComponent = () => ({
-    components: { PostOrderCard },
-    props: {
-        title: {
-            default: text('Title', 'Promotional Offer')
-        },
-        cardTitle: {
-            default: text('Card Title', 'Treat them with a Just Eat gift card')
-        },
-        description: {
-            default: text('Card Description', 'Whether you want to treat Mum to her Friday night favourite, or surprise your mate with a ‘KFC on me’, show them you care – the tasty way.')
-        },
-        image: {
-            default: text('Card Image', jeBackground)
-        },
-        icon: {
-            default: text('Card Icon', jeIcon)
-        },
-        cta: {
-            default: text('Card CTA', 'Purchase now')
-        }
+/**
+ * Definition for story for First Time Customer Card component
+ *
+ * @param {Object} args
+ * @param {{argTypes: {Array}}}
+ * @return {{
+ *  template: string,
+ *  components: {
+ *      PostOrderCardComponent: {Object}
+ *  },
+ *  provide: {Function},
+ *  props: string[]
+ * }}
+ */
+export const PostOrderCardComponent = (args, { argTypes }) => ({
+    components: {
+        PostOrderCard
     },
+
+    props: Object.keys(argTypes),
+
+    /**
+     * Stubbed copy for injecting when supplied card information is not complete
+     * @return {{emitCardView: {Function}, emitCardClick: {Function}}}
+     */
     provide () {
         return {
             emitCardView () {},
             emitCardClick () {}
         };
     },
-    data () {
-        return {
-            card: {
-                id: 'NWU1NTJjMWU2YThkNjM0ODllYzE3OGI5XyRfY2M9ZDg1MzM1ODktM2IyMC0xZmJkLWYwMzEtMTE5MjNjYjhiMjcyJm12PTVlNTUyYzFlNmE4ZDYzNDg5ZWMxNzhiZCZwaT1jbXA=',
-                viewed: false,
-                title: this.cardTitle,
-                imageUrl: null,
-                subtitle: this.description,
-                created: null,
-                updated: '2020-02-25T14:21:15.000Z',
-                categories: [],
-                expiresAt: '2020-03-25T23:55:00.000Z',
-                url: 'https://www.just-eat.co.uk/area/s637jj',
-                linkText: 'www.just-eat.co.uk',
-                aspectRatio: 1,
-                order: '1',
-                image: this.image,
-                ctaText: this.cta,
-                icon: this.icon,
-                type: 'Post_Order_Card_1',
-                pinned: false,
-                dismissible: true,
-                dismissed: false,
-                clicked: false,
-                Ra: null,
-                Rf: null
-            }
-        };
-    },
-    template: '<post-order-card :card="card" :title="title" />'
+
+    template: '<post-order-card :card="{title: cardTitle, ctaText, headline, image, icon, description: [description], url}" :tenant="tenant" />'
 });
 
 PostOrderCardComponent.storyName = 'post-order-card';
+
+PostOrderCardComponent.args = {
+    headline: 'Promotional Offer',
+    cardTitle: 'Treat them with a Just Eat gift card',
+    description: 'Whether you want to treat Mum to her Friday night favourite, or surprise your mate with a ‘KFC on me’, show them you care – the tasty way.',
+    ctaText: 'Purchase now',
+    image: 'https://picsum.photos/seed/FirstTimeCustomerCard_image/384/216?blur=3',
+    icon: 'https://picsum.photos/seed/FirstTimeCustomerCard_icon/48/48',
+    url: '#',
+    tenant: 'uk'
+};
+


### PR DESCRIPTION
The Post Order Content Card section title is currently hardcoded, however, CRM want to change the title depending on the available offer.

This change allows the title to be controlled from the Braze content card data by applying a `headline` key value pair.

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- **N/A** This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)
