### PR TITLE
f-card@v0.9.0 - Updating `pageContentWrapper` width

### DIFF
--- a/packages/f-card/CHANGELOG.md
+++ b/packages/f-card/CHANGELOG.md
@@ -3,15 +3,24 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.9.0
+------------------------------
+*November 18, 2020*
+
+### Changed
+- `pageContentWrapper` width, so that it sits on our 8px grid.
+
+
 v0.8.0
 ------------------------------
 *October 26, 2020*
 
 ### Added
 - Stylelint added to lint styling on build.
-- data-test IDs to Card Component 
+- data-test IDs to Card Component
 - Test for Card
-- Card Component-Object 
+- Card Component-Object
 
 ### Changed
 - 'jet' theme instead of 'je'

--- a/packages/f-card/package.json
+++ b/packages/f-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card",
   "description": "Fozzie Card Component – Used for providing wrapper card styling to an element (or group of elements)",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "dist/f-card.umd.min.js",
   "files": [
     "dist"
@@ -31,7 +31,7 @@
     "lint": "vue-cli-service lint --no-fix",
     "lint:fix": "yarn lint --fix",
     "lint:style": "vue-cli-service lint:style",
-    "test": "vue-cli-service test:unit", 
+    "test": "vue-cli-service test:unit",
     "test-component:chrome": "run-p --race demo webdriver:delay:chrome",
     "test:wait-for-server": "node ../../test/infrastructure/healthcheck.js",
     "webdriver:delay:chrome": "yarn test:wait-for-server && yarn webdriver:start:chrome",

--- a/packages/f-card/src/components/Card.vue
+++ b/packages/f-card/src/components/Card.vue
@@ -78,7 +78,7 @@ $card-borderColor                         : $color-border;
 $card-borderRadius                        : $border-radius;
 $card-padding                             : spacing(x2);
 
-$card--pageContentWrapper-width           : 460px;
+$card--pageContentWrapper-width           : 472px; // so that it falls on our 8px spacing grid
 
 .c-card {
     background-color: $card-bgColor;


### PR DESCRIPTION
### Changed
- `pageContentWrapper` width, so that it sits on our 8px grid.

---

## Browsers Tested

- [x] Chrome (latest)
