### PR TITLE
Exclude a11y / component tests when running jest on generated components. #trivial

### DIFF
--- a/packages/generator-component/generators/app/templates/jest.config.js
+++ b/packages/generator-component/generators/app/templates/jest.config.js
@@ -35,5 +35,10 @@ module.exports = {
 
     setupFilesAfterEnv: [
         '../../jest.setup.js'
-    ]
+    ],
+
+    modulePathIgnorePatterns: [
+        './test/specs/accessibility/',
+        './test/specs/component/',
+    ],
 };

--- a/packages/generator-component/jest.config.js
+++ b/packages/generator-component/jest.config.js
@@ -22,7 +22,8 @@ module.exports = {
     ],
 
     modulePathIgnorePatterns: [
-        './test/specs/accessibility/'
+        './test/specs/accessibility/',
+        './test/specs/component/'
     ],
 
     setupFilesAfterEnv: [

--- a/packages/generator-component/jest.config.js
+++ b/packages/generator-component/jest.config.js
@@ -22,8 +22,7 @@ module.exports = {
     ],
 
     modulePathIgnorePatterns: [
-        './test/specs/accessibility/',
-        './test/specs/component/'
+        './test/specs/accessibility/'
     ],
 
     setupFilesAfterEnv: [


### PR DESCRIPTION
- Exclude a11y / component tests when running jest on generated components.