### PR TITLE
f-button@v0.1.1 – Updating prop name `isFullWidth`

### DIFF
--- a/packages/f-button/CHANGELOG.md
+++ b/packages/f-button/CHANGELOG.md
@@ -4,8 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (to be added to next release)
+v0.1.1
 ------------------------------
+*November 12, 2020*
+
+### Fixed
+- Changed prop to be called `isFullWidth` rather than `fullWidth` to match convention.
+
 *October 23, 2020*
 
 ### Added

--- a/packages/f-button/package.json
+++ b/packages/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/f-button.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-button/src/components/Button.vue
+++ b/packages/f-button/src/components/Button.vue
@@ -4,7 +4,7 @@
             $style['o-btn'],
             $style[`o-btn--${buttonType}`],
             $style[`o-btn--size${buttonSizeClassname}`],
-            (fullWidth ? $style['o-btn--fullWidth'] : '')
+            (isFullWidth ? $style['o-btn--fullWidth'] : '')
         ]"
         data-test-id='button-component'>
         <slot />
@@ -25,7 +25,7 @@ export default {
             type: String,
             default: 'medium'
         },
-        fullWidth: {
+        isFullWidth: {
             type: Boolean,
             default: false
         }

--- a/packages/f-button/stories/Button.stories.js
+++ b/packages/f-button/stories/Button.stories.js
@@ -18,11 +18,11 @@ export const ButtonComponent = () => ({
         buttonSize: {
             default: select('Button Size', ['xsmall', 'small', 'medium', 'large'], 'medium')
         },
-        fullWidth: {
-            default: boolean('fullWidth', false)
+        isFullWidth: {
+            default: boolean('isFullWidth', false)
         }
     },
-    template: '<vue-button :buttonType="buttonType" :buttonSize="buttonSize" :fullWidth="fullWidth">Default Button Text</vue-button>'
+    template: '<vue-button :buttonType="buttonType" :buttonSize="buttonSize" :isFullWidth="isFullWidth">Default Button Text</vue-button>'
 });
 
 ButtonComponent.storyName = 'f-button';


### PR DESCRIPTION
### Fixed
- Changed prop to be called `isFullWidth` rather than `fullWidth` to match convention.

### Added
- Stylelint added to lint styling on build.
