### PR TITLE
generator-fozzie@v1.2.0 – Updating babel, rebrand amendments and small config changes

### DIFF
--- a/packages/generator-component/CHANGELOG.md
+++ b/packages/generator-component/CHANGELOG.md
@@ -3,6 +3,19 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v1.2.0
+------------------------------
+*October 14, 2020*
+
+### Changed
+- Changed path so that the generator outputs to the current directory it's in, rather than the directory above the current location.
+- Updated `babel.config.js` to run the tests through latest Node version rather than our browser config.
+- Deleted theme mixin, as no longer needed.
+- Removed font files from `Demo.vue`.
+- Storybook syntax updated to new `export` syntax (from legacy `storiesOf` syntax).
+
+
 v1.1.1
 ------------------------------
 *October 6, 2020*

--- a/packages/generator-component/generators/app/index.js
+++ b/packages/generator-component/generators/app/index.js
@@ -49,14 +49,14 @@ module.exports = class extends Generator {
                                 .replace(/__/g, ''); // We don't want to have file names such as .test.js or .stories.js, otherwise Jest or Storybook will pick them up from the templates folder.
         }));
 
-        let ignoreTestPattern = this.answers.needsUITests ? [] : ["**/*/test", '**/*/test-utils/component-objects']
-        const ignoreApiMockPattern = this.answers.needsTestingApiMocks ? [] : ["**/*/test-utils/system-test", "**/*/src/services"];
-    
+        let ignoreTestPattern = this.answers.needsUITests ? [] : ['**/*/test', '**/*/test-utils/component-objects'];
+        const ignoreApiMockPattern = this.answers.needsTestingApiMocks ? [] : ['**/*/test-utils/system-test', '**/*/src/services'];
+
         ignoreTestPattern = ignoreTestPattern.concat(ignoreApiMockPattern);
 
         this.fs.copyTpl(
             this.templatePath('**/*'),
-            this.destinationPath(`../f-${nameTransformations.default}/`),
+            this.destinationPath(`f-${nameTransformations.default}/`),
             {
                 description: this.answers.description,
                 name: nameTransformations,

--- a/packages/generator-component/generators/app/templates/babel.config.js
+++ b/packages/generator-component/generators/app/templates/babel.config.js
@@ -10,12 +10,14 @@ module.exports = api => {
     if (!isTest) {
         api.cache(true); // Caches the computed babel config function – https://babeljs.io/docs/en/config-files#apicache
         presets.push(['@vue/app', { useBuiltIns: builtIns }]);
+        // Alias for @babel/preset-env
+        // Hooks into browserslist to provide smart Babel transforms
+        // https://babeljs.io/docs/en/babel-preset-env
+        presets.push('@babel/env');
+    } else {
+        // use current node version for transpiling test files
+        presets.push(['@babel/env', { targets: { node: 'current' } }]);
     }
-
-    // Alias for @babel/preset-env
-    // Hooks into browserslist to provide smart Babel transforms
-    // https://babeljs.io/docs/en/babel-preset-env
-    presets.push('@babel/env');
 
     return {
         presets,

--- a/packages/generator-component/generators/app/templates/src/assets/scss/common.scss
+++ b/packages/generator-component/generators/app/templates/src/assets/scss/common.scss
@@ -1,7 +1,7 @@
 // Set $theme variable so that fozzie doesn't complain when vars are imported below
 // n.b. This variables isn't actually used (unless there are theme specific vars from fozzie)
 // Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
-$theme: 'je' !default;
+$theme: 'jet' !default;
 
 @import '~@justeat/f-utils/src/scss/functions/index';
 @import '~@justeat/f-utils/src/scss/mixins/index';
@@ -14,9 +14,3 @@ $theme: 'je' !default;
  * Component Variables
  */
 <%= "// $" + name.class + "-background-color: $brand--orange;" %>
-
-@mixin theme($type) {
-    [data-theme="#{$type}"] & {
-        @content;
-    }
-}

--- a/packages/generator-component/generators/app/templates/src/demo/Index.vue
+++ b/packages/generator-component/generators/app/templates/src/demo/Index.vue
@@ -20,9 +20,6 @@ export default {
 </script>
 
 <style>
-@import url('https://fonts.googleapis.com/css?family=Ubuntu:300,500&display=swap');
-@import url('https://fonts.googleapis.com/css?family=Hind+Vadodara:300,500&display=swap');
-
 body {
     margin: 0;
 }

--- a/packages/generator-component/generators/app/templates/stories/Skeleton.__stories__.js
+++ b/packages/generator-component/generators/app/templates/stories/Skeleton.__stories__.js
@@ -1,9 +1,26 @@
-import { storiesOf } from '@storybook/vue';
+// Uncomment the import below to add prop controls to your Story (and add `withKnobs` to the decorators array)
+// import {
+//     withKnobs, select, boolean
+// } from '@storybook/addon-knobs';
+import { withA11y } from '@storybook/addon-a11y';
 import <%= name.component %> from '../src/components/<%= name.filename %>.vue';
 
-storiesOf('Components', module)
-  .add('f-<%= name.default %>', () => ({
+export default {
+    title: 'Components',
+    decorators: [withA11y]
+};
+
+export const <%= name.component %>Component = () => ({
     components: { <%= name.component %> },
+    props: {
+        buttonType: {
+            default: select('Button Type', ['primary', 'primaryAlt', 'secondary', 'tertiary', 'link'])
+        },
+        fullWidth: {
+            default: boolean('fullWidth', false)
+        }
+    },
     template: `<<%= name.template %> />`
-  })
-);
+});
+
+<%= name.component %>Component.storyName = 'f-<%= name.default %>';

--- a/packages/generator-component/package.json
+++ b/packages/generator-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/generator-component",
   "description": "Generator Component – A generator for Fozzie components",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "files": [
     "generators"
   ],


### PR DESCRIPTION
- Changed path so that the generator outputs to the current directory it's in, rather than the directory above the current location.
- Updated `babel.config.js` to run the tests through latest Node version rather than our browser config.
- Deleted theme mixin, as no longer needed.
- Removed font files from `Demo.vue`.
- Storybook syntax updated to new `export` syntax (from legacy `storiesOf` syntax).