### PR TITLE
f-form-field@1.3.0 - Add focus state to text fields and dropdown

### DIFF
--- a/packages/f-form-field/CHANGELOG.md
+++ b/packages/f-form-field/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.3.0
+------------------------------
+*November 20, 2020*
+
+### Added
+- Focus and Active styles for `text`, `password`, `dropdown, and `email` inputs.
+
+### Changed
+- Inline label `font-weight` and `color`.
+
+
 v1.2.0
 ------------------------------
 *November 19, 2020*

--- a/packages/f-form-field/CHANGELOG.md
+++ b/packages/f-form-field/CHANGELOG.md
@@ -8,7 +8,7 @@ v1.3.0
 *November 20, 2020*
 
 ### Added
-- Focus and Active styles for `text`, `password`, `dropdown, and `email` inputs.
+- Focus and Active styles for `text`, `password`, `dropdown`, and `email` inputs.
 
 ### Changed
 - Inline label `font-weight` and `color`.

--- a/packages/f-form-field/package.json
+++ b/packages/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-form-field/src/components/FormDropdown.vue
+++ b/packages/f-form-field/src/components/FormDropdown.vue
@@ -56,14 +56,15 @@ export default {
 }
 
 .c-formDropdown-select {
-    padding: spacing(x1.5) spacing(x2);
+    padding: 0 spacing(x2);
     height: 100%;
     width: 100%;
+    font: inherit;
+    background: inherit;
+    outline: none;
 
     /* Remove default styling */
     border: none;
     appearance: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
 }
 </style>

--- a/packages/f-form-field/src/components/FormField.vue
+++ b/packages/f-form-field/src/components/FormField.vue
@@ -26,7 +26,8 @@
                 :data-test-id="testId"
                 :class="[
                     $style['o-form-field'],
-                    $style['c-formField-input']
+                    $style['c-formField-input'],
+                    $style['c-formField-input-textFields--focus']
                 ]"
                 :dropdown-options="dropdownOptions"
                 @update="updateOption"
@@ -43,7 +44,9 @@
                 :class="[
                     $style['o-form-field'],
                     $style['c-formField-input'],
-                    $style['c-formField-input--textField']
+                    $style['c-formField-input-textField'], {
+                        [$style['c-formField-input-textFields--focus']]: isTextField
+                    }
                 ]"
                 @input="updateValue"
                 v-on="listeners"
@@ -186,6 +189,10 @@ export default {
 
         isDropdown () {
             return this.inputType === 'dropdown';
+        },
+
+        isTextField () {
+            return !(this.inputType === 'radio' || this.inputType === 'checkbox');
         }
     },
 
@@ -231,6 +238,7 @@ $form-input-borderColour--disabled        : $color-disabled;
 $form-input-height                        : 46px; // height is 46px + 1px border = 48px
 $form-input-padding                       : spacing(x1.5) spacing(x2);
 $form-input-fontSize                      : 'body-l';
+$form-input-focus                         : $blue--light;
 
 .c-formField {
     & + & {
@@ -241,8 +249,17 @@ $form-input-fontSize                      : 'body-l';
         position: relative;
     }
 
-    .c-formField-input--textField {
+    .c-formField-input-textField {
         padding: $form-input-padding;
+    }
+
+    .c-formField-input-textFields--focus {
+        &:focus,
+        &:active,
+        &:focus-within {
+            box-shadow: 0 0 0 2pt $form-input-focus;
+            outline: none;
+        }
     }
 
     .c-formField-input {
@@ -277,4 +294,5 @@ $form-input-fontSize                      : 'body-l';
             }
         }
     }
+
 </style>

--- a/packages/f-form-field/src/components/FormField.vue
+++ b/packages/f-form-field/src/components/FormField.vue
@@ -27,7 +27,7 @@
                 :class="[
                     $style['o-form-field'],
                     $style['c-formField-input'],
-                    $style['c-formField-input-textFields--focus']
+                    $style['c-formField-input-inputFields--focus']
                 ]"
                 :dropdown-options="dropdownOptions"
                 @update="updateOption"
@@ -45,7 +45,7 @@
                     $style['o-form-field'],
                     $style['c-formField-input'],
                     $style['c-formField-input-textField'], {
-                        [$style['c-formField-input-textFields--focus']]: isTextField
+                        [$style['c-formField-input-inputFields--focus']]: isInputField
                     }
                 ]"
                 @input="updateValue"
@@ -191,7 +191,7 @@ export default {
             return this.inputType === 'dropdown';
         },
 
-        isTextField () {
+        isInputField () {
             return !(this.inputType === 'radio' || this.inputType === 'checkbox');
         }
     },
@@ -253,7 +253,7 @@ $form-input-focus                         : $blue--light;
         padding: $form-input-padding;
     }
 
-    .c-formField-input-textFields--focus {
+    .c-formField-input-inputFields--focus {
         &:focus,
         &:active,
         &:focus-within {

--- a/packages/f-form-field/src/components/FormLabel.vue
+++ b/packages/f-form-field/src/components/FormLabel.vue
@@ -37,9 +37,13 @@ export default {
 
 <style lang="scss" module>
 
-$form-label-colour    : $grey--darkest; // Text colour of form labels
-$form-label-fontSize  : 'body-s';
-$form-label-weight    : $font-weight-bold;
+$form-label-colour              : $grey--darkest; // Text colour of form labels
+$form-label-colour-inline       : $grey--dark;
+$form-label-fontSize            : 'body-s';
+$form-label-weight              : $font-weight-bold;
+$form-label-weight-inline       : $font-weight-base;
+$form-label-padding             : spacing(x1.5) spacing(x2);
+
 
 .c-formField-label {
     display: block;
@@ -52,8 +56,11 @@ $form-label-weight    : $font-weight-bold;
 .c-formField-label--inline {
     position: absolute;
     top: 50%;
-    left: 0.5rem;
     transform: translateY(-50%);
+    @include font-size($form-label-fontSize);
+    font-weight: $form-label-weight-inline;
+    color: $form-label-colour-inline;
+    padding: $form-label-padding;
     margin-bottom: 0;
     cursor: text; // make the cursor the same as the default input hover cursor
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,6 +1655,11 @@
   resolved "https://registry.yarnpkg.com/@justeat/browserslist-config-fozzie/-/browserslist-config-fozzie-1.1.1.tgz#8f27a7b683f7c40469b6ff4049384370ae6530fc"
   integrity sha512-Ypr/5NqRlQyWqLqTOA29DawRQJ3EA5wctVvKsqHgLXo47ikW+A9nNeloySTnu6La5QUjXSw/FTJxyfnuTxkqBg==
 
+"@justeat/browserslist-config-fozzie@>=1.1.1":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@justeat/browserslist-config-fozzie/-/browserslist-config-fozzie-1.2.0.tgz#52d46d15c2ce8168c803af3135326554c81c27c6"
+  integrity sha512-hChL9H75HzClJJb3+Xbl/EvJLOUV6cXYNciUZN2TNwsGpBUj39l+YbN+d/r4Or+0o7qFshtoTjLL+Wn9HccCqw==
+
 "@justeat/eslint-config-fozzie@3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@justeat/eslint-config-fozzie/-/eslint-config-fozzie-3.4.1.tgz#1c6b2348d39bf0ee9e732630be0fee35e24111b9"


### PR DESCRIPTION
### Added
- Focus and Active styles for `text`, `password`, `dropdown`, and `email` inputs.

### Changed
- Inline label `font-weight` and `color`.

## UI Review Checks
**Inline label styles**
![image](https://user-images.githubusercontent.com/24740015/99696092-36e69f00-2a86-11eb-855d-17d9ad39c649.png)

**Text fields and dropdown focus**
![image](https://user-images.githubusercontent.com/24740015/99696212-5b427b80-2a86-11eb-9cca-13758a0d18ef.png)
