### PR TITLE
f-registration@0.43.1 - Remove pointy boi

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.43.1
+------------------------------
+*December 2, 2020*
+
+### Fixed
+- Remove erroneous `>`.
+
+
 v0.43.0
 ------------------------------
 *November 20, 2020*

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",
@@ -33,7 +33,7 @@
     "lint": "vue-cli-service lint",
     "lint:fix": "yarn lint --fix",
     "lint:style": "vue-cli-service lint:style",
-    "report": "cd ../.. && yarn report", 
+    "report": "cd ../.. && yarn report",
     "test": "vue-cli-service test:unit",
     "test:coverage": "yarn test --coverage",
     "test-component:chrome": "run-p --race demo webdriver:delay:chrome",

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -26,13 +26,10 @@
                 tabindex="0"
                 @click="formStart"
                 @focus="formStart"
-                @submit.prevent="onFormSubmit"
-            >
-                <!-- TODO WCB-1031 - Extract error messages into a separate component -->
+                @submit.prevent="onFormSubmit">
                 <error-message
                     v-if="genericErrorMessage"
                     :class="$style['c-registration-genericError']">
-                    >
                     {{ genericErrorMessage }}
                 </error-message>
                 <form-field


### PR DESCRIPTION
Remove erroneous `>` which was picked up by internal beta.

---

## Browsers Tested
- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)