### PR TITLE
fozzie-components@v2.5.0 & f-button@v0.1.0 – fozzie package updates and initial f-button component setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v2.6.0
+------------------------------
+*October 21, 2020*
+
+### Added
+- Upgrading `fozzie-colour-palette` and `fozzie` package versions.
+
+
 v2.5.0
 ------------------------------
 *October 15, 2020*
@@ -10,6 +19,7 @@ v2.5.0
 ### Changed
 - Circle CI Docker image
 - Chromedriver version to v86.0.0
+
 
 v2.4.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",
@@ -28,8 +28,8 @@
     "@justeat/eslint-config-fozzie": "3.4.1",
     "@justeat/f-build-config": "0.3.0",
     "@justeat/f-utils": "1.0.0-beta.0",
-    "@justeat/fozzie": "4.0.0-beta.0",
-    "@justeat/fozzie-colour-palette": "3.0.0-beta.6",
+    "@justeat/fozzie": "4.1.0",
+    "@justeat/fozzie-colour-palette": "3.0.0",
     "@storybook/storybook-deployer": "2.8.6",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",

--- a/packages/f-button/.eslintignore
+++ b/packages/f-button/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/f-button/CHANGELOG.md
+++ b/packages/f-button/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+v0.1.0
+------------------------------
+*October 21, 2020*
+
+### Added
+- First iteration of button component. Contains variants for primary, secondary, ghost, outline and btnLink.

--- a/packages/f-button/LICENSE
+++ b/packages/f-button/LICENSE
@@ -1,0 +1,17 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+Copyright 2020 Just Eat Holding Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/f-button/README.md
+++ b/packages/f-button/README.md
@@ -1,0 +1,72 @@
+
+<div align="center">
+  <h1>f-button</h1>
+
+  <img width="125" alt="Fozzie Bear" src="../../bear.png" />
+
+  <p>The generic button component</p>
+</div>
+
+---
+
+[![npm version](https://badge.fury.io/js/%40justeat%2Ff-button.svg)](https://badge.fury.io/js/%40justeat%2Ff-button)
+[![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg&circle-token=4c77c1990b98c8e06e01b497bc80f376346f609d)](https://circleci.com/gh/justeat/workflows/fozzie-components)
+[![Coverage Status](https://coveralls.io/repos/github/justeat/f-button/badge.svg)](https://coveralls.io/github/justeat/f-button)
+[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-button/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-button?targetFile=package.json)
+
+
+## Usage
+
+1.  Install the module using NPM or Yarn:
+
+    ```bash
+    yarn add @justeat/f-button
+    ```
+
+    ```bash
+    npm install @justeat/f-button
+    ```
+
+2.  Import the component
+
+    You can import it in your Vue SFC like this (please note that styles have to be imported separately):
+
+    ```
+    import VueButton from '@justeat/f-button';
+    import '@justeat/f-button/dist/f-button.css';
+
+    export default {
+        components: {
+            VueButton
+        }
+    }
+    ```
+
+    If you are using Webpack, you can import the component dynamically to separate the `vue-button` bundle from the main `bundle.client.js`:
+
+    ```
+    import '@justeat/f-button/dist/f-button.css';
+
+    export default {
+        components: {
+            ...
+            VueButton: () => import(/* webpackChunkName: "vue-button" */ '@justeat/f-button')
+        }
+    }
+
+    ```
+
+## Development
+
+Running below `yarn` commands from the component folder, starts a development
+server displaying a preview example of the component implementation.
+
+```bash
+# cd /packages/f-button
+yarn install
+
+# followed by
+yarn demo
+```
+
+## Documentation to be completed once module is in stable state.

--- a/packages/f-button/babel.config.js
+++ b/packages/f-button/babel.config.js
@@ -1,0 +1,26 @@
+module.exports = api => {
+    // Use `isTest` to determine what presets and plugins to use with jest
+    const isTest = api.env('test');
+    const presets = [];
+    const plugins = [
+        '@babel/plugin-proposal-optional-chaining' // https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining
+    ];
+    const builtIns = (api.env('development') ? 'entry' : false);
+
+    if (!isTest) {
+        api.cache(true); // Caches the computed babel config function – https://babeljs.io/docs/en/config-files#apicache
+        presets.push(['@vue/app', { useBuiltIns: builtIns }]);
+        // Alias for @babel/preset-env
+        // Hooks into browserslist to provide smart Babel transforms
+        // https://babeljs.io/docs/en/babel-preset-env
+        presets.push('@babel/env');
+    } else {
+        // use current node version for transpiling test files
+        presets.push(['@babel/env', { targets: { node: 'current' } }]);
+    }
+
+    return {
+        presets,
+        plugins
+    };
+};

--- a/packages/f-button/jest.config.js
+++ b/packages/f-button/jest.config.js
@@ -1,0 +1,35 @@
+module.exports = {
+    moduleFileExtensions: [
+        'js',
+        'json',
+        'vue'
+    ],
+
+    transform: {
+        '^.+\\.js$': 'babel-jest',
+        '^.+\\.vue$': 'vue-jest',
+        '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub'
+    },
+
+    transformIgnorePatterns: [
+        'node_modules/(?!(lodash-es)/)'
+    ],
+
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+        '^~include-media/(.*)$': '<rootDir>../../node_modules/include-media/$1',
+        '^~@justeat/(.*)$': '<rootDir>../../node_modules/@justeat/$1'
+    },
+
+    snapshotSerializers: [
+        'jest-serializer-vue'
+    ],
+
+    globals: {
+        'vue-jest': {
+            hideStyleWarn: true // We hide style warnings given the first time we run the tests it complains about some styles. The second time the tests are run, the warning disappears. https://github.com/vuejs/vue-jest/issues/178#issuecomment-529175129
+        }
+    },
+
+    testURL: 'http://localhost/'
+};

--- a/packages/f-button/package.json
+++ b/packages/f-button/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@justeat/f-button",
+  "description": "Fozzie Button – The generic button component",
+  "version": "0.1.0",
+  "main": "dist/f-button.umd.min.js",
+  "files": [
+    "dist",
+    "test-utils"
+  ],
+  "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/f-button",
+  "contributors": [
+    "Github contributors <https://github.com/justeat/fozzie-components/graphs/contributors>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:justeat/fozzie-components.git"
+  },
+  "bugs": {
+    "url": "https://github.com/justeat/fozzie-components/issues"
+  },
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "keywords": [
+    "fozzie"
+  ],
+  "scripts": {
+    "prepublishOnly": "yarn lint && yarn test && yarn build",
+    "build": "vue-cli-service build --target lib --name f-button ./src/index.js",
+    "demo": "vue serve --port 8080 ./src/demo/Index.vue",
+    "lint": "vue-cli-service lint",
+    "lint:fix": "yarn lint --fix",
+    "test-component:chrome": "run-p --race demo webdriver:delay:chrome",
+    "test:wait-for-server": "node ../../test/infrastructure/healthcheck.js",
+    "webdriver:delay:chrome": "yarn test:wait-for-server && yarn webdriver:start:chrome",
+    "webdriver:start:chrome": "wdio ../../wdio.conf.js"
+  },
+  "browserslist": [
+    "extends @justeat/browserslist-config-fozzie"
+  ],
+  "dependencies": {},
+  "peerDependencies": {
+    "@justeat/browserslist-config-fozzie": ">=1.1.1"
+  },
+  "devDependencies": {
+    "@vue/cli-plugin-babel": "4.4.6",
+    "@vue/cli-plugin-eslint": "3.9.2",
+    "@vue/cli-plugin-unit-jest": "4.4.6",
+    "@vue/test-utils": "1.0.3",
+    "node-sass-magic-importer": "5.3.2"
+  }
+}

--- a/packages/f-button/src/assets/scss/common.scss
+++ b/packages/f-button/src/assets/scss/common.scss
@@ -1,0 +1,12 @@
+// Set $theme variable so that fozzie doesn't complain when vars are imported below
+// n.b. This variables isn't actually used (unless there are theme specific vars from fozzie)
+// Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
+$theme: 'jet' !default;
+
+@import '~@justeat/f-utils/src/scss/functions/index';
+@import '~@justeat/f-utils/src/scss/mixins/index';
+@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
+@import '~@justeat/fozzie/src/scss/settings/variables';
+@import '~@justeat/fozzie/src/scss/base/reset';
+@import '~@justeat/fozzie-colour-palette/src/scss/';
+

--- a/packages/f-button/src/components/Button.vue
+++ b/packages/f-button/src/components/Button.vue
@@ -1,0 +1,340 @@
+<template>
+    <button
+        :class="[
+            $style['o-btn'],
+            $style[`o-btn--${buttonType}`],
+            $style[`o-btn--size${buttonSizeClassname}`],
+            (fullWidth ? $style['o-btn--fullWidth'] : '')
+        ]"
+        data-test-id='button-component'>
+        <slot />
+    </button>
+</template>
+
+<script>
+
+export default {
+    name: 'VueButton',
+    components: {},
+    props: {
+        buttonType: {
+            type: String,
+            default: 'primary'
+        },
+        buttonSize: {
+            type: String,
+            default: 'medium'
+        },
+        fullWidth: {
+            type: Boolean,
+            default: false
+        }
+    },
+    computed: {
+        /**
+         * Converts the buttonSize prop into a normalised classname (that fit with our class naming scheme)
+         */
+        buttonSizeClassname () {
+            if (this.buttonSize === 'xsmall') {
+                return this.buttonSize.slice(0, 2).toUpperCase() + this.buttonSize.slice(2); // xsmall -> XSmall
+            }
+            return this.buttonSize.charAt(0).toUpperCase() + this.buttonSize.slice(1); // capitalize the first letter of the prop
+        }
+    }
+};
+</script>
+
+<style lang="scss" module>
+
+$btn-default-bgColor            : $grey--lighter;
+$btn-default-bgColor--hover     : $grey--light;
+$btn-default-borderRadius       : $border-radius;
+$btn-default-font-family        : $font-family-base;
+$btn-default-font-size          : 'body-l';
+$btn-default-weight             : $font-weight-bold;
+$btn-default-padding            : 11px 1.5em 13px;
+$btn-default-outline-color      : $color-focus-outline;
+
+$btn-primary-bgColor            : $blue;
+$btn-primary-bgColor--hover     : $blue--dark;
+$btn-primary-bgColor--focus     : $blue--darkest;
+$btn-primary-textColor          : $white;
+
+$btn-secondary-bgColor          : $blue--offWhite;
+$btn-secondary-bgColor--hover   : $blue--offWhite--dark;
+$btn-secondary-bgColor--active  : $blue--offWhite--darkest;
+$btn-secondary-textColor        : $blue;
+
+$btn-outline-bgColor            : transparent;
+$btn-outline-bgColor--hover     : rgba($black, 0.08);
+$btn-outline-bgColor--active    : rgba($black, 0.12);
+$btn-outline-textColor          : $black;
+$btn-outline-border-color       : $grey--light;
+// TODO: checking with design if $btn-outline-border-color should change on hover/active
+
+$btn-ghost-bgColor              : transparent;
+$btn-ghost-bgColor--hover       : rgba($black, 0.08);
+$btn-ghost-bgColor--active      : rgba($black, 0.12);
+$btn-ghost-textColor            : $blue;
+
+$btn-disabled-bgColor           : $grey--light;
+$btn-disabled-textColor         : $grey--midDark;
+
+$btn-sizeLarge-font-size        : 'heading-s';
+$btn-sizeLarge-padding          : 13px 1.2em 15px;
+
+$btn-sizeSmall-padding          : 7px 1em 9px;
+
+$btn-sizeXSmall-padding         : 5px 0.5em 7px;
+$btn-sizeXSmall-lineHeight      : 1;
+
+
+.o-btn {
+    display: inline-block;                      /* [1] */
+    vertical-align: middle;                     /* [2] */
+    font-family: $btn-default-font-family;      /* [3] */
+    @include font-size($btn-default-font-size); /* [3] */
+    cursor: pointer;                            /* [4] */
+    margin: 0;                                  /* [5] */
+    padding: $btn-default-padding;              /* [5, 6] */
+    overflow: visible;                          /* [7] */
+    text-align: center;
+    font-weight: $btn-default-weight;
+
+    // You may want to change this
+    background-color: $btn-default-bgColor;
+    border-radius: $btn-default-borderRadius;
+    border: 1px solid transparent;
+    user-select: none;
+
+    color: $grey--dark;
+    text-decoration: none;
+
+    &:hover,
+    &:active {
+        background-color: $btn-default-bgColor--hover;
+    }
+
+    &:focus {
+        outline: 2px dotted $btn-default-outline-color;
+    }
+
+    &:hover,
+    &:active {
+        &:not(.o-btnLink) {
+            outline: none; // no need as already has a focus/active state
+        }
+    }
+
+    &,
+    &:hover,
+    &:active,
+    &:focus,
+    &:visited {
+        text-decoration: none;
+    }
+
+    // Disabled state
+    &.is-disabled,
+    &[disabled] {
+        cursor: not-allowed;
+
+        &,
+        &:hover {
+            background-color: $btn-disabled-bgColor;
+            color: $btn-disabled-textColor;
+        }
+    }
+}
+
+/**
+ * ==========================================================================
+ * Btn Background Colour modifiers
+ * ==========================================================================
+ */
+
+/**
+ * Modifier – .o-btn--primary
+ *
+ * Sets the btn colour to site primary colour
+ */
+
+.o-btn--primary {
+    background-color: $btn-primary-bgColor;
+
+    &,
+    &:link,
+    &:visited {
+        color: $btn-primary-textColor;
+    }
+
+    &:hover,
+    &:active,
+    &:focus {
+        color: $btn-primary-textColor;
+    }
+
+    &:hover {
+        background-color: $btn-primary-bgColor--hover;
+    }
+
+    &:active {
+        background-color: $btn-primary-bgColor--focus;
+    }
+}
+
+
+/**
+ * Modifier – .o-btn--secondary
+ *
+ * Accompanying secondary style button (knocked back slightly from the primary button)
+ */
+
+.o-btn--secondary {
+    background-color: $btn-secondary-bgColor;
+    color: $btn-secondary-textColor;
+
+    &:hover {
+        background-color: $btn-secondary-bgColor--hover;
+    }
+
+    &:active {
+        background-color: $btn-secondary-bgColor--active;
+    }
+}
+
+
+/**
+ * Modifier – .o-btn--outline
+ *
+ * Accompanying button style
+ */
+
+.o-btn--outline {
+    background-color: $btn-outline-bgColor;
+    color: $btn-outline-textColor;
+    border-color: $btn-outline-border-color;
+
+    &:hover,
+    &:active,
+    &:focus {
+        color: $btn-outline-textColor;
+    }
+
+    &:hover {
+        background-color: $btn-outline-bgColor--hover;
+    }
+
+    &:active {
+        background-color: $btn-outline-bgColor--active;
+    }
+}
+
+
+/**
+ * Modifier – .o-btn--ghost
+ *
+ * Accompanying button that can be used on solid background colours (such as grey)
+ */
+
+.o-btn--ghost {
+    background-color: $btn-ghost-bgColor;
+    color: $btn-ghost-textColor;
+
+    &:hover,
+    &:active,
+    &:focus {
+        color: $btn-ghost-textColor;
+    }
+
+    &:hover {
+        background-color: $btn-ghost-bgColor--hover;
+    }
+
+    &:active {
+        background-color: $btn-ghost-bgColor--active;
+    }
+}
+
+/**
+ * ==========================================================================
+ * Btn Size Modifiers
+ * ==========================================================================
+ */
+
+.o-btn--sizeLarge {
+    @include font-size($btn-sizeLarge-font-size);
+    padding: $btn-sizeLarge-padding;
+
+    &.o-btn--primary {
+        background-color: $orange;
+    }
+}
+
+// .o-btn--sizeMedium {}
+
+.o-btn--sizeSmall {
+    padding: $btn-sizeSmall-padding;
+}
+
+.o-btn--sizeXSmall {
+    padding: $btn-sizeXSmall-padding;
+    line-height: $btn-sizeXSmall-lineHeight;
+}
+
+
+/**
+ * ==========================================================================
+ * Btn Layout Modifiers
+ * ==========================================================================
+ */
+
+/**
+ * Modifier – o-btn-fullWidth
+ *
+ * Makes the btn full width
+ */
+
+.o-btn--fullWidth {
+    display: block;
+    width: 100%;
+
+    // Vertically space out multiple fullWidth buttons
+    // same as .o-btn--fullWidth + .o-btn--fullWidth
+    & + & {
+        margin-top: spacing();
+    }
+}
+
+
+/**
+ * Modifier – .o-btn--onColour
+ *
+ * Make a button visually look like a default link
+ * Useful when we semantically want a button but don’t want all the default styling
+ *
+ * Should only be applied to buttons
+ */
+
+.o-btn--link {
+    border: 0;
+    background-color: transparent;
+    padding: 0;
+    margin: 0;
+    color: $color-link-default;
+    font-weight: $font-weight-base;
+    text-decoration: underline;
+
+    &:hover {
+        cursor: pointer;
+        color: $color-link-hover;
+        background-color: transparent;
+    }
+    &:active,
+    &:focus {
+        color: $color-link-active;
+        background-color: transparent;
+    }
+}
+
+</style>

--- a/packages/f-button/src/components/Button.vue
+++ b/packages/f-button/src/components/Button.vue
@@ -90,18 +90,17 @@ $btn-sizeXSmall-lineHeight      : 1;
 
 
 .o-btn {
-    display: inline-block;                      /* [1] */
-    vertical-align: middle;                     /* [2] */
-    font-family: $btn-default-font-family;      /* [3] */
-    @include font-size($btn-default-font-size); /* [3] */
-    cursor: pointer;                            /* [4] */
-    margin: 0;                                  /* [5] */
-    padding: $btn-default-padding;              /* [5, 6] */
-    overflow: visible;                          /* [7] */
+    display: inline-block;
+    vertical-align: middle;
+    font-family: $btn-default-font-family;
+    @include font-size($btn-default-font-size);
+    cursor: pointer;
+    margin: 0;
+    padding: $btn-default-padding;
+    overflow: visible;
     text-align: center;
     font-weight: $btn-default-weight;
 
-    // You may want to change this
     background-color: $btn-default-bgColor;
     border-radius: $btn-default-borderRadius;
     border: 1px solid transparent;
@@ -270,8 +269,6 @@ $btn-sizeXSmall-lineHeight      : 1;
         background-color: $orange;
     }
 }
-
-// .o-btn--sizeMedium {}
 
 .o-btn--sizeSmall {
     padding: $btn-sizeSmall-padding;

--- a/packages/f-button/src/components/tests/Button.test.js
+++ b/packages/f-button/src/components/tests/Button.test.js
@@ -1,0 +1,10 @@
+import { shallowMount } from '@vue/test-utils';
+import VueButton from '../Button.vue';
+
+describe('Button', () => {
+    it('should be defined', () => {
+        const propsData = {};
+        const wrapper = shallowMount(VueButton, { propsData });
+        expect(wrapper.exists()).toBe(true);
+    });
+});

--- a/packages/f-button/src/demo/Index.vue
+++ b/packages/f-button/src/demo/Index.vue
@@ -1,0 +1,25 @@
+// Demo component for testing `f-button` independently via `vue serve --open src/demo/Index.vue`
+// Fonts were added for beter comparison with the designs.
+
+<template>
+    <div>
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1">
+        <vue-button />
+    </div>
+</template>
+
+<script>
+import VueButton from '@/components/Button.vue';
+
+export default {
+    components: { VueButton }
+};
+</script>
+
+<style>
+body {
+    margin: 0;
+}
+</style>

--- a/packages/f-button/src/index.js
+++ b/packages/f-button/src/index.js
@@ -1,0 +1,35 @@
+/**
+ * @overview Fozzie Button Component JS Wrapper
+ *
+ * @module f-button
+ */
+
+
+// Import vue component
+import VueButton from '@/components/Button.vue';
+
+// Declare install function executed by Vue.use()
+export function install (Vue) {
+    if (install.installed) return;
+    install.installed = true;
+    Vue.component('VueButton', VueButton);
+}
+
+// Create module definition for Vue.use()
+const plugin = {
+    install
+};
+
+// Auto-install when vue is found (eg. in browser via <script> tag)
+let GlobalVue = null;
+if (typeof window !== 'undefined') {
+    GlobalVue = window.Vue;
+} else if (typeof global !== 'undefined') {
+    GlobalVue = global.Vue;
+}
+if (GlobalVue) {
+    GlobalVue.use(plugin);
+}
+
+// To allow use as module (npm/webpack/etc.) export component
+export default VueButton;

--- a/packages/f-button/stories/Button.stories.js
+++ b/packages/f-button/stories/Button.stories.js
@@ -1,0 +1,28 @@
+import {
+    withKnobs, select, boolean
+} from '@storybook/addon-knobs';
+import { withA11y } from '@storybook/addon-a11y';
+import VueButton from '../src/components/Button.vue';
+
+export default {
+    title: 'Components/Atoms',
+    decorators: [withKnobs, withA11y]
+};
+
+export const ButtonComponent = () => ({
+    components: { VueButton },
+    props: {
+        buttonType: {
+            default: select('Button Type', ['primary', 'secondary', 'outline', 'ghost', 'link'])
+        },
+        buttonSize: {
+            default: select('Button Size', ['xsmall', 'small', 'medium', 'large'], 'medium')
+        },
+        fullWidth: {
+            default: boolean('fullWidth', false)
+        }
+    },
+    template: '<vue-button :buttonType="buttonType" :buttonSize="buttonSize" :fullWidth="fullWidth">Default Button Text</vue-button>'
+});
+
+ButtonComponent.storyName = 'f-button';

--- a/packages/f-button/test-utils/component-objects/README.md
+++ b/packages/f-button/test-utils/component-objects/README.md
@@ -1,0 +1,13 @@
+# What is a component object?
+A component object is a file that is used to define the UI selectors / functionality of a component that is then utilised by WebDriverIO for browser-based automation testing.
+
+# Usage
+Please add a component object if this component is interacted with as part of browser-based automation tests. This can be done either by:
+- Component tests for this component.
+In this scenario, the component object should be imported into the WebDriverIO spec file.
+
+- Component tests for a parent component.
+In this scenario, the component object should be imported into the parent component object.
+
+- System tests as part of a consuming application.
+In this scenario, the `test-utils` folder needs to be added to the `files` section within `package.json` so that it can be imported by the consuming application.

--- a/packages/f-button/test-utils/component-objects/f-button.component.js
+++ b/packages/f-button/test-utils/component-objects/f-button.component.js
@@ -1,0 +1,5 @@
+const buttonComponent = () => $('[data-test-id="button-component"]');
+
+exports.waitForButtonComponent = () => buttonComponent().waitForExist();
+
+exports.isButtonComponentDisplayed = () => buttonComponent().isDisplayed();

--- a/packages/f-button/test/specs/README.md
+++ b/packages/f-button/test/specs/README.md
@@ -1,0 +1,3 @@
+# Usage
+This directory will contain WebDriverIO spec files that will allow you to test your component in isolation within the browser.
+If this component is a shared / common component that other components are dependent on, then you may delete this directory as it's likely the component can be tested indirectly.

--- a/packages/f-button/test/specs/component/README.md
+++ b/packages/f-button/test/specs/component/README.md
@@ -1,0 +1,3 @@
+# Usage
+This directory will contain WebDriverIO spec files that will allow you to test your component in isolation within the browser.
+If this component is a shared / common component that other components are dependent on, then you may delete this directory as it's likely the component can be tested indirectly.

--- a/packages/f-button/test/specs/component/f-button.component.spec.js
+++ b/packages/f-button/test/specs/component/f-button.component.spec.js
@@ -1,0 +1,13 @@
+import ButtonComponent from '../../../test-utils/component-objects/f-button.component';
+
+describe('f-button component tests', () => {
+    beforeEach(() => {
+        // Arrange
+        browser.url('http://localhost:8080');
+    })
+
+    it('should display the f-button component', () => {
+        // Assert
+        expect(ButtonComponent.isButtonComponentDisplayed()).toBe(true);
+    });
+});

--- a/packages/f-button/vue.config.js
+++ b/packages/f-button/vue.config.js
@@ -1,0 +1,17 @@
+const magicImporter = require('node-sass-magic-importer');
+
+// vue.config.js
+module.exports = {
+    chainWebpack: config => {
+        config.module
+            .rule('scss-importer')
+            .test(/\.scss$/)
+            .use('importer')
+            .loader('sass-loader')
+            .options({
+                importer: magicImporter(),
+                // eslint-disable-next-line quotes
+                data: `@import "@/assets/scss/common.scss";`
+            });
+    }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,15 +1758,20 @@
     "@justeat/f-icons" "2.3.0"
     babel-helper-vue-jsx-merge-props "2.0.3"
 
+"@justeat/fozzie-colour-palette@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0.tgz#55eb60de93c4785049eb8abc82b760e57b3ca9c0"
+  integrity sha512-WZXfILucrW3XxwHvwouFg0JEHe13QFBPHNNKKakNOnMEsU0kiwxtd042JjRT3ZwkD5r89hdNa6YLtLsraaFq5w==
+
 "@justeat/fozzie-colour-palette@3.0.0-beta.6":
   version "3.0.0-beta.6"
   resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.6.tgz#3d66dd63b48dacf649f003a3b3c7c39ecf7d94b7"
   integrity sha512-DbUvzLpVr2Q9/6QTF58/fomb1YOdn8ytGE+PLo9prNlpc24ZaFEDPfHzK63nyAvmmw1VboRNRzOpffArdW4FNQ==
 
-"@justeat/fozzie@4.0.0-beta.0":
-  version "4.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-4.0.0-beta.0.tgz#66d7ee71a90bdff3bc4b67994305d888fe8f7c64"
-  integrity sha512-/uElS2zDFD8A7DiA5bxbBmjKbUGI00u4bApJVUwCRaGBgqScEwrI9ya1cYt5/KlTD5YtFef3iOd7QppilSb5mQ==
+"@justeat/fozzie@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-4.1.0.tgz#cd9cdb1cef5f7e0b0ee13482c271292acd0dfe2d"
+  integrity sha512-6q762UPmMjIpjH70Oj+M5DLRy5AU04Nkpzq4qH1LC2BR96zKZtsqlxL4fSIrnf3DHGeKRpbfr9KaXgWAAhjkXA==
   dependencies:
     "@justeat/f-dom" "1.1.0"
     "@justeat/f-logger" "0.8.1"


### PR DESCRIPTION
## f-button@v0.1.0

### Added
- First iteration of button component. Contains variants for primary, secondary, ghost, outline and btnLink.

---

## fozzie-components@v2.5.0

### Added
- Upgrading `fozzie-colour-palette` and `fozzie` package versions.

---

## UI Review Checks

<img width="411" alt="Screen Shot 2020-10-21 at 11 01 16" src="https://user-images.githubusercontent.com/805184/96705149-d08a3600-138c-11eb-91b4-6ba4dc4cfd95.png">


- [x] README and/or UI Documentation has been created
- [ ] Unit tests have been created (will follow in separate PR)
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
