### PR TITLE
f-registration@0.23.0 Include Registration API service as part of npm f-registration

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.23.0
+------------------------------
+*September 15, 2020*
+
+### Changed
+- Include Registration API service as part of npm package for use in Magikarp contract tests
+
+
+
 v0.22.0
 ------------------------------
 *September 15, 2020*

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",
-    "test-utils"
+    "test-utils",
+    "src/services"
   ],
   "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/f-registration",
   "contributors": [


### PR DESCRIPTION
**Description**
- We need to move the consumer contract tests from fozzie-components to Magikarp because of potential security concerns exposing our endpoints / request body within these tests.

Before we can do this, we need to make the RegistrationApi service available in the f-registration package, so that when we move the tests, we're able to invoke the call.