### PR TITLE
f-registration@0.16.0 Remove tenant prop from f-registration

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.16.0
+------------------------------
+*August 28, 2020*
+
+### Changed
+- Remove tenant prop and infer from locale prop instead.
+
 v0.15.0
 ------------------------------
 *August 26, 2020*

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Form Field Component",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -188,11 +188,7 @@ export default {
     props: {
         locale: {
             type: String,
-            default: ''
-        },
-        tenant: { // TODO ACC2-506 Compute tenant value from local config instead of using this prop
-            type: String,
-            required: true
+            default: 'en-GB'
         },
         title: {
             type: String,
@@ -267,6 +263,18 @@ export default {
         },
         shouldShowLoginLink () {
             return this.loginSettings && this.loginSettings.linkText && this.loginSettings.url;
+        },
+        tenant () {
+            return {
+                'en-GB': 'uk',
+                'en-AU': 'au',
+                'en-NZ': 'nz',
+                'da-DK': 'dk',
+                'es-ES': 'es',
+                'en-IE': 'ie',
+                'it-IT': 'it',
+                'nb-NO': 'no'
+            }[this.locale];
         }
     },
 

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -8,7 +8,7 @@ jest.mock('../../services/RegistrationServiceApi', () => ({ createAccount: jest.
 
 describe('Registration', () => {
     const propsData = {
-        tenant: 'uk',
+        locale: 'en-GB',
         createAccountUrl: 'http://localhost/account/register'
     };
 
@@ -32,7 +32,7 @@ describe('Registration', () => {
         it('should show the login link if loginSettings prop set.', () => {
             const wrapper = shallowMount(Registration, {
                 propsData: {
-                    tenant: 'uk',
+                    locale: 'en-GB',
                     createAccountUrl: 'http://localhost/account/register',
                     loginSettings: {
                         preLinkText: 'Already have an account?',
@@ -50,7 +50,7 @@ describe('Registration', () => {
         it('should not show the login link if loginSettings prop set but linkText not set.', () => {
             const wrapper = shallowMount(Registration, {
                 propsData: {
-                    tenant: 'uk',
+                    locale: 'en-GB',
                     createAccountUrl: 'http://localhost/account/register',
                     loginSettings: {
                         preLinkText: 'Already have an account?'
@@ -66,7 +66,7 @@ describe('Registration', () => {
         it('should not show the login link if loginSettings prop set but url not set.', () => {
             const wrapper = shallowMount(Registration, {
                 propsData: {
-                    tenant: 'uk',
+                    locale: 'en-GB',
                     createAccountUrl: 'http://localhost/account/register',
                     loginSettings: {
                         preLinkText: 'Already have an account?',
@@ -86,6 +86,17 @@ describe('Registration', () => {
             const loginLink = wrapper.find("[data-test-id='create-account-login-link']");
 
             expect(loginLink.exists()).toBe(false);
+        });
+
+        it('should fallback to use the en-GB locale if no locale passed', () => {
+            // Arrange
+            const wrapper = shallowMount(Registration, {
+                propsData: {
+                    createAccountUrl: 'http://localhost/account/register'
+                }
+            });
+
+            expect(wrapper.vm.tenant).toBe('uk');
         });
     });
 


### PR DESCRIPTION
## Summary
Remove `tenant` prop from f-registration. Infer tenant from locale now.

## UI Review Checks

- [X] README and/or UI Documentation has been [created|updated]
- [X] Unit tests have been [created|updated]

## Browsers Tested

- [X] Chrome (latest)