### PR TITLE
storybook@v0.19.0 - Context Pattern - Add Logger and i18n Structures

### DIFF
--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.19.0
+------------------------------
+*December 3, 2020*
+
+### Added
+- Added Logger Context to allow writing to browser console within Storybook
+
+### Changed
+- Updated I18n Context Setup to follow new pattern
+
+
 v0.18.0
 ------------------------------
 *December 2, 2020*

--- a/packages/storybook/config/storybook/preview.js
+++ b/packages/storybook/config/storybook/preview.js
@@ -1,23 +1,6 @@
 import Vue from 'vue';
-import VueI18n from 'vue-i18n';
 
 // Setup Context as a Web Host (I18n, Cookies etc)
 import '../../context/index';
 
-import { addDecorator } from '@storybook/vue';
-import { ENGLISH_LOCALE } from '../../constants/globalisation';
-
-Vue.use(VueI18n);
-
 Vue.config.devtools = true;
-
-const i18n = new VueI18n({
-    locale: ENGLISH_LOCALE,
-    fallbackLocale: ENGLISH_LOCALE,
-    messages: {}
-});
-
-addDecorator(() => ({
-    template: '<story/>',
-    i18n
-}));

--- a/packages/storybook/context/i18n.context.js
+++ b/packages/storybook/context/i18n.context.js
@@ -1,0 +1,20 @@
+import Vue from 'vue';
+import VueI18n from 'vue-i18n';
+
+import { addDecorator } from '@storybook/vue';
+import { ENGLISH_LOCALE } from '../constants/globalisation';
+
+Vue.use(VueI18n);
+
+Vue.config.devtools = true;
+
+const i18n = new VueI18n({
+    locale: ENGLISH_LOCALE,
+    fallbackLocale: ENGLISH_LOCALE,
+    messages: {}
+});
+
+addDecorator(() => ({
+    template: '<story/>',
+    i18n
+}));

--- a/packages/storybook/context/i18n.context.js
+++ b/packages/storybook/context/i18n.context.js
@@ -6,8 +6,6 @@ import { ENGLISH_LOCALE } from '../constants/globalisation';
 
 Vue.use(VueI18n);
 
-Vue.config.devtools = true;
-
 const i18n = new VueI18n({
     locale: ENGLISH_LOCALE,
     fallbackLocale: ENGLISH_LOCALE,

--- a/packages/storybook/context/index.js
+++ b/packages/storybook/context/index.js
@@ -1,1 +1,2 @@
 import './cookie.context';
+import './i18n.context';

--- a/packages/storybook/context/index.js
+++ b/packages/storybook/context/index.js
@@ -1,2 +1,3 @@
 import './cookie.context';
 import './i18n.context';
+import './logger.context';

--- a/packages/storybook/context/logger.context.js
+++ b/packages/storybook/context/logger.context.js
@@ -1,0 +1,25 @@
+
+import Vue from 'vue';
+
+const appendStandardProperties = (logPayload, message, level, mode) => {
+    logPayload.message = message || 'No message provided';
+    logPayload.Level = level || 'error'; // Intentionally uppercased property
+    logPayload.mode = mode || 'client';
+};
+
+const logger = {
+    logError: (logMessage, store, logPayload = {}) => {
+        appendStandardProperties(logPayload, logMessage, 'Error', 'client');
+        console.error(logMessage, logPayload);
+    },
+    logWarn: (logMessage, store, logPayload = {}) => {
+        appendStandardProperties(logPayload, logMessage, 'Warn', 'client');
+        console.warn(logMessage, logPayload);
+    },
+    logInfo: (logMessage, store, logPayload = {}) => {
+        appendStandardProperties(logPayload, logMessage, 'Info', 'client');
+        console.log(logMessage, logPayload);
+    }
+};
+
+Vue.prototype.$logger = logger;

--- a/packages/storybook/context/logger.context.js
+++ b/packages/storybook/context/logger.context.js
@@ -1,4 +1,3 @@
-
 import Vue from 'vue';
 
 const appendStandardProperties = (logPayload, message, level, mode) => {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "scripts": {
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -s public -p 6006 -c config/storybook"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1752,6 +1752,18 @@
   dependencies:
     window-or-global "^1.0.1"
 
+"@justeat/f-metadata@3.0.0-beta.6":
+  version "3.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@justeat/f-metadata/-/f-metadata-3.0.0-beta.6.tgz#3d2ea0d38192a7b40f3ac1a8bb3a1194ccd62338"
+  integrity sha512-ZCBCcMxk2nVYw58hWaJdf5kVtfdeUQVausrhvSFq/V3bpGvTh+OJV1W0OUOKyizqRc8FnGVUEJVhqzCFeBNpew==
+  dependencies:
+    appboy-web-sdk "2.5.2"
+    date-fns "2.16.1"
+    lodash.findindex "4.6.0"
+    lodash.orderby "4.6.0"
+    lodash.startswith "4.2.1"
+    lodash.uniq "4.5.0"
+
 "@justeat/f-services@0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.13.0.tgz#b0fc67948e94800ba176addb9d92cce444d28c8e"


### PR DESCRIPTION
> This PR is a continuation of improving our context capabilities; following $cookies being added by my last PR
- You can now use the logger in any mono repo component by simply saying `this.$logger.logError('message', store, additionalPayload);` Give us visibility of the non happy path
- When running storybook; logger outputs to the browser console
- Logger is supported by CoreWeb and HomeWeb, transporting logs right into Kibana.
- Other microsites are welcome to add the $logger context to gain the same benefits; and it is recommended they do when consuming components which depend on it.
- This means we now have standard context available for `$cookies`, `i18n` and `$logger` to give you features with zero effort/wiring and zero package weight.

![image](https://user-images.githubusercontent.com/10741583/101007614-6357ec00-3559-11eb-844c-bac099e21329.png)

<hr>

**Example Usage (Zero installation)**
```
    mounted () {
        this.$logger.logError('Test Error Log', null, {
            additionalInfoObject: 'Hello World'
        });

        this.$logger.logWarn('Test Warning Log', null, {
            additionalInfoObject: 'Hello World'
        });

        this.$logger.logInfo('Test Info Log', null, {
            additionalInfoObject: 'Hello World'
        });
    }
```

<hr>

**Added**
- The $logger is now available in context in storybook in the same way it exists in CoreWeb

**Updated**
- I18n wiring in storybook updated to follow organisation convention