### PR TITLE
f-metadata@3.0.0-beta.4 - Grouped cards now contain the full card data for header and terms and conditions cards.

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.0.0-beta.4
+------------------------------
+*October 22, 2020*
+
+### Changed
+- In arrangeCardsByTitles we now push all card data into group rather than just the title, this is to aid in impressions
+ tracking and future headers that require more than the title being displayed.
+
 v3.0.0-beta.3
 ------------------------------
 *October 22, 2020*

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "main": "src/index.js",
   "files": [
     "src"

--- a/packages/f-metadata/src/services/contentCard.service.js
+++ b/packages/f-metadata/src/services/contentCard.service.js
@@ -93,7 +93,7 @@ class ContentCards {
         this.groups = this.cards.reduce((acc, card) => {
             const { type } = card;
             if (type && (startsWith(type, 'Header_Card') || startsWith(type, 'Terms_And_Conditions_Card'))) {
-                return [...acc, { title: card.title, cards: [] }];
+                return [...acc, { ...card, cards: [] }];
             }
             if (!acc.length) {
                 return [{ title: '', cards: [card] }];


### PR DESCRIPTION
In discussion around how we want to handle card impressions on the grouped cards in f-content-cards, it was realised that we might want all the data for the group cards not just the title.  Please see PR  #374 and #383 as reference.
