### PR TITLE
#trivial - Enable Vue Dev Tools in Storybook

### DIFF
--- a/packages/storybook/README.md
+++ b/packages/storybook/README.md
@@ -12,6 +12,10 @@ Storybook runs outside of your app. This allows you to develop UI components in 
 `yarn storybook:deploy`
 
 
+### Using the Vue Dev tools
+To use the Vue Dev tools you need to open the canvas in a new tab (using the link in the top right of Storybook).
+
+
 
 
 ## More Info

--- a/packages/storybook/config/storybook/preview.js
+++ b/packages/storybook/config/storybook/preview.js
@@ -5,6 +5,8 @@ import { ENGLISH_LOCALE } from '../../constants/globalisation';
 
 Vue.use(VueI18n);
 
+Vue.config.devtools = true;
+
 const i18n = new VueI18n({
     locale: ENGLISH_LOCALE,
     fallbackLocale: ENGLISH_LOCALE,


### PR DESCRIPTION
This uses the new `preview.js` file to turn on dev tools within Storybook.

You need to "Open the Canvas in a new Tab" to allow the dev tools to detect the component; there is a bug within Storybook thats existed for a long time which means it doesn't work in the same panel.

![image](https://user-images.githubusercontent.com/10741583/98938923-8e15ce00-24e0-11eb-9446-84643e20ff46.png)

Then it works
![image](https://user-images.githubusercontent.com/10741583/98938967-9ec64400-24e0-11eb-8bb6-3b75892b8fb1.png)
