### PR TITLE
f-searchbox - Fix jest config. #trivial

### DIFF
--- a/packages/f-searchbox/jest.config.js
+++ b/packages/f-searchbox/jest.config.js
@@ -38,13 +38,9 @@ module.exports = {
         './test/specs/accessibility/'
     ],
 
-    modulePathIgnorePatterns: [
-        './test/specs/*'
-    ],
-
     setupFilesAfterEnv: [
         '../../jest.setup.js'
-    ], 
+    ],
 
 
 };


### PR DESCRIPTION
Dup `modulePathIgnorePatterns` key, removed the old one.