### PR TITLE
f-content-cards@2.2.0-beta.8 💾 Bumps `@justeat/f-metadata` version

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.2.0-beta.8
+------------------------------
+*November 30, 2020*
+
+### Changed
+- Bumped `@justeat/f-metadata` version
+
+
 v2.2.0-beta.7
 ------------------------------
 *November 30, 2020*

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@justeat/f-vue-icons": "1.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
-    "@justeat/f-metadata": "3.0.0-beta.5",
+    "@justeat/f-metadata": "3.0.0-beta.6",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",


### PR DESCRIPTION
f-content-cards@v2.2.0-beta.8
------------------------------
*November 30, 2020*

### Changed
- Bumped `@justeat/f-metadata` version

