### PR TITLE
f-content-cards@2.2.0-beta.9 - logging callbacks

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.2.0-beta.9
+------------------------------
+*December 03, 2020*
+
+### Changed
+- Added in the logging callback for f-metadata
+- Updated f-metadata to latest
+
+
 v2.2.0-beta.8
 ------------------------------
 *November 30, 2020*

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "2.2.0-beta.8",
+  "version": "2.2.0-beta.9",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@justeat/f-vue-icons": "1.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
-    "@justeat/f-metadata": "3.0.0-beta.6",
+    "@justeat/f-metadata": "3.0.0-beta.7",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -329,7 +329,7 @@ export default {
                     handleContentCardsGrouped: this.metadataContentCardsGrouped
                 },
                 loggerCallbacks: {
-                    logger: this.handleLogging()
+                    logger: this.handleLogging
                 }
             })
             .then(dispatcher => {
@@ -545,7 +545,10 @@ export default {
         },
 
         handleLogging () {
-
+            // eslint-disable-next-line func-names
+            return function (type, logMessage, payload) {
+                if (this.$logger) this.$logger[type](logMessage, payload);
+            };
         }
     }
 };

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -550,9 +550,9 @@ export default {
          */
         handleLogging (logger) {
             // eslint-disable-next-line func-names
-            return ((type, logMessage, payload) => {
+            return (type, logMessage, payload) => {
                 if (logger && logger[type]) logger[type](logMessage, null, payload);
-            });
+            };
         }
     }
 };

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -544,10 +544,14 @@ export default {
                 this.testId && `ContentCard-${this.testId}-${index}`;
         },
 
+        /**
+         * Handles logging from f-metadata (callback)
+         * @returns {function(*, *=, *=): void}
+         */
         handleLogging () {
             // eslint-disable-next-line func-names
             return function (type, logMessage, payload) {
-                if (this.$logger) this.$logger[type](logMessage, payload);
+                if (this.$logger && this.$logger[type]) this.$logger[type](logMessage, null, payload);
             };
         }
     }

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -327,6 +327,9 @@ export default {
                 callbacks: {
                     handleContentCards: this.metadataContentCards,
                     handleContentCardsGrouped: this.metadataContentCardsGrouped
+                },
+                loggerCallbacks: {
+                    logger: this.handleLogging()
                 }
             })
             .then(dispatcher => {
@@ -539,6 +542,10 @@ export default {
             return groupIndex !== null ?
                 this.testId && `ContentCard-${this.testId}-${index}-${groupIndex}` :
                 this.testId && `ContentCard-${this.testId}-${index}`;
+        },
+
+        handleLogging () {
+
         }
     }
 };

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -550,9 +550,9 @@ export default {
          */
         handleLogging (logger) {
             // eslint-disable-next-line func-names
-            return function (type, logMessage, payload) {
+            return ((type, logMessage, payload) => {
                 if (logger && logger[type]) logger[type](logMessage, null, payload);
-            };
+            });
         }
     }
 };

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -549,9 +549,10 @@ export default {
          * @returns {function(*, *=, *=): void}
          */
         handleLogging (logger) {
-            // eslint-disable-next-line func-names
             return (type, logMessage, payload) => {
-                if (logger && logger[type]) logger[type](logMessage, null, payload);
+                if (logger && logger[type]) {
+                    logger[type](logMessage, null, payload);
+                }
             };
         }
     }

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -329,7 +329,7 @@ export default {
                     handleContentCardsGrouped: this.metadataContentCardsGrouped
                 },
                 loggerCallbacks: {
-                    logger: this.handleLogging
+                    logger: this.handleLogging(this.$logger)
                 }
             })
             .then(dispatcher => {
@@ -548,10 +548,10 @@ export default {
          * Handles logging from f-metadata (callback)
          * @returns {function(*, *=, *=): void}
          */
-        handleLogging () {
+        handleLogging (logger) {
             // eslint-disable-next-line func-names
             return function (type, logMessage, payload) {
-                if (this.$logger && this.$logger[type]) this.$logger[type](logMessage, null, payload);
+                if (logger && logger[type]) logger[type](logMessage, null, payload);
             };
         }
     }

--- a/packages/f-content-cards/src/components/tests/ContentCards.test.js
+++ b/packages/f-content-cards/src/components/tests/ContentCards.test.js
@@ -881,7 +881,7 @@ describe('ContentCards', () => {
             // Assert
             expect(instance.vm.$logger.logInfo).toHaveBeenCalledWith(testMessage, null, testPayload);
         });
-        it('should NOT return a function with the correct logging parameters when callback is called with incorrect logging type', async () => {
+        it('should NOT return a function when the callback is called with incorrect logging type', async () => {
             // Arrange
             const loggingType = 'foo';
             const instance = shallowMount(ContentCards, {

--- a/packages/f-content-cards/src/components/tests/ContentCards.test.js
+++ b/packages/f-content-cards/src/components/tests/ContentCards.test.js
@@ -851,4 +851,60 @@ describe('ContentCards', () => {
             expect(instance.find(`[data-test-id="ContentCard-${testId}-1-2"]`).exists()).toBeTruthy();
         });
     });
+    describe('logging callback', () => {
+        const testMessage = '__TEST_MESSAGE__';
+        const testPayload = { test: 'PAYLOAD' };
+        const testId = 'foo';
+
+        it('should return a function with the correct logging parameters when callback is called', async () => {
+            // Arrange
+            const loggingType = 'logInfo';
+            const instance = shallowMount(ContentCards, {
+                propsData: {
+                    apiKey,
+                    userId,
+                    groupCards: true,
+                    testId
+                },
+                mocks: {
+                    $logger: {
+                        logInfo: jest.fn()
+                    }
+                }
+            });
+
+            // Act
+            const loggingCallback = instance.vm.handleLogging(instance.vm.$logger);
+            loggingCallback(loggingType, testMessage, testPayload);
+            await instance.vm.$nextTick();
+
+            // Assert
+            expect(instance.vm.$logger.logInfo).toHaveBeenCalledWith(testMessage, null, testPayload);
+        });
+        it('should NOT return a function with the correct logging parameters when callback is called with incorrect logging type', async () => {
+            // Arrange
+            const loggingType = 'foo';
+            const instance = shallowMount(ContentCards, {
+                propsData: {
+                    apiKey,
+                    userId,
+                    groupCards: true,
+                    testId
+                },
+                mocks: {
+                    $logger: {
+                        logInfo: jest.fn()
+                    }
+                }
+            });
+
+            // Act
+            const loggingCallback = instance.vm.handleLogging(instance.vm.$logger);
+            loggingCallback(loggingType, testMessage, testPayload);
+            await instance.vm.$nextTick();
+
+            // Assert
+            expect(instance.vm.$logger.logInfo).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1752,6 +1752,18 @@
   dependencies:
     window-or-global "^1.0.1"
 
+"@justeat/f-metadata@3.0.0-beta.6":
+  version "3.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@justeat/f-metadata/-/f-metadata-3.0.0-beta.6.tgz#3d2ea0d38192a7b40f3ac1a8bb3a1194ccd62338"
+  integrity sha512-ZCBCcMxk2nVYw58hWaJdf5kVtfdeUQVausrhvSFq/V3bpGvTh+OJV1W0OUOKyizqRc8FnGVUEJVhqzCFeBNpew==
+  dependencies:
+    appboy-web-sdk "2.5.2"
+    date-fns "2.16.1"
+    lodash.findindex "4.6.0"
+    lodash.orderby "4.6.0"
+    lodash.startswith "4.2.1"
+    lodash.uniq "4.5.0"
+
 "@justeat/f-services@0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.13.0.tgz#b0fc67948e94800ba176addb9d92cce444d28c8e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1752,18 +1752,6 @@
   dependencies:
     window-or-global "^1.0.1"
 
-"@justeat/f-metadata@3.0.0-beta.6":
-  version "3.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@justeat/f-metadata/-/f-metadata-3.0.0-beta.6.tgz#3d2ea0d38192a7b40f3ac1a8bb3a1194ccd62338"
-  integrity sha512-ZCBCcMxk2nVYw58hWaJdf5kVtfdeUQVausrhvSFq/V3bpGvTh+OJV1W0OUOKyizqRc8FnGVUEJVhqzCFeBNpew==
-  dependencies:
-    appboy-web-sdk "2.5.2"
-    date-fns "2.16.1"
-    lodash.findindex "4.6.0"
-    lodash.orderby "4.6.0"
-    lodash.startswith "4.2.1"
-    lodash.uniq "4.5.0"
-
 "@justeat/f-services@0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.13.0.tgz#b0fc67948e94800ba176addb9d92cce444d28c8e"


### PR DESCRIPTION
A small PR to add a callback to the new f-metadata `loggerCallbacks`. Added tests and changes to package json to include new f-metadata 