### PR TITLE
Minor - Don't use DIST for story file

### DIFF
--- a/packages/f-vue-icons/stories/Icons.stories.js
+++ b/packages/f-vue-icons/stories/Icons.stories.js
@@ -1,6 +1,6 @@
 import { withA11y } from '@storybook/addon-a11y';
 
-import * as IconsComponents from '../dist/f-vue-icons.es';
+import * as IconsComponents from '../src/index';
 import './icons.css';
 
 const icons = {};


### PR DESCRIPTION
Storybook falls over because the vue-icons package uses Dist to import its components. This means it won't work for anybody until they CD into Vue icons and build it; which is undesirable.

This PR corrects the story to load the components from the src directory.

Not versioned because I don't intend to publish vue-icons.