### PR TITLE
f-services@1.2.0 - Handle missing navigator API

### DIFF
--- a/packages/f-services/CHANGELOG.md
+++ b/packages/f-services/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.2.0
+------------------------------
+*September 2, 2020*
+
+### Changed
+- Handle missing navigator API so that the default axios timeout is returned when used on the server.
+
+
 v1.1.0
 ------------------------------
 *August 26, 2020*

--- a/packages/f-services/package.json
+++ b/packages/f-services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-services",
   "description": "Fozzie Services - Shared Services for Components and projects",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "dist/f-services.umd.js",
   "module": "dist/f-services.esm.js",
   "source": "src/index.js",

--- a/packages/f-services/src/axios.js
+++ b/packages/f-services/src/axios.js
@@ -16,7 +16,8 @@ const getNetworkDetails = () => {
 
     return navigator.connection
         || navigator.mozConnection
-        || navigator.webkitConnection;
+        || navigator.webkitConnection
+        || null;
 };
 
 /**

--- a/packages/f-services/src/axios.js
+++ b/packages/f-services/src/axios.js
@@ -11,9 +11,13 @@ import {
 /**
  * Wrapper for navigator.connection and its Firefox/Safari implementations
  */
-const getNetworkDetails = () => navigator.connection
+const getNetworkDetails = () => {
+    if (typeof navigator === 'undefined') return null;
+
+    return navigator.connection
         || navigator.mozConnection
         || navigator.webkitConnection;
+};
 
 /**
  * Returns a timeout in milliseconds based on the current connection speed. Slower connections will have longer timeouts.

--- a/packages/f-services/tests/axios.test.js
+++ b/packages/f-services/tests/axios.test.js
@@ -37,9 +37,11 @@ describe('getNetworkDetails', () => {
         expect(connection).toBe(null);
     });
 
-    it('should return navigation.connection if it is defined', () => {
+    it('should return navigator.connection if it is available', () => {
         // Arrange
-        windowSpy.mockImplementation(() => ({ connection: 'CONNECTION' }));
+        windowSpy.mockImplementation(() => ({
+            connection: 'CONNECTION'
+        }));
 
         // Act
         const connection = getNetworkDetails();
@@ -48,7 +50,7 @@ describe('getNetworkDetails', () => {
         expect(connection).toBe('CONNECTION');
     });
 
-    it('should return navigation.mozConnection if it is defined and navigator.connection is not', () => {
+    it('should return navigator.mozConnection if it is available', () => {
         // Arrange
         windowSpy.mockImplementation(() => ({
             mozConnection: 'MOZ-CONNECTION'
@@ -61,21 +63,7 @@ describe('getNetworkDetails', () => {
         expect(connection).toBe('MOZ-CONNECTION');
     });
 
-    it('should return navigation.mozConnection preferentially over navigator.webkitConnection', () => {
-        // Arrange
-        windowSpy.mockImplementation(() => ({
-            mozConnection: 'MOZ-CONNECTION',
-            webkitConnection: 'WEBKIT-CONNECTION'
-        }));
-
-        // Act
-        const connection = getNetworkDetails();
-
-        // Assert
-        expect(connection).toBe('MOZ-CONNECTION');
-    });
-
-    it('should return navigation.webkitConnection if it is defined and navigator.connection and navigator.mozConnection are not', () => {
+    it('should return navigator.webkitConnection if it is available', () => {
         // Arrange
         windowSpy.mockImplementation(() => ({
             webkitConnection: 'WEBKIT-CONNECTION'

--- a/packages/f-services/tests/axios.test.js
+++ b/packages/f-services/tests/axios.test.js
@@ -4,9 +4,9 @@ import axiosServices from '../src/axios';
 
 const { getNetworkDetails, setupResponseTimeRecording } = axiosServices;
 
+let callback;
 let instance;
 let mock;
-let callback;
 let windowSpy;
 
 // eslint-disable-next-line no-unused-vars
@@ -22,9 +22,12 @@ afterEach(() => {
 });
 
 describe('getNetworkDetails', () => {
+    beforeEach(() => {
+        windowSpy = jest.spyOn(window, 'navigator', 'get');
+    });
+
     it('should return `null` when navigator is undefined', () => {
         // Arrange
-        windowSpy = jest.spyOn(window, 'navigator', 'get');
         windowSpy.mockImplementation(() => undefined);
 
         // Act
@@ -36,7 +39,6 @@ describe('getNetworkDetails', () => {
 
     it('should return navigation.connection if it is defined', () => {
         // Arrange
-        windowSpy = jest.spyOn(window, 'navigator', 'get');
         windowSpy.mockImplementation(() => ({ connection: 'CONNECTION' }));
 
         // Act
@@ -48,7 +50,6 @@ describe('getNetworkDetails', () => {
 
     it('should return navigation.mozConnection if it is defined and navigator.connection is not', () => {
         // Arrange
-        windowSpy = jest.spyOn(window, 'navigator', 'get');
         windowSpy.mockImplementation(() => ({
             mozConnection: 'MOZ-CONNECTION'
         }));
@@ -62,7 +63,6 @@ describe('getNetworkDetails', () => {
 
     it('should return navigation.mozConnection preferentially over navigator.webkitConnection', () => {
         // Arrange
-        windowSpy = jest.spyOn(window, 'navigator', 'get');
         windowSpy.mockImplementation(() => ({
             mozConnection: 'MOZ-CONNECTION',
             webkitConnection: 'WEBKIT-CONNECTION'
@@ -77,7 +77,6 @@ describe('getNetworkDetails', () => {
 
     it('should return navigation.webkitConnection if it is defined and navigator.connection and navigator.mozConnection are not', () => {
         // Arrange
-        windowSpy = jest.spyOn(window, 'navigator', 'get');
         windowSpy.mockImplementation(() => ({
             webkitConnection: 'WEBKIT-CONNECTION'
         }));


### PR DESCRIPTION
### Changed
- Handle missing navigator API so that the default axios timeout is returned when used on the server.

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]

## Browsers Tested
- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)