### PR TITLE
f-checkout@v0.17.0 - Development Context

### DIFF
--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.17.0
+------------------------------
+*December 7, 2020*
+
+### Changed
+- Consume F-Development-Context for the WebDriver Demo Script
+
 
 v0.16.1
 ------------------------------

--- a/packages/f-checkout/package.json
+++ b/packages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",
@@ -61,6 +61,7 @@
     "vuex": "3.5.1"
   },
   "devDependencies": {
+    "@justeat/f-development-context": "1.0.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",

--- a/packages/f-checkout/src/demo/demo.js
+++ b/packages/f-checkout/src/demo/demo.js
@@ -1,27 +1,12 @@
-import Vue from 'vue';
-import Vuex from 'vuex';
-import { VueI18n } from '@justeat/f-globalisation';
-import VueDemo from './Demo.vue';
-import { ENGLISH_LOCALE } from '../../../storybook/constants/globalisation';
+import initialise from '@justeat/f-development-context';
+
+import VueCheckout from '../components/Checkout.vue';
 import CheckoutMock from './checkoutMock';
 
 CheckoutMock.setupCheckoutMethod('/checkout-delivery.json');
 
-Vue.config.productionTip = false;
+const props = {
+    checkoutUrl: '/checkout-delivery.json'
+};
 
-Vue.use(VueI18n);
-Vue.use(Vuex);
-
-const i18n = new VueI18n({
-    locale: ENGLISH_LOCALE,
-    fallbackLocale: ENGLISH_LOCALE,
-    messages: {}
-});
-
-/* eslint-disable no-new */
-new Vue({
-    i18n,
-    store: new Vuex.Store({}),
-    components: { VueDemo },
-    render: h => h(VueDemo)
-}).$mount('#app');
+initialise(VueCheckout, props);


### PR DESCRIPTION
**Changed**
- Consume F-Development-Context for the WebDriver Demo Script

This means the demo script is now externalised! and $cookies, $logger, i18n and VueX are available to yarn demo.

![image](https://user-images.githubusercontent.com/10741583/101349252-00ca5d00-3885-11eb-87dc-7706d9cf7859.png)
