### PR TITLE
f-services@v1.7.0 - Add 'es-ES' to phone and postcode validations

### DIFF
--- a/packages/f-services/CHANGELOG.md
+++ b/packages/f-services/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.7.0
+------------------------------
+*December 1, 2020*
+
+### Added
+- `es-ES` validations to postcode and phone validations.
+### Changed
+- `isValidPostcode` to accept locale.
+
+
 v1.6.0
 ------------------------------
 *December 1, 2020*

--- a/packages/f-services/CHANGELOG.md
+++ b/packages/f-services/CHANGELOG.md
@@ -5,10 +5,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.7.0
 ------------------------------
-*December 1, 2020*
+*December 7, 2020*
 
 ### Added
 - `es-ES` validations to postcode and phone validations.
+
 ### Changed
 - `isValidPostcode` to accept locale.
 
@@ -19,6 +20,7 @@ v1.6.0
 
 ### Added
 - `getDeepObjectByPath` to `utilities.js` to traverse an object using a given path.
+
 ### Changed
 - `getFormValidationState` function to return the full path of a nested object.
 

--- a/packages/f-services/package.json
+++ b/packages/f-services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-services",
   "description": "Fozzie Services - Shared Services for Components and projects",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "main": "dist/f-services.umd.js",
   "module": "dist/f-services.esm.js",
   "source": "src/index.js",

--- a/packages/f-services/src/validations.js
+++ b/packages/f-services/src/validations.js
@@ -32,7 +32,7 @@ const getFormValidationState = $v => {
 const POSTCODE_REGEX = {
     // https://stackoverflow.com/questions/164979/uk-postcode-regex-comprehensive#164994
     'en-GB': /^([Gg][Ii][Rr]\s?0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})$/,
-    'es-ES': /^(?:0[1-9]|[1-4]\d|5[0-2])\d{3}$/
+    'es-ES': /^\d{5}$/
 };
 
 const isValidPostcode = (postcode, locale) => POSTCODE_REGEX[locale].test(postcode);
@@ -47,7 +47,7 @@ const meetsCharacterValidationRules = value => /^[\u0060\u00C0-\u00F6\u00F8-\u01
 
 const PHONE_REGEX = {
     'en-GB': /^(\+(44))?[0-9]{10,11}$/,
-    'es-ES': /^(\+(34))?[0-9]{9,}$/
+    'es-ES': /^\d{9,}$/
 };
 
 const isValidPhoneNumber = (number, locale) => PHONE_REGEX[locale].test(number);

--- a/packages/f-services/src/validations.js
+++ b/packages/f-services/src/validations.js
@@ -29,10 +29,13 @@ const getFormValidationState = $v => {
     };
 };
 
-// https://stackoverflow.com/questions/164979/uk-postcode-regex-comprehensive#164994
-const POSTCODE_REGEX = /^([Gg][Ii][Rr]\s?0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})$/;
+const POSTCODE_REGEX = {
+    // https://stackoverflow.com/questions/164979/uk-postcode-regex-comprehensive#164994
+    'en-GB': /^([Gg][Ii][Rr]\s?0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})$/,
+    'es-ES': /^(?:0[1-9]|[1-4]\d|5[0-2])\d{3}$/
+};
 
-const isValidPostcode = postcode => POSTCODE_REGEX.test(postcode);
+const isValidPostcode = (postcode, locale) => POSTCODE_REGEX[locale].test(postcode);
 
 /**
  * Tests for existence of valid chars only in a string.
@@ -42,7 +45,10 @@ const isValidPostcode = postcode => POSTCODE_REGEX.test(postcode);
  */
 const meetsCharacterValidationRules = value => /^[\u0060\u00C0-\u00F6\u00F8-\u017Fa-zA-Z-' ]*$/.test(value);
 
-const PHONE_REGEX = { 'en-GB': /^(\+(44))?[0-9]{10,11}$/ };
+const PHONE_REGEX = {
+    'en-GB': /^(\+(44))?[0-9]{10,11}$/,
+    'es-ES': /^(\+(34))?[0-9]{9,}$/
+};
 
 const isValidPhoneNumber = (number, locale) => PHONE_REGEX[locale].test(number);
 

--- a/packages/f-services/tests/validations.test.js
+++ b/packages/f-services/tests/validations.test.js
@@ -149,25 +149,26 @@ describe('isValidPostcode', () => {
         expect(actual).toBe(expected);
     });
 
-    // it.each([
-    //     ['AR51 1AA', true],
-    //     ['BS1 4DJ', true],
-    //     ['bs14dj', true],
-    //     ['ec4m 7rf', true],
-    //     ['EC4M7RF', true],
-    //     ['A11A', false],
-    //     ['TEST1A', false],
-    //     ['not even trying', false],
-    //     ['BS! 4DJ', false],
-    //     ['', false],
-    //     [null, false]
-    // ])('should validate %s as %s with `es-ES` locale', (postcode, expected) => {
-    //     // Act
-    //     const actual = isValidPostcode(postcode, 'en-GB');
+    it.each([
+        ['01000', true],
+        ['52430', true],
+        ['342567', false],
+        ['4521', false],
+        ['AR51 1AA', false],
+        ['ATEGD', false],
+        ['00 000', false],
+        ['23', false],
+        ['not even trying', false],
+        ['01!23', false],
+        ['', false],
+        [null, false]
+    ])('should validate %s as %s with `es-ES` locale', (postcode, expected) => {
+        // Act
+        const actual = isValidPostcode(postcode, 'es-ES');
 
-    //     // Assert
-    //     expect(actual).toBe(expected);
-    // });
+        // Assert
+        expect(actual).toBe(expected);
+    });
 });
 
 describe('isValidPhoneNumber', () => {
@@ -183,6 +184,21 @@ describe('isValidPhoneNumber', () => {
     ])('should validate %s as %s with `en-GB` locale', (number, expected) => {
         // Act
         const actual = isValidPhoneNumber(number, 'en-GB');
+
+        // Assert
+        expect(actual).toBe(expected);
+    });
+
+    it.each([
+        ['111111111', true],
+        ['11111111', false],
+        ['!askfjt%$', false],
+        ['not even trying', false],
+        ['', false],
+        [null, false]
+    ])('should validate %s as %s with `es-ES` locale', (number, expected) => {
+        // Act
+        const actual = isValidPhoneNumber(number, 'es-ES');
 
         // Assert
         expect(actual).toBe(expected);

--- a/packages/f-services/tests/validations.test.js
+++ b/packages/f-services/tests/validations.test.js
@@ -141,13 +141,33 @@ describe('isValidPostcode', () => {
         ['BS! 4DJ', false],
         ['', false],
         [null, false]
-    ])('should validate %s as %s', (postcode, expected) => {
+    ])('should validate %s as %s with `en-GB` locale', (postcode, expected) => {
         // Act
-        const actual = isValidPostcode(postcode);
+        const actual = isValidPostcode(postcode, 'en-GB');
 
         // Assert
         expect(actual).toBe(expected);
     });
+
+    // it.each([
+    //     ['AR51 1AA', true],
+    //     ['BS1 4DJ', true],
+    //     ['bs14dj', true],
+    //     ['ec4m 7rf', true],
+    //     ['EC4M7RF', true],
+    //     ['A11A', false],
+    //     ['TEST1A', false],
+    //     ['not even trying', false],
+    //     ['BS! 4DJ', false],
+    //     ['', false],
+    //     [null, false]
+    // ])('should validate %s as %s with `es-ES` locale', (postcode, expected) => {
+    //     // Act
+    //     const actual = isValidPostcode(postcode, 'en-GB');
+
+    //     // Assert
+    //     expect(actual).toBe(expected);
+    // });
 });
 
 describe('isValidPhoneNumber', () => {


### PR DESCRIPTION
### Added
- `es-ES` validations to postcode and phone validations.

### Changed
- `isValidPostcode` to accept locale.