### PR TITLE
f-checkout@0.13.0 - Updating f-services version and related tests.

### DIFF
--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.13.0
+------------------------------
+*December 1, 2020*
+
+### Changed
+- `f-services` version.
+- Tests to match the new version of `f-services`.
+
+
 v0.12.0
 ------------------------------
 *December 1, 2020*

--- a/packages/f-checkout/package.json
+++ b/packages/f-checkout/package.json
@@ -51,7 +51,7 @@
     "@justeat/f-error-message": "0.3.0",
     "@justeat/f-form-field": "1.4.0",
     "@justeat/f-globalisation": "0.2.0",
-    "@justeat/f-services": "1.4.0",
+    "@justeat/f-services": "1.6.0",
     "axios": "0.20.0",
     "axios-mock-adapter": "1.19.0",
     "vuelidate": "0.7.6"

--- a/packages/f-checkout/package.json
+++ b/packages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-checkout/src/components/tests/Checkout.test.js
+++ b/packages/f-checkout/src/components/tests/Checkout.test.js
@@ -275,7 +275,7 @@ describe('Checkout', () => {
                 expect(wrapper.vm.isMobileNumberValid).toBe(false);
                 expect(mobileNumberEmptyMessage).toMatchSnapshot();
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
-                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('customer');
+                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('customer.mobileNumber');
             });
 
             it('should show error message and emit failure event when the mobile number field is populated with a < 10 numbers', async () => {
@@ -290,7 +290,7 @@ describe('Checkout', () => {
                 expect(wrapper.vm.isMobileNumberValid).toBe(false);
                 expect(mobileNumberEmptyMessage).toMatchSnapshot();
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
-                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('customer');
+                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('customer.mobileNumber');
             });
 
             it('should show error message and emit failure event when the mobile number field is populated with non numeric value', async () => {
@@ -305,7 +305,7 @@ describe('Checkout', () => {
                 expect(wrapper.vm.isMobileNumberValid).toBe(false);
                 expect(mobileNumberEmptyMessage).toMatchSnapshot();
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
-                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('customer');
+                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('customer.mobileNumber');
             });
 
             it('should not create validations for address', () => {
@@ -365,7 +365,7 @@ describe('Checkout', () => {
                 // Assert
                 expect(addressLine1EmptyMessage).toMatchSnapshot();
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
-                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment');
+                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment.address.line1');
             });
 
             it('should emit failure event and display error message when city input field is empty', async () => {
@@ -376,7 +376,7 @@ describe('Checkout', () => {
                 // Assert
                 expect(addressCityEmptyMessage).toMatchSnapshot();
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
-                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment');
+                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment.address.city');
             });
 
             it('should emit failure event and display error message when postcode input field is empty', async () => {
@@ -387,7 +387,7 @@ describe('Checkout', () => {
                 // Assert
                 expect(addressPostcodeEmptyMessage).toMatchSnapshot();
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
-                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment');
+                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment.address.postcode');
             });
 
             it('should emit failure event and display error message when postcode contains incorrect characters', async () => {
@@ -401,7 +401,7 @@ describe('Checkout', () => {
                 // Assert
                 expect(addressPostcodeTypeErrorMessage).toMatchSnapshot();
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
-                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment');
+                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment.address.postcode');
             });
 
 
@@ -416,7 +416,7 @@ describe('Checkout', () => {
                 // Assert
                 expect(addressPostcodeTypeErrorMessage).toMatchSnapshot();
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
-                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment');
+                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment.address.postcode');
             });
 
             it('should create validations for address', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1735,14 +1735,6 @@
   dependencies:
     "@justeat/f-services" "1.0.0"
 
-"@justeat/f-form-field@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-1.4.0.tgz#4f5151996e2f80419bc74f6b126741161db7128a"
-  integrity sha512-LLiZ8McS9i8BTWrzujL0lWru7TlqDPp2JWjW3eUFCW8nUEbEIoDV5HJzQ1M21oLY7wSr0OH6wCqfNUfnRI5q/Q==
-  dependencies:
-    "@justeat/f-services" "1.0.0"
-    "@justeat/f-vue-icons" "1.11.0"
-
 "@justeat/f-icons@2.12.0":
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-2.12.0.tgz#07b221b284b4827ddcc6e04841228f77f24df45d"
@@ -1825,6 +1817,13 @@
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.11.0.tgz#3c5c91dcc04cd72e81d12f09bc8c9fec893909a5"
   integrity sha512-xw/Y0tOd1XQXUy6bl8VA3prBmgP2n0n2IHDKQFUOvGwupkAJ+3vwnlkhiMGlN8bripAPK80g01Abt/ZBBbXrUw==
+  dependencies:
+    babel-helper-vue-jsx-merge-props "2.0.3"
+
+"@justeat/f-vue-icons@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.12.0.tgz#31f99cf5719f7b745534726a99516a1449827e73"
+  integrity sha512-qPSa3JzyWUKAzriu3O8Y/1PVk6e2tDymo8R5eSSmGSYVaxPcw8tdwGDzwbTnT8F+MoOokdAUzk+M4UnUiA2Q6Q==
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
 


### PR DESCRIPTION
v0.13.0
------------------------------
*December 1, 2020*

### Changed
- `f-services` version.
- Tests to match the new version of `f-services`.