### PR TITLE
f-checkout@v0.15.0 - Updated f-checkout to support new prop value changes.

### DIFF
--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -11,6 +11,7 @@ v0.15.0
 - Ability to change prop values in demo file for WebDriverIO component tests.
 - New `Demo.vue` for f-checkout controls.
 
+
 v0.14.0
 ------------------------------
 *December 2, 2020*

--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.15.0
+------------------------------
+*December 3, 2020*
+
+### Added
+- Ability to change prop values in demo file for WebDriverIO component tests.
+- New `Demo.vue` for f-checkout controls.
+
 v0.14.0
 ------------------------------
 *December 2, 2020*

--- a/packages/f-checkout/package.json
+++ b/packages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-checkout/src/demo/Demo.vue
+++ b/packages/f-checkout/src/demo/Demo.vue
@@ -1,0 +1,43 @@
+<template>
+    <div>
+        <div data-test-id="component-controls">
+            <h1>Component Controls</h1>
+            <label for="checkoutMethod">Checkout Method</label>
+            <select
+                v-model="controls.checkoutMethod"
+                name="checkoutMethod"
+                data-test-id="control-checkoutMethod"
+                @change="updateCheckoutMethod">
+                <option value="/checkout-delivery.json">
+                    Delivery
+                </option>
+                <option value="/checkout-collection.json">
+                    Collection
+                </option>
+            </select>
+        </div>
+        <vue-checkout
+            :checkout-url='controls.checkoutMethod' />
+    </div>
+</template>
+
+<script>
+import axios from 'axios';
+import VueCheckout from '../components/Checkout.vue';
+import CheckoutMock from './checkoutMock';
+
+export default {
+    components: { VueCheckout },
+    data: () => ({
+        controls: {
+            checkoutMethod: '/checkout-delivery.json'
+        }
+    }),
+    methods: {
+        updateCheckoutMethod () {
+            CheckoutMock.setupCheckoutMethod(this.controls.checkoutMethod);
+            axios.get(this.controls.checkoutMethod);
+        }
+    }
+};
+</script>

--- a/packages/f-checkout/src/demo/Demo.vue
+++ b/packages/f-checkout/src/demo/Demo.vue
@@ -8,10 +8,14 @@
                 name="checkoutMethod"
                 data-test-id="control-checkoutMethod"
                 @change="updateCheckoutMethod">
-                <option value="/checkout-delivery.json">
+                <option
+                    name="delivery"
+                    value="/checkout-delivery.json">
                     Delivery
                 </option>
-                <option value="/checkout-collection.json">
+                <option
+                    name="collection"
+                    value="/checkout-collection.json">
                     Collection
                 </option>
             </select>

--- a/packages/f-checkout/src/demo/checkoutMock.js
+++ b/packages/f-checkout/src/demo/checkoutMock.js
@@ -6,11 +6,17 @@ import checkoutCollection from './checkout-collection.json';
 const mock = new MockAdapter(axios);
 
 export default {
-    setupDelivery (path) {
-        mock.onGet(path).reply(200, checkoutDelivery);
-    },
 
-    setupCollection (path) {
-        mock.onGet(path).reply(200, checkoutCollection);
+    setupCheckoutMethod (path) {
+        switch (path) {
+            case '/checkout-delivery.json':
+                mock.onGet(path).reply(200, checkoutDelivery);
+                break;
+            case '/checkout-collection.json':
+                mock.onGet(path).reply(200, checkoutCollection);
+                break;
+            default:
+                throw new Error(`${path} is not valid`);
+        }
     }
 };

--- a/packages/f-checkout/src/demo/demo.js
+++ b/packages/f-checkout/src/demo/demo.js
@@ -1,11 +1,11 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import { VueI18n } from '@justeat/f-globalisation';
-import VueCheckout from '../components/Checkout.vue';
+import VueDemo from './Demo.vue';
 import { ENGLISH_LOCALE } from '../../../storybook/constants/globalisation';
 import CheckoutMock from './checkoutMock';
 
-CheckoutMock.setupDelivery('/checkout-delivery.json');
+CheckoutMock.setupCheckoutMethod('/checkout-delivery.json');
 
 Vue.config.productionTip = false;
 
@@ -22,9 +22,6 @@ const i18n = new VueI18n({
 new Vue({
     i18n,
     store: new Vuex.Store({}),
-    render: h => h(VueCheckout, {
-        props: {
-            checkoutUrl: '/checkout-delivery.json'
-        }
-    })
+    components: { VueDemo },
+    render: h => h(VueDemo)
 }).$mount('#app');

--- a/packages/f-checkout/test-utils/component-objects/demo-controls.js
+++ b/packages/f-checkout/test-utils/component-objects/demo-controls.js
@@ -1,0 +1,11 @@
+const componentControls = () => $('[data-test-id="component-controls"]');
+
+const controlCheckoutMethod = () => componentControls().$('[data-test-id="control-checkoutMethod"]');
+
+/**
+ * Sets the checkout type of a component based off the 'Checkout Type' control dropdown value
+ * @param {string} checkoutType
+ */
+exports.selectCheckoutMethod = checkoutType => {
+    controlCheckoutMethod().selectByAttribute('name', checkoutType);
+};


### PR DESCRIPTION
### Added
- Ability to change prop values in demo file for WebDriverIO component tests.
- New `Demo.vue` for f-checkout controls.