### PR TITLE
generator-component@1.7.0

### DIFF
--- a/packages/generator-component/CHANGELOG.md
+++ b/packages/generator-component/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.7.0
+------------------------------
+*November 10, 2020*
+
+### Added
+- F-Globalisation wiring to the component template
+
+### Removed
+- Erroneous props in the story template
+
+
 v1.6.0
 ------------------------------
 *October 28, 2020*

--- a/packages/generator-component/README.md
+++ b/packages/generator-component/README.md
@@ -26,7 +26,7 @@
     npm install
     ```
 
-2.  Run the generator
+2.  Run the generator in '/packages'
 
     ```bash
     yo @justeat/component

--- a/packages/generator-component/generators/app/index.js
+++ b/packages/generator-component/generators/app/index.js
@@ -26,12 +26,6 @@ module.exports = class extends Generator {
                 name: 'needsTestingApiMocks',
                 type: 'confirm',
                 default: false
-            },
-            {
-                message: 'Does the component require localisation?',
-                name: 'needsLocalisation',
-                type: 'confirm',
-                default: true
             }
         ]);
     }

--- a/packages/generator-component/generators/app/index.js
+++ b/packages/generator-component/generators/app/index.js
@@ -26,6 +26,12 @@ module.exports = class extends Generator {
                 name: 'needsTestingApiMocks',
                 type: 'confirm',
                 default: false
+            },
+            {
+                message: 'Does the component require localisation?',
+                name: 'needsLocalisation',
+                type: 'confirm',
+                default: true
             }
         ]);
     }
@@ -50,7 +56,7 @@ module.exports = class extends Generator {
         }));
         let ignoreTestPattern = this.answers.needsComponentTests ? [] : ["**/*/test/specs/component", '**/*/test-utils/component-objects']
         const ignoreApiMockPattern = this.answers.needsTestingApiMocks ? [] : ["**/*/src/services"];
-    
+
         ignoreTestPattern = ignoreTestPattern.concat(ignoreApiMockPattern);
 
         const date = new Date();

--- a/packages/generator-component/generators/app/templates/__package__.json
+++ b/packages/generator-component/generators/app/templates/__package__.json
@@ -33,6 +33,7 @@
     "lint": "vue-cli-service lint",
     "lint:fix": "yarn lint --fix",
     "lint:style": "vue-cli-service lint:style",
+    "test": "vue-cli-service test:unit",
     "test-component:chrome": "run-p --race demo webdriver:delay:chrome",
     "test:wait-for-server": "node ../../test/infrastructure/healthcheck.js",
     "webdriver:delay:chrome": "yarn test:wait-for-server && yarn webdriver:start:chrome",
@@ -42,6 +43,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
+    "@justeat/f-globalisation": "0.1.0",
     "@justeat/f-services": "1.0.0"<% if(needsTestingApiMocks) { %>,
     "axios": "0.19.2"<% } %>
   },

--- a/packages/generator-component/generators/app/templates/src/components/Skeleton.vue
+++ b/packages/generator-component/generators/app/templates/src/components/Skeleton.vue
@@ -1,34 +1,27 @@
 <template>
     <div
-        :data-theme="theme"
+        data-theme="jet"
         :class="$style['c-<%= name.class %>']"
         data-test-id='<%= name.class %>-component'>
-        {{ copy.text }}
+        {{ $t('text') }}
     </div>
 </template>
 
 <script>
-import { globalisationServices } from '@justeat/f-services';
+import VueGlobalisation from '@justeat/f-globalisation';
 import tenantConfigs from '../tenants';<% if(needsTestingApiMocks) { %>
 import <%= name.filename%>ServiceApi from '../services/<%= name.filename%>ServiceApi';<%}%>
 
 export default {
     name: '<%= name.component %>',
-    components: {},
-    props: {
-        locale: {
-            type: String,
-            default: ''
-        }
-    },
-    data () {
-        const locale = globalisationServices.getLocale(tenantConfigs, this.locale, this.$i18n);
-        const localeConfig = tenantConfigs[locale];
-        const theme = globalisationServices.getTheme(locale);
 
+    components: {},
+
+    mixins: [VueGlobalisation],
+
+    data () {
         return {
-            copy: { ...localeConfig },
-            theme
+            tenantConfigs
         };
     }
 };

--- a/packages/generator-component/generators/app/templates/stories/Skeleton.__stories__.js
+++ b/packages/generator-component/generators/app/templates/stories/Skeleton.__stories__.js
@@ -2,8 +2,14 @@
 // import {
 //     withKnobs, select, boolean
 // } from '@storybook/addon-knobs';
+import { select, boolean } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
 import <%= name.component %> from '../src/components/<%= name.filename %>.vue';
+
+import {
+    VALID_LOCALES,
+    ENGLISH_LOCALE
+} from '../../storybook/constants/globalisation';
 
 export default {
     title: 'Components',
@@ -13,6 +19,9 @@ export default {
 export const <%= name.component %>Component = () => ({
     components: { <%= name.component %> },
     props: {
+        locale: {
+            default: select('Locale', VALID_LOCALES, ENGLISH_LOCALE)
+        },
         buttonType: {
             default: select('Button Type', ['primary', 'primaryAlt', 'secondary', 'tertiary', 'link'])
         },
@@ -20,7 +29,7 @@ export const <%= name.component %>Component = () => ({
             default: boolean('fullWidth', false)
         }
     },
-    template: `<<%= name.template %> />`
+    template: `<<%= name.template %> :locale="locale" />`
 });
 
 <%= name.component %>Component.storyName = 'f-<%= name.default %>';

--- a/packages/generator-component/generators/app/templates/stories/Skeleton.__stories__.js
+++ b/packages/generator-component/generators/app/templates/stories/Skeleton.__stories__.js
@@ -2,7 +2,7 @@
 // import {
 //     withKnobs, select, boolean
 // } from '@storybook/addon-knobs';
-import { select, boolean } from '@storybook/addon-knobs';
+import { select } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
 import <%= name.component %> from '../src/components/<%= name.filename %>.vue';
 
@@ -21,12 +21,6 @@ export const <%= name.component %>Component = () => ({
     props: {
         locale: {
             default: select('Locale', VALID_LOCALES, ENGLISH_LOCALE)
-        },
-        buttonType: {
-            default: select('Button Type', ['primary', 'primaryAlt', 'secondary', 'tertiary', 'link'])
-        },
-        fullWidth: {
-            default: boolean('fullWidth', false)
         }
     },
     template: `<<%= name.template %> :locale="locale" />`

--- a/packages/generator-component/package.json
+++ b/packages/generator-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/generator-component",
   "description": "Generator Component – A generator for Fozzie components",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "files": [
     "generators"
   ],


### PR DESCRIPTION
This Pull Request updates the Generator Component to consume the new F-Globalisation service, which wires up the localisation of messages within components.

**Changes to the generator that affect new components...**
- A prop called `locale` is added to component stories; so out of the box you can change languages in storybook
- A dependency to F-Globalisation is added
- Existing copy mechanism is replaced by Vue-I18n capabilities like `$t`

<hr>

_This is what a component looks like now out of the box._
![image](https://user-images.githubusercontent.com/10741583/98681988-4580d800-235b-11eb-850c-387ed56cc3b9.png)