### PR TITLE
fozzie-components@v2.16.0 – Making `sassOptions` vue config reusable #globalconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.16.0
+------------------------------
+*November 17, 2020*
+
+### Updated
+- Splitting out `sassOptions` config to allow Eyeglass includes, so all components can use the same config.
+
+
 v2.15.0
 ------------------------------
 *November 12, 2020*

--- a/config/sassOptions.js
+++ b/config/sassOptions.js
@@ -1,0 +1,21 @@
+const magicImporter = require('node-sass-magic-importer');
+const eyeglass = require('eyeglass');
+
+module.exports = function init (rootDir) {
+    const sassOptions = eyeglass({
+        eyeglass: {
+            root: rootDir
+        },
+        includePaths: ['node_modules/'],
+        sourceMap: true
+    });
+
+    sassOptions.importer = [
+        magicImporter({
+            cwd: rootDir
+        }),
+        sassOptions.importer
+    ];
+
+    return sassOptions;
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.17.0
+------------------------------
+*November 17, 2020*
+
+### Changed
+- Moved `sassOptions` config out of the Storybook `vue.config.js` so that it can be used by other components.
+
+
 v0.16.0
 ------------------------------
 *November 16, 2020*

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "scripts": {
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -s public -p 6006 -c config/storybook"

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -1,23 +1,8 @@
-const magicImporter = require('node-sass-magic-importer');
 const path = require('path');
-const eyeglass = require('eyeglass');
 
 const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../config/sassOptions')(rootDir);
 
-const sassOptions = eyeglass({
-    eyeglass: {
-        root: rootDir
-    },
-    includePaths: ['node_modules/'],
-    sourceMap: true
-});
-
-sassOptions.importer = [
-    magicImporter({
-        cwd: rootDir
-    }),
-    sassOptions.importer
-];
 
 // vue.config.js
 module.exports = {
@@ -55,6 +40,7 @@ module.exports = {
 @import "@justeat/fozzie/src/scss/fozzie";
 @include reset();
 @include typography();
+@include links();
 @import "${relPath}";`;
                 }
             });


### PR DESCRIPTION
### Updated
- Splitting out `sassOptions` config to allow Eyeglass includes, so all components can use the same config.