### PR TITLE
f-content-cards@2.1.3 Fixes display times handling

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.1.3
+------------------------------
+*November 23, 2020*
+
+### Fixed
+- isCardCurrentlyActive now respects displayTimes JSON as specified
+
+
 v2.1.2
 ------------------------------
 *November 19, 2020*

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/src/services/utils/_tests/isCardCurrentlyActive.test.js
+++ b/packages/f-content-cards/src/services/utils/_tests/isCardCurrentlyActive.test.js
@@ -56,10 +56,12 @@ describe('services › utils › transformCardData', () => {
         const date = Date.parse('14 Sep 2020 13:00:00 GMT');
         MockDate.set(date);
         const displayTimes = {
-            Mon: {
-                start: '09:00',
-                end: '17:00'
-            }
+            Mon: [
+                {
+                    Start: '09:00',
+                    End: '17:00'
+                }
+            ]
         };
 
         // Act
@@ -74,10 +76,12 @@ describe('services › utils › transformCardData', () => {
         const date = Date.parse('14 Sep 2020 13:00:00 GMT');
         MockDate.set(date);
         const displayTimes = {
-            Any: {
-                start: '09:00',
-                end: '17:00'
-            }
+            Any: [
+                {
+                    Start: '09:00',
+                    End: '17:00'
+                }
+            ]
         };
 
         // Act
@@ -92,10 +96,18 @@ describe('services › utils › transformCardData', () => {
         const date = Date.parse('14 Sep 2020 08:00:00 GMT');
         MockDate.set(date);
         const displayTimes = {
-            Mon: {
-                start: '12:00',
-                end: '17:00'
-            }
+            Mon: [
+                {
+                    Start: '12:00',
+                    End: '17:00'
+                }
+            ],
+            Any: [
+                {
+                    Start: '05:00',
+                    End: '07:00'
+                }
+            ]
         };
 
         // Act

--- a/packages/f-content-cards/src/services/utils/isCardCurrentlyActive.js
+++ b/packages/f-content-cards/src/services/utils/isCardCurrentlyActive.js
@@ -18,14 +18,18 @@ const isCardCurrentlyActive = (card = {}, brands = []) => {
 
     const now = new Date();
     const currentDay = format(now, 'E');
-    const { start, end } = displayTimes[currentDay] || displayTimes.All || {};
+    const times = displayTimes[currentDay] || displayTimes.Any || [];
 
-    if (!start || !end) return true;
+    return !(times instanceof Array)
+        || times.length === 0
+        || times.some(({ Start: start, End: end }) => {
+            if (!start || !end) return true;
 
-    const startTime = parse(start, 'HH:mm', now);
-    const endTime = parse(end, 'HH:mm', now);
+            const startTime = parse(start, 'HH:mm', now);
+            const endTime = parse(end, 'HH:mm', now);
 
-    return isAfter(now, startTime) && isBefore(now, endTime);
+            return isAfter(now, startTime) && isBefore(now, endTime);
+        });
 };
 
 export default isCardCurrentlyActive;


### PR DESCRIPTION
v2.1.3
------------------------------
*November 23, 2020*

Hopefully the last fix required to get Home promotion cards working as specified on the homepage. Once this is confirmed working, I'll prepare a merge of the content-cards 2.1.x hotfix branch back into master, which will require some of the changes to be ported across to f-metadata.

### Fixed
- isCardCurrentlyActive now respects displayTimes JSON as specified