### PR TITLE
f-registration@v0.39.0

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Latest (to be added to next release)
 ------------------------------
+*November 3, 2020*
+
+### Changed
+- Added f-error-message for inline registration page errors
+
 *October 28, 2020*
 
 ### Added

--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (to be added to next release)
+v0.39.0
 ------------------------------
 *November 3, 2020*
 

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -41,27 +41,21 @@
                     label-style="inlineNarrow"
                     @blur="formFieldBlur('firstName')">
                     <template #error>
-                        <p
+                        <error-message
                             v-if="shouldShowFirstNameRequiredError"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-first-name-empty'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
+                            data-test-title='error-first-name-empty'>
                             {{ copy.validationMessages.firstName.requiredError }}
-                        </p>
-                        <p
+                        </error-message>
+                        <error-message
                             v-if="shouldShowFirstNameMaxLengthError"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-first-name-maxlength'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
+                            data-test-title='error-first-name-maxlength'>
                             {{ copy.validationMessages.firstName.maxLengthError }}
-                        </p>
-                        <p
+                        </error-message>
+                        <error-message
                             v-if="shouldShowFirstNameInvalidCharError"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-first-name-invalid'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
+                            data-test-title='error-first-name-invalid'>
                             {{ copy.validationMessages.firstName.invalidCharError }}
-                        </p>
+                        </error-message>
                     </template>
                 </form-field>
 
@@ -74,27 +68,21 @@
                     label-style="inlineNarrow"
                     @blur="formFieldBlur('lastName')">
                     <template #error>
-                        <p
+                        <error-message
                             v-if="shouldShowLastNameRequiredError"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-last-name-empty'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
+                            data-test-title='error-last-name-empty'>
                             {{ copy.validationMessages.lastName.requiredError }}
-                        </p>
-                        <p
+                        </error-message>
+                        <error-message
                             v-if="shouldShowLastNameMaxLengthError"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-last-name-maxlength'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
+                            data-test-title='error-last-name-maxlength'>
                             {{ copy.validationMessages.lastName.maxLengthError }}
-                        </p>
-                        <p
+                        </error-message>
+                        <error-message
                             v-if="shouldShowLastNameInvalidCharError"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-last-name-invalid'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
+                            data-test-title='error-last-name-invalid'>
                             {{ copy.validationMessages.lastName.invalidCharError }}
-                        </p>
+                        </error-message>
                     </template>
                 </form-field>
 
@@ -107,34 +95,26 @@
                     label-style="inlineNarrow"
                     @blur="formFieldBlur('email')">
                     <template #error>
-                        <p
+                        <error-message
                             v-if="shouldShowEmailRequiredError"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-email-empty'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
+                            data-test-title='error-email-empty'>
                             {{ copy.validationMessages.email.requiredError }}
-                        </p>
-                        <p
+                        </error-message>
+                        <error-message
                             v-else-if="shouldShowEmailInvalidError"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-email-invalid'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
+                            data-test-title='error-email-invalid'>
                             {{ copy.validationMessages.email.invalidEmailError }}
-                        </p>
-                        <p
+                        </error-message>
+                        <error-message
                             v-if="shouldShowEmailMaxLengthError"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-email-maxlength'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
+                            data-test-title='error-email-maxlength'>
                             {{ copy.validationMessages.email.maxLengthError }}
-                        </p>
-                        <p
+                        </error-message>
+                        <error-message
                             v-else-if="shouldShowEmailAlreadyExistsError"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-email-exists'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
+                            data-test-title='error-email-exists'>
                             {{ copy.validationMessages.email.alreadyExistsError }}
-                        </p>
+                        </error-message>
                     </template>
                 </form-field>
 
@@ -147,20 +127,16 @@
                     label-style="inlineNarrow"
                     @blur="formFieldBlur('password')">
                     <template #error>
-                        <p
+                        <error-message
                             v-if="shouldShowPasswordRequiredError"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-password-empty'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
+                            data-test-title='error-password-empty'>
                             {{ copy.validationMessages.password.requiredError }}
-                        </p>
-                        <p
+                        </error-message>
+                        <error-message
                             v-if="shouldShowPasswordMinLengthError"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-password-minlength'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
+                            data-test-title='error-password-minlength'>
                             {{ copy.validationMessages.password.minLengthError }}
-                        </p>
+                        </error-message>
                     </template>
                 </form-field>
 
@@ -207,6 +183,8 @@ import Card from '@justeat/f-card';
 import '@justeat/f-card/dist/f-card.css';
 import FormField from '@justeat/f-form-field';
 import '@justeat/f-form-field/dist/f-form-field.css';
+import ErrorMessage from '@justeat/f-error-message';
+import '@justeat/f-error-message/dist/f-error-message.css';
 import FormButton from './Button.vue';
 import tenantConfigs from '../tenants';
 import RegistrationServiceApi from '../services/RegistrationServiceApi';
@@ -247,7 +225,8 @@ export default {
         FormButton,
         FormField,
         WarningIcon,
-        BagCelebrateIcon
+        BagCelebrateIcon,
+        ErrorMessage
     },
 
     mixins: [validationMixin],

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -443,20 +443,6 @@ export default {
     @include font-size(body-l);
 }
 
-.o-form-error {
-    display: flex;
-    align-items: center;
-    color: $red;
-    @include font-size(body-s);
-    margin-top: spacing();
-}
-
-.o-form-error-icon {
-    width: 16px;
-    height: 16px;
-    margin-right: spacing(x0.5);
-}
-
 * + .o-form {
     margin-top: spacing(x2);
 }

--- a/packages/f-registration/test-utils/component-objects/f-registration.component.js
+++ b/packages/f-registration/test-utils/component-objects/f-registration.component.js
@@ -10,19 +10,19 @@ const privacyPolicyLink = () => registrationComponent().$('[data-test-id="privac
 const cookiesPolicyLink = () => registrationComponent().$('[data-test-id="cookies-policy-link"]');
 
 // Validation errors
-const firstNameEmptyError = () => $('[data-test-id="error-first-name-empty"]');
-const firstNameMaxLengthError = () => $('[data-test-id="error-first-name-maxlength"]');
-const firstNameInvalidError = () => $('[data-test-id="error-first-name-invalid"]');
+const firstNameEmptyError = () => $('[data-test-title="error-first-name-empty"]');
+const firstNameMaxLengthError = () => $('[data-test-title="error-first-name-maxlength"]');
+const firstNameInvalidError = () => $('[data-test-title="error-first-name-invalid"]');
 
-const lastNameEmptyError = () => $('[data-test-id="error-last-name-empty"]');
-const lastNameMaxLengthError = () => $('[data-test-id="error-last-name-maxlength"]');
-const lastNameInvalidError = () => $('[data-test-id="error-last-name-invalid"]');
+const lastNameEmptyError = () => $('[data-test-title="error-last-name-empty"]');
+const lastNameMaxLengthError = () => $('[data-test-title="error-last-name-maxlength"]');
+const lastNameInvalidError = () => $('[data-test-title="error-last-name-invalid"]');
 
-const emailEmptyError = () => $('[data-test-id="error-email-empty"]');
-const emailInvalidError = () => $('[data-test-id="error-email-invalid"]');
-const emailExistsError = () => $('[data-test-id="error-email-exists"]');
+const emailEmptyError = () => $('[data-test-title="error-email-empty"]');
+const emailInvalidError = () => $('[data-test-title="error-email-invalid"]');
+const emailExistsError = () => $('[data-test-title="error-email-exists"]');
 
-const passwordEmptyError = () => $('[data-test-id="error-password-empty"]');
+const passwordEmptyError = () => $('[data-test-title="error-password-empty"]');
 
 /**
  * @description


### PR DESCRIPTION
Added f-error-message to inline error messages in f-registration

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)
