### PR TITLE
f-registration@v0.43.3 - Removing tabindex from form element as not needed

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -3,13 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.43.3
+------------------------------
+*December 8, 2020*
+
+### Fixed
+- Remove tabindex from form element – results in visible border temporarily appearing around form when inputs are clicked.
+
+
 v0.43.2
 ------------------------------
 *December 7, 2020*
 
 ### Fixed
 - All tests now run in component spec files.
-
 
 
 v0.43.1

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.43.2",
+  "version": "0.43.3",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -23,7 +23,6 @@
             <form
                 type="post"
                 :class="$style['c-registration-form']"
-                tabindex="0"
                 @click="formStart"
                 @focus="formStart"
                 @submit.prevent="onFormSubmit">


### PR DESCRIPTION
### Fixed
- Remove tabindex from form element – results in visible border temporarily appearing around form when inputs are clicked.

---

## UI Review Checks

- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)