### PR TITLE
f-button@v0.2.0 - Added hover and active states for primary large button

### DIFF
--- a/packages/f-button/CHANGELOG.md
+++ b/packages/f-button/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.2.0
+------------------------------
+*November 17, 2020*
+
+### Added
+- `background-colour` for `:hover` and `:active` states for primary large buttons.
+
+
 v0.1.1
 ------------------------------
 *November 12, 2020*

--- a/packages/f-button/package.json
+++ b/packages/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "main": "dist/f-button.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-button/src/components/Button.vue
+++ b/packages/f-button/src/components/Button.vue
@@ -267,6 +267,13 @@ $btn-sizeXSmall-lineHeight      : 1;
 
     &.o-btn--primary {
         background-color: $orange;
+
+        &:hover {
+            background-color: $orange--dark;
+        }
+        &:active {
+            background-color: $orange--darkest;
+        }
     }
 }
 


### PR DESCRIPTION
### Added
- `background-colour` for `:hover` and `:active` states for primary large buttons.

---

## UI Review Checks

- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
