### PR TITLE
f-header@4.1.0 - Added property to show/hide the Help link and improved hamburger icon behaviour.

### DIFF
--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.1.0
+------------------------------
+*September 28, 2020*
+
+### Added
+- Property to show/hide the Help link.
+
+### Changed
+- Hamburger icon. Hide it if there are no visible links to be shown.
+- Storybook property from free text to boolean for "Show login/user info".
+
 
 v4.0.0
 ------------------------------

--- a/packages/f-header/README.md
+++ b/packages/f-header/README.md
@@ -71,12 +71,15 @@ The props that can be defined are as follows:
 | orderCountUrl             | `String`      | `false` | ?? |
 | showDeliveryEnquiry       | `Boolean`     | `false` | Defines if it is necessary to show the "Deliver with Just Eat" link in the header. |
 | showOffersLink            | `Boolean`     | `false` | Defines whether the offers link should be shown in the navigation. |
+| showHelpLink              | `Boolean`     | `true` | Defines whether the help link should be shown in the navigation. |
 | showLoginInfo             | `Boolean`     | `true` | Defines whether the login & user info icon should be shown in the navigation. |
 | userInfoProp              | `Object`      | `{}`     | Optional object conaining user details. If not provided `userInfoProp` is set via XHR call to `/api/account/details` |
 | userInfoUrl               | `String`      | `false` | URL to call to retrieve the userInfo (when `userInfoProp` isn't set). |
 
 
     `showLoginInfo` - Optional Boolean property with `true` as a default value, defines whether the login / user info icon should be shown in the navigation.
+
+**Important:** if you're adding a new property to show/hide something on the navigation bar, you probably want to check the `hasNavigationLinks` computed property, since you might have to update it.
 
 ## Demo and local development
 

--- a/packages/f-header/package.json
+++ b/packages/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-header/src/components/Header.vue
+++ b/packages/f-header/src/components/Header.vue
@@ -23,6 +23,7 @@
                 :show-delivery-enquiry="showDeliveryEnquiryWithContent"
                 :offers-copy="copy.offers"
                 :show-offers-link="showOffersLink"
+                :show-help-link="showHelpLink"
                 :error-log="errorLog"
                 :user-info-prop="userInfoProp"
                 :user-info-url="userInfoUrl"
@@ -81,6 +82,11 @@ export default {
         },
 
         showLoginInfo: {
+            type: Boolean,
+            default: true
+        },
+
+        showHelpLink: {
             type: Boolean,
             default: true
         },

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -177,9 +177,10 @@
                     </a>
                 </li>
 
-                <li class="c-nav-list-item c-nav-list-item--support">
+                <li
+                    v-if="showHelpLink"
+                    class="c-nav-list-item c-nav-list-item--support">
                     <a
-                        v-if="showHelpLink"
                         :href="help.url"
                         :data-trak='`{
                                 "trakEvent": "click",

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -379,8 +379,7 @@ export default {
             return this.showOffersLink ||
                 this.showHelpLink ||
                 this.showDeliveryEnquiry ||
-                this.showLoginInfo ||
-                this.userInfo;
+                this.showLoginInfo;
         }
     },
 

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -1,5 +1,8 @@
 <template>
-    <nav class="c-nav c-nav--global">
+    <nav
+        v-if="hasNavigationLinks"
+        class="c-nav c-nav--global"
+        data-js-test="nav-container">
         <button
             :class="['c-nav-trigger c-nav-toggle is-hidden--noJS', navToggleThemeClass, {
                 'is-open': navIsOpen
@@ -370,6 +373,14 @@ export default {
          */
         getAnalyticsBlob () {
             return window.localStorage.getItem('je-analytics') || false;
+        },
+
+        hasNavigationLinks () {
+            return this.showOffersLink ||
+                this.showHelpLink ||
+                this.showDeliveryEnquiry ||
+                this.showLoginInfo ||
+                this.userInfo;
         }
     },
 

--- a/packages/f-header/src/components/Navigation.vue
+++ b/packages/f-header/src/components/Navigation.vue
@@ -176,6 +176,7 @@
 
                 <li class="c-nav-list-item c-nav-list-item--support">
                     <a
+                        v-if="showHelpLink"
                         :href="help.url"
                         :data-trak='`{
                                 "trakEvent": "click",
@@ -273,6 +274,11 @@ export default {
         showOffersLink: {
             type: Boolean,
             default: false
+        },
+
+        showHelpLink: {
+            type: Boolean,
+            default: true
         },
 
         showLoginInfo: {

--- a/packages/f-header/src/components/tests/Navigation.test.js
+++ b/packages/f-header/src/components/tests/Navigation.test.js
@@ -641,12 +641,19 @@ describe('Navigation', () => {
             // Arrange
             const propsData = {
                 ...defaultPropsData,
-                showLoginInfo: false,
-                userInfoProp: true
+                showLoginInfo: false
             };
 
             // Act
-            const wrapper = shallowMount(Navigation, { propsData });
+            const wrapper = shallowMount(Navigation, { 
+                propsData,
+                computed: {
+                    hasNavigationLinks () {
+                        return true;
+                    }
+                } 
+            });
+
             await wrapper.setData({
                 ...defaultData,
                 userInfo: {
@@ -725,24 +732,6 @@ describe('Navigation', () => {
             expect(wrapper.vm.hasNavigationLinks).toBe(true);
         });
 
-        it('should return true if `userInfo` is not empty', async () => {
-            // Arrange
-            const propsData = {
-                ...defaultPropsData,
-                userInfoProp: true
-            };
-
-            // Act
-            const wrapper = shallowMount(Navigation, {
-                propsData
-            });
-
-            await wrapper.setData(defaultData);
-
-            // Assert
-            expect(wrapper.vm.hasNavigationLinks).toBe(true);
-        });
-
         it('should return false if there are no underlying links to show', async () => {
             // Arrange
             const propsData = {
@@ -750,8 +739,7 @@ describe('Navigation', () => {
                 showLoginInfo: false,
                 showOffersLink: false,
                 showHelpLink: false,
-                showDeliveryEnquiry: false,
-                userInfoProp: false
+                showDeliveryEnquiry: false
             };
 
             // Act

--- a/packages/f-header/src/components/tests/Navigation.test.js
+++ b/packages/f-header/src/components/tests/Navigation.test.js
@@ -24,6 +24,8 @@ const defaultPropsData = {
     isOrderCountSupported: true,
     offersCopy: {},
     showOffersLink: false,
+    showHelpLink: false,
+    userInfoProp: false,
     headerBackgroundTheme: 'white'
 };
 
@@ -188,6 +190,45 @@ describe('Navigation', () => {
         expect(wrapper.find('[data-js-test="login"]').exists()).toBe(true);
     });
 
+    it('should show the navbar if there are navigation links', async () => {
+        // Arrange
+        const propsData = {
+            ...defaultPropsData
+        };
+
+        // Act
+        const wrapper = shallowMount(Navigation, {
+            propsData,
+            computed: {
+                hasNavigationLinks () {
+                    return true;
+                }
+            }
+        });
+
+        // Assert
+        expect(wrapper.find('[data-js-test="nav-container"]').exists()).toBe(true);
+    });
+
+    it('should NOT show the navbar if there are no navigation links', async () => {
+        // Arrange
+        const propsData = {
+            ...defaultPropsData
+        };
+
+        // Act
+        const wrapper = shallowMount(Navigation, {
+            propsData,
+            computed: {
+                hasNavigationLinks () {
+                    return false;
+                }
+            }
+        });
+
+        // Assert
+        expect(wrapper.find('[data-js-test="nav-container"]').exists()).toBe(false);
+    });
 
     describe('nav links', () => {
         it('should be shown on mobile when is "navIsOpen" is true', async () => {
@@ -394,7 +435,8 @@ describe('Navigation', () => {
         it('should be shown when "showHelpLink" is not explicitly set', () => {
             // Arrange
             const propsData = {
-                ...defaultPropsData
+                ...defaultPropsData,
+                showHelpLink: undefined
             };
 
             // Act
@@ -599,7 +641,8 @@ describe('Navigation', () => {
             // Arrange
             const propsData = {
                 ...defaultPropsData,
-                showLoginInfo: false
+                showLoginInfo: false,
+                userInfoProp: true
             };
 
             // Act
@@ -614,5 +657,110 @@ describe('Navigation', () => {
             // Assert
             expect(wrapper.find('[data-js-test="user-info-icon"]').classes()).toContain('is-hidden');
         });
+    });
+
+
+    describe('hasNavigationLinks', () => {
+        it('should return true if `showOffersLink` is true', async () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showOffersLink: true
+            };
+
+            // Act
+            const wrapper = shallowMount(Navigation, {
+                propsData
+            });
+
+            // Assert
+            expect(wrapper.vm.hasNavigationLinks).toBe(true);
+        });
+
+        it('should return true if `showHelpLink` is true', async () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showHelpLink: true
+            };
+
+            // Act
+            const wrapper = shallowMount(Navigation, {
+                propsData
+            });
+
+            // Assert
+            expect(wrapper.vm.hasNavigationLinks).toBe(true);
+        });
+
+        it('should return true if `showDeliveryEnquiry` is true', async () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showDeliveryEnquiry: true
+            };
+
+            // Act
+            const wrapper = shallowMount(Navigation, {
+                propsData
+            });
+
+            // Assert
+            expect(wrapper.vm.hasNavigationLinks).toBe(true);
+        });
+
+        it('should return true if `showLoginInfo` is true', async () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showLoginInfo: true
+            };
+
+            // Act
+            const wrapper = shallowMount(Navigation, {
+                propsData
+            });
+
+            // Assert
+            expect(wrapper.vm.hasNavigationLinks).toBe(true);
+        });
+
+        it('should return true if `userInfo` is not empty', async () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                userInfoProp: true
+            };
+
+            // Act
+            const wrapper = shallowMount(Navigation, {
+                propsData
+            });
+
+            await wrapper.setData(defaultData);
+
+            // Assert
+            expect(wrapper.vm.hasNavigationLinks).toBe(true);
+        });
+
+        it('should return false if there are no underlying links to show', async () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showLoginInfo: false,
+                showOffersLink: false,
+                showHelpLink: false,
+                showDeliveryEnquiry: false,
+                userInfoProp: false
+            };
+
+            // Act
+            const wrapper = shallowMount(Navigation, {
+                propsData
+            });
+
+            // Assert
+            expect(wrapper.vm.hasNavigationLinks).toBe(false);
+        });        
     });
 });

--- a/packages/f-header/src/components/tests/Navigation.test.js
+++ b/packages/f-header/src/components/tests/Navigation.test.js
@@ -673,7 +673,7 @@ describe('Navigation', () => {
             'showHelpLink',
             'showDeliveryEnquiry',
             'showLoginLink'
-        ])('should return true if `%s` is true', async navLink => {
+        ])('should return true if `%s` is true', navLink => {
             // Arrange
             const propsData = {
                 ...defaultPropsData,
@@ -689,7 +689,7 @@ describe('Navigation', () => {
             expect(wrapper.vm.hasNavigationLinks).toBe(true);
         });
 
-        it('should return false if there are no underlying links to show', async () => {
+        it('should return false if there are no underlying links to show', () => {
             // Arrange
             const propsData = {
                 ...defaultPropsData,

--- a/packages/f-header/src/components/tests/Navigation.test.js
+++ b/packages/f-header/src/components/tests/Navigation.test.js
@@ -645,13 +645,13 @@ describe('Navigation', () => {
             };
 
             // Act
-            const wrapper = shallowMount(Navigation, { 
+            const wrapper = shallowMount(Navigation, {
                 propsData,
                 computed: {
                     hasNavigationLinks () {
                         return true;
                     }
-                } 
+                }
             });
 
             await wrapper.setData({
@@ -668,59 +668,16 @@ describe('Navigation', () => {
 
 
     describe('hasNavigationLinks', () => {
-        it('should return true if `showOffersLink` is true', async () => {
+        it.each([
+            'showOffersLink',
+            'showHelpLink',
+            'showDeliveryEnquiry',
+            'showLoginLink'
+        ])('should return true if `%s` is true', async navLink => {
             // Arrange
             const propsData = {
                 ...defaultPropsData,
-                showOffersLink: true
-            };
-
-            // Act
-            const wrapper = shallowMount(Navigation, {
-                propsData
-            });
-
-            // Assert
-            expect(wrapper.vm.hasNavigationLinks).toBe(true);
-        });
-
-        it('should return true if `showHelpLink` is true', async () => {
-            // Arrange
-            const propsData = {
-                ...defaultPropsData,
-                showHelpLink: true
-            };
-
-            // Act
-            const wrapper = shallowMount(Navigation, {
-                propsData
-            });
-
-            // Assert
-            expect(wrapper.vm.hasNavigationLinks).toBe(true);
-        });
-
-        it('should return true if `showDeliveryEnquiry` is true', async () => {
-            // Arrange
-            const propsData = {
-                ...defaultPropsData,
-                showDeliveryEnquiry: true
-            };
-
-            // Act
-            const wrapper = shallowMount(Navigation, {
-                propsData
-            });
-
-            // Assert
-            expect(wrapper.vm.hasNavigationLinks).toBe(true);
-        });
-
-        it('should return true if `showLoginInfo` is true', async () => {
-            // Arrange
-            const propsData = {
-                ...defaultPropsData,
-                showLoginInfo: true
+                [navLink]: true
             };
 
             // Act
@@ -749,6 +706,6 @@ describe('Navigation', () => {
 
             // Assert
             expect(wrapper.vm.hasNavigationLinks).toBe(false);
-        });        
+        });
     });
 });

--- a/packages/f-header/src/components/tests/Navigation.test.js
+++ b/packages/f-header/src/components/tests/Navigation.test.js
@@ -361,6 +361,50 @@ describe('Navigation', () => {
         });
     });
 
+
+    describe('help link', () => {
+        it('should be shown when "showHelpLink" is true', () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showHelpLink: true
+            };
+
+            // Act
+            const wrapper = shallowMount(Navigation, { propsData });
+
+            // Assert
+            expect(wrapper.find('[data-test-id="help-link"]').exists()).toBe(true);
+        });
+
+        it('should not be shown when "showHelpLink" is false', () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData,
+                showHelpLink: false
+            };
+
+            // Act
+            const wrapper = shallowMount(Navigation, { propsData });
+
+            // Assert
+            expect(wrapper.find('[data-test-id="help-link"]').exists()).toBe(false);
+        });
+
+        it('should be shown when "showHelpLink" is not explicitly set', () => {
+            // Arrange
+            const propsData = {
+                ...defaultPropsData
+            };
+
+            // Act
+            const wrapper = shallowMount(Navigation, { propsData });
+
+            // Assert
+            expect(wrapper.find('[data-test-id="help-link"]').exists()).toBe(true);
+        });
+    });
+
     describe('isOrderCountOutOfDate', () => {
         it('should return true if the order count IS OUT of date', async () => {
             // Arrange

--- a/packages/f-header/src/components/tests/Navigation.test.js
+++ b/packages/f-header/src/components/tests/Navigation.test.js
@@ -190,7 +190,7 @@ describe('Navigation', () => {
         expect(wrapper.find('[data-js-test="login"]').exists()).toBe(true);
     });
 
-    it('should show the navbar if there are navigation links', async () => {
+    it('should show the navbar if there are navigation links', () => {
         // Arrange
         const propsData = {
             ...defaultPropsData
@@ -210,7 +210,7 @@ describe('Navigation', () => {
         expect(wrapper.find('[data-js-test="nav-container"]').exists()).toBe(true);
     });
 
-    it('should NOT show the navbar if there are no navigation links', async () => {
+    it('should NOT show the navbar if there are no navigation links', () => {
         // Arrange
         const propsData = {
             ...defaultPropsData

--- a/packages/f-header/src/components/tests/__snapshots__/Header.test.js.snap
+++ b/packages/f-header/src/components/tests/__snapshots__/Header.test.js.snap
@@ -5,7 +5,7 @@ exports[`Header should render default component markup 1`] = `
   <skip-to-main-stub text="Skip to main content" transparentbg="true"></skip-to-main-stub>
   <div class="c-header-container">
     <logo-stub theme="je" companyname="Just Eat" logogtmlabel="click_logo" headerbackgroundtheme="transparent"></logo-stub>
-    <navigation-stub accountlogin="[object Object]" accountlogout="[object Object]" navlinks="[object Object]" help="[object Object]" openmenutext="Open Menu" deliveryenquiry="[object Object]" offerscopy="[object Object]" showlogininfo="true" userinfourl="/api/account/details" ordercounturl="/api/analytics/ordercount" isordercountsupported="true" headerbackgroundtheme="transparent"></navigation-stub>
+    <navigation-stub accountlogin="[object Object]" accountlogout="[object Object]" navlinks="[object Object]" help="[object Object]" openmenutext="Open Menu" deliveryenquiry="[object Object]" offerscopy="[object Object]" showhelplink="true" showlogininfo="true" userinfourl="/api/account/details" ordercounturl="/api/analytics/ordercount" isordercountsupported="true" headerbackgroundtheme="transparent"></navigation-stub>
   </div>
 </header>
 `;

--- a/packages/f-header/stories/header.stories.js
+++ b/packages/f-header/stories/header.stories.js
@@ -40,13 +40,16 @@ export const HeaderComponent = () => ({
             default: object('User info', userInfo)
         },
         showLoginInfo: {
-            default: object('Show login/user info link', true)
+            default: boolean('Show login/user info link', true)
+        },
+        showHelpLink: {
+            default: boolean('Show help link', true)
         }
     },
     parameters: {
         notes: 'some documentation here'
     },
-    template: '<vue-header :userInfoProp="userInfoProp" :showOffersLink="showOffersLink" :locale="locale" :headerBackgroundTheme="headerBackgroundTheme" :showDeliveryEnquiry="showDeliveryEnquiry" :showLoginInfo="showLoginInfo" />'
+    template: '<vue-header :userInfoProp="userInfoProp" :showOffersLink="showOffersLink" :showHelpLink="showHelpLink" :locale="locale" :headerBackgroundTheme="headerBackgroundTheme" :showDeliveryEnquiry="showDeliveryEnquiry" :showLoginInfo="showLoginInfo" />'
 });
 
 HeaderComponent.storyName = 'f-header';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,6 +1761,13 @@
     "@justeat/f-icons" "2.0.0-beta.9"
     babel-helper-vue-jsx-merge-props "^2.0.3"
 
+"@justeat/f-vue-icons@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.2.0.tgz#74b08c7539f3790cddc7f98df148c2642fcf0a75"
+  integrity sha512-TI0Jwd2vBCVCwR26CDZhzp2Xdd35T+12sX3mkoztx14XpJ+EXJ7elR9SmI/N1vZ59o8sRP6Ix7iV+mSeAGv9Zg==
+  dependencies:
+    babel-helper-vue-jsx-merge-props "2.0.3"
+
 "@justeat/fozzie-colour-palette@3.0.0-beta.6":
   version "3.0.0-beta.6"
   resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.6.tgz#3d66dd63b48dacf649f003a3b3c7c39ecf7d94b7"


### PR DESCRIPTION
v4.1.0
------------------------------
*September 28, 2020*

### Added
- Property to show/hide the Help link.

### Changed
- Hamburger icon. Hide it if there are no visible links to be shown.
- Storybook property from free text to boolean for "Show login/user info".

## UI Review Checks

**Without links:**
![image](https://user-images.githubusercontent.com/10439518/94439300-26a5f800-0198-11eb-85ff-05b5ca6b617d.png)

**With links:**
![image](https://user-images.githubusercontent.com/10439518/94439363-3ae9f500-0198-11eb-94dc-a8c6ee96c1ab.png)

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
