### PR TITLE
f-card@v0.7.0

### DIFF
--- a/packages/f-card/CHANGELOG.md
+++ b/packages/f-card/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.7.0
+------------------------------
+*October 13, 2020*
+
+### Changed
+- Removed 'beta' style from card heading to align font-size with designs.
+
+
 v0.6.0
 ------------------------------
 *September 21, 2020*

--- a/packages/f-card/package.json
+++ b/packages/f-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card",
   "description": "Fozzie Card Component – Used for providing wrapper card styling to an element (or group of elements)",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "dist/f-card.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-card/src/components/Card.vue
+++ b/packages/f-card/src/components/Card.vue
@@ -10,7 +10,6 @@
         <h1
             v-if="cardHeading"
             :class="[
-                'beta',
                 $style['c-card-heading'],
                 (cardHeadingPosition !== 'left' ? $style[`c-card--${cardHeadingPosition}`] : '')
             ]"


### PR DESCRIPTION
This PR removes the `beta` class from the card header to ensure the correct font size is set.

