### PR TITLE
f-searchbox@v4.0.0-beta.8 - Emit custom events for consuming applicat…

### DIFF
--- a/packages/f-searchbox/CHANGELOG.md
+++ b/packages/f-searchbox/CHANGELOG.md
@@ -3,6 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.0.0-beta.8
+------------------------------
+*December 4, 2020*
+
+### Added
+- Base line $emit events for consuming apps to listen to
+    - `@address-search-focus`
+    - `@submit-saved-address`
+    - `@track-postcode-changed`
+    - `@submit-valid-address`
+    - `@searchbox-error`
+- event-types folder to hold events specific constants.
+- Tests to cover changes to events.
+
+
 v4.0.0-beta.7
 ------------------------------
 *December 3, 2020*

--- a/packages/f-searchbox/README.md
+++ b/packages/f-searchbox/README.md
@@ -146,7 +146,7 @@ This will also work with the headings.
 ```js
 const copyOverrides = {
     buttonText: "Confirm",
-    fieldLabel: "Enter you address",
+    fieldLabel: "Enter your address",
     // ...
 }
 ```
@@ -174,11 +174,11 @@ Fires when the address input is focussed.
 
 ### `@submit-saved-address`
 
-Fires if an address is submitted with no errors.
+Fires if user submits an address with the same address as previously recorded by the searchbox.
 
 ### `@submit-valid-address`
 
-Fires if user submits an address with the same address as previously recorded by the searchbox.
+Fires if an address is submitted with no errors.
 
 ### `@track-postcode-changed`
 

--- a/packages/f-searchbox/README.md
+++ b/packages/f-searchbox/README.md
@@ -129,3 +129,56 @@ Applies query parameters to the form URL to enable filters and other options on 
     }"
 />
 ```
+
+## Override copy
+
+You can override the `f-searchbox` copy using `copy-override`.
+This will also work with the headings.
+
+```vue
+<template>
+    <search-box
+        locale="en-GB"
+        :copy-override="{ buttonText: 'Confirm' }" />
+</template>
+```
+
+```js
+const copyOverrides = {
+    buttonText: "Confirm",
+    fieldLabel: "Enter you address",
+    // ...
+}
+```
+
+## Custom analytic events
+
+`f-searchbox` exposes a number of hooks that can be used to trigger functions in the consuming application.
+
+```js
+<search-box
+    @searchbox-error="handleSearchboxError"
+    @address-search-focus="addressFocus"
+    @submit-saved-address="validSavedAddressSearch"
+    @submit-valid-address="validSearch" />
+```
+
+### `@searchbox-error`
+
+Fires when an error is thrown by searchbox.
+
+### `@address-search-focus`
+
+Fires when the address input is focussed.
+
+### `@submit-saved-address`
+
+Fires if an address is submitted with no errors.
+
+### `@submit-valid-address`
+
+Fires if user submits an address with the same address as previously recorded by the searchbox.
+
+### `@track-postcode-changed`
+
+Fires when the address input value has changed from a previous address to a new valid address.

--- a/packages/f-searchbox/README.md
+++ b/packages/f-searchbox/README.md
@@ -160,7 +160,8 @@ const copyOverrides = {
     @searchbox-error="handleSearchboxError"
     @address-search-focus="addressFocus"
     @submit-saved-address="validSavedAddressSearch"
-    @submit-valid-address="validSearch" />
+    @submit-valid-address="validSearch"
+    @track-postcode-changed="onPostcodeChanged"/>
 ```
 
 ### `@searchbox-error`

--- a/packages/f-searchbox/package.json
+++ b/packages/f-searchbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-searchbox",
   "description": "Fozzie Searchbox – Just Eat Takeaway Global Searchbox",
-  "version": "4.0.0-beta.7",
+  "version": "4.0.0-beta.8",
   "main": "dist/f-searchbox.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-searchbox/src/components/formElements/FormSearchField.vue
+++ b/packages/f-searchbox/src/components/formElements/FormSearchField.vue
@@ -40,6 +40,7 @@
 <script>
 import { mapActions, mapState } from 'vuex';
 import FormSearchInnerFieldWrapper from './FormSearchInnerFieldWrapper.vue';
+import { ADDRESS_SEARCH_FOCUS } from '../../event-types';
 
 const ALLOWED_SELECTION_TIME = 500;
 
@@ -120,9 +121,14 @@ export default {
          * @param {Boolean} value
          */
         toggleEnterLeaveInput (value) {
-            setTimeout(() => {
+            if (value) {
                 this.setInputFocus(value);
-            }, value ? 0 : ALLOWED_SELECTION_TIME);
+                this.$emit(ADDRESS_SEARCH_FOCUS);
+            } else {
+                setTimeout(() => {
+                    this.setInputFocus(value);
+                }, ALLOWED_SELECTION_TIME);
+            }
         }
     }
 };

--- a/packages/f-searchbox/src/components/tests/Form.test.js
+++ b/packages/f-searchbox/src/components/tests/Form.test.js
@@ -418,7 +418,7 @@ describe('`Form`', () => {
                         expect(spy).toHaveBeenCalledWith(['Error']);
                     });
 
-                    it('should `$emit` `searchbox-error` event when errors are received from an invalid submission', () => {
+                    it('should `$emit` `searchbox-error` event along with the error `types` when errors are received from an invalid submission', () => {
                         // Arrange
                         const address = 'AR511AR';
                         const errors = ['SOME_INVALID_MESSAGE'];

--- a/packages/f-searchbox/src/components/tests/Form.test.js
+++ b/packages/f-searchbox/src/components/tests/Form.test.js
@@ -308,6 +308,62 @@ describe('`Form`', () => {
                         // Assert
                         expect(spy).toHaveBeenCalledWith(true);
                     });
+
+                    it('should invoke `verifyHasPostcodeChanged` to check if a user has changed their postcode', () => {
+                        // Arrange
+                        const address = 'AR511AR';
+                        const propsData = {
+                            config: {
+                                address,
+                                locationFormat: () => jest.fn()
+                            },
+                            service: {
+                                isValid: jest.fn(() => true)
+                            }
+                        };
+                        const wrapper = shallowMount(Form, {
+                            propsData,
+                            store: createStore(),
+                            localVue
+                        });
+
+                        const spy = jest.spyOn(wrapper.vm, 'verifyHasPostcodeChanged');
+                        wrapper.setData({ address });
+
+                        // Act
+                        wrapper.vm.submit(event);
+
+                        // Assert
+                        expect(spy).toHaveBeenCalled();
+                    });
+
+                    it('should `$emit` with `submit-valid-address`', () => {
+                        // Arrange
+                        const address = 'AR511AR';
+                        const propsData = {
+                            config: {
+                                address,
+                                locationFormat: () => jest.fn()
+                            },
+                            service: {
+                                isValid: jest.fn(() => true)
+                            }
+                        };
+                        const wrapper = shallowMount(Form, {
+                            propsData,
+                            store: createStore(),
+                            localVue
+                        });
+
+                        const spy = jest.spyOn(wrapper.vm, '$emit');
+                        wrapper.setData({ address, lastAddress: '' });
+
+                        // Act
+                        wrapper.vm.submit(event);
+
+                        // Assert
+                        expect(spy).toHaveBeenCalledWith('submit-valid-address');
+                    });
                 });
 
                 describe('when `address` `isValid` is falsy', () => {
@@ -360,6 +416,37 @@ describe('`Form`', () => {
 
                         // Assert
                         expect(spy).toHaveBeenCalledWith(['Error']);
+                    });
+
+                    it('should `$emit` `searchbox-error` event when errors are received from an invalid submission', () => {
+                        // Arrange
+                        const address = 'AR511AR';
+                        const errors = ['SOME_INVALID_MESSAGE'];
+                        const propsData = {
+                            config: {
+                                address,
+                                locationFormat: () => jest.fn()
+                            },
+                            service: {
+                                isValid: jest.fn(() => errors)
+                            }
+                        };
+                        const wrapper = shallowMount(Form, {
+                            propsData,
+                            store: createStore({
+                                errors
+                            }),
+                            localVue
+                        });
+
+                        const spy = jest.spyOn(wrapper.vm, '$emit');
+                        wrapper.setData({ address, lastAddress: '' });
+
+                        // Act
+                        wrapper.vm.submit(event);
+
+                        // Assert
+                        expect(spy).toHaveBeenCalledWith('searchbox-error', errors);
                     });
                 });
             });
@@ -477,6 +564,89 @@ describe('`Form`', () => {
                     // Assert
                     expect(spy).toHaveBeenCalledWith(searchPayload, {
                         location: 'nebulae'
+                    });
+                });
+            });
+        });
+
+        describe('`verifyHasPostcodeChanged`', () => {
+            it('should exist', () => {
+                // Arrange
+                const propsData = {
+                    config: {
+                        address: 'something',
+                        locationFormat: () => jest.fn()
+                    },
+                    service: {
+                        isValid: jest.fn(() => [])
+                    }
+                };
+                const wrapper = shallowMount(Form, {
+                    propsData,
+                    store: createStore(),
+                    localVue
+                });
+
+                // Assert
+                expect(wrapper.vm.verifyHasPostcodeChanged).toBeDefined();
+            });
+
+            describe('when invoked', () => {
+                describe('AND the `lastAddress` previously saved (je-location) matches the current address entered', () => {
+                    it('should not invoke `$emit`', () => {
+                        // Arrange
+                        const propsData = {
+                            config: {
+                                address: 'something',
+                                locationFormat: () => jest.fn()
+                            },
+                            service: {
+                                isValid: jest.fn(() => [])
+                            }
+                        };
+                        const wrapper = shallowMount(Form, {
+                            propsData,
+                            store: createStore(),
+                            localVue
+                        });
+                        const address = 'Eridanus';
+                        wrapper.setData({ address, lastAddress: address });
+                        const spy = jest.spyOn(wrapper.vm, '$emit');
+
+                        // Act
+                        wrapper.vm.verifyHasPostcodeChanged();
+
+                        // Assert
+                        expect(spy).not.toHaveBeenCalled();
+                    });
+                });
+
+                describe('AND the `lastAddress` previously saved (je-location) does not match the current address entered', () => {
+                    it('should invoke `$emit` with `track-postcode-changed` to indicate the user has changed to a new postcode', () => {
+                        // Arrange
+                        const propsData = {
+                            config: {
+                                address: 'something',
+                                locationFormat: () => jest.fn()
+                            },
+                            service: {
+                                isValid: jest.fn(() => [])
+                            }
+                        };
+                        const wrapper = shallowMount(Form, {
+                            propsData,
+                            store: createStore(),
+                            localVue
+                        });
+                        const address = 'Eridanus';
+                        wrapper.setData({ address, lastAddress: 'Theta Eridani' });
+                        const spy = jest.spyOn(wrapper.vm, '$emit');
+
+                        // Act
+                        wrapper.vm.verifyHasPostcodeChanged();
+
+                        // Assert
+                        expect(spy).toHaveBeenCalledWith('track-postcode-changed');
                     });
                 });
             });

--- a/packages/f-searchbox/src/event-types/index.js
+++ b/packages/f-searchbox/src/event-types/index.js
@@ -1,0 +1,7 @@
+export const ADDRESS_SEARCH_FOCUS = 'address-search-focus';
+export const SUBMIT_SAVED_ADDRESS = 'submit-saved-address';
+export const SUBMIT_VALID_ADDRESS = 'submit-valid-address';
+export const SEARCHBOX_ERROR = 'searchbox-error';
+export const TRACK_POSTCODE_CHANGED = 'track-postcode-changed';
+
+


### PR DESCRIPTION
Allows emit events to be listened to from the consuming application.

### Added
- Base line $emit events for consuming apps to listen to
    - `@address-search-focus`
    - `@submit-saved-address`
    - `@track-postcode-changed`
    - `@submit-valid-address`
    - `@searchbox-error`
- event-types folder to hold events specific constants.
- Tests to cover changes to events.


## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
