### PR TITLE
f-registration@0.39.1: added f-error-message to dependencies

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.39.1
+------------------------------
+*November 5, 2020*
+
+### Added
+- Added f-error-message into dependencies for f-registration
 
 v0.39.0
 ------------------------------

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",
@@ -48,6 +48,7 @@
     "@justeat/f-form-field": "0.7.1",
     "@justeat/f-services": "1.0.0",
     "@justeat/f-vue-icons": "1.3.0",
+    "@justeat/f-error-message": "0.2.0",
     "axios": "0.19.2",
     "vuelidate": "0.7.5"
   },


### PR DESCRIPTION
Adding in the missing dependency for `f-error-message` in `f-registration`
