### PR TITLE
storybook@v0.18.0 - Add Cookie Universal to Context

### DIFF
--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.18.0
+------------------------------
+*December 2, 2020*
+
+### Changed
+- Add Cookie Universal into Context so Mono Repo components can do this.$cookies.get('my-cookie-name');
+
 
 v0.17.0
 ------------------------------

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -7,7 +7,7 @@ v0.18.0
 ------------------------------
 *December 2, 2020*
 
-### Changed
+### Added
 - Add Cookie Universal into Context so Mono Repo components can do this.$cookies.get('my-cookie-name');
 
 

--- a/packages/storybook/config/storybook/preview.js
+++ b/packages/storybook/config/storybook/preview.js
@@ -1,5 +1,9 @@
 import Vue from 'vue';
 import VueI18n from 'vue-i18n';
+
+// Setup Context as a Web Host (I18n, Cookies etc)
+import '../../context/index';
+
 import { addDecorator } from '@storybook/vue';
 import { ENGLISH_LOCALE } from '../../constants/globalisation';
 

--- a/packages/storybook/context/cookie.context.js
+++ b/packages/storybook/context/cookie.context.js
@@ -1,0 +1,6 @@
+import Vue from 'vue';
+import Cookie from 'cookie-universal';
+
+// Check out the Cookie Universal docs for usage -> https://www.npmjs.com/package/cookie-universal
+// In your mono repo component use this.$cookies.get('je-auser');
+Vue.prototype.$cookies = Cookie();

--- a/packages/storybook/context/index.js
+++ b/packages/storybook/context/index.js
@@ -1,0 +1,1 @@
+import './cookie.context';

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "scripts": {
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -s public -p 6006 -c config/storybook"
@@ -16,6 +16,7 @@
     "@storybook/addon-knobs": "6.0.28",
     "@storybook/addon-links": "6.0.28",
     "@storybook/vue": "6.0.28",
+    "cookie-universal": "2.1.4",
     "eyeglass": "1.4.1",
     "node-sass-magic-importer": "5.3.2",
     "npm-run-all": "4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3547,6 +3547,11 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
 "@types/cucumber@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/cucumber/-/cucumber-6.0.1.tgz#0fe9673d34568d35ff21957af049883635472fcd"
@@ -7782,10 +7787,23 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
+cookie-universal@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cookie-universal/-/cookie-universal-2.1.4.tgz#826a273da7eb9b08bfb0139bae12ea70770d564b"
+  integrity sha512-dwWXs7NGBzaBYDypu3jWH5M3NJW+zu5QdyJkFMHJvhLuyL4/eXG4105fwtTDwfIqyTunwVvQX4PHdtfPDS7URQ==
+  dependencies:
+    "@types/cookie" "^0.3.3"
+    cookie "^0.4.0"
+
 cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookie@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
> This PR adds Cookie Universal to context in Storybook. It already exists in Context within CoreWeb.

- This means the method signatures are identical between StoryBook and CoreWeb as we use the same library, and other web hosts can use the same package which provides both SSR and CSR implementations
- Cookie Universal is isomorphic; however Storybook isn't, so only the client implementation is placed into context in Storybook
- **The PR establishes a pattern I intend to use** to update the I18n wiring within StoryBook, and add logger wiring too!
- In the very rare situations where a component is exported native for non vue websites; you can just import cookie universal in your component and add it to context.

**Advantages**

- Using an Isomorphic third party package within Web hosts gives us consistency and doesn't affect/increase bundle sizes for components
- Components don't need to install or manage package versions, simply rely on context
- Components will never be using different versions with different signatures and features!
- The library provides all the latest features like maxage, samesite and secure options
- This particular library has been in use in CoreWeb for some time, as it has a Nuxt official wrapper

**Example**
> Lets say we want to read a cookie in F-Button on mounted and write it to the console. All you need to do is
```
mounted () {
  const myName = this.$cookies.get('my-name');
  console.log(myName);
}
```

**What about tests?**
- Its a context value, and you don't want to test that cookies are actually set, thats not your problem
- If you REALLY want to add cookies in tests, you can import it as a devDependency and use it that way, I would argue you should never do this though.
- Simply mock the context by adding the cookie context with the methods you use, for example...


```
const context = {
  $cookies: {
    get: jest.fn()
  }
};
```

**What about other microsites?**
- If they use a component which relies on a context value; that microsite will also need to implement the context value, its pretty simple though; simply look at the context folder in storybook for the wiring you can steal. If a component relies on $cookies or i18n or $logger and the web host running it doesn't implement that, it will error until you wire it up.

**The pattern**
> The pattern means that instead of importing each individual concern into each individual component as it is needed; we rely on the website itself to be configured in a specific way. When this works components can use a wide range of features with zero wiring and zero package weight - with the core features even being available while developing in storybook. It means components work in the same way, not with subtly different implementations depending on who did it.