### PR TITLE
f-error-message@0.3.0 - Update Icon to display inline with text

### DIFF
--- a/packages/f-error-message/CHANGELOG.md
+++ b/packages/f-error-message/CHANGELOG.md
@@ -3,14 +3,25 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.3.0
+------------------------------
+*November 11, 2020*
+
+### Changed
+- Icon from `Warning Icon` to `Danger Icon`.
+
+### Added
+- Styling to display icon inline with text for multiline messages.
+
 
 v0.2.0
 ------------------------------
 *October 26, 2020*
 
-### Added
+
 - Built out functionality
 - Added unit tests
+
 
 v0.1.0
 ------------------------------

--- a/packages/f-error-message/CHANGELOG.md
+++ b/packages/f-error-message/CHANGELOG.md
@@ -18,7 +18,7 @@ v0.2.0
 ------------------------------
 *October 26, 2020*
 
-
+### Added
 - Built out functionality
 - Added unit tests
 

--- a/packages/f-error-message/CHANGELOG.md
+++ b/packages/f-error-message/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.3.0
 ------------------------------
-*November 11, 2020*
+*November 12, 2020*
 
 ### Changed
 - Icon from `Warning Icon` to `Danger Icon`.

--- a/packages/f-error-message/package.json
+++ b/packages/f-error-message/package.json
@@ -37,7 +37,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-vue-icons": "1.0.0"
+    "@justeat/f-vue-icons": "1.10.0"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1"

--- a/packages/f-error-message/package.json
+++ b/packages/f-error-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-error-message",
   "description": "Fozzie Error Message – Generic inline error message",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/f-error-message.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-error-message/src/components/ErrorMessage.vue
+++ b/packages/f-error-message/src/components/ErrorMessage.vue
@@ -52,7 +52,6 @@ export default {
 .c-errorMessage-icon {
     position: absolute;
     width: 16px;
-    line-height: 20px;
     margin-top: 2px;
 }
 </style>

--- a/packages/f-error-message/src/components/ErrorMessage.vue
+++ b/packages/f-error-message/src/components/ErrorMessage.vue
@@ -52,6 +52,7 @@ export default {
     width: 16px;
     line-height: 20px;
     margin-right: spacing();
+    margin-top: 2px;
     float: left;
 }
 

--- a/packages/f-error-message/src/components/ErrorMessage.vue
+++ b/packages/f-error-message/src/components/ErrorMessage.vue
@@ -36,8 +36,8 @@ export default {
 </script>
 
 <style lang="scss" module>
-
 .c-errorMessage {
+    position: relative;
     color: $color-text--danger;
     @include font-size(base);
     margin-top: spacing();
@@ -46,14 +46,13 @@ export default {
 .c-errorMessage-content {
     display: block;
     overflow: hidden;
+    margin-left: spacing(x3);
 }
 
 .c-errorMessage-icon {
+    position: absolute;
     width: 16px;
     line-height: 20px;
-    margin-right: spacing();
     margin-top: 2px;
-    float: left;
 }
-
 </style>

--- a/packages/f-error-message/src/components/ErrorMessage.vue
+++ b/packages/f-error-message/src/components/ErrorMessage.vue
@@ -4,20 +4,22 @@
         :class="$style['c-errorMessage']"
         data-test-id="error-message"
         :data-test-title="dataTestTitle">
-        <warning-icon :class="$style['c-errorMessage-icon']" />
-        <span data-test-id="content">
+        <danger-icon :class="$style['c-errorMessage-icon']" />
+        <span
+            data-test-id="content"
+            :class="$style['c-errorMessage-content']">
             <slot />
         </span>
     </p>
 </template>
 
 <script>
-import { WarningIcon } from '@justeat/f-vue-icons';
+import { DangerIcon } from '@justeat/f-vue-icons';
 
 export default {
     name: 'ErrorMessage',
     components: {
-        WarningIcon
+        DangerIcon
     },
     props: {
         dataTestTitle: {
@@ -36,17 +38,21 @@ export default {
 <style lang="scss" module>
 
 .c-errorMessage {
-    display: flex;
-    align-items: center;
     color: $color-text--danger;
     @include font-size(base);
     margin-top: spacing();
 }
 
+.c-errorMessage-content {
+    display: block;
+    overflow: hidden;
+}
+
 .c-errorMessage-icon {
     width: 16px;
-    height: 16px;
-    margin-right: spacing(x0.5);
+    line-height: 20px;
+    margin-right: spacing();
+    float: left;
 }
 
 </style>

--- a/packages/f-error-message/stories/ErrorMessage.stories.js
+++ b/packages/f-error-message/stories/ErrorMessage.stories.js
@@ -13,7 +13,7 @@ export const ErrorMessageComponent = () => ({
     components: { ErrorMessage },
     props: {},
     template:
-        '<error-message>Your phone number should be at least 10 characters long and shouldn\'t contain letters or special characters</error-message>'
+        '<error-message>Default error message</error-message>'
 });
 
 ErrorMessageComponent.storyName = 'f-error-message';

--- a/packages/f-error-message/stories/ErrorMessage.stories.js
+++ b/packages/f-error-message/stories/ErrorMessage.stories.js
@@ -1,8 +1,8 @@
 import {
     withKnobs, boolean, select, text
 } from '@storybook/addon-knobs';
-import ErrorMessage from '../src/components/ErrorMessage.vue';
 import { withA11y } from '@storybook/addon-a11y';
+import ErrorMessage from '../src/components/ErrorMessage.vue';
 
 export default {
     title: 'Components/Atoms',
@@ -13,7 +13,7 @@ export const ErrorMessageComponent = () => ({
     components: { ErrorMessage },
     props: {},
     template:
-        '<error-message>Default error message</error-message>'
+        '<error-message>Your phone number should be at least 10 characters long and shouldn\'t contain letters or special characters</error-message>'
 });
 
 ErrorMessageComponent.storyName = 'f-error-message';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,6 +1663,13 @@
   dependencies:
     qwery "4.0.0"
 
+"@justeat/f-error-message@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-error-message/-/f-error-message-0.2.0.tgz#5c8831681b6e64c13e51800c7489bbb7f632d3e0"
+  integrity sha512-U6lyk1UbjQJEfdzl926SlwV8b0JY35XuMRWiJ0/BLxYR6UZm+OlWY8NGdiiZHfAL4eoXUYaS2kwxzzJDjEw+Jg==
+  dependencies:
+    "@justeat/f-vue-icons" "1.0.0"
+
 "@justeat/f-form-field@0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-0.7.1.tgz#789f5e9f342f964b9cc5f985fc162c616dbf192f"
@@ -1742,6 +1749,13 @@
   version "1.0.0-beta.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-1.0.0-beta.0.tgz#4d0765efda51ed78b5cd6a377fcea02b343dc1ff"
   integrity sha512-CkvBhv9pJMY/qqbYAu1c2buLcyfGfR8LbGGmIUh8LdTf+P1UvPi5868N+7W5pKStNRD2WOOK5Oo6TBRLMgt1Pg==
+
+"@justeat/f-vue-icons@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.0.0.tgz#368bf02d1f2befe623342e41ae14dce24c62ee79"
+  integrity sha512-nIF9q0B9V3Bra7SgFWtCM8KtlcpnMwoLN1EDfT2tK7Zciv+HW1vPSjTR2DX29qTQZ4Qkf2bo2b73dtypaqr5vg==
+  dependencies:
+    babel-helper-vue-jsx-merge-props "2.0.3"
 
 "@justeat/f-vue-icons@1.2.0":
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,6 +1725,14 @@
     lodash-es "4.17.15"
     window-or-global "1.0.1"
 
+"@justeat/f-services@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-1.3.0.tgz#0165f7fe3f69e0b6e6388bce7194e080bbfc9445"
+  integrity sha512-OTFFi7gBBzDphpUse2bcBo36nk+F+J4pEo/yivxdTrUEVYE6zcSht+ZRD+t4T7cncRDIue7AaCADdKpGIOhD2Q==
+  dependencies:
+    lodash-es "4.17.15"
+    window-or-global "1.0.1"
+
 "@justeat/f-utils@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-1.0.0.tgz#d4f38f6c2b2992fefa39789f1ce742dc083798b1"
@@ -1734,13 +1742,6 @@
   version "1.0.0-beta.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-1.0.0-beta.0.tgz#4d0765efda51ed78b5cd6a377fcea02b343dc1ff"
   integrity sha512-CkvBhv9pJMY/qqbYAu1c2buLcyfGfR8LbGGmIUh8LdTf+P1UvPi5868N+7W5pKStNRD2WOOK5Oo6TBRLMgt1Pg==
-
-"@justeat/f-vue-icons@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.0.0.tgz#368bf02d1f2befe623342e41ae14dce24c62ee79"
-  integrity sha512-nIF9q0B9V3Bra7SgFWtCM8KtlcpnMwoLN1EDfT2tK7Zciv+HW1vPSjTR2DX29qTQZ4Qkf2bo2b73dtypaqr5vg==
-  dependencies:
-    babel-helper-vue-jsx-merge-props "2.0.3"
 
 "@justeat/f-vue-icons@1.2.0":
   version "1.2.0"


### PR DESCRIPTION
### Changed
- Icon from `Warning Icon` to `Danger Icon`.

### Added
- Styling to display icon inline with text for multiline messages.
---

## UI Review Checks

**f-error-message**
| **Multiline message** | **Single line message** |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/24740015/98824509-4da84880-242b-11eb-8bd3-83158094e750.png) | ![image](https://user-images.githubusercontent.com/24740015/98824636-72042500-242b-11eb-9930-357539fe184f.png) |

**Designs**
| **Multiline message** | **Single line message** |
| -- | -- |
![image](https://user-images.githubusercontent.com/24740015/98822091-4469ac80-2428-11eb-9ab3-2068ba937659.png) | ![image](https://user-images.githubusercontent.com/24740015/98822048-3582fa00-2428-11eb-8a13-7b3f24c3c570.png) 


