### PR TITLE
f-registration@v0.36.0

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.36.0
+------------------------------
+*October 20, 2020*
+### Added
+- Handling of 403 responses in `f-registration`. 
+
+
 v0.35.0
 ------------------------------
 *October 16, 2020*

--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -8,6 +8,7 @@ v0.36.0
 *October 20, 2020*
 ### Added
 - Handling of 403 responses in `f-registration`. 
+- New prop to set the form AJAX call timeout.
 
 
 v0.35.0

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -422,6 +422,7 @@ export default {
                         this.shouldShowEmailAlreadyExistsError = true;
                     } else if (thrownErrors.some(thrownError => thrownError.errorCode === '403')) {
                         this.$emit(EventNames.LoginBlocked);
+
                         shouldEmitCreateAccountFailure = false;
                     } else {
                         this.genericErrorMessage = thrownErrors[0].description || 'Something went wrong, please try again later';

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -415,19 +415,23 @@ export default {
                 if (error && error.response && error.response.data && error.response.data.errors) {
                     thrownErrors = error.response.data.errors;
                 }
-
-                this.$emit(EventNames.CreateAccountFailure, thrownErrors);
+                let shouldEmitCreateAccountFailure = true;
 
                 if (Array.isArray(thrownErrors)) {
                     if (thrownErrors.some(thrownError => thrownError.errorCode === '409')) {
                         this.shouldShowEmailAlreadyExistsError = true;
                     } else if (thrownErrors.some(thrownError => thrownError.errorCode === '403')) {
-                        window.location.href = this.copy.navLinks.login.url;
+                        this.$emit(EventNames.LoginBlocked);
+                        shouldEmitCreateAccountFailure = false;
                     } else {
                         this.genericErrorMessage = thrownErrors[0].description || 'Something went wrong, please try again later';
                     }
                 } else {
                     this.genericErrorMessage = error;
+                }
+
+                if (shouldEmitCreateAccountFailure) {
+                    this.$emit(EventNames.CreateAccountFailure, thrownErrors);
                 }
             } finally {
                 this.shouldDisableCreateAccountButton = false;

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -416,16 +416,19 @@ export default {
                     thrownErrors = error.response.data.errors;
                 }
 
+                this.$emit(EventNames.CreateAccountFailure, thrownErrors);
+
                 if (Array.isArray(thrownErrors)) {
                     if (thrownErrors.some(thrownError => thrownError.errorCode === '409')) {
                         this.shouldShowEmailAlreadyExistsError = true;
+                    } else if (thrownErrors.some(thrownError => thrownError.errorCode === '403')) {
+                        window.location.href = this.copy.navLinks.login.url;
                     } else {
                         this.genericErrorMessage = thrownErrors[0].description || 'Something went wrong, please try again later';
                     }
                 } else {
                     this.genericErrorMessage = error;
                 }
-                this.$emit(EventNames.CreateAccountFailure, thrownErrors);
             } finally {
                 this.shouldDisableCreateAccountButton = false;
             }

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -261,6 +261,11 @@ export default {
             type: String,
             required: true
         },
+        createAccountTimeout: {
+            type: Number,
+            required: false,
+            default: 1000
+        },
         showLoginLink: {
             type: Boolean,
             default: true
@@ -408,7 +413,7 @@ export default {
                     registrationSource: 'Native',
                     marketingPreferences: []
                 };
-                await RegistrationServiceApi.createAccount(this.createAccountUrl, this.tenant, registrationData);
+                await RegistrationServiceApi.createAccount(this.createAccountUrl, this.tenant, registrationData, this.createAccountTimeout);
                 this.$emit(EventNames.CreateAccountSuccess);
             } catch (error) {
                 let thrownErrors = error;

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -135,7 +135,7 @@ describe('Registration', () => {
 
             it('should emit login blocked event when service responds with a 403', async () => {
                 // Arrange
-                const err = { response: { data: { faultId: '123', traceId: '123', errors: [{ description: 'Not authorized.', errorCode: '403' }] } } };
+                const err = { response: { data: { faultId: '123', traceId: '123', errors: [{ description: 'Forbidden.', errorCode: '403' }] } } };
                 RegistrationServiceApi.createAccount.mockImplementation(async () => { throw err; });
                 const wrapper = mountComponentAndAttachToDocument();
                 Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -133,17 +133,12 @@ describe('Registration', () => {
                 }
             });
 
-            it('should emit failure event when service responds with a 403 and redirect to the login page', async () => {
+            it('should emit login blocked event when service responds with a 403', async () => {
                 // Arrange
                 const err = { response: { data: { faultId: '123', traceId: '123', errors: [{ description: 'Not authorized.', errorCode: '403' }] } } };
                 RegistrationServiceApi.createAccount.mockImplementation(async () => { throw err; });
                 const wrapper = mountComponentAndAttachToDocument();
                 Object.defineProperty(wrapper.vm.$v, '$invalid', { get: jest.fn(() => false) });
-                Object.defineProperty(window, 'location', {
-                    value: {
-                        href: 'https://www.just-eat-test.co.uk/account/register'
-                    }
-                });
 
                 try {
                     // Act
@@ -151,8 +146,8 @@ describe('Registration', () => {
                     await flushPromises();
 
                     // Assert
-                    expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
-                    expect(window.location.href).toBe('/account/login');
+                    expect(wrapper.emitted(EventNames.LoginBlocked).length).toBe(1);
+                    expect(wrapper.emitted(EventNames.CreateAccountFailure)).toBeUndefined();
                 } finally {
                     wrapper.destroy();
                 }

--- a/packages/f-registration/src/components/tests/f-registration.integration.test.js
+++ b/packages/f-registration/src/components/tests/f-registration.integration.test.js
@@ -83,7 +83,7 @@ describe('Registration API service', () => {
             traceId: 'H3TKh4QSJUSwVBCBqEtkKw',
             errors: [
                 {
-                    description: 'Not authorized.',
+                    description: 'Forbidden.',
                     errorCode: '403'
                 }
             ]

--- a/packages/f-registration/src/components/tests/f-registration.integration.test.js
+++ b/packages/f-registration/src/components/tests/f-registration.integration.test.js
@@ -25,6 +25,7 @@ describe('Registration API service', () => {
 
     afterEach(() => {
         wrapper.destroy();
+        jest.clearAllMocks();
     });
 
     it('responds with 201 when request is made with valid details', async () => {
@@ -73,5 +74,41 @@ describe('Registration API service', () => {
         // Assert
         expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
         expect(wrapper.vm.shouldShowEmailAlreadyExistsError).toBe(true);
+    });
+
+    it('responds with 403 when login blocked by ravelin or recaptcha', async () => {
+        // Arrange
+        Object.defineProperty(window, 'location', {
+            value: {
+                href: 'https://www.just-eat-test.co.uk/account/register'
+            }
+        });
+
+
+        axiosMock.onPost(propsData.createAccountUrl, CONSUMERS_REQUEST_DATA).reply(403, {
+            faultId: '25bbe062-c53d-4fbc-9d6c-3df6127b94fd',
+            traceId: 'H3TKh4QSJUSwVBCBqEtkKw',
+            errors: [
+                {
+                    description: 'Not authorized.',
+                    errorCode: '403'
+                }
+            ]
+        });
+
+        // Act
+        wrapper.find('[data-test-id="input-first-name"]').setValue(CONSUMERS_REQUEST_DATA.firstName);
+        wrapper.find('[data-test-id="input-last-name"]').setValue(CONSUMERS_REQUEST_DATA.lastName);
+        wrapper.find('[data-test-id="input-email"]').setValue(CONSUMERS_REQUEST_DATA.emailAddress);
+        wrapper.find('[data-test-id="input-password"]').setValue(CONSUMERS_REQUEST_DATA.password);
+        // TODO: Add marketing preferences checkbox when it exists
+
+        // Act
+        await wrapper.vm.onFormSubmit();
+        await flushPromises();
+
+        // Assert
+        expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+        expect(window.location.href).toBe('/account/login');
     });
 });

--- a/packages/f-registration/src/components/tests/f-registration.integration.test.js
+++ b/packages/f-registration/src/components/tests/f-registration.integration.test.js
@@ -78,13 +78,6 @@ describe('Registration API service', () => {
 
     it('responds with 403 when login blocked by ravelin or recaptcha', async () => {
         // Arrange
-        Object.defineProperty(window, 'location', {
-            value: {
-                href: 'https://www.just-eat-test.co.uk/account/register'
-            }
-        });
-
-
         axiosMock.onPost(propsData.createAccountUrl, CONSUMERS_REQUEST_DATA).reply(403, {
             faultId: '25bbe062-c53d-4fbc-9d6c-3df6127b94fd',
             traceId: 'H3TKh4QSJUSwVBCBqEtkKw',
@@ -108,7 +101,7 @@ describe('Registration API service', () => {
         await flushPromises();
 
         // Assert
-        expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
-        expect(window.location.href).toBe('/account/login');
+        expect(wrapper.emitted(EventNames.LoginBlocked).length).toBe(1);
+        expect(wrapper.emitted(EventNames.CreateAccountFailure)).toBeUndefined();
     });
 });

--- a/packages/f-registration/src/demo/Index.vue
+++ b/packages/f-registration/src/demo/Index.vue
@@ -9,7 +9,8 @@
         >
         <registration
             locale="en-GB"
-            show-login-link=true
+            :show-login-link=true
+            create-account-url="/account/register"
             class="registration-form" />
     </div>
 </template>

--- a/packages/f-registration/src/event-names.js
+++ b/packages/f-registration/src/event-names.js
@@ -3,11 +3,13 @@ const CreateAccountFailure = 'registration-create-account-failure';
 const CreateAccountStart = 'registration-create-account-start';
 const CreateAccountInlineError = 'registration-create-account-inline-error';
 const VisitLoginPage = 'registration-visit-login-page';
+const LoginBlocked = 'registration-login-blocked';
 
 export default {
     CreateAccountSuccess,
     CreateAccountFailure,
     CreateAccountStart,
     CreateAccountInlineError,
-    VisitLoginPage
+    VisitLoginPage,
+    LoginBlocked
 };

--- a/packages/f-registration/src/services/RegistrationServiceApi.js
+++ b/packages/f-registration/src/services/RegistrationServiceApi.js
@@ -1,14 +1,14 @@
 import axios from 'axios';
 
 export default {
-    async createAccount (url, tenant, data) {
+    async createAccount (url, tenant, data, timeout) {
         const config = {
             method: 'post',
             headers: {
                 'Content-Type': 'application/json',
                 'Accept-Tenant': tenant
             },
-            timeout: 1000
+            timeout
         };
         return axios
             .post(url, data, config);

--- a/packages/f-registration/src/tenants/en-GB.js
+++ b/packages/f-registration/src/tenants/en-GB.js
@@ -21,7 +21,7 @@ export default {
         },
         login: {
             text: 'Already on Just Eat?',
-            url: '/login'
+            url: '/account/login'
         }
     },
 


### PR DESCRIPTION
This PR adds handling for `403` responses when an account is created. This can happen when the authentication attempt on the newly created account gets either blocked by ravelin or a Recaptcha is served. In these instances, we need to navigate the user to the login page to manually log in. 