### PR TITLE
 f-registration@0.26.0 Validation changes

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -3,12 +3,22 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.25.0
+------------------------------
+*September 17 , 2020*
+
+### Changed
+- Validation for inputs now displayed when focus is lost
+
+
 v0.24.0
 ------------------------------
 *September 15, 2020*
 
 ### Changed
 - Include Registration API service as part of npm package for use in Magikarp contract tests
+
 
 v0.23.0
 ------------------------------
@@ -17,12 +27,14 @@ v0.23.0
 ### Changed
 - font-weight for the Button bold text is now 500
 
+
 v0.22.0
 ------------------------------
 *September 15, 2020*
 
 ### Changed
 - font-weight for the Button bold text is now 600
+
 
 v0.21.0
 ------------------------------

--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -11,6 +11,10 @@ v0.26.0
 ### Changed
 - Validation for inputs now displayed when focus is lost
 
+### Added
+- Email input max length is now 50 characters
+- Password input must be between 4 and 50 characters
+
 
 v0.25.0
 ------------------------------

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -31,7 +31,8 @@
                 data-test-id="input-first-name"
                 label-text="First name"
                 input-type="text"
-                label-style="inline">
+                label-style="inline"
+                @blur="$v.firstName.$touch">
                 <template #error>
                     <p
                         v-if="shouldShowFirstNameRequiredError"
@@ -63,7 +64,8 @@
                 data-test-id="input-last-name"
                 label-text="Last name"
                 input-type="text"
-                label-style="inline">
+                label-style="inline"
+                @blur="$v.lastName.$touch">
                 <template #error>
                     <p
                         v-if="shouldShowLastNameRequiredError"
@@ -95,7 +97,8 @@
                 data-test-id="input-email"
                 label-text="Email"
                 input-type="email"
-                label-style="inline">
+                label-style="inline"
+                @blur="$v.email.$touch">
                 <!-- For when we want to add validation on blur of input - @blur="$v.email.$touch" -->
                 <template #error>
                     <p
@@ -128,7 +131,8 @@
                 data-test-id="input-password"
                 label-text="Password"
                 input-type="password"
-                label-style="inline">
+                label-style="inline"
+                @blur="$v.password.$touch">
                 <template #error>
                     <p
                         v-if="shouldShowPasswordRequiredError"

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -99,7 +99,6 @@
                 input-type="email"
                 label-style="inline"
                 @blur="$v.email.$touch">
-                <!-- For when we want to add validation on blur of input - @blur="$v.email.$touch" -->
                 <template #error>
                     <p
                         v-if="shouldShowEmailRequiredError"
@@ -114,6 +113,13 @@
                         data-test-id='error-email-invalid'>
                         <warning-icon :class="$style['o-form-error-icon']" />
                         Please enter a valid email address
+                    </p>
+                    <p
+                        v-if="shouldShowEmailMaxLengthError"
+                        :class="$style['o-form-error']"
+                        data-test-id='error-email-maxlength'>
+                        <warning-icon :class="$style['o-form-error-icon']" />
+                        Email exceeds 50 characters
                     </p>
                     <p
                         v-else-if="shouldShowEmailAlreadyExistsError"
@@ -140,6 +146,20 @@
                         data-test-id='error-password-empty'>
                         <warning-icon :class="$style['o-form-error-icon']" />
                         Please enter a password
+                    </p>
+                    <p
+                        v-if="shouldShowPasswordMinLengthError"
+                        :class="$style['o-form-error']"
+                        data-test-id='error-password-minlength'>
+                        <warning-icon :class="$style['o-form-error-icon']" />
+                        Password is less than four characters
+                    </p>
+                    <p
+                        v-if="shouldShowPasswordMaxLengthError"
+                        :class="$style['o-form-error']"
+                        data-test-id='error-password-maxlength'>
+                        <warning-icon :class="$style['o-form-error-icon']" />
+                        Password exceeds 50 characters
                     </p>
                 </template>
             </form-field>
@@ -175,7 +195,9 @@
 <script>
 import { globalisationServices } from '@justeat/f-services';
 import { validationMixin } from 'vuelidate';
-import { required, email, maxLength } from 'vuelidate/lib/validators';
+import {
+    required, email, minLength, maxLength
+} from 'vuelidate/lib/validators';
 import { WarningIcon } from '@justeat/f-vue-icons';
 import Card from '@justeat/f-card';
 import '@justeat/f-card/dist/f-card.css';
@@ -276,11 +298,20 @@ export default {
         shouldShowEmailRequiredError () {
             return !this.$v.email.required && this.$v.email.$dirty;
         },
+        shouldShowEmailMaxLengthError () {
+            return !this.$v.email.maxLength && this.$v.email.$dirty;
+        },
         shouldShowEmailInvalidError () {
             return !this.$v.email.email && this.$v.email.$dirty;
         },
         shouldShowPasswordRequiredError () {
             return !this.$v.password.required && this.$v.password.$dirty;
+        },
+        shouldShowPasswordMinLengthError () {
+            return !this.$v.password.minLength && this.$v.password.$dirty;
+        },
+        shouldShowPasswordMaxLengthError () {
+            return !this.$v.password.maxLength && this.$v.password.$dirty;
         },
         shouldShowLoginLink () {
             return this.loginSettings && this.loginSettings.linkText && this.loginSettings.url;
@@ -312,10 +343,13 @@ export default {
         },
         email: {
             required,
-            email
+            email,
+            maxLength: maxLength(50)
         },
         password: {
-            required
+            required,
+            minLength: minLength(4),
+            maxLength: maxLength(50)
         }
     },
 

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -119,7 +119,7 @@
                         :class="$style['o-form-error']"
                         data-test-id='error-email-maxlength'>
                         <warning-icon :class="$style['o-form-error-icon']" />
-                        Email exceeds 50 characters
+                        Email address exceeds 50 characters
                     </p>
                     <p
                         v-else-if="shouldShowEmailAlreadyExistsError"

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -237,6 +237,25 @@ describe('Registration', () => {
             }
         });
 
+        it('should show error message when the first name field is populated with invalid input and focus is lost', async () => {
+            // Arrange
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                const firstNameInput = wrapper.find('[data-test-id="input-first-name"]');
+                firstNameInput.setValue('wh4t @ w3!rd |\\|ame');
+
+                // Act
+                firstNameInput.trigger('blur');
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowFirstNameInvalidCharError).toBe(true);
+            } finally {
+                wrapper.destroy();
+            }
+        });
+
         it('should show error message and emit failure event when the first name field is populated with too long an input', async () => {
             // Arrange
             const wrapper = mountComponentAndAttachToDocument();
@@ -310,6 +329,26 @@ describe('Registration', () => {
                 // Assert
                 expect(wrapper.vm.shouldShowLastNameMaxLengthError).toBe(true);
                 expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+            } finally {
+                wrapper.destroy();
+            }
+        });
+
+        it('should show error message when the last name field is populated with too long an input and focus is lost', async () => {
+            // Arrange
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                const longValue = 'abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij';
+                const lastNameInput = wrapper.find('[data-test-id="input-last-name"]');
+                lastNameInput.setValue(longValue);
+
+                // Act
+                lastNameInput.trigger('blur');
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowLastNameMaxLengthError).toBe(true);
             } finally {
                 wrapper.destroy();
             }

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -354,6 +354,65 @@ describe('Registration', () => {
             }
         });
 
+        it('should show error message and emit failure event when the password field is populated with too long an input', async () => {
+            // Arrange
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                const longValue = 'abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij';
+                wrapper.find('[data-test-id="input-password"]').setValue(longValue);
+
+                // Act
+                await wrapper.vm.onFormSubmit();
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowPasswordMaxLengthError).toBe(true);
+                expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+            } finally {
+                wrapper.destroy();
+            }
+        });
+
+        it('should show error message and emit failure event when the password field is populated with too short an input', async () => {
+            // Arrange
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                wrapper.find('[data-test-id="input-password"]').setValue('dog');
+
+                // Act
+                await wrapper.vm.onFormSubmit();
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowPasswordMinLengthError).toBe(true);
+                expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+            } finally {
+                wrapper.destroy();
+            }
+        });
+
+        it('should show error message and emit failure event when the email field is populated with too long an input', async () => {
+            // Arrange
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                const longEmail = 'test-user-with-somewhat-long-email@justeattakeaway.com';
+                wrapper.find('[data-test-id="input-email"]').setValue(longEmail);
+
+                // Act
+                await wrapper.vm.onFormSubmit();
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowEmailMaxLengthError).toBe(true);
+                expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+            } finally {
+                wrapper.destroy();
+            }
+        });
+
         it('should emit success event when all fields are populated correctly', async () => {
             // Arrange
             RegistrationServiceApi.createAccount.mockImplementation(async () => Promise.resolve());

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -393,6 +393,25 @@ describe('Registration', () => {
             }
         });
 
+        it('should show error message when the password field is populated with too short an input and focus is lost', async () => {
+            // Arrange
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                const passwordInput = wrapper.find('[data-test-id="input-password"]');
+                passwordInput.setValue('dog');
+
+                // Act
+                passwordInput.trigger('blur');
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowPasswordMinLengthError).toBe(true);
+            } finally {
+                wrapper.destroy();
+            }
+        });
+
         it('should show error message and emit failure event when the email field is populated with too long an input', async () => {
             // Arrange
             const wrapper = mountComponentAndAttachToDocument();
@@ -408,6 +427,25 @@ describe('Registration', () => {
                 // Assert
                 expect(wrapper.vm.shouldShowEmailMaxLengthError).toBe(true);
                 expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+            } finally {
+                wrapper.destroy();
+            }
+        });
+
+        it('should show error message when the email field is invalid and focus is lost', async () => {
+            // Arrange
+            const wrapper = mountComponentAndAttachToDocument();
+            Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
+            try {
+                const emailInput = wrapper.find('[data-test-id="input-email"]');
+                emailInput.setValue('invalid email');
+
+                // Act
+                emailInput.trigger('blur');
+                await flushPromises();
+
+                // Assert
+                expect(wrapper.vm.shouldShowEmailInvalidError).toBe(true);
             } finally {
                 wrapper.destroy();
             }


### PR DESCRIPTION
## PR Changelog
### Changed
- Validation for inputs now displayed when focus is lost

### Added
- Email input max length is now 50 characters
- Password input must be between 4 and 50 characters

## UI Review Checks
- [X] README and/or UI Documentation has been [created|updated]
- [X] Unit tests have been [created|updated]
- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [X] Chrome (latest)
- [X] Mobile - Pixel 2 - Chrome

