### PR TITLE
f-registration@v0.42.0 - Adding box-shadow and spacing tweaks

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.42.0
+------------------------------
+*November 18, 2020*
+
+### Added
+- `box-shadow` around component card.
+
+### Changed
+- Some minor spacing tweaks.
+
+
 v0.41.0
 ------------------------------
 *November 18, 2020*

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -12,7 +12,10 @@
             <bag-celebrate-icon :class="$style['c-registration-icon']" />
             <p
                 v-if="showLoginLink"
-                :class="$style['c-registration-link']"
+                :class="[
+                    $style['c-registration-link'],
+                    $style['c-registration-link--subtitle']
+                ]"
                 data-test-id="create-account-login-link"
                 @click="visitLoginPage">
                 <a :href="copy.navLinks.login.url">{{ copy.navLinks.login.text }}</a>
@@ -440,13 +443,17 @@ $registration-icon-height--narrow : 74px;
 
 // Form styling
 .c-registration {
-    margin-top: 100px;
+    margin-top: 112px;
 }
 
     .c-registration-card {
         position: relative;
-        padding-top: spacing(x5);
+        padding-top: spacing(x7);
         padding-bottom: spacing(x6);
+        // TODO: box shadow value will eventually come from PIE design tokens, but hard coding here for now
+        box-shadow: 0 1px 1px 0 rgba($black, 0.03),
+                    0 2px 1px -1px rgba($black, 0.07),
+                    0 1px 3px 0 rgba($black, 0.06);
 
         @include media('<mid') {
             padding-bottom: spacing(x4);
@@ -468,12 +475,12 @@ $registration-icon-height--narrow : 74px;
     }
 
     .c-registration-form {
-        margin-top: spacing(x2);
+        margin-top: spacing(x3);
     }
 
     .c-registration-submit {
         margin-top: spacing(x4);
-        margin-bottom: spacing(x3);
+        margin-bottom: spacing(x4);
     }
 
     .c-registration-link {
@@ -490,5 +497,8 @@ $registration-icon-height--narrow : 74px;
             }
         }
     }
+        .c-registration-link--subtitle {
+            margin-top: - spacing(); // shift the subtitle link closer to the main title
+        }
 
 </style>

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -450,13 +450,16 @@ $registration-icon-height--narrow : 74px;
         position: relative;
         padding-top: spacing(x7);
         padding-bottom: spacing(x6);
-        // TODO: box shadow value will eventually come from PIE design tokens, but hard coding here for now
-        box-shadow: 0 1px 1px 0 rgba($black, 0.03),
-                    0 2px 1px -1px rgba($black, 0.07),
-                    0 1px 3px 0 rgba($black, 0.06);
 
         @include media('<mid') {
             padding-bottom: spacing(x4);
+        }
+
+        @include media('>=narrow') {
+            // TODO: box shadow value will eventually come from PIE design tokens, but hard coding here for now
+            box-shadow: 0 1px 1px 0 rgba($black, 0.03),
+                    0 2px 1px -1px rgba($black, 0.07),
+                    0 1px 3px 0 rgba($black, 0.06);
         }
     }
 
@@ -497,6 +500,7 @@ $registration-icon-height--narrow : 74px;
             }
         }
     }
+
         .c-registration-link--subtitle {
             margin-top: - spacing(); // shift the subtitle link closer to the main title
         }


### PR DESCRIPTION
### Added
- `box-shadow` around component card.

### Changed
- Some minor spacing tweaks.

---

## UI Review Checks

<img width="695" alt="Screen Shot 2020-11-18 at 11 32 06" src="https://user-images.githubusercontent.com/805184/99525454-be061b00-2991-11eb-8531-c6e02846cf60.png">

- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
