### PR TITLE
f-registration@v0.41.0 – Hover state updates

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.41.0
+------------------------------
+*November 18, 2020*
+
+### Added
+- Underline for link `:hover` and `:focus` states.
+
+### Changed
+- Updating `f-button` to pull in new hover states.
+
+
 v0.40.0
 ------------------------------
 *November 17, 2020*

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",
@@ -44,7 +44,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-button": "0.1.1",
+    "@justeat/f-button": "0.2.0",
     "@justeat/f-card": "0.7.0",
     "@justeat/f-error-message": "0.3.1",
     "@justeat/f-form-field": "1.1.0",

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -483,6 +483,11 @@ $registration-icon-height--narrow : 74px;
             // TODO: check default link styles in PIE and update fozzie // (should be able to remove these styles then)
             text-decoration: none;
             font-weight: $font-weight-bold;
+
+            &:hover,
+            &:focus {
+                text-decoration: underline;
+            }
         }
     }
 


### PR DESCRIPTION
### Added
- Underline for link `:hover` and `:focus` states.

### Changed
- Updating `f-button` to pull in new hover states.

---

## UI Review Checks

- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
