### PR TITLE
f-error-message@v0.3.1 – Fixes reference to old `base` variable

### DIFF
--- a/packages/f-error-message/CHANGELOG.md
+++ b/packages/f-error-message/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.3.1
+------------------------------
+*November 12, 2020*
+
+### Fixed
+- Reference to old `base` variable in font-size mixin.
+
+
 v0.3.0
 ------------------------------
 *November 12, 2020*

--- a/packages/f-error-message/package.json
+++ b/packages/f-error-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-error-message",
   "description": "Fozzie Error Message – Generic inline error message",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "dist/f-error-message.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-error-message/src/components/ErrorMessage.vue
+++ b/packages/f-error-message/src/components/ErrorMessage.vue
@@ -39,7 +39,7 @@ export default {
 .c-errorMessage {
     position: relative;
     color: $color-text--danger;
-    @include font-size(base);
+    @include font-size();
     margin-top: spacing();
 }
 


### PR DESCRIPTION
### Fixed
- Reference to old `base` variable in font-size mixin.