### PR TITLE
f-alert@0.3.0 - Add prop control to f-alert demo file for WebDriverIO component tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.20.0
+------------------------------
+*November 30, 2020*
+
+### Added
+- `demo-controls-helper.js` to contain any shared functions for controlling props values in WebDriverIO tests
+
 v2.19.0
 ------------------------------
 *November 24, 2020*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v2.20.0
 ### Added
 - `demo-controls-helper.js` to contain any shared functions for controlling props values in WebDriverIO tests
 
+
 v2.19.0
 ------------------------------
 *November 24, 2020*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",

--- a/packages/f-alert/CHANGELOG.md
+++ b/packages/f-alert/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.3.0
+------------------------------
+*November 30, 2020*
+
+### Added
+- Ability to change prop values in demo file for WebDriverIO component tests.
+- New `demo-controls.js` component object for f-alert controls.
+
+
 v0.2.0
 ------------------------------
 *October 26, 2020*

--- a/packages/f-alert/package.json
+++ b/packages/f-alert/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-alert",
   "description": "Fozzie Alert – Fozzie Alert Component",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/f-alert.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-alert/src/components/Alert.vue
+++ b/packages/f-alert/src/components/Alert.vue
@@ -19,7 +19,7 @@
                 {{ heading }}
             </h2>
             <button
-                v-if="isDismissable"
+                v-if="isDismissible"
                 type="button"
                 :class="[$style['c-alert-dismiss'], 'o-btn o-btn--icon']"
                 data-test-id="alert-dismiss"
@@ -73,7 +73,7 @@ export default {
             type: String,
             required: true
         },
-        isDismissable: {
+        isDismissible: {
             type: Boolean,
             default: false
         }

--- a/packages/f-alert/src/components/tests/Alert.test.js
+++ b/packages/f-alert/src/components/tests/Alert.test.js
@@ -55,9 +55,9 @@ describe('Alert', () => {
     });
 
     describe('dismiss', () => {
-        it('should render the dismiss button if `isDismissable` is true', () => {
+        it('should render the dismiss button if `isDismissible` is true', () => {
             // Arrange
-            const wrapper = shallowMount(VueAlert, { propsData: { ...defaultPropsData, isDismissable: true } });
+            const wrapper = shallowMount(VueAlert, { propsData: { ...defaultPropsData, isDismissible: true } });
 
             // Act
             const dismiss = wrapper.find('[data-test-id="alert-dismiss"]');
@@ -66,9 +66,9 @@ describe('Alert', () => {
             expect(dismiss.exists()).toBe(true);
         });
 
-        it('should not render the dismiss button if `isDismissable` is false', () => {
+        it('should not render the dismiss button if `isDismissible` is false', () => {
             // Arrange
-            const wrapper = shallowMount(VueAlert, { propsData: { ...defaultPropsData, isDismissable: false } });
+            const wrapper = shallowMount(VueAlert, { propsData: { ...defaultPropsData, isDismissible: false } });
 
             // Act
             const dismiss = wrapper.find('[data-test-id="alert-dismiss"]');
@@ -82,7 +82,7 @@ describe('Alert', () => {
             const dismissSpy = jest.spyOn(VueAlert.methods, 'dismiss');
 
             const wrapper = shallowMount(VueAlert, {
-                propsData: { ...defaultPropsData, isDismissable: true }
+                propsData: { ...defaultPropsData, isDismissible: true }
             });
 
             // Act

--- a/packages/f-alert/src/demo/Index.vue
+++ b/packages/f-alert/src/demo/Index.vue
@@ -43,9 +43,9 @@
             <label for="is-dismissable">Is Dismissable</label>
             <input
                 id="is-dismissable"
-                v-model="controls.isDismissable"
+                v-model="controls.isDismissible"
                 type="checkbox"
-                data-test-id='control-isDismissable'>
+                data-test-id='control-isDismissible'>
             <br>
             <label for="heading">Heading</label>
             <input
@@ -54,11 +54,10 @@
                 type="text"
                 data-test-id='control-heading'>
         </div>
-
         <vue-alert
             :locale='controls.locale'
             :type="controls.alertType"
-            :is-dismissable="controls.isDismissable"
+            :is-dismissible="controls.isDismissible"
             :heading="controls.heading">
             You can put any HTML here!
         </vue-alert>
@@ -74,7 +73,7 @@ export default {
         controls: {
             locale: 'en-GB',
             alertType: 'success',
-            isDismissable: true,
+            isDismissible: true,
             heading: 'Title of the alert'
         }
     })

--- a/packages/f-alert/src/demo/Index.vue
+++ b/packages/f-alert/src/demo/Index.vue
@@ -9,24 +9,50 @@
         <div data-test-id="component-controls">
             <h1>Component Controls</h1>
             <label for='locale'>Locale</label>
-            <select name='locale' data-test-id='control-locale' v-model="controls.locale">
-                <option value='en-GB'>en-GB</option>
-                <option value='en-AU'>en-AU</option>
+            <select
+                v-model="controls.locale"
+                name='locale'
+                data-test-id='control-locale'>
+                <option value='en-GB'>
+                    en-GB
+                </option>
+                <option value='en-AU'>
+                    en-AU
+                </option>
             </select>
             <br>
             <label for='alert-type'>Alert Type</label>
-            <select name='alert-type' data-test-id='control-alertType' v-model="controls.alertType">
-                <option value='success'>success</option>
-                <option value='warning'>warning</option>
-                <option value='danger'>danger</option>
-                <option value='info'>info</option>
+            <select
+                v-model="controls.alertType"
+                name='alert-type'
+                data-test-id='control-alertType'>
+                <option value='success'>
+                    success
+                </option>
+                <option value='warning'>
+                    warning
+                </option>
+                <option value='danger'>
+                    danger
+                </option>
+                <option value='info'>
+                    info
+                </option>
             </select>
             <br>
             <label for="is-dismissable">Is Dismissable</label>
-            <input id="is-dismissable" type="checkbox" data-test-id='control-isDismissable' v-model="controls.isDismissable">
+            <input
+                id="is-dismissable"
+                v-model="controls.isDismissable"
+                type="checkbox"
+                data-test-id='control-isDismissable'>
             <br>
             <label for="heading">Heading</label>
-            <input id="heading" type="text" data-test-id='control-heading' v-model='controls.heading'> 
+            <input
+                id="heading"
+                v-model='controls.heading'
+                type="text"
+                data-test-id='control-heading'>
         </div>
 
         <vue-alert
@@ -61,8 +87,8 @@ body {
 }
 
 .component-controls {
-    color: #ffffff;
+    color: #fff;
     font-family: 'Helvetica Neue', sans-serif;
-    background-color:#ffa500;
+    background-color: #ffa500;
 }
 </style>

--- a/packages/f-alert/src/demo/Index.vue
+++ b/packages/f-alert/src/demo/Index.vue
@@ -40,7 +40,7 @@
                 </option>
             </select>
             <br>
-            <label for="is-dismissible">Is Dismissable</label>
+            <label for="is-dismissible">Is Dismissible</label>
             <input
                 id="is-dismissible"
                 v-model="controls.isDismissible"

--- a/packages/f-alert/src/demo/Index.vue
+++ b/packages/f-alert/src/demo/Index.vue
@@ -11,48 +11,48 @@
             <label for='locale'>Locale</label>
             <select
                 v-model="controls.locale"
-                name='locale'
-                data-test-id='control-locale'>
-                <option value='en-GB'>
+                name="locale"
+                data-test-id="control-locale">
+                <option value="en-GB">
                     en-GB
                 </option>
-                <option value='en-AU'>
+                <option value="en-AU">
                     en-AU
                 </option>
             </select>
             <br>
-            <label for='alert-type'>Alert Type</label>
+            <label for="alert-type">Alert Type</label>
             <select
                 v-model="controls.alertType"
-                name='alert-type'
-                data-test-id='control-alertType'>
-                <option value='success'>
+                name="alert-type"
+                data-test-id="control-alertType">
+                <option value="success">
                     success
                 </option>
-                <option value='warning'>
+                <option value="warning">
                     warning
                 </option>
-                <option value='danger'>
+                <option value="danger">
                     danger
                 </option>
-                <option value='info'>
+                <option value="info">
                     info
                 </option>
             </select>
             <br>
-            <label for="is-dismissable">Is Dismissable</label>
+            <label for="is-dismissible">Is Dismissable</label>
             <input
-                id="is-dismissable"
+                id="is-dismissible"
                 v-model="controls.isDismissible"
                 type="checkbox"
-                data-test-id='control-isDismissible'>
+                data-test-id="control-isDismissible">
             <br>
             <label for="heading">Heading</label>
             <input
                 id="heading"
-                v-model='controls.heading'
+                v-model="controls.heading"
                 type="text"
-                data-test-id='control-heading'>
+                data-test-id="control-heading">
         </div>
         <vue-alert
             :locale='controls.locale'

--- a/packages/f-alert/src/demo/Index.vue
+++ b/packages/f-alert/src/demo/Index.vue
@@ -74,7 +74,7 @@ export default {
         controls: {
             locale: 'en-GB',
             alertType: 'success',
-            isDismissable: false,
+            isDismissable: true,
             heading: 'Title of the alert'
         }
     })

--- a/packages/f-alert/src/demo/Index.vue
+++ b/packages/f-alert/src/demo/Index.vue
@@ -8,7 +8,7 @@
             content="width=device-width, initial-scale=1">
         <div data-test-id="component-controls">
             <h1>Component Controls</h1>
-            <label for='locale'>Locale</label>
+            <label for="locale">Locale</label>
             <select
                 v-model="controls.locale"
                 name="locale"
@@ -55,7 +55,7 @@
                 data-test-id="control-heading">
         </div>
         <vue-alert
-            :locale='controls.locale'
+            :locale="controls.locale"
             :type="controls.alertType"
             :is-dismissible="controls.isDismissible"
             :heading="controls.heading">

--- a/packages/f-alert/src/demo/Index.vue
+++ b/packages/f-alert/src/demo/Index.vue
@@ -6,11 +6,34 @@
         <meta
             name="viewport"
             content="width=device-width, initial-scale=1">
+        <div data-test-id="component-controls">
+            <h1>Component Controls</h1>
+            <label for='locale'>Locale</label>
+            <select name='locale' data-test-id='control-locale' v-model="controls.locale">
+                <option value='en-GB'>en-GB</option>
+                <option value='en-AU'>en-AU</option>
+            </select>
+            <br>
+            <label for='alert-type'>Alert Type</label>
+            <select name='alert-type' data-test-id='control-alertType' v-model="controls.alertType">
+                <option value='success'>success</option>
+                <option value='warning'>warning</option>
+                <option value='danger'>danger</option>
+                <option value='info'>info</option>
+            </select>
+            <br>
+            <label for="is-dismissable">Is Dismissable</label>
+            <input id="is-dismissable" type="checkbox" data-test-id='control-isDismissable' v-model="controls.isDismissable">
+            <br>
+            <label for="heading">Heading</label>
+            <input id="heading" type="text" data-test-id='control-heading' v-model='controls.heading'> 
+        </div>
+
         <vue-alert
-            locale="en-GB"
-            type="success"
-            :is-dismissable="true"
-            heading="Title of the alert">
+            :locale='controls.locale'
+            :type="controls.alertType"
+            :is-dismissable="controls.isDismissable"
+            :heading="controls.heading">
             You can put any HTML here!
         </vue-alert>
     </div>
@@ -20,12 +43,26 @@
 import VueAlert from '@/components/Alert.vue';
 
 export default {
-    components: { VueAlert }
+    components: { VueAlert },
+    data: () => ({
+        controls: {
+            locale: 'en-GB',
+            alertType: 'success',
+            isDismissable: false,
+            heading: 'Title of the alert'
+        }
+    })
 };
 </script>
 
 <style>
 body {
     margin: 0;
+}
+
+.component-controls {
+    color: #ffffff;
+    font-family: 'Helvetica Neue', sans-serif;
+    background-color:#ffa500;
 }
 </style>

--- a/packages/f-alert/stories/Alert.stories.js
+++ b/packages/f-alert/stories/Alert.stories.js
@@ -21,8 +21,8 @@ export const AlertComponent = () => ({
         heading: {
             default: text('Heading', 'Title of the alert')
         },
-        isDismissable: {
-            default: boolean('Is it dismissable?', true)
+        isDismissible: {
+            default: boolean('Is it dismissible?', true)
         }
     },
     template: `
@@ -34,7 +34,7 @@ export const AlertComponent = () => ({
         <vue-alert
             :locale="locale"
             :type="type"
-            :isDismissable="isDismissable"
+            :isDismissible="isDismissible"
             :heading="heading">
             You can put any HTML here!
         </vue-alert>

--- a/packages/f-alert/test-utils/component-objects/demo-controls.js
+++ b/packages/f-alert/test-utils/component-objects/demo-controls.js
@@ -17,7 +17,7 @@ exports.selectAlertTypeByValue = alertType => {
  * @param {boolean} isDismissable
  */
 exports.isDissmiable = isDismissable => {
-    if (!isDismissable) {
+    if (!isDismissable && controlIsDismissable().isSelected()) {
         controlIsDismissable().click();
     }
 };

--- a/packages/f-alert/test-utils/component-objects/demo-controls.js
+++ b/packages/f-alert/test-utils/component-objects/demo-controls.js
@@ -27,6 +27,3 @@ exports.isDissmiable = () => {
 exports.setHeaderTextValue = headerText => {
     controlHeading().setValue(headerText);
 };
-
-
-

--- a/packages/f-alert/test-utils/component-objects/demo-controls.js
+++ b/packages/f-alert/test-utils/component-objects/demo-controls.js
@@ -13,8 +13,8 @@ exports.selectAlertTypeByValue = alertType => {
 };
 
 /**
- * Sets the alert type of a component based off the 'Alert Type' control dropdown value
- * @param {string} alertType
+ * Sets whether the component is dismissable based off the 'Is Dismissable' checkbox
+ * @param {boolean} isDismissable
  */
 exports.isDissmiable = isDismissable => {
     if (!isDismissable) {

--- a/packages/f-alert/test-utils/component-objects/demo-controls.js
+++ b/packages/f-alert/test-utils/component-objects/demo-controls.js
@@ -13,7 +13,7 @@ exports.selectAlertTypeByValue = alertType => {
 };
 
 /**
- * Sets whether the component is dismissable based off the 'Is Dismissable' checkbox
+ * Sets whether the component is dismissible based off the 'Is Dismissible' checkbox
  * @param {boolean} isDismissible
  */
 exports.isDismissible = isDismissible => {

--- a/packages/f-alert/test-utils/component-objects/demo-controls.js
+++ b/packages/f-alert/test-utils/component-objects/demo-controls.js
@@ -1,0 +1,32 @@
+const componentControls = () => $('[data-test-id="component-controls"]');
+
+const controlAlertType = () => componentControls().$('[data-test-id="control-alertType"]');
+const controlIsDismissable = () => componentControls().$('[data-test-id="control-isDismissable"]');
+const controlHeading = () => componentControls().$('[data-test-id="control-heading"]');
+
+/**
+ * Sets the alert type of a component based off the 'Alert Type' control dropdown value
+ * @param {string} alertType
+ */
+exports.selectAlertTypeByValue = alertType => {
+    controlAlertType().selectByAttribute('value', alertType);
+};
+
+/**
+ * Sets the alert type of a component based off the 'Alert Type' control dropdown value
+ * @param {string} alertType
+ */
+exports.isDissmiable = () => {
+    controlIsDismissable().click();
+};
+
+/**
+ * Sets the alert heading of a component based off the 'Heading' control input value
+ * @param {string} headerText
+ */
+exports.setHeaderTextValue = headerText => {
+    controlHeading().setValue(headerText);
+};
+
+
+

--- a/packages/f-alert/test-utils/component-objects/demo-controls.js
+++ b/packages/f-alert/test-utils/component-objects/demo-controls.js
@@ -16,8 +16,8 @@ exports.selectAlertTypeByValue = alertType => {
  * Sets whether the component is dismissable based off the 'Is Dismissable' checkbox
  * @param {boolean} isDismissible
  */
-exports.isDismisible = isDismisible => {
-    if (!isDismisible && controlIsDismissible().isSelected()) {
+exports.isDismissible = isDismissible => {
+    if (!isDismissible && controlIsDismissible().isSelected()) {
         controlIsDismissible().click();
     }
 };

--- a/packages/f-alert/test-utils/component-objects/demo-controls.js
+++ b/packages/f-alert/test-utils/component-objects/demo-controls.js
@@ -1,7 +1,7 @@
 const componentControls = () => $('[data-test-id="component-controls"]');
 
 const controlAlertType = () => componentControls().$('[data-test-id="control-alertType"]');
-const controlIsDismissable = () => componentControls().$('[data-test-id="control-isDismissable"]');
+const controlIsDismissible = () => componentControls().$('[data-test-id="control-isDismissible"]');
 const controlHeading = () => componentControls().$('[data-test-id="control-heading"]');
 
 /**
@@ -14,11 +14,11 @@ exports.selectAlertTypeByValue = alertType => {
 
 /**
  * Sets whether the component is dismissable based off the 'Is Dismissable' checkbox
- * @param {boolean} isDismissable
+ * @param {boolean} isDismissible
  */
-exports.isDissmiable = isDismissable => {
-    if (!isDismissable && controlIsDismissable().isSelected()) {
-        controlIsDismissable().click();
+exports.isDismisible = isDismisible => {
+    if (!isDismisible && controlIsDismissible().isSelected()) {
+        controlIsDismissible().click();
     }
 };
 

--- a/packages/f-alert/test-utils/component-objects/demo-controls.js
+++ b/packages/f-alert/test-utils/component-objects/demo-controls.js
@@ -16,8 +16,10 @@ exports.selectAlertTypeByValue = alertType => {
  * Sets the alert type of a component based off the 'Alert Type' control dropdown value
  * @param {string} alertType
  */
-exports.isDissmiable = () => {
-    controlIsDismissable().click();
+exports.isDissmiable = isDismissable => {
+    if (!isDismissable) {
+        controlIsDismissable().click();
+    }
 };
 
 /**

--- a/test/utils/demo-controls-helper.js
+++ b/test/utils/demo-controls-helper.js
@@ -8,4 +8,4 @@ const controlLocale = () => componentControls().$('[data-test-id="control-locale
  */
 exports.selectLocaleByValue = locale => {
     controlLocale().selectByAttribute('value', locale);
-}
+};

--- a/test/utils/demo-controls-helper.js
+++ b/test/utils/demo-controls-helper.js
@@ -1,0 +1,11 @@
+const componentControls = () => $('[data-test-id="component-controls"]');
+
+const controlLocale = () => componentControls().$('[data-test-id="control-locale"]');
+
+/**
+ * Sets the locale of a component based off the 'Locale' control dropdown value
+ * @param {string} locale
+ */
+exports.selectLocaleByValue = locale => {
+    controlLocale().selectByAttribute('value', locale);
+}


### PR DESCRIPTION
This PR gives the WebDriverIO component tests the ability to change component prop values as part of test setup, mimicking the Storybook Knobs functionality.

This is more of a POC to see if people are happy with the approach, as we'll need this functionality for f-checkout.

![image](https://user-images.githubusercontent.com/14013357/100630353-5ac9a080-3322-11eb-85bd-f4e90e56e243.png)
