### PR TITLE
f-footer@4.4.0 - new huawei link

### DIFF
--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.4.0
+------------------------------
+*November 2, 2020*
+
+### Added
+- New Huawei icon and link in app links for the UK.
+
+
 v4.3.0
 ------------------------------
 *October 30, 2020*

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "@justeat/f-services": "1.3.0",
-    "@justeat/f-vue-icons": "1.9.0",
+    "@justeat/f-vue-icons": "1.10.0",
     "v-click-outside": "3.1.2"
   },
   "peerDependencies": {

--- a/packages/f-footer/package.json
+++ b/packages/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist",
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "@justeat/f-services": "1.3.0",
-    "@justeat/f-vue-icons": "1.7.0",
+    "@justeat/f-vue-icons": "1.9.0",
     "v-click-outside": "3.1.2"
   },
   "peerDependencies": {

--- a/packages/f-footer/src/components/AppStoreIcon.vue
+++ b/packages/f-footer/src/components/AppStoreIcon.vue
@@ -13,7 +13,8 @@ import {
     AppIosIcon as IosIconEnGb,
     AppIosEsIcon as IosIconEsEs,
     AppIosItIcon as IosIconItIt,
-    AppIosNoIcon as IosIconNbNo
+    AppIosNoIcon as IosIconNbNo,
+    AppHuaweiUkIcon as HuaweiIconEnGb
 } from '@justeat/f-vue-icons';
 import iconPropsMixin from '../mixins/iconProps.mixin';
 
@@ -34,7 +35,8 @@ export default {
         IosIconEnNz: IosIconEnGb,
         IosIconEsEs,
         IosIconItIt,
-        IosIconNbNo
+        IosIconNbNo,
+        HuaweiIconEnGb
     },
 
     mixins: [

--- a/packages/f-footer/src/components/Footer.vue
+++ b/packages/f-footer/src/components/Footer.vue
@@ -245,4 +245,8 @@ $footer-heading-font-size: 'heading-s';
     }
 }
 
+.c-footer-list--noBottomMargin {
+    margin-bottom: 0;
+}
+
 </style>

--- a/packages/f-footer/src/components/IconList.vue
+++ b/packages/f-footer/src/components/IconList.vue
@@ -12,7 +12,8 @@
             {{ title }}
         </h2>
 
-        <ul :class="['c-footer-list c-footer-list--inline', {
+        <ul
+            :class="['c-footer-list c-footer-list--inline', {
                 'c-footer-list--noBottomMargin': isApps
             }]">
             <li

--- a/packages/f-footer/src/components/IconList.vue
+++ b/packages/f-footer/src/components/IconList.vue
@@ -12,7 +12,9 @@
             {{ title }}
         </h2>
 
-        <ul class="c-footer-list c-footer-list--inline">
+        <ul :class="['c-footer-list c-footer-list--inline', {
+                'c-footer-list--noBottomMargin': isApps
+            }]">
             <li
                 v-for="(icon, i) in icons"
                 :key="i + '_Icon'"
@@ -127,10 +129,14 @@ export default {
 }
 
 .c-iconList--apps {
-    flex-basis: 42%;
 
     .c-iconList-listItem {
         margin-right: spacing(x2);
+        margin-bottom: spacing(x2);
+
+        &:last-child {
+            margin-right: 0;
+        }
     }
 
     svg {

--- a/packages/f-footer/src/components/tests/__snapshots__/Footer.test.js.snap
+++ b/packages/f-footer/src/components/tests/__snapshots__/Footer.test.js.snap
@@ -13,7 +13,7 @@ exports[`Footer should render default component markup 1`] = `
     <div class="c-footer-container">
       <!---->
       <div class="c-footer-row">
-        <icon-list-stub icons="[object Object],[object Object]" title="Download our apps" isapps="true" locale="en-GB"></icon-list-stub>
+        <icon-list-stub icons="[object Object],[object Object],[object Object]" title="Download our apps" isapps="true" locale="en-GB"></icon-list-stub>
         <feedback-block-stub title="Feedback" text="Help us improve our website" buttontext="Send feedback"></feedback-block-stub>
         <icon-list-stub icons="[object Object],[object Object],[object Object]" title="Follow us" issocial="true" locale="en-GB"></icon-list-stub>
       </div>

--- a/packages/f-footer/src/tenants/en-GB.js
+++ b/packages/f-footer/src/tenants/en-GB.js
@@ -204,6 +204,12 @@ export default {
             name: 'android',
             alt: 'Get it on Google Play',
             gtm: 'click_download_android_app'
+        },
+        {
+            url: 'https://appgallery.cloud.huawei.com/ag/n/app/C101688679?channelId=JustEat+website&id=f7c5193d2ec8406c9774188a3a7360a0&s=81F93139C63A9427F2E6E58C3F34313F7EF771664E5EE8F919F929ED301468F9&detailType=0&v=',
+            name: 'huawei',
+            alt: 'Get it on HUAWEI AppGallery',
+            gtm: 'click_download_huawei_app'
         }
     ],
     feedback: 'Feedback',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1760,13 +1760,6 @@
     "@justeat/f-icons" "2.3.0"
     babel-helper-vue-jsx-merge-props "2.0.3"
 
-"@justeat/f-vue-icons@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.7.0.tgz#a48b7a5102d2bb22c5dc1cbe72ea872683a7d35b"
-  integrity sha512-QeCXY+zxRRu6YIcBIhp2wh2SRnCX8yk6z3yWEJDpEf+qrTAAcZv3X/DobrtpzFUuXf+2Hbvb4CmdB7HFQ2BzaA==
-  dependencies:
-    babel-helper-vue-jsx-merge-props "2.0.3"
-
 "@justeat/fozzie-colour-palette@3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0.tgz#55eb60de93c4785049eb8abc82b760e57b3ca9c0"


### PR DESCRIPTION
### Added
- New Huawei icon and link in app links for the UK.

Desktop:
![Screen Shot 2020-11-02 at 11 57 54](https://user-images.githubusercontent.com/19548183/97865899-dbd15000-1d02-11eb-8c78-0eac7b06522e.png)

Tablet:
![Screen Shot 2020-11-02 at 11 59 07](https://user-images.githubusercontent.com/19548183/97865918-e1c73100-1d02-11eb-8b40-8f67dd2830d6.png)

Mobile (414px and 320px):
![Screen Shot 2020-11-02 at 11 58 18](https://user-images.githubusercontent.com/19548183/97865967-f4da0100-1d02-11eb-8525-f26e7dbbd4f3.png)

![Screen Shot 2020-11-02 at 11 58 40](https://user-images.githubusercontent.com/19548183/97865976-f73c5b00-1d02-11eb-860a-71d0f061a2bc.png)

