### PR TITLE
f-content-cards@2.2.0-beta.7 - minor change to remove last of legacy styles from the content cards

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.2.0-beta.7
+------------------------------
+*November 30, 2020*
+
+### Changed
+- Minor change to remove last of legacy styles in the content card container
+
+
 v2.2.0-beta.6
 ------------------------------
 *November 25, 2020*

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -25,10 +25,7 @@
                 :class="$style['c-contentCard-thumbnail']">
             <div :class="$style['c-content-card-body']">
                 <h3
-                    :class="[$style['c-contentCard-title'], {
-                        [$style['c-contentCard-title-legacy']]: !shouldEmboldenTitle,
-                        [$style['c-emboldenedText--title']]: shouldEmboldenText
-                    }]">
+                    :class="[$style['c-contentCard-title']]">
                     {{ title }}
                 </h3>
                 <h4 :class="[$style['c-contentCard-subTitle'], { [$style['c-emboldenedText--subtitle']]: shouldEmboldenText }]">
@@ -250,10 +247,6 @@ export default {
         display: -webkit-box; /* stylelint-disable-line value-no-vendor-prefix */
         -webkit-line-clamp: 2; // stop at 2 lines
         -webkit-box-orient: vertical;
-    }
-
-    .c-contentCard-title-legacy {
-        font-weight: normal;
     }
 
     .c-contentCard-subTitle {


### PR DESCRIPTION
Minor changes to remove some last remaining legacy styles.
