### PR TITLE
f-metadata@3.0.0-beta.6 🎫 Handles unset card orders gracefully

### DIFF
--- a/packages/f-metadata/CHANGELOG.md
+++ b/packages/f-metadata/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.0.0-beta.6
+------------------------------
+*November 30, 2020*
+
+### Fixed
+- Where cards do not have an order, they are assigned one of `9e9` for ordering, preventing
+  erroneous ordering.
+
+
 v3.0.0-beta.5
 ------------------------------
 *November 23, 2020*

--- a/packages/f-metadata/package.json
+++ b/packages/f-metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-metadata",
   "description": "Fozzie Metadata Component",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.6",
   "main": "src/index.js",
   "files": [
     "src"

--- a/packages/f-metadata/src/services/_tests/contentCard.service.test.js
+++ b/packages/f-metadata/src/services/_tests/contentCard.service.test.js
@@ -33,6 +33,40 @@ describe('`contentCardService`', () => {
             // Assert
             expect(cardOrderValues).toEqual(['1', '3', '4']);
         });
+
+        it('should handle cards without `order` value by pinning them to the back', () => {
+            // Arrange
+            const cards = [
+                {
+                    title: 'Stephenson 2-18',
+                    extras: { }
+                },
+                {
+                    title: 'Kepler‑10b',
+                    extras: { order: '4' }
+                },
+                {
+                    title: 'Kepler‑69c',
+                    extras: { order: '3' }
+                },
+                {
+                    title: 'UY Scuti',
+                    extras: { }
+                },
+                {
+                    title: 'Kepler‑186f',
+                    extras: { order: '1' }
+                }
+            ];
+            const service = new ContentCardService({ cards });
+
+            // Act
+            const { cards: result } = service.orderCardsByOrderValue().output();
+            const cardOrderValues = result.map(({ order }) => order);
+
+            // Assert
+            expect(cardOrderValues).toEqual(['1', '3', '4', undefined, undefined]);
+        });
     });
 
     describe('`orderCardsByUpdateValue`, method', () => {

--- a/packages/f-metadata/src/services/contentCard.service.js
+++ b/packages/f-metadata/src/services/contentCard.service.js
@@ -5,6 +5,12 @@ import transformCardData from './utils/transformCardData';
 import isCardCurrentlyActive from './utils/isCardCurrentlyActive';
 
 /**
+ * A 'large number' to force cards without an order to be ordered to the back
+ * @type {number}
+ */
+const DEFAULT_ORDER_VALUE = 9e9;
+
+/**
  * List of enabled card types
  *
  * @type {string[]}
@@ -68,7 +74,12 @@ class ContentCards {
      * @returns {ContentCards}
      */
     orderCardsByOrderValue () {
-        this.cards.sort(({ order: a }, { order: b }) => +a - +b);
+        this.cards.sort((
+            { order: a = DEFAULT_ORDER_VALUE },
+            { order: b = DEFAULT_ORDER_VALUE }
+        ) => (
+            +a - +b
+        ));
         return this;
     }
 


### PR DESCRIPTION
v3.0.0-beta.6
------------------------------
*November 30, 2020*

### Fixed
- Where cards do not have an order, they are assigned one of `9e9` for ordering, preventing
  erroneous ordering.

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

