### PR TITLE
f-registration@0.35.0 - Move text into translations file

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.35.0
 ------------------------------
-*October 9, 2020*
+*October 15, 2020*
 ### Added
 - Moved text into translations file 
 - Support for locale en-GB

--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.35.0
 ------------------------------
-*October 15, 2020*
+*October 16, 2020*
 ### Added
 - Moved text into translations file 
 - Support for locale en-GB

--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.35.0
+------------------------------
+*October 9, 2020*
+### Added
+- Moved text into translations file 
+- Support for locale en-GB
+
+
 v0.34.0
 ------------------------------
 *October 9, 2020*

--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -9,6 +9,10 @@ v0.35.0
 ### Added
 - Moved text into translations file 
 - Support for locale en-GB
+- Emit VisitLoginPage event on login page click interaction
+
+### Changed
+- Prop for showing login link changed to boolean called `showLoginLink`
 
 
 v0.34.0

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -13,7 +13,8 @@
             <p
                 v-if="shouldShowLoginLink"
                 :class="$style['c-loginLink']"
-                data-test-id="create-account-login-link">
+                data-test-id="create-account-login-link"
+                @click="visitLoginPage">
                 <a :href="copy.navLinks.login.url">{{ copy.navLinks.login.text }}</a>
             </p>
             <form
@@ -371,6 +372,10 @@ export default {
                 this.$emit(EventNames.CreateAccountStart);
                 this.formStarted = true;
             }
+        },
+
+        visitLoginPage () {
+            this.$emit(EventNames.VisitLoginPage);
         },
 
         formFieldBlur (field) {

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -11,7 +11,7 @@
             data-test-id="registration-component"
             :class="$style['c-card-padding']">
             <p
-                v-if="shouldShowLoginLink"
+                v-if="showLoginLink"
                 :class="$style['c-loginLink']"
                 data-test-id="create-account-login-link"
                 @click="visitLoginPage">
@@ -263,7 +263,7 @@ export default {
         },
         showLoginLink: {
             type: Boolean,
-            default: false
+            default: true
         }
     },
 
@@ -326,9 +326,6 @@ export default {
         },
         shouldShowPasswordMinLengthError () {
             return !this.$v.password.minLength && this.$v.password.$dirty;
-        },
-        shouldShowLoginLink () {
-            return this.showLoginLink;
         },
         tenant () {
             return {

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -14,7 +14,7 @@
                 v-if="shouldShowLoginLink"
                 :class="$style['c-loginLink']"
                 data-test-id="create-account-login-link">
-                {{ loginSettings.preLinkText }} <a :href="loginSettings.url">{{ loginSettings.linkText }}</a>
+                <a :href="loginUrl">{{ copy.navLinks.alreadyHaveAnAccount.text }}</a>
             </p>
             <form
                 type="post"
@@ -35,7 +35,7 @@
                     v-model="firstName"
                     name="firstName"
                     data-test-id="input-first-name"
-                    label-text="First name"
+                    :label-text="copy.labels.firstName"
                     input-type="text"
                     label-style="inlineNarrow"
                     @blur="formFieldBlur('firstName')">
@@ -45,21 +45,21 @@
                             :class="$style['o-form-error']"
                             data-test-id='error-first-name-empty'>
                             <warning-icon :class="$style['o-form-error-icon']" />
-                            Please include your first name
+                            {{ copy.validationMessages.firstName.requiredError }}
                         </p>
                         <p
                             v-if="shouldShowFirstNameMaxLengthError"
                             :class="$style['o-form-error']"
                             data-test-id='error-first-name-maxlength'>
                             <warning-icon :class="$style['o-form-error-icon']" />
-                            First name exceeds 50 characters
+                            {{ copy.validationMessages.firstName.maxLengthError }}
                         </p>
                         <p
                             v-if="shouldShowFirstNameInvalidCharError"
                             :class="$style['o-form-error']"
                             data-test-id='error-first-name-invalid'>
                             <warning-icon :class="$style['o-form-error-icon']" />
-                            First name should only contain letters, hyphens or apostrophes
+                            {{ copy.validationMessages.firstName.invalidCharError }}
                         </p>
                     </template>
                 </form-field>
@@ -68,7 +68,7 @@
                     v-model="lastName"
                     name="lastName"
                     data-test-id="input-last-name"
-                    label-text="Last name"
+                    :label-text="copy.labels.lastName"
                     input-type="text"
                     label-style="inlineNarrow"
                     @blur="formFieldBlur('lastName')">
@@ -78,21 +78,21 @@
                             :class="$style['o-form-error']"
                             data-test-id='error-last-name-empty'>
                             <warning-icon :class="$style['o-form-error-icon']" />
-                            Please include your last name
+                            {{ copy.validationMessages.lastName.requiredError }}
                         </p>
                         <p
                             v-if="shouldShowLastNameMaxLengthError"
                             :class="$style['o-form-error']"
                             data-test-id='error-last-name-maxlength'>
                             <warning-icon :class="$style['o-form-error-icon']" />
-                            Last name exceeds 50 characters
+                            {{ copy.validationMessages.lastName.maxLengthError }}
                         </p>
                         <p
                             v-if="shouldShowLastNameInvalidCharError"
                             :class="$style['o-form-error']"
                             data-test-id='error-last-name-invalid'>
                             <warning-icon :class="$style['o-form-error-icon']" />
-                            Last name should only contain letters, hyphens or apostrophes
+                            {{ copy.validationMessages.lastName.invalidCharError }}
                         </p>
                     </template>
                 </form-field>
@@ -101,7 +101,7 @@
                     v-model="email"
                     name="email"
                     data-test-id="input-email"
-                    label-text="Email"
+                    :label-text="copy.labels.email"
                     input-type="email"
                     label-style="inlineNarrow"
                     @blur="formFieldBlur('email')">
@@ -111,28 +111,28 @@
                             :class="$style['o-form-error']"
                             data-test-id='error-email-empty'>
                             <warning-icon :class="$style['o-form-error-icon']" />
-                            Please enter your email address
+                            {{ copy.validationMessages.email.requiredError }}
                         </p>
                         <p
                             v-else-if="shouldShowEmailInvalidError"
                             :class="$style['o-form-error']"
                             data-test-id='error-email-invalid'>
                             <warning-icon :class="$style['o-form-error-icon']" />
-                            Please enter a valid email address
+                            {{ copy.validationMessages.email.invalidEmailError }}
                         </p>
                         <p
                             v-if="shouldShowEmailMaxLengthError"
                             :class="$style['o-form-error']"
                             data-test-id='error-email-maxlength'>
                             <warning-icon :class="$style['o-form-error-icon']" />
-                            Email address exceeds 50 characters
+                            {{ copy.validationMessages.email.maxLengthError }}
                         </p>
                         <p
                             v-else-if="shouldShowEmailAlreadyExistsError"
                             :class="$style['o-form-error']"
                             data-test-id='error-email-exists'>
                             <warning-icon :class="$style['o-form-error-icon']" />
-                            Email address is already registered
+                            {{ copy.validationMessages.email.alreadyExistsError }}
                         </p>
                     </template>
                 </form-field>
@@ -141,7 +141,7 @@
                     v-model="password"
                     name="password"
                     data-test-id="input-password"
-                    label-text="Password"
+                    :label-text="copy.labels.password"
                     input-type="password"
                     label-style="inlineNarrow"
                     @blur="formFieldBlur('password')">
@@ -151,14 +151,14 @@
                             :class="$style['o-form-error']"
                             data-test-id='error-password-empty'>
                             <warning-icon :class="$style['o-form-error-icon']" />
-                            Please enter a password
+                            {{ copy.validationMessages.password.requiredError }}
                         </p>
                         <p
                             v-if="shouldShowPasswordMinLengthError"
                             :class="$style['o-form-error']"
                             data-test-id='error-password-minlength'>
                             <warning-icon :class="$style['o-form-error-icon']" />
-                            Password is less than four characters
+                            {{ copy.validationMessages.password.minLengthError }}
                         </p>
                     </template>
                 </form-field>
@@ -258,19 +258,19 @@ export default {
         },
         title: {
             type: String,
-            default: 'Create Account'
+            default: null
         },
         buttonText: {
             type: String,
-            default: 'Create Account'
+            default: null
         },
         createAccountUrl: {
             type: String,
             required: true
         },
-        loginSettings: {
-            type: Object,
-            default: () => {}
+        loginUrl: {
+            type: String,
+            default: null
         }
     },
 
@@ -335,7 +335,7 @@ export default {
             return !this.$v.password.minLength && this.$v.password.$dirty;
         },
         shouldShowLoginLink () {
-            return this.loginSettings && this.loginSettings.linkText && this.loginSettings.url;
+            return this.loginUrl;
         },
         tenant () {
             return {
@@ -348,6 +348,15 @@ export default {
                 'it-IT': 'it',
                 'nb-NO': 'no'
             }[this.locale];
+        }
+    },
+
+    created () {
+        if (!this.title) {
+            this.title = this.copy.labels.createAccountTitle;
+        }
+        if (!this.buttonText) {
+            this.buttonText = this.copy.labels.createAccountBtn;
         }
     },
 

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -3,7 +3,7 @@
         <bag-celebrate-icon :class="$style['bag-icon']" />
         <card
             :data-theme-registration="theme"
-            :card-heading="title"
+            :card-heading="copy.labels.createAccountTitle"
             is-rounded
             has-outline
             is-page-content-wrapper
@@ -14,7 +14,7 @@
                 v-if="shouldShowLoginLink"
                 :class="$style['c-loginLink']"
                 data-test-id="create-account-login-link">
-                <a :href="loginUrl">{{ copy.navLinks.alreadyHaveAnAccount.text }}</a>
+                <a :href="copy.navLinks.login.url">{{ copy.navLinks.login.text }}</a>
             </p>
             <form
                 type="post"
@@ -168,7 +168,7 @@
                     button-style="primary"
                     is-full-width
                     :disabled="shouldDisableCreateAccountButton">
-                    {{ buttonText }}
+                    {{ copy.labels.createAccountBtn }}
                 </form-button>
             </form>
             <p :class="$style['c-legal-hyperlinks']">
@@ -256,21 +256,13 @@ export default {
             type: String,
             default: 'en-GB'
         },
-        title: {
-            type: String,
-            default: null
-        },
-        buttonText: {
-            type: String,
-            default: null
-        },
         createAccountUrl: {
             type: String,
             required: true
         },
-        loginUrl: {
-            type: String,
-            default: null
+        showLoginLink: {
+            type: Boolean,
+            default: false
         }
     },
 
@@ -335,7 +327,7 @@ export default {
             return !this.$v.password.minLength && this.$v.password.$dirty;
         },
         shouldShowLoginLink () {
-            return this.loginUrl;
+            return this.showLoginLink;
         },
         tenant () {
             return {
@@ -348,15 +340,6 @@ export default {
                 'it-IT': 'it',
                 'nb-NO': 'no'
             }[this.locale];
-        }
-    },
-
-    created () {
-        if (!this.title) {
-            this.title = this.copy.labels.createAccountTitle;
-        }
-        if (!this.buttonText) {
-            this.buttonText = this.copy.labels.createAccountBtn;
         }
     },
 

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -29,16 +29,12 @@ describe('Registration', () => {
             expect(wrapper.exists()).toBe(true);
         });
 
-        it('should show the login link if loginSettings prop set.', () => {
+        it('should show the login link if login url prop set.', () => {
             const wrapper = shallowMount(Registration, {
                 propsData: {
                     locale: 'en-GB',
                     createAccountUrl: 'http://localhost/account/register',
-                    loginSettings: {
-                        preLinkText: 'Already have an account?',
-                        linkText: 'Log in',
-                        url: '/login'
-                    }
+                    loginUrl: '/login'
                 }
             });
 
@@ -47,14 +43,12 @@ describe('Registration', () => {
             expect(loginLink.exists()).toBe(true);
         });
 
-        it('should not show the login link if loginSettings prop set but linkText not set.', () => {
+        it('should not show the login link if login url not set.', () => {
             const wrapper = shallowMount(Registration, {
                 propsData: {
                     locale: 'en-GB',
                     createAccountUrl: 'http://localhost/account/register',
-                    loginSettings: {
-                        preLinkText: 'Already have an account?'
-                    }
+                    loginUrl: ''
                 }
             });
 
@@ -63,24 +57,7 @@ describe('Registration', () => {
             expect(loginLink.exists()).toBe(false);
         });
 
-        it('should not show the login link if loginSettings prop set but url not set.', () => {
-            const wrapper = shallowMount(Registration, {
-                propsData: {
-                    locale: 'en-GB',
-                    createAccountUrl: 'http://localhost/account/register',
-                    loginSettings: {
-                        preLinkText: 'Already have an account?',
-                        linkText: 'Log in'
-                    }
-                }
-            });
-
-            const loginLink = wrapper.find("[data-test-id='create-account-login-link']");
-
-            expect(loginLink.exists()).toBe(false);
-        });
-
-        it('shoud not show the login link if loginSettings prop not set', () => {
+        it('shoud not show the login link if login url prop not set', () => {
             const wrapper = shallowMount(Registration, { propsData });
 
             const loginLink = wrapper.find("[data-test-id='create-account-login-link']");

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -8,7 +8,6 @@ jest.mock('../../services/RegistrationServiceApi', () => ({ createAccount: jest.
 
 describe('Registration', () => {
     const propsData = {
-        locale: 'en-GB',
         createAccountUrl: 'http://localhost/account/register'
     };
 
@@ -32,7 +31,6 @@ describe('Registration', () => {
         it('should show the login link if showLoginLink prop set to true.', () => {
             const wrapper = shallowMount(Registration, {
                 propsData: {
-                    locale: 'en-GB',
                     createAccountUrl: 'http://localhost/account/register',
                     showLoginLink: true
                 }
@@ -46,7 +44,6 @@ describe('Registration', () => {
         it('should not show the login link if showLoginLink is set to false.', () => {
             const wrapper = shallowMount(Registration, {
                 propsData: {
-                    locale: 'en-GB',
                     createAccountUrl: 'http://localhost/account/register',
                     showLoginLink: false
                 }
@@ -63,6 +60,21 @@ describe('Registration', () => {
             const loginLink = wrapper.find("[data-test-id='create-account-login-link']");
 
             expect(loginLink.exists()).toBe(false);
+        });
+
+        it('should show emit VisitLoginPage event when login link is clicked.', () => {
+            const wrapper = shallowMount(Registration, {
+                propsData: {
+                    createAccountUrl: 'http://localhost/account/register',
+                    showLoginLink: true
+                }
+            });
+
+            const loginLink = wrapper.find("[data-test-id='create-account-login-link']");
+            loginLink.trigger('click');
+
+            // Assert
+            expect(wrapper.emitted(EventNames.VisitLoginPage).length).toBe(1);
         });
 
         it('should fallback to use the en-GB locale if no locale passed', () => {

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -29,12 +29,12 @@ describe('Registration', () => {
             expect(wrapper.exists()).toBe(true);
         });
 
-        it('should show the login link if login url prop set.', () => {
+        it('should show the login link if showLoginLink prop set to true.', () => {
             const wrapper = shallowMount(Registration, {
                 propsData: {
                     locale: 'en-GB',
                     createAccountUrl: 'http://localhost/account/register',
-                    loginUrl: '/login'
+                    showLoginLink: true
                 }
             });
 
@@ -43,12 +43,12 @@ describe('Registration', () => {
             expect(loginLink.exists()).toBe(true);
         });
 
-        it('should not show the login link if login url not set.', () => {
+        it('should not show the login link if showLoginLink is set to false.', () => {
             const wrapper = shallowMount(Registration, {
                 propsData: {
                     locale: 'en-GB',
                     createAccountUrl: 'http://localhost/account/register',
-                    loginUrl: ''
+                    showLoginLink: false
                 }
             });
 
@@ -57,7 +57,7 @@ describe('Registration', () => {
             expect(loginLink.exists()).toBe(false);
         });
 
-        it('shoud not show the login link if login url prop not set', () => {
+        it('should not show the login link if showLoginLink prop not set', () => {
             const wrapper = shallowMount(Registration, { propsData });
 
             const loginLink = wrapper.find("[data-test-id='create-account-login-link']");

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -54,19 +54,18 @@ describe('Registration', () => {
             expect(loginLink.exists()).toBe(false);
         });
 
-        it('should not show the login link if showLoginLink prop not set', () => {
+        it('should show the login link if showLoginLink prop not set', () => {
             const wrapper = shallowMount(Registration, { propsData });
 
             const loginLink = wrapper.find("[data-test-id='create-account-login-link']");
 
-            expect(loginLink.exists()).toBe(false);
+            expect(loginLink.exists()).toBe(true);
         });
 
         it('should show emit VisitLoginPage event when login link is clicked.', () => {
             const wrapper = shallowMount(Registration, {
                 propsData: {
-                    createAccountUrl: 'http://localhost/account/register',
-                    showLoginLink: true
+                    createAccountUrl: 'http://localhost/account/register'
                 }
             });
 

--- a/packages/f-registration/src/demo/Index.vue
+++ b/packages/f-registration/src/demo/Index.vue
@@ -9,7 +9,7 @@
         >
         <registration
             locale="en-GB"
-            login-url="/login"
+            show-login-link=true
             class="registration-form" />
     </div>
 </template>

--- a/packages/f-registration/src/demo/Index.vue
+++ b/packages/f-registration/src/demo/Index.vue
@@ -9,11 +9,7 @@
         >
         <registration
             locale="en-GB"
-            :login-settings="{
-                preLinkText: 'Already have an account?',
-                linkText: 'Log in',
-                url: '/login'
-            }"
+            login-url="/login"
             class="registration-form" />
     </div>
 </template>

--- a/packages/f-registration/src/event-names.js
+++ b/packages/f-registration/src/event-names.js
@@ -2,10 +2,12 @@ const CreateAccountSuccess = 'registration-create-account-success';
 const CreateAccountFailure = 'registration-create-account-failure';
 const CreateAccountStart = 'registration-create-account-start';
 const CreateAccountInlineError = 'registration-create-account-inline-error';
+const VisitLoginPage = 'registration-visit-login-page';
 
 export default {
     CreateAccountSuccess,
     CreateAccountFailure,
     CreateAccountStart,
-    CreateAccountInlineError
+    CreateAccountInlineError,
+    VisitLoginPage
 };

--- a/packages/f-registration/src/tenants/en-GB.js
+++ b/packages/f-registration/src/tenants/en-GB.js
@@ -19,8 +19,9 @@ export default {
             url: '/info/cookies-policy',
             suffix: '.'
         },
-        alreadyHaveAnAccount: {
-            text: 'Already on Just Eat?'
+        login: {
+            text: 'Already on Just Eat?',
+            url: '/login'
         }
     },
 

--- a/packages/f-registration/src/tenants/en-GB.js
+++ b/packages/f-registration/src/tenants/en-GB.js
@@ -18,6 +18,44 @@ export default {
             text: 'Cookie Policy',
             url: '/info/cookies-policy',
             suffix: '.'
+        },
+        alreadyHaveAnAccount: {
+            text: 'Already on Just Eat?'
+        }
+    },
+
+    labels: {
+        createAccountTitle: 'Create an account',
+        createAccountBtn: 'Create account',
+        firstName: 'First Name',
+        lastName: 'Last Name',
+        email: 'Email',
+        password: 'Password'
+    },
+
+    validationMessages: {
+        firstName: {
+            requiredError: 'Please include your first name',
+            maxLengthError: 'First name exceeds 50 characters',
+            invalidCharError: 'Your name can only contain letters, hyphens or apostrophes'
+        },
+
+        lastName: {
+            requiredError: 'Please include your last name',
+            maxLengthError: 'Last name exceeds 50 characters',
+            invalidCharError: 'Your last name can only contain letters, hyphens or apostrophes'
+        },
+
+        email: {
+            requiredError: 'Please include your email address',
+            maxLengthError: 'Email address exceeds 50 characters',
+            invalidEmailError: 'Please enter your email address correctly',
+            alreadyExistsError: 'Email address is already registered'
+        },
+
+        password: {
+            requiredError: 'Please enter a password',
+            minLengthError: 'Password is less than four characters '
         }
     }
 };


### PR DESCRIPTION
v0.35.0
------------------------------
*October 16, 2020*
### Added
- Moved text into translations file 
- Support for locale en-GB

### Changed
- Prop for showing login link changed to boolean called `showLoginLink`

## UI Review Checks
- [X] README and/or UI Documentation has been [created|updated]
- [X] Unit tests have been [created|updated]
- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

![image](https://user-images.githubusercontent.com/1670343/96142815-67bd3c80-0efa-11eb-8624-830ff63822cd.png)


## Browsers Tested

- [X] Chrome (latest)