### PR TITLE
storybook@v0.20.0 - Consistency with F-Development-Context

### DIFF
--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.20.0
+------------------------------
+*December 7, 2020*
+
+### Changed
+- Updated Context structure to make it identical to F-Development-Context which is used by WebDriver
+
+
 v0.19.0
 ------------------------------
 *December 3, 2020*

--- a/packages/storybook/config/storybook/preview.js
+++ b/packages/storybook/config/storybook/preview.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
+import setupContext from '../../context';
 
-// Setup Context as a Web Host (I18n, Cookies etc)
-import '../../context/index';
+setupContext();
 
 Vue.config.devtools = true;

--- a/packages/storybook/context/cookie.context.js
+++ b/packages/storybook/context/cookie.context.js
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import Cookie from 'cookie-universal';
 
-// Check out the Cookie Universal docs for usage -> https://www.npmjs.com/package/cookie-universal
-// In your mono repo component use this.$cookies.get('je-auser');
-Vue.prototype.$cookies = Cookie();
+export default () => {
+    // Check out the Cookie Universal docs for usage -> https://www.npmjs.com/package/cookie-universal
+    // In your mono repo component use this.$cookies.get('je-auser');
+    Vue.prototype.$cookies = Cookie();
+};

--- a/packages/storybook/context/i18n.context.js
+++ b/packages/storybook/context/i18n.context.js
@@ -2,17 +2,22 @@ import Vue from 'vue';
 import VueI18n from 'vue-i18n';
 
 import { addDecorator } from '@storybook/vue';
-import { ENGLISH_LOCALE } from '../constants/globalisation';
 
-Vue.use(VueI18n);
+export default () => {
+    Vue.use(VueI18n);
 
-const i18n = new VueI18n({
-    locale: ENGLISH_LOCALE,
-    fallbackLocale: ENGLISH_LOCALE,
-    messages: {}
-});
+    const ENGLISH_LOCALE = 'en-GB';
 
-addDecorator(() => ({
-    template: '<story/>',
-    i18n
-}));
+    const i18n = new VueI18n({
+        locale: ENGLISH_LOCALE,
+        fallbackLocale: ENGLISH_LOCALE,
+        messages: {}
+    });
+
+    addDecorator(() => ({
+        template: '<story/>',
+        i18n
+    }));
+
+    return i18n;
+};

--- a/packages/storybook/context/index.js
+++ b/packages/storybook/context/index.js
@@ -1,3 +1,13 @@
-import './cookie.context';
-import './i18n.context';
-import './logger.context';
+import i18nContext from './i18n.context';
+import stateContext from './vuex.context';
+import cookieContext from './cookie.context';
+import loggerContext from './logger.context';
+
+const initialise = () => {
+    i18nContext();
+    stateContext();
+    cookieContext();
+    loggerContext();
+};
+
+export default initialise;

--- a/packages/storybook/context/logger.context.js
+++ b/packages/storybook/context/logger.context.js
@@ -1,24 +1,27 @@
 import Vue from 'vue';
 
-const appendStandardProperties = (logPayload, message, level, mode) => {
-    logPayload.message = message || 'No message provided';
-    logPayload.Level = level || 'error'; // Intentionally uppercased property
-    logPayload.mode = mode || 'client';
+export default () => {
+    const appendStandardProperties = (logPayload, message, level, mode) => {
+        logPayload.message = message || 'No message provided';
+        logPayload.Level = level || 'error'; // Intentionally uppercased property
+        logPayload.mode = mode || 'client';
+    };
+
+    const logger = {
+        logError: (logMessage, store, logPayload = {}) => {
+            appendStandardProperties(logPayload, logMessage, 'Error', 'client');
+            console.error(logMessage, logPayload);
+        },
+        logWarn: (logMessage, store, logPayload = {}) => {
+            appendStandardProperties(logPayload, logMessage, 'Warn', 'client');
+            console.warn(logMessage, logPayload);
+        },
+        logInfo: (logMessage, store, logPayload = {}) => {
+            appendStandardProperties(logPayload, logMessage, 'Info', 'client');
+            console.log(logMessage, logPayload);
+        }
+    };
+
+    Vue.prototype.$logger = logger;
 };
 
-const logger = {
-    logError: (logMessage, store, logPayload = {}) => {
-        appendStandardProperties(logPayload, logMessage, 'Error', 'client');
-        console.error(logMessage, logPayload);
-    },
-    logWarn: (logMessage, store, logPayload = {}) => {
-        appendStandardProperties(logPayload, logMessage, 'Warn', 'client');
-        console.warn(logMessage, logPayload);
-    },
-    logInfo: (logMessage, store, logPayload = {}) => {
-        appendStandardProperties(logPayload, logMessage, 'Info', 'client');
-        console.log(logMessage, logPayload);
-    }
-};
-
-Vue.prototype.$logger = logger;

--- a/packages/storybook/context/vuex.context.js
+++ b/packages/storybook/context/vuex.context.js
@@ -1,0 +1,10 @@
+import Vue from 'vue';
+import Vuex from 'vuex';
+
+export default () => {
+    Vue.use(Vuex);
+
+    const newStore = new Vuex.Store({});
+
+    return newStore;
+};

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "scripts": {
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -s public -p 6006 -c config/storybook"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1697,6 +1697,14 @@
   dependencies:
     "@justeat/f-services" "1.0.0"
 
+"@justeat/f-form-field@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-1.4.0.tgz#4f5151996e2f80419bc74f6b126741161db7128a"
+  integrity sha512-LLiZ8McS9i8BTWrzujL0lWru7TlqDPp2JWjW3eUFCW8nUEbEIoDV5HJzQ1M21oLY7wSr0OH6wCqfNUfnRI5q/Q==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+    "@justeat/f-vue-icons" "1.11.0"
+
 "@justeat/f-icons@2.12.0":
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-2.12.0.tgz#07b221b284b4827ddcc6e04841228f77f24df45d"


### PR DESCRIPTION
- My aim is for the context (including standard feature sets) to be consistent between Storybook, the WebDriver Demo Scripts and CoreWeb (+ Other Microsites following the pattern).
This PR makes some minor changes to Storybook's context to make it consistent with the new `F-Development-Context` package used by WebDriver
- I wanted to consume `F-Development-Context` in storybook; but there were some impassable hurdles, I am happy to duplicate small parts in storybook (per ruleof3) as this will only be twice; and unlikely to change often.

**Changed**
- Updated Context structure to make it identical to F-Development-Context which is used by WebDriver