### PR TITLE
f-registration@v0.43.0 – Fixed margin issue on mobile & generic error

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -12,6 +12,9 @@ v0.43.0
 - Margin at top of component updated for narrow widths.
 - De-capitalised `name` on form labels.
 
+### Fixed
+- Generic error message updated to use `f-error-message` component.
+
 
 v0.42.0
 ------------------------------

--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.43.0
+------------------------------
+*November 20, 2020*
+
+### Changed
+- Margin at top of component updated for narrow widths.
+- De-capitalised `name` on form labels.
+
+
 v0.42.0
 ------------------------------
 *November 18, 2020*

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -436,6 +436,8 @@ export default {
 
 <style lang="scss" module>
 
+$registration-topMargin           : spacing() * 14;
+$registration-topMargin--narrow   : spacing(x9);
 $registration-icon-width          : 97px;
 $registration-icon-width--narrow  : 92px;
 $registration-icon-height         : 78px;
@@ -443,7 +445,11 @@ $registration-icon-height--narrow : 74px;
 
 // Form styling
 .c-registration {
-    margin-top: 112px;
+    margin-top: $registration-topMargin--narrow;
+
+    @include media('>mid') {
+        margin-top: $registration-topMargin;
+    }
 }
 
     .c-registration-card {

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -29,12 +29,12 @@
                 @submit.prevent="onFormSubmit"
             >
                 <!-- TODO WCB-1031 - Extract error messages into a separate component -->
-                <p
+                <error-message
                     v-if="genericErrorMessage"
-                    :class="$style['o-form-error']">
-                    <warning-icon :class="$style['o-form-error-icon']" />
+                    :class="$style['c-registration-genericError']">
+                    >
                     {{ genericErrorMessage }}
-                </p>
+                </error-message>
                 <form-field
                     v-model="firstName"
                     name="firstName"
@@ -179,7 +179,7 @@ import {
     minLength,
     maxLength
 } from 'vuelidate/lib/validators';
-import { WarningIcon, BagCelebrateIcon } from '@justeat/f-vue-icons';
+import { BagCelebrateIcon } from '@justeat/f-vue-icons';
 import ButtonComponent from '@justeat/f-button';
 import '@justeat/f-button/dist/f-button.css';
 import CardComponent from '@justeat/f-card';
@@ -226,7 +226,6 @@ export default {
         ButtonComponent,
         CardComponent,
         FormField,
-        WarningIcon,
         BagCelebrateIcon,
         ErrorMessage
     },
@@ -485,6 +484,11 @@ $registration-icon-height--narrow : 74px;
 
     .c-registration-form {
         margin-top: spacing(x3);
+    }
+
+    .c-registration-genericError {
+        margin-top: 0;
+        margin-bottom: spacing(x2);
     }
 
     .c-registration-submit {

--- a/packages/f-registration/src/tenants/en-GB.js
+++ b/packages/f-registration/src/tenants/en-GB.js
@@ -28,8 +28,8 @@ export default {
     labels: {
         createAccountTitle: 'Create account',
         createAccountBtn: 'Create account',
-        firstName: 'First Name',
-        lastName: 'Last Name',
+        firstName: 'First name',
+        lastName: 'Last name',
         email: 'Email',
         password: 'Password'
     },


### PR DESCRIPTION
### Changed
- Margin at top of component updated for narrow widths.
- De-capitalised `name` on form labels.

### Fixed
- Generic error message updated to use `f-error-message` component.

---

## UI Review Checks

- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] iPhone X
