### PR TITLE
f-alert@0.4.0 - vue-button

### DIFF
--- a/packages/f-alert/CHANGELOG.md
+++ b/packages/f-alert/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.4.0
+------------------------------
+*December 7, 2020*
+
+### Changed
+- Regular button changed to vue button component
+
+### Updated
+- `f-vue-icons` to the latest version (1.13.0)
+
+
 v0.3.0
 ------------------------------
 *November 30, 2020*

--- a/packages/f-alert/CHANGELOG.md
+++ b/packages/f-alert/CHANGELOG.md
@@ -10,6 +10,7 @@ v0.4.0
 
 ### Changed
 - Regular button changed to vue button component
+- Renamed VueAlert to FAlert
 
 ### Updated
 - `f-vue-icons` to the latest version (1.13.0)

--- a/packages/f-alert/README.md
+++ b/packages/f-alert/README.md
@@ -32,17 +32,17 @@
     You can import it in your Vue SFC like this (please note that styles have to be imported separately):
 
     ```
-    import VueAlert from '@justeat/f-alert';
+    import FAlert from '@justeat/f-alert';
     import '@justeat/f-alert/dist/f-alert.css';
 
     export default {
         components: {
-            VueAlert
+            FAlert
         }
     }
     ```
 
-    If you are using Webpack, you can import the component dynamically to separate the `vue-alert` bundle from the main `bundle.client.js`:
+    If you are using Webpack, you can import the component dynamically to separate the `f-alert` bundle from the main `bundle.client.js`:
 
     ```
     import '@justeat/f-alert/dist/f-alert.css';
@@ -50,7 +50,7 @@
     export default {
         components: {
             ...
-            VueAlert: () => import(/* webpackChunkName: "vue-alert" */ '@justeat/f-alert')
+            FAlert: () => import(/* webpackChunkName: "f-alert" */ '@justeat/f-alert')
         }
     }
 

--- a/packages/f-alert/jest.config.js
+++ b/packages/f-alert/jest.config.js
@@ -18,7 +18,8 @@ module.exports = {
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',
         '^~include-media/(.*)$': '<rootDir>../../node_modules/include-media/$1',
-        '^~@justeat/(.*)$': '<rootDir>../../node_modules/@justeat/$1'
+        '^~@justeat/(.*)$': '<rootDir>../../node_modules/@justeat/$1',
+        '\\.(css|scss)$': 'jest-transform-stub'
     },
 
     snapshotSerializers: [

--- a/packages/f-alert/package.json
+++ b/packages/f-alert/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-alert",
   "description": "Fozzie Alert – Fozzie Alert Component",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "dist/f-alert.umd.min.js",
   "files": [
     "dist"
@@ -32,7 +32,7 @@
     "lint:fix": "yarn lint --fix",
     "lint:style": "vue-cli-service lint:style",
     "report": "cd ../.. && yarn report",
-    "test": "vue-cli-service test:unit", 
+    "test": "vue-cli-service test:unit",
     "test-component:chrome": "run-p --race demo webdriver:delay:chrome",
     "test:wait-for-server": "node ../../test/infrastructure/healthcheck.js",
     "webdriver:delay:chrome": "yarn test:wait-for-server && yarn webdriver:start:chrome",
@@ -47,8 +47,9 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
+    "@justeat/f-button": "0.4.0",
     "@justeat/f-services": "1.0.0",
-    "@justeat/f-vue-icons": "1.4.0"
+    "@justeat/f-vue-icons": "1.13.0"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1"

--- a/packages/f-alert/package.json
+++ b/packages/f-alert/package.json
@@ -47,9 +47,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-button": "0.4.0",
-    "@justeat/f-services": "1.0.0",
-    "@justeat/f-vue-icons": "1.13.0"
+    "@justeat/f-services": "1.0.0"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1"
@@ -60,6 +58,8 @@
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
     "@vue/test-utils": "1.0.3",
-    "node-sass-magic-importer": "5.3.2"
+    "node-sass-magic-importer": "5.3.2",
+    "@justeat/f-button": "0.4.0",
+    "@justeat/f-vue-icons": "1.13.0"
   }
 }

--- a/packages/f-alert/src/components/Alert.vue
+++ b/packages/f-alert/src/components/Alert.vue
@@ -18,19 +18,21 @@
                 data-test-id="alert-heading">
                 {{ heading }}
             </h2>
-            <button
+            <vue-button
                 v-if="isDismissible"
                 type="button"
-                :class="[$style['c-alert-dismiss'], 'o-btn o-btn--icon']"
+                :class="[$style['c-alert-dismiss']]"
+                button-type="icon"
+                button-size="xsmall"
                 data-test-id="alert-dismiss"
-                @click="dismiss">
+                @click.native="dismiss">
                 <cross-icon
                     :class="[$style['c-alert-dismiss-icon']]"
                 />
                 <span class="is-visuallyHidden">
                     {{ copy.dismissAlertText }}
                 </span>
-            </button>
+            </vue-button>
         </div>
         <div
             :class="$style['c-alert-content']">
@@ -48,7 +50,9 @@ import {
     WarningIcon
 } from '@justeat/f-vue-icons';
 import { globalisationServices } from '@justeat/f-services';
+import VueButton from '@justeat/f-button';
 import tenantConfigs from '../tenants';
+import '@justeat/f-button/dist/f-button.css';
 
 export default {
     name: 'VueAlert',
@@ -57,7 +61,8 @@ export default {
         DangerIcon,
         InfoIcon,
         SuccessIcon,
-        WarningIcon
+        WarningIcon,
+        VueButton
     },
     props: {
         locale: {
@@ -158,7 +163,7 @@ $alert-borderRadius: $border-radius;
             margin-right: 10px;
         }
 
-    button.c-alert-dismiss { // TODO: Needed more specificity here.
+    .c-alert-dismiss {
         text-indent: 0;
         margin-left: auto;
         margin-right: spacing();
@@ -170,6 +175,10 @@ $alert-borderRadius: $border-radius;
     }
 
         .c-alert-dismiss-icon {
-            height: 13px;
+            height: 16px;
+
+            * {
+                fill: $color-border--interactive;
+            }
         }
 </style>

--- a/packages/f-alert/src/components/Alert.vue
+++ b/packages/f-alert/src/components/Alert.vue
@@ -18,7 +18,7 @@
                 data-test-id="alert-heading">
                 {{ heading }}
             </h2>
-            <button-component
+            <f-button
                 v-if="isDismissible"
                 type="button"
                 :class="[$style['c-alert-dismiss']]"
@@ -32,7 +32,7 @@
                 <span class="is-visuallyHidden">
                     {{ copy.dismissAlertText }}
                 </span>
-            </button-component>
+            </f-button>
         </div>
         <div
             :class="$style['c-alert-content']">
@@ -50,19 +50,19 @@ import {
     WarningIcon
 } from '@justeat/f-vue-icons';
 import { globalisationServices } from '@justeat/f-services';
-import ButtonComponent from '@justeat/f-button';
+import FButton from '@justeat/f-button';
 import tenantConfigs from '../tenants';
 import '@justeat/f-button/dist/f-button.css';
 
 export default {
-    name: 'VueAlert',
+    name: 'FAlert',
     components: {
         CrossIcon,
         DangerIcon,
         InfoIcon,
         SuccessIcon,
         WarningIcon,
-        ButtonComponent
+        FButton
     },
     props: {
         locale: {

--- a/packages/f-alert/src/components/Alert.vue
+++ b/packages/f-alert/src/components/Alert.vue
@@ -18,7 +18,7 @@
                 data-test-id="alert-heading">
                 {{ heading }}
             </h2>
-            <vue-button
+            <button-component
                 v-if="isDismissible"
                 type="button"
                 :class="[$style['c-alert-dismiss']]"
@@ -32,7 +32,7 @@
                 <span class="is-visuallyHidden">
                     {{ copy.dismissAlertText }}
                 </span>
-            </vue-button>
+            </button-component>
         </div>
         <div
             :class="$style['c-alert-content']">
@@ -50,7 +50,7 @@ import {
     WarningIcon
 } from '@justeat/f-vue-icons';
 import { globalisationServices } from '@justeat/f-services';
-import VueButton from '@justeat/f-button';
+import ButtonComponent from '@justeat/f-button';
 import tenantConfigs from '../tenants';
 import '@justeat/f-button/dist/f-button.css';
 
@@ -62,7 +62,7 @@ export default {
         InfoIcon,
         SuccessIcon,
         WarningIcon,
-        VueButton
+        ButtonComponent
     },
     props: {
         locale: {

--- a/packages/f-alert/src/components/tests/Alert.test.js
+++ b/packages/f-alert/src/components/tests/Alert.test.js
@@ -1,5 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
-import VueAlert from '../Alert.vue';
+import FAlert from '../Alert.vue';
 
 const defaultPropsData = { heading: 'Alert title', type: 'info' };
 
@@ -11,7 +11,7 @@ describe('Alert', () => {
 
     it('should be defined', () => {
         // Arrange & Act
-        const wrapper = shallowMount(VueAlert, { propsData: defaultPropsData });
+        const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
         // Assert
         expect(wrapper.exists()).toBe(true);
@@ -19,7 +19,7 @@ describe('Alert', () => {
 
     it('should have the alert role for accessibility purposes', () => {
         // Arrange
-        const wrapper = shallowMount(VueAlert, { propsData: defaultPropsData });
+        const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
         // Act
         const alert = wrapper.find('[data-test-id="alert-component"]');
@@ -31,7 +31,7 @@ describe('Alert', () => {
     describe('icon', () => {
         it.each(['danger', 'success', 'info', 'warning'])('should show the %s icon for type %s', type => {
             // Arrange
-            const wrapper = shallowMount(VueAlert, { propsData: { heading: 'Alert title', type } });
+            const wrapper = shallowMount(FAlert, { propsData: { heading: 'Alert title', type } });
 
             // Act
             const icon = wrapper.find('[data-test-id="alert-icon"]');
@@ -44,7 +44,7 @@ describe('Alert', () => {
     describe('heading', () => {
         it('should render the heading passed into the alert', () => {
             // Arrange
-            const wrapper = shallowMount(VueAlert, { propsData: defaultPropsData });
+            const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
             // Act
             const heading = wrapper.find('[data-test-id="alert-heading"]');
@@ -57,7 +57,7 @@ describe('Alert', () => {
     describe('dismiss', () => {
         it('should render the dismiss button if `isDismissible` is true', () => {
             // Arrange
-            const wrapper = shallowMount(VueAlert, { propsData: { ...defaultPropsData, isDismissible: true } });
+            const wrapper = shallowMount(FAlert, { propsData: { ...defaultPropsData, isDismissible: true } });
 
             // Act
             const dismiss = wrapper.find('[data-test-id="alert-dismiss"]');
@@ -68,7 +68,7 @@ describe('Alert', () => {
 
         it('should not render the dismiss button if `isDismissible` is false', () => {
             // Arrange
-            const wrapper = shallowMount(VueAlert, { propsData: { ...defaultPropsData, isDismissible: false } });
+            const wrapper = shallowMount(FAlert, { propsData: { ...defaultPropsData, isDismissible: false } });
 
             // Act
             const dismiss = wrapper.find('[data-test-id="alert-dismiss"]');
@@ -79,9 +79,9 @@ describe('Alert', () => {
 
         it('should call `dismiss` when clicked', () => {
             // Arrange
-            const dismissSpy = jest.spyOn(VueAlert.methods, 'dismiss');
+            const dismissSpy = jest.spyOn(FAlert.methods, 'dismiss');
 
-            const wrapper = shallowMount(VueAlert, {
+            const wrapper = shallowMount(FAlert, {
                 propsData: { ...defaultPropsData, isDismissible: true }
             });
 
@@ -97,7 +97,7 @@ describe('Alert', () => {
         describe('type', () => {
             it('should be required', () => {
                 // Arrange
-                const wrapper = shallowMount(VueAlert, { propsData: defaultPropsData });
+                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
                 // Act
                 const { type } = wrapper.vm.$options.props;
@@ -108,7 +108,7 @@ describe('Alert', () => {
 
             it('should only allow `danger`, `success`, `info` or `warning` to be passed in.', () => {
                 // Arrange
-                const wrapper = shallowMount(VueAlert, { propsData: defaultPropsData });
+                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
                 // Act
                 const { type } = wrapper.vm.$options.props;
@@ -125,7 +125,7 @@ describe('Alert', () => {
         describe('heading', () => {
             it('should be required', () => {
                 // Arrange
-                const wrapper = shallowMount(VueAlert, { propsData: defaultPropsData });
+                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
                 // Act
                 const { heading } = wrapper.vm.$options.props;
@@ -140,7 +140,7 @@ describe('Alert', () => {
         describe('dismiss', () => {
             it('should set `isDismissed` to `true`', () => {
                 // Arrange
-                const wrapper = shallowMount(VueAlert, { propsData: defaultPropsData });
+                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
                 // Act
                 wrapper.vm.dismiss();
@@ -155,7 +155,7 @@ describe('Alert', () => {
         describe('icon', () => {
             it('should return the type with `Icon` camelCased', () => {
                 // Arrange
-                const wrapper = shallowMount(VueAlert, { propsData: defaultPropsData });
+                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
                 // Act
                 const result = wrapper.vm.icon;

--- a/packages/f-alert/src/demo/Index.vue
+++ b/packages/f-alert/src/demo/Index.vue
@@ -54,21 +54,21 @@
                 type="text"
                 data-test-id="control-heading">
         </div>
-        <vue-alert
+        <f-alert
             :locale="controls.locale"
             :type="controls.alertType"
             :is-dismissible="controls.isDismissible"
             :heading="controls.heading">
             You can put any HTML here!
-        </vue-alert>
+        </f-alert>
     </div>
 </template>
 
 <script>
-import VueAlert from '@/components/Alert.vue';
+import FAlert from '@/components/Alert.vue';
 
 export default {
-    components: { VueAlert },
+    components: { FAlert },
     data: () => ({
         controls: {
             locale: 'en-GB',

--- a/packages/f-alert/src/index.js
+++ b/packages/f-alert/src/index.js
@@ -6,13 +6,13 @@
 
 
 // Import vue component
-import VueAlert from '@/components/Alert.vue';
+import FAlert from '@/components/Alert.vue';
 
 // Declare install function executed by Vue.use()
 export function install (Vue) {
     if (install.installed) return;
     install.installed = true;
-    Vue.component('VueAlert', VueAlert);
+    Vue.component('FAlert', FAlert);
 }
 
 // Create module definition for Vue.use()
@@ -32,4 +32,4 @@ if (GlobalVue) {
 }
 
 // To allow use as module (npm/webpack/etc.) export component
-export default VueAlert;
+export default FAlert;

--- a/packages/f-alert/stories/Alert.stories.js
+++ b/packages/f-alert/stories/Alert.stories.js
@@ -1,7 +1,7 @@
 import { boolean, select, text
 } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
-import VueAlert from '../src/components/Alert.vue';
+import FAlert from '../src/components/Alert.vue';
 import VueCard from '../../f-card/src/components/Card.vue';
 
 export default {
@@ -10,7 +10,7 @@ export default {
 };
 
 export const AlertComponent = () => ({
-    components: { VueAlert, VueCard },
+    components: { FAlert, VueCard },
     props: {
         locale: {
             default: select('Locale', ['en-GB', 'es-ES'])
@@ -31,13 +31,13 @@ export const AlertComponent = () => ({
         is-rounded
         has-outline
         is-page-content-wrapper>
-        <vue-alert
+        <f-alert
             :locale="locale"
             :type="type"
             :isDismissible="isDismissible"
             :heading="heading">
             You can put any HTML here!
-        </vue-alert>
+        </f-alert>
         <p>
             Mollit aliqua labore excepteur voluptate consequat ut dolore
             ipsum nostrud magna elit proident laboris. Irure do nulla

--- a/packages/f-button/CHANGELOG.md
+++ b/packages/f-button/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.4.1
+------------------------------
+*December 8, 2020*
+
+### Changed
+- Renamed VueButton to FButton
+
+
 v0.4.0
 ------------------------------
 *December 4, 2020*

--- a/packages/f-button/README.md
+++ b/packages/f-button/README.md
@@ -32,17 +32,17 @@
     You can import it in your Vue SFC like this (please note that styles have to be imported separately):
 
     ```
-    import ButtonComponent from '@justeat/f-button';
+    import FButton from '@justeat/f-button';
     import '@justeat/f-button/dist/f-button.css';
 
     export default {
         components: {
-            ButtonComponent
+            FButton
         }
     }
     ```
 
-    If you are using Webpack, you can import the component dynamically to separate the `button-component` bundle from the main `bundle.client.js`:
+    If you are using Webpack, you can import the component dynamically to separate the `f-button` bundle from the main `bundle.client.js`:
 
     ```
     import '@justeat/f-button/dist/f-button.css';
@@ -50,7 +50,7 @@
     export default {
         components: {
             ...
-            ButtonComponent: () => import(/* webpackChunkName: "button-component" */ '@justeat/f-button')
+            FButton: () => import(/* webpackChunkName: "f-button" */ '@justeat/f-button')
         }
     }
 
@@ -59,7 +59,7 @@
 3.  Call the component in your template:
 
     ```
-    <button-component buttonType="secondary" buttonSize="small" isFullWidth />
+    <f-button buttonType="secondary" buttonSize="small" isFullWidth />
     ```
 
     Accepted properties:

--- a/packages/f-button/README.md
+++ b/packages/f-button/README.md
@@ -32,17 +32,17 @@
     You can import it in your Vue SFC like this (please note that styles have to be imported separately):
 
     ```
-    import VueButton from '@justeat/f-button';
+    import ButtonComponent from '@justeat/f-button';
     import '@justeat/f-button/dist/f-button.css';
 
     export default {
         components: {
-            VueButton
+            ButtonComponent
         }
     }
     ```
 
-    If you are using Webpack, you can import the component dynamically to separate the `vue-button` bundle from the main `bundle.client.js`:
+    If you are using Webpack, you can import the component dynamically to separate the `button-component` bundle from the main `bundle.client.js`:
 
     ```
     import '@justeat/f-button/dist/f-button.css';
@@ -50,7 +50,7 @@
     export default {
         components: {
             ...
-            VueButton: () => import(/* webpackChunkName: "vue-button" */ '@justeat/f-button')
+            ButtonComponent: () => import(/* webpackChunkName: "button-component" */ '@justeat/f-button')
         }
     }
 
@@ -59,7 +59,7 @@
 3.  Call the component in your template:
 
     ```
-    <vue-button buttonType="secondary" buttonSize="small" isFullWidth/>
+    <button-component buttonType="secondary" buttonSize="small" isFullWidth />
     ```
 
     Accepted properties:

--- a/packages/f-button/package.json
+++ b/packages/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/f-button.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-button/src/components/Button.vue
+++ b/packages/f-button/src/components/Button.vue
@@ -14,7 +14,7 @@
 <script>
 
 export default {
-    name: 'VueButton',
+    name: 'FButton',
     components: {},
     props: {
         buttonType: {

--- a/packages/f-button/src/components/tests/Button.test.js
+++ b/packages/f-button/src/components/tests/Button.test.js
@@ -1,11 +1,11 @@
 import { shallowMount } from '@vue/test-utils';
-import VueButton from '../Button.vue';
+import FButton from '../Button.vue';
 
 describe('Button', () => {
     allure.feature('Button');
     it('should be defined', () => {
         const propsData = {};
-        const wrapper = shallowMount(VueButton, { propsData });
+        const wrapper = shallowMount(FButton, { propsData });
         expect(wrapper.exists()).toBe(true);
     });
 });

--- a/packages/f-button/src/demo/Index.vue
+++ b/packages/f-button/src/demo/Index.vue
@@ -6,15 +6,15 @@
         <meta
             name="viewport"
             content="width=device-width, initial-scale=1">
-        <vue-button />
+        <f-button />
     </div>
 </template>
 
 <script>
-import VueButton from '@/components/Button.vue';
+import FButton from '@/components/Button.vue';
 
 export default {
-    components: { VueButton }
+    components: { FButton }
 };
 </script>
 

--- a/packages/f-button/src/index.js
+++ b/packages/f-button/src/index.js
@@ -6,13 +6,13 @@
 
 
 // Import vue component
-import VueButton from '@/components/Button.vue';
+import FButton from '@/components/Button.vue';
 
 // Declare install function executed by Vue.use()
 export function install (Vue) {
     if (install.installed) return;
     install.installed = true;
-    Vue.component('VueButton', VueButton);
+    Vue.component('FButton', FButton);
 }
 
 // Create module definition for Vue.use()
@@ -32,4 +32,4 @@ if (GlobalVue) {
 }
 
 // To allow use as module (npm/webpack/etc.) export component
-export default VueButton;
+export default FButton;

--- a/packages/f-button/stories/Button.stories.js
+++ b/packages/f-button/stories/Button.stories.js
@@ -2,7 +2,7 @@ import {
     withKnobs, select, boolean
 } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
-import VueButton from '../src/components/Button.vue';
+import FButton from '../src/components/Button.vue';
 
 export default {
     title: 'Components/Atoms',
@@ -10,7 +10,7 @@ export default {
 };
 
 export const ButtonComponent = () => ({
-    components: { VueButton },
+    components: { FButton },
     props: {
         buttonType: {
             default: select('Button Type', ['primary', 'secondary', 'outline', 'ghost', 'link', 'icon'], 'primary')
@@ -22,7 +22,7 @@ export const ButtonComponent = () => ({
             default: boolean('isFullWidth', false)
         }
     },
-    template: '<vue-button :buttonType="buttonType" :buttonSize="buttonSize" :isFullWidth="isFullWidth">Default Button Text</vue-button>'
+    template: '<f-button :buttonType="buttonType" :buttonSize="buttonSize" :isFullWidth="isFullWidth">Default Button Text</f-button>'
 });
 
 ButtonComponent.storyName = 'f-button';


### PR DESCRIPTION
## F-alert 0.4.0:

### Changed
- Regular button changed to vue button component
- Renamed VueAlert to FAlert

### Updated
- `f-vue-icons` to the latest version

![Screen Shot 2020-12-07 at 11 21 56](https://user-images.githubusercontent.com/19548183/101345089-71ba4680-387e-11eb-8601-b0a67484cfe2.png)


## F-button 0.4.1:

### Changed
- Renamed VueButton to FButton