### PR TITLE
f-globalisation@0.2.0 - Export a wrap of vue-i18n

### DIFF
--- a/services/f-globalisation/CHANGELOG.md
+++ b/services/f-globalisation/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.2.0
+------------------------------
+*November 10, 2020*
+
+### Added
+- Provided a wrapper around the vue-i18n module for component tests to import
+
 
 v0.1.0
 ------------------------------

--- a/services/f-globalisation/README.md
+++ b/services/f-globalisation/README.md
@@ -28,10 +28,10 @@
     F-Globalisation contains a mixin which should be imported into your "Smart Component", for example in F-Checkout import it into the Checkout.vue component as that is the root.
 
     ```
-    import VueGlobalisation from '@justeat/f-globalisation';
+    import { VueGlobalisationMixin } from '@justeat/f-globalisation';
 
     export default {
-        mixins: [VueGlobalisation]
+        mixins: [VueGlobalisationMixin]
     }
     ```
 
@@ -43,7 +43,7 @@
     import tenantConfigs from '../tenants';
 
     export default {
-        mixins: [globalisationMixin],
+        mixins: [VueGlobalisationMixin],
 
         data () {
             return {

--- a/services/f-globalisation/package.json
+++ b/services/f-globalisation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-globalisation",
   "description": "Fozzie Globalisation – A utility which wires up vue-i18n within your Smart Component",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/f-globalisation.umd.min.js",
   "files": [
     "dist"
@@ -34,13 +34,15 @@
   "browserslist": [
     "extends @justeat/browserslist-config-fozzie"
   ],
+  "dependencies": {
+    "vue-i18n": "8.0.0"
+  },
   "devDependencies": {
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
     "@vue/test-utils": "1.0.3",
-    "vue": "2.6.10",
-    "vue-i18n": "8.0.0"
+    "vue": "2.6.10"
   }
 }

--- a/services/f-globalisation/src/index.js
+++ b/services/f-globalisation/src/index.js
@@ -6,13 +6,14 @@
 
 
 // Import vue component
-import VueGlobalisation from '@/mixins/globalisation.mixin.vue';
+import VueI18n from 'vue-i18n';
+import VueGlobalisationMixin from './mixins/globalisation.mixin.vue';
 
 // Declare install function executed by Vue.use()
 export function install (Vue) {
     if (install.installed) return;
     install.installed = true;
-    Vue.mixin('VueGlobalisation', VueGlobalisation);
+    Vue.mixin('VueGlobalisation', VueGlobalisationMixin);
 }
 
 // Create module definition for Vue.use()
@@ -32,4 +33,7 @@ if (GlobalVue) {
 }
 
 // To allow use as module (npm/webpack/etc.) export component
-export default VueGlobalisation;
+export {
+    VueGlobalisationMixin,
+    VueI18n
+};


### PR DESCRIPTION
> Although components don't need to initialise Vue-I18n, as this is the concern of the web host; our component tests still require the package as they have no web host to install it.

This pull request imports and exports vue-i18n, this means that tests within components using F-Globalisation do not need to install it themselves, and we will always have the same version in use across component tests.

### Added
- Provided a wrapper around the vue-i18n module for component tests to import