### PR TITLE
f-card@v0.6.0 - Apply appropriate margins when isPageContentWrapper

### DIFF
--- a/packages/f-card/CHANGELOG.md
+++ b/packages/f-card/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.6.0
+------------------------------
+*September 21, 2020*
+
+### Fixed
+- Add top and bottom margins to F-Card when 'isPageContentWrapper' is enabled
+
 
 v0.5.1
 ------------------------------

--- a/packages/f-card/package.json
+++ b/packages/f-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card",
   "description": "Fozzie Card Component – Used for providing wrapper card styling to an element (or group of elements)",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "main": "dist/f-card.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-card/src/components/Card.vue
+++ b/packages/f-card/src/components/Card.vue
@@ -107,6 +107,7 @@ $card--pageContentWrapper-width           : 460px;
         transition: 250ms padding ease-in-out;
         padding-left: 6%;
         padding-right: 6%;
+        margin: spacing() * 5 0;
 
         @include media('>=narrow') {
             padding-left: 10%;
@@ -115,7 +116,7 @@ $card--pageContentWrapper-width           : 460px;
 
         @include media('>=#{$card--pageContentWrapper-width}') {
             width: $card--pageContentWrapper-width;
-            margin: 0 auto;
+            margin: spacing() * 5 auto;
             padding-left: spacing() * 10;
             padding-right: spacing() * 10;
         }

--- a/packages/f-card/src/components/Card.vue
+++ b/packages/f-card/src/components/Card.vue
@@ -107,7 +107,7 @@ $card--pageContentWrapper-width           : 460px;
         transition: 250ms padding ease-in-out;
         padding-left: 6%;
         padding-right: 6%;
-        margin: spacing() * 5 0;
+        margin: spacing(x5) 0;
 
         @include media('>=narrow') {
             padding-left: 10%;
@@ -116,9 +116,9 @@ $card--pageContentWrapper-width           : 460px;
 
         @include media('>=#{$card--pageContentWrapper-width}') {
             width: $card--pageContentWrapper-width;
-            margin: spacing() * 5 auto;
-            padding-left: spacing() * 10;
-            padding-right: spacing() * 10;
+            margin: spacing(x5) auto;
+            padding-left: spacing(x10);
+            padding-right: spacing(x10);
         }
     }
 


### PR DESCRIPTION
- A small non functional UI change which adds margin to the top and bottom of the F-Card when 'isPageContentWrapper' is true.
- This enables the component to not sit flush with the F-Header on the new Registration Page
---

## UI Review Checks

F-Card change
![image](https://user-images.githubusercontent.com/10741583/93903693-e86c8c80-fcf0-11ea-985a-8e7757f3153d.png)

Which enables
![image](https://user-images.githubusercontent.com/10741583/93903740-f9b59900-fcf0-11ea-85e7-e7803be61815.png)

Which enables
![image](https://user-images.githubusercontent.com/10741583/93903810-0d60ff80-fcf1-11ea-8262-09eaf57f4c05.png)


## Browsers Tested

- [x] Chrome (latest)
- [x] Internet Explorer 11
- [x] Chrome - Emulated Mobile and Tablet