### PR TITLE
f-content-cards@2.1.1 🐞 Bugfix: braze card data correctly handled

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.1.1
+------------------------------
+*November 18, 2020*
+
+### Fixed
+- HomePromoCard 1 & 2 render out content background colour correctly
+- HomePromoCard 1 & 2 separates description lines into paragraph tags
+- transformCardData now preserves brand_name as provided by braze
+
+
 v2.1.0
 ------------------------------
 *September 29, 2020*

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
@@ -46,7 +46,7 @@ export default {
             ctaText,
             button,
             backgroundColor,
-            contentContainerBackground,
+            contentBackgroundColor,
             type,
             icon,
             title,
@@ -57,7 +57,7 @@ export default {
         return {
             title,
             backgroundColor,
-            contentContainerBackground,
+            contentBackgroundColor,
             image,
             ctaText,
             button,

--- a/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
@@ -2,12 +2,17 @@
     <div
         :data-test-id="testId"
         :class="['c-contentCards-homePromotionCard2', $style['c-contentCards-homePromotionCard2']]"
-        :style="{ background: contentContainerBackground }">
+        :style="{ background: contentBackgroundColor }">
         <div
             :class="['c-contentCards-homePromotionCard2-image', $style['c-contentCards-homePromotionCard2-image']]"
             :style="{ backgroundImage: `url('${image}')` }" />
         <h3>{{ title }}</h3>
-        <p>{{ description }}</p>
+        <template v-for="(textItem, textIndex) in description">
+            <p
+                :key="textIndex">
+                {{ textItem }}
+            </p>
+        </template>
         <p v-if="url">
             <a
                 :href="url"
@@ -33,7 +38,7 @@ export default {
         const {
             image,
             ctaText,
-            contentContainerBackground,
+            contentBackgroundColor,
             title,
             url,
             description
@@ -41,7 +46,7 @@ export default {
 
         return {
             title,
-            contentContainerBackground,
+            contentBackgroundColor,
             image,
             ctaText,
             url,

--- a/packages/f-content-cards/src/services/utils/transformCardData.js
+++ b/packages/f-content-cards/src/services/utils/transformCardData.js
@@ -22,6 +22,7 @@ const transformCardData = card => {
 
     const {
         background_color: backgroundColor,
+        brand_name: brandName,
         content_container_background: contentBackgroundColor,
         banner,
         button_1: ctaText = linkText,
@@ -54,6 +55,7 @@ const transformCardData = card => {
 
     return {
         backgroundColor,
+        brandName,
         contentBackgroundColor,
         banner,
         ctaText,


### PR DESCRIPTION
Creating a hotfix branch for issues flagged in the current 2.1.0 release of `f-content-cards`

Note: This is merging into non-master as it branches from a point further back in the history to meet expectations for the currently consumed version of the package - the changes here will also be merged back into master, but needs some further changes to cope with the latest version of the module.