### PR TITLE
f-registration@v0.27.0 - Bump F-Card

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.27.0
+------------------------------
+*September 23, 2020*
+
+### Changed
+- Use the latest version of F-Card to apply top and bottom margins to the registration component
+
+
 v0.26.2
 ------------------------------
 *September 23, 2020*

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.26.2",
+  "version": "0.27.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",
@@ -44,7 +44,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-card": "0.3.1",
+    "@justeat/f-card": "0.6.0",
     "@justeat/f-form-field": "0.5.0",
     "@justeat/f-services": "1.0.0",
     "@justeat/f-vue-icons": "1.0.0-beta.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1660,13 +1660,6 @@
     webpack-cli "3.3.1"
     webpack-log "2.0.0"
 
-"@justeat/f-card@0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@justeat/f-card/-/f-card-0.3.1.tgz#b327827e64f4077b45d28a27905f32405f63b50c"
-  integrity sha512-k/V+5CmqgTLqvLs0fR30lUy2WivMZXasmuVwaMUjM65ipgqWAij/tXCNibA50DBC115dtz793roIlr5MH5mT2A==
-  dependencies:
-    "@justeat/f-services" "0.13.0"
-
 "@justeat/f-dom@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-dom/-/f-dom-1.1.0.tgz#491ba78240ab73a3c4687d93eb8004415fe8a9c7"


### PR DESCRIPTION
Grabbing the latest version of F-Card which applies appropriate margins to the top and bottom of the registration component.

---

## Browsers Tested

- [x] Chrome (latest)

![image](https://user-images.githubusercontent.com/10741583/94021538-06e38e00-fdac-11ea-86ad-de7b59cc6c14.png)

