### PR TITLE
f-metadata@3.0.0-beta.3 - Add Grouped output option via alternative callback / API to f-metadata

### DIFF
--- a/packages/f-metadata/README.md
+++ b/packages/f-metadata/README.md
@@ -59,6 +59,7 @@ const config = {
   disableComponent: false,
   callbacks: {
     handleContentCards: cards => console.log(cards), // Braze content cards data
+    handleContentCardsGrouped: groupedCards => console.log(groupedCards), // Braze content cards data
     interceptInAppMessages: inAppMessage => console.log(inAppMessage) // Braze in app message data
   }
 };
@@ -108,6 +109,10 @@ Enable/Disable the Braze SDK when running experiments or feature toggling.
 ### `config.callbacks.handleContentCards`
 
 A callback to be invoked when content cards have been retrieved.
+
+### `config.callbacks.handleContentCardsGrouped`
+
+A callback to be invoked when content cards have been retrieved, grouped by header card title.
 
 ### `config.callbacks.interceptInAppMessages`
 

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -38,7 +38,8 @@
     "appboy-web-sdk": "2.5.2",
     "date-fns": "2.16.1",
     "lodash.findindex": "4.6.0",
-    "lodash.orderby": "4.6.0"
+    "lodash.orderby": "4.6.0",
+    "lodash.startswith": "4.2.1"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "main": "src/index.js",
   "files": [
     "src"

--- a/packages/f-metadata/src/services/_tests/contentCard.service.test.js
+++ b/packages/f-metadata/src/services/_tests/contentCard.service.test.js
@@ -304,73 +304,73 @@ describe('`contentCardService`', () => {
     });
 
     describe('`arrangeCardsByTitles` method', () => {
+        const cards = [
+            {
+                title: '20% off at ASOS.',
+                extras: {
+                    order: '1',
+                    custom_card_type: 'Promotion_Card_1' // eslint-disable-line camelcase
+                }
+            },
+            {
+                title: 'Hot deals on the takeaways you love',
+                extras: {
+                    order: '40',
+                    custom_card_type: 'Header_Card' // eslint-disable-line camelcase
+                }
+            },
+            {
+                title: 'OK Pizza.',
+                extras: {
+                    order: '41',
+                    custom_card_type: 'Promotion_Card_2' // eslint-disable-line camelcase
+                }
+            },
+            {
+                title: 'OK Burgers.',
+                extras: {
+                    order: '42',
+                    custom_card_type: 'Promotion_Card_2' // eslint-disable-line camelcase
+                }
+            },
+            {
+                title: 'The tastiest offers near you!',
+                extras: {
+                    order: '50',
+                    custom_card_type: 'Header_Card' // eslint-disable-line camelcase
+                }
+            },
+            {
+                title: 'Best Pizza.',
+                extras: {
+                    order: '51',
+                    custom_card_type: 'Promotion_Card_2' // eslint-disable-line camelcase
+                }
+            },
+            {
+                title: 'Bristol Burgers.',
+                extras: {
+                    order: '52',
+                    custom_card_type: 'Promotion_Card_2' // eslint-disable-line camelcase
+                }
+            },
+            {
+                title: 'Full terms and conditions here.',
+                extras: {
+                    order: '100',
+                    custom_card_type: 'Terms_And_Conditions_Card_2' // eslint-disable-line camelcase
+                }
+            }
+        ];
         it('should group content cards by type where type starts with either `Header_Card` or `Terms_And_Conditions_Card`', () => {
             // Arrange
-            const cards = [
-                {
-                    title: '20% off at ASOS.',
-                    extras: {
-                        order: '1',
-                        custom_card_type: 'Promotion_Card_1' // eslint-disable-line camelcase
-                    }
-                },
-                {
-                    title: 'Hot deals on the takeaways you love',
-                    extras: {
-                        order: '40',
-                        custom_card_type: 'Header_Card' // eslint-disable-line camelcase
-                    }
-                },
-                {
-                    title: 'OK Pizza.',
-                    extras: {
-                        order: '41',
-                        custom_card_type: 'Promotion_Card_2' // eslint-disable-line camelcase
-                    }
-                },
-                {
-                    title: 'OK Burgers.',
-                    extras: {
-                        order: '42',
-                        custom_card_type: 'Promotion_Card_2' // eslint-disable-line camelcase
-                    }
-                },
-                {
-                    title: 'The tastiest offers near you!',
-                    extras: {
-                        order: '50',
-                        custom_card_type: 'Header_Card' // eslint-disable-line camelcase
-                    }
-                },
-                {
-                    title: 'Best Pizza.',
-                    extras: {
-                        order: '51',
-                        custom_card_type: 'Promotion_Card_2' // eslint-disable-line camelcase
-                    }
-                },
-                {
-                    title: 'Bristol Burgers.',
-                    extras: {
-                        order: '52',
-                        custom_card_type: 'Promotion_Card_2' // eslint-disable-line camelcase
-                    }
-                },
-                {
-                    title: 'Full terms and conditions here.',
-                    extras: {
-                        order: '100',
-                        custom_card_type: 'Terms_And_Conditions_Card_2' // eslint-disable-line camelcase
-                    }
-                }
-            ];
             const service = new ContentCardService({ cards });
-
             // Act
             const {
                 groups: contentCards
             } = service.arrangeCardsByTitles().outputGroups();
 
+            // Assert
             expect(contentCards).toHaveLength(4);
             expect(contentCards[1].cards).toHaveLength(2);
             expect(contentCards[2].cards).toHaveLength(2);

--- a/packages/f-metadata/src/services/_tests/contentCard.service.test.js
+++ b/packages/f-metadata/src/services/_tests/contentCard.service.test.js
@@ -302,4 +302,78 @@ describe('`contentCardService`', () => {
             });
         });
     });
+
+    describe('`arrangeCardsByTitles` method', () => {
+        it('should group content cards by type where type starts with either `Header_Card` or `Terms_And_Conditions_Card`', () => {
+            // Arrange
+            const cards = [
+                {
+                    title: '20% off at ASOS.',
+                    extras: {
+                        order: '1',
+                        custom_card_type: 'Promotion_Card_1' // eslint-disable-line camelcase
+                    }
+                },
+                {
+                    title: 'Hot deals on the takeaways you love',
+                    extras: {
+                        order: '40',
+                        custom_card_type: 'Header_Card' // eslint-disable-line camelcase
+                    }
+                },
+                {
+                    title: 'OK Pizza.',
+                    extras: {
+                        order: '41',
+                        custom_card_type: 'Promotion_Card_2' // eslint-disable-line camelcase
+                    }
+                },
+                {
+                    title: 'OK Burgers.',
+                    extras: {
+                        order: '42',
+                        custom_card_type: 'Promotion_Card_2' // eslint-disable-line camelcase
+                    }
+                },
+                {
+                    title: 'The tastiest offers near you!',
+                    extras: {
+                        order: '50',
+                        custom_card_type: 'Header_Card' // eslint-disable-line camelcase
+                    }
+                },
+                {
+                    title: 'Best Pizza.',
+                    extras: {
+                        order: '51',
+                        custom_card_type: 'Promotion_Card_2' // eslint-disable-line camelcase
+                    }
+                },
+                {
+                    title: 'Bristol Burgers.',
+                    extras: {
+                        order: '52',
+                        custom_card_type: 'Promotion_Card_2' // eslint-disable-line camelcase
+                    }
+                },
+                {
+                    title: 'Full terms and conditions here.',
+                    extras: {
+                        order: '100',
+                        custom_card_type: 'Terms_And_Conditions_Card_2' // eslint-disable-line camelcase
+                    }
+                }
+            ];
+            const service = new ContentCardService({ cards });
+
+            // Act
+            const {
+                groups: contentCards
+            } = service.arrangeCardsByTitles().outputGroups();
+
+            expect(contentCards).toHaveLength(4);
+            expect(contentCards[1].cards).toHaveLength(2);
+            expect(contentCards[2].cards).toHaveLength(2);
+        });
+    });
 });

--- a/packages/f-metadata/src/services/_tests/contentCard.service.test.js
+++ b/packages/f-metadata/src/services/_tests/contentCard.service.test.js
@@ -362,9 +362,11 @@ describe('`contentCardService`', () => {
                 }
             }
         ];
+
         it('should group content cards by type where type starts with either `Header_Card` or `Terms_And_Conditions_Card`', () => {
             // Arrange
             const service = new ContentCardService({ cards });
+
             // Act
             const {
                 groups: contentCards

--- a/packages/f-metadata/src/services/_tests/contentCard.service.test.js
+++ b/packages/f-metadata/src/services/_tests/contentCard.service.test.js
@@ -368,7 +368,7 @@ describe('`contentCardService`', () => {
             // Act
             const {
                 groups: contentCards
-            } = service.arrangeCardsByTitles().outputGroups();
+            } = service.arrangeCardsByTitles().output();
 
             // Assert
             expect(contentCards).toHaveLength(4);

--- a/packages/f-metadata/src/services/contentCard.service.js
+++ b/packages/f-metadata/src/services/contentCard.service.js
@@ -1,4 +1,5 @@
 import orderBy from 'lodash.orderby';
+import startsWith from 'lodash.startswith';
 import findIndex from 'lodash.findindex';
 import transformCardData from './utils/transformCardData';
 import isCardCurrentlyActive from './utils/isCardCurrentlyActive';
@@ -35,12 +36,11 @@ class ContentCards {
     constructor (appboy = {}, opts = {}) {
         const { cards = [] } = appboy;
         const { enabledCardTypes = [] } = opts;
-        this.enabledCardTypes = enabledCardTypes.length
-            ? enabledCardTypes
-            : defaultEnabledCardTypes;
+        this.enabledCardTypes = enabledCardTypes.length ? enabledCardTypes : defaultEnabledCardTypes;
         this.appboy = appboy;
         this.rawCards = cards;
         this.cards = cards.map(transformCardData);
+        this.groups = [];
         this.titleCard = {};
     }
 
@@ -54,6 +54,20 @@ class ContentCards {
         return {
             titleCard: this.titleCard,
             cards: this.cards,
+            rawCards: this.rawCards
+        };
+    }
+
+    /**
+     * Outputs grouped results
+     * @returns {object} output
+     * @returns {object} output.titleCard
+     * @returns {object[]} output.groups
+     */
+    outputGroups () {
+        return {
+            titleCard: this.titleCard,
+            groups: this.groups,
             rawCards: this.rawCards
         };
     }
@@ -87,12 +101,9 @@ class ContentCards {
      * @returns {ContentCards}
      */
     arrangeCardsByTitles () {
-        this.cards.reduce((acc, card) => {
+        this.groups = this.cards.reduce((acc, card) => {
             const { type } = card;
-            if (
-                type &&
-                (type === 'Header_Card' || type === 'Terms_And_Conditions_Card')
-            ) {
+            if (type && (startsWith(type, 'Header_Card') || startsWith(type, 'Terms_And_Conditions_Card'))) {
                 return [...acc, { title: card.title, cards: [] }];
             }
             if (!acc.length) {
@@ -111,27 +122,19 @@ class ContentCards {
      * @returns {ContentCards}
      */
     getTitleCard () {
-        const index = findIndex(
-            this.cards,
-            card => card.type === 'Terms_And_Conditions_Card' &&
-                card.url &&
-                card.pinned
-        );
+        const index = findIndex(this.cards, card => card.type === 'Terms_And_Conditions_Card' && card.url && card.pinned);
         const [titleCard] = index > -1 ? this.cards.splice(index, 1) : [{}];
         this.titleCard = titleCard;
         return this;
     }
 
     /**
-     * Filters out card types based on `enabledCardTypes` and display times
+     * Filters out card types based on `enabledCardTypes`
      * @property {Object[]} this.cards
      * @returns {ContentCards}
      */
-    filterCards (brands) {
-        this.cards = this.cards
-            .sort(({ order: a }, { order: b }) => +a - +b)
-            .filter(({ type }) => (type ? this.enabledCardTypes.includes(type) : false))
-            .filter(card => isCardCurrentlyActive(card, brands));
+    filterCards () {
+        this.cards = this.cards.sort(({ order: a }, { order: b }) => +a - +b).filter(({ type }) => (type ? this.enabledCardTypes.includes(type) : false));
         return this;
     }
 
@@ -144,12 +147,7 @@ class ContentCards {
      * @returns {ContentCards}
      */
     removeDuplicateContentCards () {
-        this.cards = orderBy(this.cards, 'updated').filter((contentCard, index, item) => index ===
-            findIndex(
-                item,
-                card => card.title === contentCard.title &&
-                    card.type === contentCard.type
-            ));
+        this.cards = orderBy(this.cards, 'updated').filter((contentCard, index, item) => index === findIndex(item, card => (card.title === contentCard.title && card.type === contentCard.type)));
         return this;
     }
 }

--- a/packages/f-metadata/src/services/contentCard.service.js
+++ b/packages/f-metadata/src/services/contentCard.service.js
@@ -36,9 +36,9 @@ class ContentCards {
     constructor (appboy = {}, opts = {}) {
         const { cards = [] } = appboy;
         const { enabledCardTypes = [] } = opts;
-        this.enabledCardTypes = enabledCardTypes.length ?
-            enabledCardTypes :
-            defaultEnabledCardTypes;
+        this.enabledCardTypes = enabledCardTypes.length
+            ? enabledCardTypes
+            : defaultEnabledCardTypes;
         this.appboy = appboy;
         this.rawCards = cards;
         this.cards = cards.map(transformCardData);
@@ -127,8 +127,8 @@ class ContentCards {
         const index = findIndex(
             this.cards,
             card => card.type === 'Terms_And_Conditions_Card' &&
-                    card.url &&
-                    card.pinned
+                card.url &&
+                card.pinned
         );
         const [titleCard] = index > -1 ? this.cards.splice(index, 1) : [{}];
         this.titleCard = titleCard;
@@ -160,8 +160,8 @@ class ContentCards {
         this.cards = orderBy(this.cards, 'updated').filter((contentCard, index, item) => index ===
             findIndex(
                 item,
-                card => (card.title === contentCard.title &&
-                    card.type === contentCard.type)
+                card => card.title === contentCard.title &&
+                    card.type === contentCard.type
             ));
         return this;
     }

--- a/packages/f-metadata/src/services/contentCard.service.js
+++ b/packages/f-metadata/src/services/contentCard.service.js
@@ -56,19 +56,6 @@ class ContentCards {
         return {
             titleCard: this.titleCard,
             cards: this.cards,
-            rawCards: this.rawCards
-        };
-    }
-
-    /**
-     * Outputs grouped results
-     * @returns {object} output
-     * @returns {object} output.titleCard
-     * @returns {object[]} output.groups
-     */
-    outputGroups () {
-        return {
-            titleCard: this.titleCard,
             groups: this.groups,
             rawCards: this.rawCards
         };

--- a/packages/f-metadata/src/services/contentCard.service.js
+++ b/packages/f-metadata/src/services/contentCard.service.js
@@ -36,7 +36,9 @@ class ContentCards {
     constructor (appboy = {}, opts = {}) {
         const { cards = [] } = appboy;
         const { enabledCardTypes = [] } = opts;
-        this.enabledCardTypes = enabledCardTypes.length ? enabledCardTypes : defaultEnabledCardTypes;
+        this.enabledCardTypes = enabledCardTypes.length ?
+            enabledCardTypes :
+            defaultEnabledCardTypes;
         this.appboy = appboy;
         this.rawCards = cards;
         this.cards = cards.map(transformCardData);
@@ -122,19 +124,27 @@ class ContentCards {
      * @returns {ContentCards}
      */
     getTitleCard () {
-        const index = findIndex(this.cards, card => card.type === 'Terms_And_Conditions_Card' && card.url && card.pinned);
+        const index = findIndex(
+            this.cards,
+            card => card.type === 'Terms_And_Conditions_Card' &&
+                    card.url &&
+                    card.pinned
+        );
         const [titleCard] = index > -1 ? this.cards.splice(index, 1) : [{}];
         this.titleCard = titleCard;
         return this;
     }
 
     /**
-     * Filters out card types based on `enabledCardTypes`
+     * Filters out card types based on `enabledCardTypes` and display times
      * @property {Object[]} this.cards
      * @returns {ContentCards}
      */
-    filterCards () {
-        this.cards = this.cards.sort(({ order: a }, { order: b }) => +a - +b).filter(({ type }) => (type ? this.enabledCardTypes.includes(type) : false));
+    filterCards (brands) {
+        this.cards = this.cards
+            .sort(({ order: a }, { order: b }) => +a - +b)
+            .filter(({ type }) => (type ? this.enabledCardTypes.includes(type) : false))
+            .filter(card => isCardCurrentlyActive(card, brands));
         return this;
     }
 
@@ -147,7 +157,12 @@ class ContentCards {
      * @returns {ContentCards}
      */
     removeDuplicateContentCards () {
-        this.cards = orderBy(this.cards, 'updated').filter((contentCard, index, item) => index === findIndex(item, card => (card.title === contentCard.title && card.type === contentCard.type)));
+        this.cards = orderBy(this.cards, 'updated').filter((contentCard, index, item) => index ===
+            findIndex(
+                item,
+                card => (card.title === contentCard.title &&
+                    card.type === contentCard.type)
+            ));
         return this;
     }
 }

--- a/packages/f-metadata/src/tests/BrazeDispatcher.test.js
+++ b/packages/f-metadata/src/tests/BrazeDispatcher.test.js
@@ -273,15 +273,12 @@ describe('BrazeDispatcher operation', () => {
                 ContentCards.prototype.removeDuplicateContentCards.mockReturnThis();
                 ContentCards.prototype.output.mockReturnValue({
                     cards: rawCards,
-                    rawCards
-                });
-                ContentCards.prototype.outputGroups.mockReturnValue({
                     groups: groupedCards,
                     rawCards
                 });
             });
 
-            it('should instantiate ContentCards and call required methods in order of [removeDuplicateContentCards, filterCards, getTitleCard]', () => {
+            it('should instantiate ContentCards and call required methods in order of [removeDuplicateContentCards, filterCards, getTitleCard, output]', () => {
                 // Arrange & Act
                 contentCardsHandler();
 
@@ -291,27 +288,7 @@ describe('BrazeDispatcher operation', () => {
                     .toHaveBeenCalledBefore(contentCardsInstance.filterCards);
                 expect(contentCardsInstance.filterCards)
                     .toHaveBeenCalledBefore(contentCardsInstance.getTitleCard);
-            });
-
-            it('should call the arrangeCardsByTitles method before outputGroups method is called', () => {
-                // Arrange & Act
-                contentCardsHandler();
-
-                const [contentCardsInstance] = ContentCards.mock.instances;
-
-                // Assert
                 expect(contentCardsInstance.arrangeCardsByTitles)
-                    .toHaveBeenCalledBefore(contentCardsInstance.outputGroups);
-            });
-
-            it('should call the getTitleCard method before output method is called', () => {
-                // Arrange & Act
-                contentCardsHandler();
-
-                const [contentCardsInstance] = ContentCards.mock.instances;
-
-                // Assert
-                expect(contentCardsInstance.getTitleCard)
                     .toHaveBeenCalledBefore(contentCardsInstance.output);
             });
 
@@ -421,9 +398,6 @@ describe('BrazeDispatcher operation', () => {
             ContentCards.prototype.removeDuplicateContentCards.mockReturnThis();
             ContentCards.prototype.output.mockReturnValue({
                 cards: rawCards,
-                rawCards
-            });
-            ContentCards.prototype.outputGroups.mockReturnValue({
                 groups: groupedCards,
                 rawCards
             });

--- a/packages/f-metadata/src/tests/BrazeDispatcher.test.js
+++ b/packages/f-metadata/src/tests/BrazeDispatcher.test.js
@@ -281,7 +281,7 @@ describe('BrazeDispatcher operation', () => {
                 });
             });
 
-            it('should instantiate ContentCards and call required methods in order up to output method', () => {
+            it('should instantiate ContentCards and call required methods in order of [removeDuplicateContentCards, filterCards, getTitleCard]', () => {
                 // Arrange & Act
                 contentCardsHandler();
 
@@ -299,6 +299,7 @@ describe('BrazeDispatcher operation', () => {
 
                 const [contentCardsInstance] = ContentCards.mock.instances;
 
+                // Assert
                 expect(contentCardsInstance.arrangeCardsByTitles)
                     .toHaveBeenCalledBefore(contentCardsInstance.outputGroups);
             });
@@ -309,6 +310,7 @@ describe('BrazeDispatcher operation', () => {
 
                 const [contentCardsInstance] = ContentCards.mock.instances;
 
+                // Assert
                 expect(contentCardsInstance.getTitleCard)
                     .toHaveBeenCalledBefore(contentCardsInstance.output);
             });

--- a/yarn.lock
+++ b/yarn.lock
@@ -14054,6 +14054,11 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
+lodash.startswith@4.6.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.startswith/-/lodash.startswith-4.2.1.tgz#c598c4adce188a27e53145731cdc6c0e7177600c"
+  integrity sha1-xZjErc4YiiflMUVzHNxsDnF3YAw=
+
 lodash.template@^4.0.2, lodash.template@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1691,6 +1691,16 @@
   dependencies:
     window-or-global "^1.0.1"
 
+"@justeat/f-metadata@3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@justeat/f-metadata/-/f-metadata-3.0.0-beta.2.tgz#5f8a226165011fd148ca6c0e4b3eee4ef46bc19d"
+  integrity sha512-PD4dK4nmLkujWQ0PWO8HDOA+sGlEMUUVjLTsVkYJNSoMwe1DY+gBWkNEjD3iL1jyANXQWtsvwX5D1gC8fm6UfA==
+  dependencies:
+    appboy-web-sdk "2.5.2"
+    date-fns "2.16.1"
+    lodash.findindex "4.6.0"
+    lodash.orderby "4.6.0"
+
 "@justeat/f-services@0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.13.0.tgz#b0fc67948e94800ba176addb9d92cce444d28c8e"
@@ -14054,7 +14064,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash.startswith@4.6.0:
+lodash.startswith@4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.startswith/-/lodash.startswith-4.2.1.tgz#c598c4adce188a27e53145731cdc6c0e7177600c"
   integrity sha1-xZjErc4YiiflMUVzHNxsDnF3YAw=


### PR DESCRIPTION
Request was made to allow the braze dispatcher library to support grouped by title cards, I have modified the code and added a new attribute `groups`.  I have added groups variable to `ContentCards` service, which `output` now uses. 

The new output is only applied to the new callback `handleContentCardsGrouped`. If this format is wanted when consuming the f-metadata API you must add this to the callback functions list. 

Added Test to cover the grouping output for `ContentCards` service and updated the `BrazeDispatcher` tests to account for the grouped output inside the `contentCardsHandler` function. 

I have changed the `arrangeCardsByTitles` to include `startsWith` lodash function (startsWith is es15 only so if our babel transpile allows es15 to es5 then I can sub in the es15 version). It is only imported in the f-metadata component, individually loaded. I included this in the as a result of some card json supplied to me, which showed `Terms_And_Conditions_Card_2` being used as type rather than the previous checked value `Terms_And_Conditions_Card`. If this is not correct let me know and I will remove it / put it back to just looking for `Terms_And_Conditions_Card` and `Header_Card`. 

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]

