### PR TITLE
f-checkout@v0.18.0 -  Update `f-services` validations and remove Spanish locale

### DIFF
--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -12,7 +12,7 @@ v0.18.0
 - Postcode validation.
 
 ## Removed
-- Spanish Locale from storybook;=.
+- Spanish Locale from storybook.
 
 
 v0.17.0

--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.18.0
+------------------------------
+*December 8, 2020*
+
+### Changed
+- `f-services` version.
+- Postcode validation.
+
+## Removed
+- Spanish Locale from storybook;=.
+
+
 v0.17.0
 ------------------------------
 *December 7, 2020*

--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -11,7 +11,7 @@ v0.18.0
 - `f-services` version.
 - Postcode validation.
 
-## Removed
+### Removed
 - Spanish Locale from storybook.
 
 

--- a/packages/f-checkout/package.json
+++ b/packages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",
@@ -51,7 +51,7 @@
     "@justeat/f-error-message": "0.3.0",
     "@justeat/f-form-field": "1.4.0",
     "@justeat/f-globalisation": "0.2.0",
-    "@justeat/f-services": "1.6.0",
+    "@justeat/f-services": "1.7.0",
     "axios": "0.20.0",
     "axios-mock-adapter": "1.19.0",
     "vuelidate": "0.7.6"

--- a/packages/f-checkout/src/components/Checkout.vue
+++ b/packages/f-checkout/src/components/Checkout.vue
@@ -328,6 +328,10 @@ export default {
         */
         isValidPhoneNumber () {
             return validations.isValidPhoneNumber(this.customer.mobileNumber, this.$i18n.locale);
+        },
+
+        isValidPostcode () {
+            return validations.isValidPostcode(this.fulfillment.address.postcode, this.$i18n.locale);
         }
     },
 
@@ -352,7 +356,7 @@ export default {
                     },
                     postcode: {
                         required,
-                        isValidPostcode: validations.isValidPostcode
+                        isValidPostcode: this.isValidPostcode
                     }
                 }
             };

--- a/packages/f-checkout/src/components/Checkout.vue
+++ b/packages/f-checkout/src/components/Checkout.vue
@@ -330,6 +330,10 @@ export default {
             return validations.isValidPhoneNumber(this.customer.mobileNumber, this.$i18n.locale);
         },
 
+        /*
+        * Use postcode validation in `f-services` to check if customer postcode is
+        * valid in current locale
+        */
         isValidPostcode () {
             return validations.isValidPostcode(this.fulfillment.address.postcode, this.$i18n.locale);
         }

--- a/packages/f-checkout/stories/Checkout.stories.js
+++ b/packages/f-checkout/stories/Checkout.stories.js
@@ -28,7 +28,7 @@ export const CheckoutComponent = () => ({
     components: { VueCheckout },
     props: {
         locale: {
-            default: select('Locale', VALID_LOCALES, ENGLISH_LOCALE)
+            default: select('Locale', [ENGLISH_LOCALE])
         },
         checkoutUrl: {
             default: select('Checkout Url', [deliveryUrl, collectionUrl], deliveryUrl)


### PR DESCRIPTION
### Changed
- `f-services` version.
- Postcode validation.

### Removed
- Spanish Locale from storybook.