### PR TITLE
f-development-context@v1.0.0 - Create new service

### DIFF
--- a/services/f-development-context/.eslintignore
+++ b/services/f-development-context/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/services/f-development-context/CHANGELOG.md
+++ b/services/f-development-context/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+v1.0.0
+------------------------------
+*November 16, 2019*
+
+### Added
+- Created f-development-context Package supporting i18n, vuex, logger and cookies

--- a/services/f-development-context/README.md
+++ b/services/f-development-context/README.md
@@ -1,0 +1,25 @@
+# f-development-context
+- f-development-context provides entry points for the WebDriver Demo within components so that they can install the standard context of features
+- You shouldn't manually add this to any of your components; the generator will add the devDependency and wire up the WebDriver test scripts automatically
+
+<hr>
+
+## Contexts Added
+- **$logger** - The standard way to provide diagnostic output through `this.$logger`
+- **$cookies** - The standard way to interact with cookies through `this.$cookies`
+- **i18n** - The standard way to localise your components using `<i18n>`, `this.i18n` and `$t('message')`
+- **VueX** - The standard way to store state information in components
+
+### $logger Interface
+- logError(message, store, additionalProperties)
+- logWarn(message, store, additionalProperties)
+- logInfo(message, store, additionalProperties)
+
+### $cookies Interface
+- Refer to third party documentation: https://www.npmjs.com/package/cookie-universal
+
+### i18n Interface
+- Refer to third party documentation: https://kazupon.github.io/vue-i18n/introduction.html
+
+### VueX Interface
+- Refer to third party documentation: https://vuex.vuejs.org/guide/

--- a/services/f-development-context/babel.config.js
+++ b/services/f-development-context/babel.config.js
@@ -1,0 +1,22 @@
+module.exports = api => {
+    // Use isTest to determine what presets and plugins to use with jest
+    const isTest = api.env('test');
+    const presets = [];
+    const plugins = [
+        '@babel/plugin-proposal-optional-chaining'
+    ];
+
+    if (isTest) {
+        plugins.push('@babel/plugin-transform-runtime');
+    } else {
+        api.cache(true);
+    }
+
+    // use for both test and dev/live
+    presets.push('@babel/env');
+
+    return {
+        presets,
+        plugins
+    };
+};

--- a/services/f-development-context/jest.config.js
+++ b/services/f-development-context/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    moduleFileExtensions: [
+        'js',
+        'json'
+    ],
+
+    transform: {
+        '^.+\\.js$': 'babel-jest'
+    }
+};

--- a/services/f-development-context/package.json
+++ b/services/f-development-context/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@justeat/f-development-context",
+  "description": "A package to provide development context options for Storybook and WebDriver",
+  "version": "1.0.0",
+  "main": "dist/f-development-context.umd.js",
+  "module": "dist/f-development-context.esm.js",
+  "source": "src/index.js",
+  "files": [
+    "dist"
+  ],
+  "homepage": "https://github.com/justeat/fozzie-components/tree/master/services/f-development-context",
+  "contributors": [
+    "Github contributors <https://github.com/justeat/fozzie-components/graphs/contributors>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:justeat/fozzie-components.git"
+  },
+  "bugs": {
+    "url": "https://github.com/justeat/fozzie-components/issues"
+  },
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "keywords": [
+    "fozzie"
+  ],
+  "scripts": {
+    "prepublishOnly": "yarn build",
+    "build": "rollup --config"
+  },
+  "browserslist": [
+    "extends @justeat/browserslist-config-fozzie"
+  ],
+  "devDependencies": {
+    "@babel/plugin-transform-runtime": "7.11.0",
+    "@rollup/plugin-commonjs": "11.0.2",
+    "@rollup/plugin-json": "4.0.2",
+    "@rollup/plugin-node-resolve": "7.1.1",
+    "rollup": "1.26.3",
+    "rollup-plugin-babel": "4.4.0",
+    "rollup-plugin-terser": "5.1.2"
+  }
+}

--- a/services/f-development-context/rollup.config.js
+++ b/services/f-development-context/rollup.config.js
@@ -1,0 +1,32 @@
+import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
+import resolve from '@rollup/plugin-node-resolve';
+import { terser } from 'rollup-plugin-terser';
+import babel from 'rollup-plugin-babel';
+import pkg from './package.json';
+
+export default {
+    input: pkg.source,
+    output: [
+        {
+            file: pkg.main,
+            format: 'umd',
+            name: 'f-development-context'
+        },
+        { file: pkg.module, format: 'es' }
+    ],
+    plugins: [
+        resolve({
+            browser: true,
+            preferBuiltins: false
+        }),
+        commonjs({
+            include: /node_modules/
+        }),
+        terser(),
+        babel({
+            exclude: ['node_modules/**']
+        }),
+        json()
+    ]
+};

--- a/services/f-development-context/src/cookie.context.js
+++ b/services/f-development-context/src/cookie.context.js
@@ -1,0 +1,6 @@
+import Vue from 'vue';
+import Cookie from 'cookie-universal';
+
+// Check out the Cookie Universal docs for usage -> https://www.npmjs.com/package/cookie-universal
+// In your mono repo component use this.$cookies.get('je-auser');
+Vue.prototype.$cookies = Cookie();

--- a/services/f-development-context/src/i18n.context.js
+++ b/services/f-development-context/src/i18n.context.js
@@ -1,0 +1,16 @@
+import Vue from 'vue';
+import VueI18n from 'vue-i18n';
+
+export default () => {
+    Vue.use(VueI18n);
+
+    const ENGLISH_LOCALE = 'en-GB';
+
+    const i18n = new VueI18n({
+        locale: ENGLISH_LOCALE,
+        fallbackLocale: ENGLISH_LOCALE,
+        messages: {}
+    });
+
+    return i18n;
+};

--- a/services/f-development-context/src/index.js
+++ b/services/f-development-context/src/index.js
@@ -1,0 +1,21 @@
+import Vue from 'vue';
+
+import i18nContext from './i18n.context';
+import storeContext from './vuex.context';
+
+import './logger.context';
+import './cookie.context';
+
+Vue.config.productionTip = false;
+
+const initialise = (component, props) => {
+    new Vue({
+        i18n: i18nContext(),
+        store: storeContext(),
+        render: h => h(component, {
+            props
+        })
+    }).$mount('#app');
+};
+
+export default initialise;

--- a/services/f-development-context/src/logger.context.js
+++ b/services/f-development-context/src/logger.context.js
@@ -1,0 +1,24 @@
+import Vue from 'vue';
+
+const appendStandardProperties = (logPayload, message, level, mode) => {
+    logPayload.message = message || 'No message provided';
+    logPayload.Level = level || 'error'; // Intentionally uppercased property
+    logPayload.mode = mode || 'client';
+};
+
+const logger = {
+    logError: (logMessage, store, logPayload = {}) => {
+        appendStandardProperties(logPayload, logMessage, 'Error', 'client');
+        console.error(logMessage, logPayload);
+    },
+    logWarn: (logMessage, store, logPayload = {}) => {
+        appendStandardProperties(logPayload, logMessage, 'Warn', 'client');
+        console.warn(logMessage, logPayload);
+    },
+    logInfo: (logMessage, store, logPayload = {}) => {
+        appendStandardProperties(logPayload, logMessage, 'Info', 'client');
+        console.log(logMessage, logPayload);
+    }
+};
+
+Vue.prototype.$logger = logger;

--- a/services/f-development-context/src/vuex.context.js
+++ b/services/f-development-context/src/vuex.context.js
@@ -1,0 +1,10 @@
+import Vue from 'vue';
+import Vuex from 'vuex';
+
+export default () => {
+    Vue.use(Vuex);
+
+    const newStore = new Vuex.Store({});
+
+    return newStore;
+};


### PR DESCRIPTION
WebDriver uses the `yarn demo` script in components, the demo script does not have a way to setup cookies, logger, i18n or vuex without bespoke implementation.

`f-development-context` creates the solution for that, a service which will be added as a devDependency to packages OOTB, the demo script will use it to initialise the demo vue app, meaning all components initialise WebDriver tests in an identical way with all the OOTB features.

This also means when we add new capabilities; we don't need to update every single component, just this.

