### PR TITLE
f-checkout@0.8.0 Get necessary data from the CheckoutOrchestrator

### DIFF
--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.8.0
+------------------------------
+*November 4, 2020*
+
+### Added
+- Checkout component calls server to get data
+- Allergen modal
+- Messages list
+
+
 v0.6.0
 ------------------------------
 *November 2, 2020*

--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -9,8 +9,6 @@ v0.8.0
 
 ### Added
 - Checkout component calls server to get data
-- Allergen modal
-- Messages list
 
 
 v0.6.0

--- a/packages/f-checkout/package.json
+++ b/packages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.6.0",
+  "version": "0.8.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",
@@ -44,10 +44,11 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "axios": "0.20.0",
     "@justeat/f-card": "0.6.0",
     "@justeat/f-form-field": "0.7.1",
-    "@justeat/f-services": "1.0.0"
+    "@justeat/f-services": "1.0.0",
+    "axios": "0.20.0",
+    "axios-mock-adapter": "^1.19.0"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1"

--- a/packages/f-checkout/package.json
+++ b/packages/f-checkout/package.json
@@ -48,7 +48,7 @@
     "@justeat/f-form-field": "0.7.1",
     "@justeat/f-services": "1.0.0",
     "axios": "0.20.0",
-    "axios-mock-adapter": "^1.19.0"
+    "axios-mock-adapter": "1.19.0"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1"

--- a/packages/f-checkout/src/components/Address.vue
+++ b/packages/f-checkout/src/components/Address.vue
@@ -46,18 +46,16 @@ export default {
         labels: {
             type: Object,
             default: () => ({})
-        }
-    },
-
-    data () {
-        return {
-            address: {
+        },
+        address: {
+            type: Object,
+            default: () => ({
                 line1: null,
                 line2: null,
                 city: null,
                 postcode: null
-            }
-        };
+            })
+        }
     }
 };
 </script>

--- a/packages/f-checkout/src/components/Checkout.vue
+++ b/packages/f-checkout/src/components/Checkout.vue
@@ -59,7 +59,7 @@ import Card from '@justeat/f-card';
 import '@justeat/f-card/dist/f-card.css';
 import FormField from '@justeat/f-form-field';
 import '@justeat/f-form-field/dist/f-form-field.css';
-import { VALID_CHECKOUT_METHOD, CHECKOUT_METHOD_DELIVERY } from '../constants';
+import { VALID_CHECKOUT_METHOD, CHECKOUT_METHOD_DELIVERY, TENANT_MAP } from '../constants';
 import AddressBlock from './Address.vue';
 import FormSelector from './Selector.vue';
 import UserNote from './UserNote.vue';
@@ -142,7 +142,7 @@ export default {
         },
 
         title () {
-            return this.name ? `${this.name}, confirm your details` : '';
+            return `${this.name}, confirm your details`;
         },
 
         isDelivery () {
@@ -150,16 +150,7 @@ export default {
         },
 
         tenant () {
-            return {
-                'en-GB': 'uk',
-                'en-AU': 'au',
-                'en-NZ': 'nz',
-                'da-DK': 'dk',
-                'es-ES': 'es',
-                'en-IE': 'ie',
-                'it-IT': 'it',
-                'nb-NO': 'no'
-            }[this.locale];
+            return TENANT_MAP[this.locale];
         }
     },
 

--- a/packages/f-checkout/src/components/Checkout.vue
+++ b/packages/f-checkout/src/components/Checkout.vue
@@ -110,7 +110,7 @@ export default {
             isOpen: true,
             copy: { ...localeConfig },
             theme,
-            id: '',
+            checkoutId: '',
             isFulfillable: true,
             customer: {
                 dateOfBirth: '',
@@ -175,7 +175,7 @@ export default {
 
     methods: {
         mapResponse (data) {
-            this.id = data.id;
+            this.checkoutId = data.id;
             this.isFulfillable = data.isFulfillable;
             this.customer = data.customer;
             this.fulfillment.times = data.fulfillment.times;
@@ -186,6 +186,7 @@ export default {
                 city: data.fulfillment.address.lines[3],
                 postcode: data.fulfillment.address.postalCode
             };
+
             this.messages = data.messages;
             this.notes = data.notes;
             this.notices = data.notices;

--- a/packages/f-checkout/src/components/Selector.vue
+++ b/packages/f-checkout/src/components/Selector.vue
@@ -13,13 +13,14 @@
         <select
             id="time-selection"
             v-model="selectedTime"
+            @change="selectionChanged"
             :class="$style['o-form-select-input']"
             data-test-id="delivery-time">
             <option
                 v-for="(time, index) in times"
                 :key="index"
-                :value="time">
-                {{ time }}
+                :value="time.from">
+                {{ time.label.text }}
             </option>
         </select>
     </div>
@@ -30,7 +31,7 @@ export default {
     props: {
         times: {
             type: Array,
-            default: () => ['', 'As soon as possible', 'Today in 5 minutes']
+            default: () => []
         },
 
         orderMethod: {
@@ -43,6 +44,25 @@ export default {
         return {
             selectedTime: null
         };
+    },
+
+    watch: {
+        times (newValue) {
+            const selected = newValue.find(t => t.selected);
+            if (selected) {
+                this.selectedTime = selected.from;
+            }
+        }
+    },
+
+    methods: {
+        selectionChanged () {
+            this.times.forEach(el => { el.selected = false; });
+            const newSelected = this.times.find(t => t.from === this.selectedTime);
+            if (newSelected) {
+                newSelected.selected = true;
+            }
+        }
     }
 };
 </script>

--- a/packages/f-checkout/src/components/tests/Checkout.test.js
+++ b/packages/f-checkout/src/components/tests/Checkout.test.js
@@ -3,8 +3,10 @@ import { VALID_CHECKOUT_METHOD } from '../../constants';
 import VueCheckout from '../Checkout.vue';
 
 describe('Checkout', () => {
+    const checkoutUrl = '/checkout/uk/12345';
+
     it('should be defined', () => {
-        const propsData = { checkoutUrl: '/checkout/uk/12345' };
+        const propsData = { checkoutUrl };
         const wrapper = shallowMount(VueCheckout, { propsData });
         expect(wrapper.exists()).toBe(true);
     });
@@ -15,7 +17,7 @@ describe('Checkout', () => {
                 // Arrange
                 const propsData = {
                     checkoutMethod: definedType,
-                    checkoutUrl: '/checkout/uk/12345'
+                    checkoutUrl
                 };
 
                 // Act
@@ -30,7 +32,7 @@ describe('Checkout', () => {
                 // Arrange
                 const propsData = {
                     checkoutMethod: 'delivery',
-                    checkoutUrl: '/checkout/uk/12345'
+                    checkoutUrl
                 };
 
                 // Act
@@ -45,7 +47,7 @@ describe('Checkout', () => {
                 // Arrange
                 const propsData = {
                     checkoutMethod: 'collection',
-                    checkoutUrl: '/checkout/uk/12345'
+                    checkoutUrl
                 };
 
                 // Act
@@ -59,7 +61,7 @@ describe('Checkout', () => {
     });
 
     describe('computed ::', () => {
-        const propsData = { checkoutUrl: '/checkout/uk/12345' };
+        const propsData = { checkoutUrl };
         const data = { customer: { firstName: 'name' } };
 
         describe('name ::', () => {

--- a/packages/f-checkout/src/components/tests/Checkout.test.js
+++ b/packages/f-checkout/src/components/tests/Checkout.test.js
@@ -4,7 +4,7 @@ import VueCheckout from '../Checkout.vue';
 
 describe('Checkout', () => {
     it('should be defined', () => {
-        const propsData = {};
+        const propsData = { checkoutUrl: '/checkout/uk/12345' };
         const wrapper = shallowMount(VueCheckout, { propsData });
         expect(wrapper.exists()).toBe(true);
     });
@@ -14,7 +14,8 @@ describe('Checkout', () => {
             it.each(VALID_CHECKOUT_METHOD)('should update the Selector `ordermethod` attribute to match checkoutMethod=%p', definedType => {
                 // Arrange
                 const propsData = {
-                    checkoutMethod: definedType
+                    checkoutMethod: definedType,
+                    checkoutUrl: '/checkout/uk/12345'
                 };
 
                 // Act
@@ -25,10 +26,11 @@ describe('Checkout', () => {
                 expect(selectorComponent.attributes('ordermethod')).toEqual(definedType);
             });
 
-            it('should display the address block if set to `Delivery`', () => {
+            it('should display the address block if set to `delivery`', () => {
                 // Arrange
                 const propsData = {
-                    checkoutMethod: 'Delivery'
+                    checkoutMethod: 'delivery',
+                    checkoutUrl: '/checkout/uk/12345'
                 };
 
                 // Act
@@ -39,10 +41,11 @@ describe('Checkout', () => {
                 expect(addressBlock.exists()).toBe(true);
             });
 
-            it('should not display the address block if set to `Collection`', () => {
+            it('should not display the address block if set to `collection`', () => {
                 // Arrange
                 const propsData = {
-                    checkoutMethod: 'Collection'
+                    checkoutMethod: 'collection',
+                    checkoutUrl: '/checkout/uk/12345'
                 };
 
                 // Act
@@ -56,8 +59,8 @@ describe('Checkout', () => {
     });
 
     describe('computed ::', () => {
-        const propsData = {};
-        const data = { firstName: 'name' };
+        const propsData = { checkoutUrl: '/checkout/uk/12345' };
+        const data = { customer: { firstName: 'name' } };
 
         describe('name ::', () => {
             it('should capitalize `firstName` data', async () => {

--- a/packages/f-checkout/src/constants.js
+++ b/packages/f-checkout/src/constants.js
@@ -1,4 +1,4 @@
-export const CHECKOUT_METHOD_COLLECTION = 'Collection';
-export const CHECKOUT_METHOD_DELIVERY = 'Delivery';
+export const CHECKOUT_METHOD_COLLECTION = 'collection';
+export const CHECKOUT_METHOD_DELIVERY = 'delivery';
 
 export const VALID_CHECKOUT_METHOD = [CHECKOUT_METHOD_COLLECTION, CHECKOUT_METHOD_DELIVERY];

--- a/packages/f-checkout/src/constants.js
+++ b/packages/f-checkout/src/constants.js
@@ -2,3 +2,14 @@ export const CHECKOUT_METHOD_COLLECTION = 'collection';
 export const CHECKOUT_METHOD_DELIVERY = 'delivery';
 
 export const VALID_CHECKOUT_METHOD = [CHECKOUT_METHOD_COLLECTION, CHECKOUT_METHOD_DELIVERY];
+
+export const TENANT_MAP = {
+    'en-GB': 'uk',
+    'en-AU': 'au',
+    'en-NZ': 'nz',
+    'da-DK': 'dk',
+    'es-ES': 'es',
+    'en-IE': 'ie',
+    'it-IT': 'it',
+    'nb-NO': 'no'
+};

--- a/packages/f-checkout/src/demo/Index.vue
+++ b/packages/f-checkout/src/demo/Index.vue
@@ -8,12 +8,16 @@
             content="width=device-width, initial-scale=1">
         <vue-checkout
             locale="en-GB"
-            checkout-method="Delivery" />
+            checkout-url="checkout.json" />
     </div>
 </template>
 
 <script>
+
 import VueCheckout from '@/components/Checkout.vue';
+import CheckoutMock from './checkoutMock';
+
+CheckoutMock.setup('/checkout.json');
 
 export default {
     components: { VueCheckout }

--- a/packages/f-checkout/src/demo/checkout.json
+++ b/packages/f-checkout/src/demo/checkout.json
@@ -1,0 +1,78 @@
+{
+  "id": "12345",
+  "serviceType": "delivery",
+  "customer": {
+    "firstName": "Joe",
+    "lastName": "Bloggs",
+    "phoneNumber": "\u002B447111111111",
+    "dateOfBirth": "1980-01-30",
+    "emailAddress": "joe.bloggs@justeattakeaway.com"
+  },
+  "fulfillment": {
+    "times": [
+      {
+        "label": {
+          "text": "As soon as possible"
+        },
+        "from": "2020-01-01T00:00\u002B00:00",
+        "to": "2020-01-01T00:00\u002B00:00",
+        "selected": true
+      },
+      {
+        "label": {
+          "text": "Monday 00:15"
+        },
+        "from": "2020-01-01T00:15\u002B00:00",
+        "to": "2020-01-01T00:15\u002B00:00",
+        "selected": false
+      },
+      {
+        "label": {
+          "text": "Monday 00:30"
+        },
+        "from": "2020-01-01T00:30\u002B00:00",
+        "to": "2020-01-01T00:30\u002B00:00",
+        "selected": false
+      }
+    ],
+    "address": {
+      "lines": [
+        "1 Bristol Road",
+        "",
+        "",
+        "Bristol",
+        "Somerset"
+      ],
+      "postalCode": "BS1 1AA"
+    }
+  },
+  "notes": [
+    {
+      "type": "delivery",
+      "note": "Test note for delivery"
+    }
+  ],
+  "isFulfillable": true,
+  "notices": [
+    {
+      "type": "allergy",
+      "notice": {
+        "text": "If you have a food allergy or intolerance (or someone you\u0027re ordering for has), \u003Ca href=\u0022https://greggs.co.uk/nutrition\u0022 data-test-id=\u0022allergen-url-link\u0022 target=\u0022_blank\u0022 rel=\u0022noopener\u0022\u003Eread what this restaurant has to say about allergies\u003C/a\u003E before placing your order. Do not order if you cannot get the allergy information you need."
+      }
+    }
+  ],
+  "messages": [
+    {
+      "type": "warning",
+      "message": {
+        "text": "Please hurry, the restaurant is closing soon"
+      }
+    },
+    {
+      "type": "information",
+      "message": {
+        "text": "We\u0027re sorry, some items in your basket are no longer available"
+      }
+    }
+  ]
+}

--- a/packages/f-checkout/src/demo/checkoutMock.js
+++ b/packages/f-checkout/src/demo/checkoutMock.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import checkoutJson from './checkout.json';
+
+
+export default {
+    setup (path) {
+        const mock = new MockAdapter(axios);
+        mock.onGet(path).reply(200, checkoutJson);
+    }
+};

--- a/packages/f-checkout/src/demo/checkoutMock.js
+++ b/packages/f-checkout/src/demo/checkoutMock.js
@@ -2,7 +2,6 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import checkoutJson from './checkout.json';
 
-
 export default {
     setup (path) {
         const mock = new MockAdapter(axios);

--- a/packages/f-checkout/src/services/CheckoutServiceApi.js
+++ b/packages/f-checkout/src/services/CheckoutServiceApi.js
@@ -1,16 +1,16 @@
 import axios from 'axios';
 
 export default {
-    async getData (url, tenant, data) {
+    async getData (url, tenant, timeout) {
         const config = {
             method: 'get',
             headers: {
                 'Content-Type': 'application/json',
                 'Accept-Tenant': tenant
             },
-            timeout: 1000
+            timeout
         };
         return axios
-            .get(url, data, config);
+            .get(url, config);
     }
 };

--- a/packages/f-checkout/stories/Checkout.stories.js
+++ b/packages/f-checkout/stories/Checkout.stories.js
@@ -2,12 +2,16 @@ import { withTests } from '@storybook/addon-jest';
 import { VALID_CHECKOUT_METHOD, CHECKOUT_METHOD_COLLECTION } from '../src/constants';
 import VueCheckout from '../src/components/Checkout.vue';
 import results from '../src/components/tests/.jest-test-results.json';
+import CheckoutMock from '../src/demo/checkoutMock';
+
+CheckoutMock.setup('/checkout.json');
 
 export default {
     title: 'Components/Organisms',
     decorators: [withTests({ results })],
     argTypes: {
-        checkoutMethod: { control: { type: 'select', options: VALID_CHECKOUT_METHOD } }
+        checkoutMethod: { control: { type: 'select', options: VALID_CHECKOUT_METHOD } },
+        checkoutUrl: { control: { type: 'text' } },
     }
 };
 
@@ -15,7 +19,7 @@ export const Checkout = args => ({
     components: { VueCheckout },
     props: Object.keys(args),
     template:
-        '<vue-checkout :checkoutMethod="checkoutMethod" />'
+        '<vue-checkout :checkoutMethod="checkoutMethod" :checkout-url="checkoutUrl" />'
 });
 
 Checkout.parameters = {
@@ -25,5 +29,6 @@ Checkout.parameters = {
 Checkout.storyName = 'f-checkout';
 
 Checkout.args = {
-    checkoutMethod: CHECKOUT_METHOD_COLLECTION
+    checkoutMethod: CHECKOUT_METHOD_COLLECTION,
+    checkoutUrl: '/checkout.json'
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5423,7 +5423,7 @@ axios-mock-adapter@1.18.2:
     fast-deep-equal "^3.1.1"
     is-buffer "^2.0.3"
 
-axios-mock-adapter@^1.19.0:
+axios-mock-adapter@1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz#9d72e321a6c5418e1eff067aa99761a86c5188a4"
   integrity sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5423,6 +5423,14 @@ axios-mock-adapter@1.18.2:
     fast-deep-equal "^3.1.1"
     is-buffer "^2.0.3"
 
+axios-mock-adapter@^1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz#9d72e321a6c5418e1eff067aa99761a86c5188a4"
+  integrity sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    is-buffer "^2.0.3"
+
 axios@0.19.2, axios@^0.19.0, axios@^0.19.2:
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
@@ -10030,7 +10038,7 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==


### PR DESCRIPTION
Displays data populated from GET endpoint

v0.8.0
------------------------------
*November 4, 2020*

### Added
- Checkout component calls server to get data

---

## UI Review Checks
<img width="300" alt="Screenshot 2020-11-05 at 10 28 26" src="https://user-images.githubusercontent.com/6950110/98229409-c56d0380-1f51-11eb-91e4-ed6fe515ca8f.png">
<img width="300" alt="Screenshot 2020-11-05 at 10 28 58" src="https://user-images.githubusercontent.com/6950110/98229415-c867f400-1f51-11eb-8d30-11b857fa32f6.png">


- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)

