### PR TITLE
f-form-field@v1.5.0 – Updating data-test-id and tidy-up of styling

### DIFF
--- a/packages/f-form-field/CHANGELOG.md
+++ b/packages/f-form-field/CHANGELOG.md
@@ -8,8 +8,12 @@ v1.5.0
 *December 3, 2020*
 
 ### Changed
+- `data-test-id`'s updated across `FormField` and `FormDropdown` components.
 - Updating CSS variable names and classnames.
 - Updated `isInputField` to be called `isSelectionControl`.
+
+### Fixed
+- Extra space removed in `option` tag of dropdown component.
 
 
 v1.4.0

--- a/packages/f-form-field/CHANGELOG.md
+++ b/packages/f-form-field/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.5.0
+------------------------------
+*December 3, 2020*
+
+### Changed
+- Updating CSS variable names and classnames.
+- Updated `isInputField` to be called `isSelectionControl`.
+
+
 v1.4.0
 ------------------------------
 *November 30, 2020*
@@ -10,6 +19,7 @@ v1.4.0
 ### Changed
 - `padding` and `font-size` for inline label.
 - `fill` for dropdown arrow, `color` and `background` hover state.
+
 
 v1.3.0
 ------------------------------

--- a/packages/f-form-field/package.json
+++ b/packages/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-form-field/src/components/FormDropdown.vue
+++ b/packages/f-form-field/src/components/FormDropdown.vue
@@ -1,22 +1,21 @@
 <template>
     <div
         :class="$style['c-formDropdown']"
-        data-test-id="formDropdown">
+        :data-test-id="testId.container">
         <caret-icon
             :class="$style['c-formDropdown-icon']"
-            data-test-id="formDropdown-icon" />
+            :data-test-id="testId.icon" />
         <select
             id="time-selection"
             :class="$style['c-formDropdown-select']"
-            data-test-id="formDropdown-select"
+            :data-test-id="testId.select"
+            v-bind="attributes"
             @change="updateOption">
             <option
                 v-for="(option, index) in dropdownOptions"
                 :key="index"
-                :data-test-id="`formDropdown-option-${index}`"
-                :value="option">
-                {{ option }}
-            </option>
+                :data-test-id="`${testId.option}-${index}`"
+                :value="option">{{ option }}</option>
         </select>
     </div>
 </template>
@@ -32,9 +31,26 @@ export default {
     },
 
     props: {
+        attributes: {
+            type: Object,
+            default: () => {}
+        },
         dropdownOptions: {
             type: Array,
             default: () => null
+        }
+    },
+
+    computed: {
+        testId () {
+            const formFieldName = (this.attributes && this.attributes.name ? this.attributes.name : null);
+
+            return {
+                container: formFieldName ? `formfield-${formFieldName}-dropdown` : 'formfield-dropdown',
+                icon: formFieldName ? `formfield-${formFieldName}-dropdown-icon` : 'formfield-dropdown-icon',
+                select: formFieldName ? `formfield-${formFieldName}-dropdown-select` : 'formfield-dropdown-select',
+                option: formFieldName ? `formfield-${formFieldName}-dropdown-option` : 'formfield-dropdown-option'
+            };
         }
     },
 

--- a/packages/f-form-field/src/components/FormField.vue
+++ b/packages/f-form-field/src/components/FormField.vue
@@ -21,9 +21,8 @@
             <form-dropdown
                 v-if="isDropdown"
                 :id="`${uniqueId}`"
-                v-bind="$attrs"
+                :attributes="$attrs"
                 :type="normalisedInputType"
-                :data-test-id="testId.input"
                 :class="[
                     $style['c-formField-input'],
                     $style['c-formField-dropdownContainer'],
@@ -53,7 +52,7 @@
                 :label-style="normalisedLabelStyle"
                 :for="uniqueId"
                 :is-inline="isInline"
-                :data-test-id="testId.label + '--inline'">
+                :data-test-id="`${testId.label}--inline`">
                 {{ labelText }}
             </form-label>
         </div>

--- a/packages/f-form-field/src/components/FormField.vue
+++ b/packages/f-form-field/src/components/FormField.vue
@@ -6,7 +6,7 @@
                 [$style['c-formField--invalid']]: hasError
             }
         ]"
-        data-test-id="form-field-component">
+        :data-test-id="testId.container">
         <div
             :class="$style['c-formField-inputWrapper']">
             <form-label
@@ -14,7 +14,7 @@
                 :label-style="normalisedLabelStyle"
                 :for="uniqueId"
                 :is-inline="isInline"
-                data-test-id="form-field-label">
+                :data-test-id="testId.label">
                 {{ labelText }}
             </form-label>
 
@@ -23,11 +23,11 @@
                 :id="`${uniqueId}`"
                 v-bind="$attrs"
                 :type="normalisedInputType"
-                :data-test-id="testId"
+                :data-test-id="testId.input"
                 :class="[
-                    $style['o-form-field'],
                     $style['c-formField-input'],
-                    $style['c-formField-input-inputFields--focus']
+                    $style['c-formField-dropdownContainer'],
+                    $style['c-formField-input--focus']
                 ]"
                 :dropdown-options="dropdownOptions"
                 @update="updateOption"
@@ -40,13 +40,10 @@
                 v-bind="$attrs"
                 :type="normalisedInputType"
                 placeholder=" "
-                :data-test-id="testId"
+                :data-test-id="testId.input"
                 :class="[
-                    $style['o-form-field'],
                     $style['c-formField-input'],
-                    $style['c-formField-input-textField'], {
-                        [$style['c-formField-input-inputFields--focus']]: isInputField
-                    }
+                    (isSelectionControl ? $style['c-formField-input--focus'] : '')
                 ]"
                 @input="updateValue"
                 v-on="listeners"
@@ -56,7 +53,7 @@
                 :label-style="normalisedLabelStyle"
                 :for="uniqueId"
                 :is-inline="isInline"
-                data-test-id="form-field-label--inline">
+                :data-test-id="testId.label + '--inline'">
                 {{ labelText }}
             </form-label>
         </div>
@@ -121,11 +118,6 @@ export default {
             default: false
         },
 
-        dataTestId: {
-            type: String,
-            default: ''
-        },
-
         dropdownOptions: {
             type: Array,
             default: () => null
@@ -179,7 +171,13 @@ export default {
         },
 
         testId () {
-            return this.dataTestId || this.$attrs.name || false;
+            const formFieldName = this.$attrs.name;
+
+            return {
+                container: formFieldName ? `formfield-${formFieldName}` : 'formfield-container',
+                input: formFieldName ? `formfield-${formFieldName}-input` : 'formfield-input',
+                label: formFieldName ? `formfield-${formFieldName}-label` : 'formfield-label'
+            };
         },
 
         isInline () {
@@ -191,7 +189,7 @@ export default {
             return this.inputType === 'dropdown';
         },
 
-        isInputField () {
+        isSelectionControl () {
             return !(this.inputType === 'radio' || this.inputType === 'checkbox');
         }
     },
@@ -249,30 +247,19 @@ $form-input-focus                         : $blue--light;
         position: relative;
     }
 
-    .c-formField-input-textField {
-        padding: $form-input-padding;
-    }
-
-    .c-formField-input-inputFields--focus {
-        &:focus,
-        &:active,
-        &:focus-within {
-            box-shadow: 0 0 0 2pt $form-input-focus;
-            outline: none;
-        }
-    }
-
     .c-formField-input {
         width: 100%;
-        @include rem(height, $form-input-height); //convert height to rem
-        @include font-size($form-input-fontSize);
         font-family: $font-family-base;
-        color: $form-input-textColour;
+        @include font-size($form-input-fontSize);
         font-weight: $font-weight-base;
+        color: $form-input-textColour;
+        @include rem(height, $form-input-height); //convert height to rem
+
         background-color: $form-input-bg;
         border: $form-input-borderWidth solid $form-input-borderColour;
         border-radius: $form-input-borderRadius;
         background-clip: padding-box;
+        padding: $form-input-padding;
 
         &:hover {
             background-color: $form-input-bg--hover;
@@ -294,5 +281,18 @@ $form-input-focus                         : $blue--light;
             }
         }
     }
+
+    .c-formField-input--focus {
+        &:focus,
+        &:active,
+        &:focus-within {
+            box-shadow: 0 0 0 2pt $form-input-focus;
+            outline: none;
+        }
+    }
+
+        .c-formField-dropdownContainer {
+            padding: 0;
+        }
 
 </style>

--- a/packages/f-form-field/src/components/FormLabel.vue
+++ b/packages/f-form-field/src/components/FormLabel.vue
@@ -38,12 +38,14 @@ export default {
 <style lang="scss" module>
 
 $form-label-colour              : $grey--darkest; // Text colour of form labels
-$form-label-colour-inline       : $grey--dark;
 $form-label-fontSize            : 'body-s';
-$form-label-fontSize-inline     : 'body-l';
 $form-label-weight              : $font-weight-bold;
-$form-label-weight-inline       : $font-weight-base;
-$form-label-padding             : spacing(x1.5);
+
+$form-inlineLabel-padding       : spacing(x1.5) spacing(x2);
+$form-inlineLabel-colour        : $grey--dark;
+$form-inlineLabel-fontSize      : 'body-l';
+$form-inlineLabel-weight        : $font-weight-base;
+
 
 .c-formField-label {
     display: block;
@@ -56,13 +58,14 @@ $form-label-padding             : spacing(x1.5);
 .c-formField-label--inline {
     position: absolute;
     top: 50%;
-    transform: translateY(-50%);
-    @include font-size($form-label-fontSize-inline);
-    font-weight: $form-label-weight-inline;
-    color: $form-label-colour-inline;
-    padding: $form-label-padding;
     left: 1px;  // Adds pixel to match `FormField` border
+    padding: $form-inlineLabel-padding;
     margin-bottom: 0;
+    transform: translateY(-50%);
+
+    @include font-size($form-inlineLabel-fontSize);
+    font-weight: $form-inlineLabel-weight;
+    color: $form-inlineLabel-colour;
     cursor: text; // make the cursor the same as the default input hover cursor
 }
 

--- a/packages/f-form-field/src/components/tests/FormDropdown.test.js
+++ b/packages/f-form-field/src/components/tests/FormDropdown.test.js
@@ -16,7 +16,7 @@ describe('FormDropdown', () => {
                 // Arrange && Act
                 const propsData = { dropdownOptions };
                 const wrapper = shallowMount(FormDropdown, { propsData });
-                const option = wrapper.find('[data-test-id="formDropdown-option-0"]');
+                const option = wrapper.find('[data-test-id="formfield-dropdown-option-0"]');
 
                 // Assert
                 expect(option.text()).toEqual('option 0');
@@ -26,7 +26,7 @@ describe('FormDropdown', () => {
                 // Arrange && Act
                 const propsData = {};
                 const wrapper = shallowMount(FormDropdown, { propsData });
-                const option = wrapper.find('[data-test-id="formDropdown-option-0"]');
+                const option = wrapper.find('[data-test-id="formfield-dropdown-option-0"]');
 
                 // Assert
                 expect(option.exists()).toBe(false);
@@ -38,7 +38,7 @@ describe('FormDropdown', () => {
         describe('updateOption ::', () => {
             const propsData = { dropdownOptions };
 
-            it('should emit `update` whens option selected', async () => {
+            it('should emit `update` when an option is selected', async () => {
                 // Arrange
                 const wrapper = shallowMount(FormDropdown, { propsData });
 

--- a/packages/f-form-field/src/components/tests/FormField.test.js
+++ b/packages/f-form-field/src/components/tests/FormField.test.js
@@ -158,7 +158,7 @@ describe('FormField', () => {
 
     describe('attrs ::', () => {
         describe('name ::', () => {
-            it('when name is not set, testId.container should be set to `formfield-container`', () => {
+            it('should set testId.container to `formfield-container when name is is not set`', () => {
                 // Arrange
                 const attrsData = {};
 
@@ -169,7 +169,7 @@ describe('FormField', () => {
                 expect(wrapper.attributes('data-test-id')).toBe('formfield-container');
             });
 
-            it('when name is set, it should be included in the generated testId.container data-test-id', () => {
+            it('should include attribute `name` in the generated container data-test-id when it is set', () => {
                 // Arrange
                 const attrsData = {
                     attrs: {
@@ -184,7 +184,7 @@ describe('FormField', () => {
                 expect(wrapper.attributes('data-test-id')).toBe(`formfield-${attrsData.attrs.name}`);
             });
 
-            it('when name is set, it should be included in the generated testId.input data-test-id', () => {
+            it('should include attribute `name` in the generated input data-test-id when it is set', () => {
                 // Arrange
                 const attrsData = {
                     attrs: {

--- a/packages/f-form-field/src/components/tests/FormField.test.js
+++ b/packages/f-form-field/src/components/tests/FormField.test.js
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, mount } from '@vue/test-utils';
 import FormField from '../FormField.vue';
 import FormDropdown from '../FormDropdown.vue';
 import {
@@ -125,8 +125,8 @@ describe('FormField', () => {
                     // Act
                     const wrapper = await shallowMount(FormField, { propsData });
 
-                    const defaultLabel = wrapper.find('[data-test-id="form-field-label"]');
-                    const inlineLabel = wrapper.find('[data-test-id="form-field-label--inline"]');
+                    const defaultLabel = wrapper.find('[data-test-id="formfield-label"]');
+                    const inlineLabel = wrapper.find('[data-test-id="formfield-label--inline"]');
 
                     // Assert
                     expect(defaultLabel.exists()).toBe(true);
@@ -145,13 +145,75 @@ describe('FormField', () => {
                     // Act
                     const wrapper = await shallowMount(FormField, { propsData });
 
-                    const defaultLabel = wrapper.find('[data-test-id="form-field-label"]');
-                    const inlineLabel = wrapper.find('[data-test-id="form-field-label--inline"]');
+                    const defaultLabel = wrapper.find('[data-test-id="formfield-label"]');
+                    const inlineLabel = wrapper.find('[data-test-id="formfield-label--inline"]');
 
                     // Assert
                     expect(defaultLabel.exists()).toBe(false);
                     expect(inlineLabel.exists()).toBe(true);
                 });
+            });
+        });
+    });
+
+    describe('attrs ::', () => {
+        describe('name ::', () => {
+            it('when name is not set, testId.container should be set to `formfield-container`', () => {
+                // Arrange
+                const attrsData = {};
+
+                // Act
+                const wrapper = shallowMount(FormField, { attrsData });
+
+                // Assert
+                expect(wrapper.attributes('data-test-id')).toBe('formfield-container');
+            });
+
+            it('when name is set, it should be included in the generated testId.container data-test-id', () => {
+                // Arrange
+                const attrsData = {
+                    attrs: {
+                        name: 'email'
+                    }
+                };
+
+                // Act
+                const wrapper = shallowMount(FormField, attrsData);
+
+                // Assert
+                expect(wrapper.attributes('data-test-id')).toBe(`formfield-${attrsData.attrs.name}`);
+            });
+
+            it('when name is set, it should be included in the generated testId.input data-test-id', () => {
+                // Arrange
+                const attrsData = {
+                    attrs: {
+                        name: 'email'
+                    }
+                };
+
+                // Act
+                const wrapper = shallowMount(FormField, attrsData);
+                const formInput = wrapper.find('input');
+
+                // Assert
+                expect(formInput.attributes('data-test-id')).toBe(`formfield-${attrsData.attrs.name}-input`);
+            });
+
+            it('when name is set, it should be included in the generated testId.input data-test-id', () => {
+                // Arrange
+                const attrsData = {
+                    attrs: {
+                        name: 'email'
+                    }
+                };
+
+                // Act
+                const wrapper = mount(FormField, attrsData);
+                const formLabel = wrapper.find('label');
+
+                // Assert
+                expect(formLabel.attributes('data-test-id')).toBe(`formfield-${attrsData.attrs.name}-label`);
             });
         });
     });

--- a/packages/f-form-field/src/demo/Index.vue
+++ b/packages/f-form-field/src/demo/Index.vue
@@ -9,7 +9,7 @@
         <form-field
             locale="en-GB"
             label-text="First Name"
-            data-test-id="form-field-input" />
+            name="firstname" />
     </div>
 </template>
 

--- a/packages/f-form-field/stories/FormField.stories.js
+++ b/packages/f-form-field/stories/FormField.stories.js
@@ -17,7 +17,7 @@ export const FormFieldComponent = () => ({
             default: select('Locale', ['en-GB', 'en-AU'])
         },
         labelText: {
-            default: text('Label Text', 'First Name')
+            default: text('Label Text', 'First name')
         },
         inputType: {
             default: select('Input Type', VALID_INPUT_TYPES.concat(CUSTOM_INPUT_TYPES))

--- a/packages/f-form-field/test-utils/component-objects/f-form-field.component.js
+++ b/packages/f-form-field/test-utils/component-objects/f-form-field.component.js
@@ -1,6 +1,6 @@
-const formFieldComponent = () => $('[data-test-id="form-field-component"]');
-const testLabel = () => $('[data-test-id="form-field-label"]');
-const input = () => $('[data-test-id="form-field-input"]');
+const formFieldComponent = () => $('[data-test-id="formfield-firstname"]');
+const testLabel = () => $('[data-test-id="formfield-firstname-label"]');
+const input = () => $('[data-test-id="formfield-firstname-input"]');
 /**
  * @param {Object} userInput
  * @param {String} userInput.firstName The user's first name


### PR DESCRIPTION
### Changed
- `data-test-id`'s updated across `FormField` and `FormDropdown` components.
- Updating CSS variable names and classnames.
- Updated `isInputField` to be called `isSelectionControl`.

### Fixed
- Extra space removed in `option` tag of dropdown component.

---

## UI Review Checks

- [x] Unit tests have been updated

## Browsers Tested

- [x] Chrome (latest)
