### PR TITLE
f-form-field@v1.4.0 - Update dropdown and inline label

### DIFF
--- a/packages/f-form-field/CHANGELOG.md
+++ b/packages/f-form-field/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.4.0
+------------------------------
+*November 30, 2020*
+
+### Changed
+- `padding` and `font-size` for inline label.
+- `fill` for dropdown arrow, `color` and `bacgkround` hover state.
+
 v1.3.0
 ------------------------------
 *November 20, 2020*

--- a/packages/f-form-field/CHANGELOG.md
+++ b/packages/f-form-field/CHANGELOG.md
@@ -9,7 +9,7 @@ v1.4.0
 
 ### Changed
 - `padding` and `font-size` for inline label.
-- `fill` for dropdown arrow, `color` and `bacgkround` hover state.
+- `fill` for dropdown arrow, `color` and `background` hover state.
 
 v1.3.0
 ------------------------------

--- a/packages/f-form-field/package.json
+++ b/packages/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-form-field/src/components/FormDropdown.vue
+++ b/packages/f-form-field/src/components/FormDropdown.vue
@@ -53,6 +53,10 @@ export default {
     right: spacing(x3);
     bottom: 20px;
     transform: rotate(180deg);
+
+    path {
+        fill: $grey--dark;
+    }
 }
 
 .c-formDropdown-select {
@@ -60,7 +64,8 @@ export default {
     height: 100%;
     width: 100%;
     font: inherit;
-    background: inherit;
+    color: inherit;
+    background: transparent;
     outline: none;
 
     /* Remove default styling */

--- a/packages/f-form-field/src/components/FormLabel.vue
+++ b/packages/f-form-field/src/components/FormLabel.vue
@@ -40,10 +40,10 @@ export default {
 $form-label-colour              : $grey--darkest; // Text colour of form labels
 $form-label-colour-inline       : $grey--dark;
 $form-label-fontSize            : 'body-s';
+$form-label-fontSize-inline     : 'body-l';
 $form-label-weight              : $font-weight-bold;
 $form-label-weight-inline       : $font-weight-base;
-$form-label-padding             : spacing(x1.5) spacing(x2);
-
+$form-label-padding             : spacing(x1.5);
 
 .c-formField-label {
     display: block;
@@ -57,10 +57,11 @@ $form-label-padding             : spacing(x1.5) spacing(x2);
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    @include font-size($form-label-fontSize);
+    @include font-size($form-label-fontSize-inline);
     font-weight: $form-label-weight-inline;
     color: $form-label-colour-inline;
     padding: $form-label-padding;
+    left: 1px;  // Adds pixel to match `FormField` border
     margin-bottom: 0;
     cursor: text; // make the cursor the same as the default input hover cursor
 }


### PR DESCRIPTION
### Changed
- `padding` and `font-size` for inline label.
- `fill` for dropdown arrow, `color` and `background` hover state.