### PR TITLE
f-registration@v0.44.0 - Add loginURL Prop to support returnURL

### DIFF
--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -3,6 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.44.0
+------------------------------
+*December 9, 2020*
+
+### Added
+- 'loginUrl' prop so that returnUrl is not lost when clicking 'Already on Just Eat' as it can be passed in by the parent
+
+### Changed
+- Updated storybook to include missing props
+- Make 'showLoginLink' a required prop
+
+### Removed
+- Unsupported EU tenants
+- Obselete localisation message for loginUrl
+
 
 v0.43.3
 ------------------------------

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.43.3",
+  "version": "0.44.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -18,7 +18,7 @@
                 ]"
                 data-test-id="create-account-login-link"
                 @click="visitLoginPage">
-                <a :href="copy.navLinks.login.url">{{ copy.navLinks.login.text }}</a>
+                <a :href="loginUrl">{{ copy.navLinks.login.text }}</a>
             </p>
             <form
                 type="post"
@@ -244,7 +244,11 @@ export default {
         },
         showLoginLink: {
             type: Boolean,
-            default: true
+            required: true
+        },
+        loginUrl: {
+            type: String,
+            required: true
         }
     },
 

--- a/packages/f-registration/src/components/tests/Registration.test.js
+++ b/packages/f-registration/src/components/tests/Registration.test.js
@@ -9,7 +9,9 @@ jest.mock('../../services/RegistrationServiceApi', () => ({ createAccount: jest.
 describe('Registration', () => {
     allure.feature('Registration');
     const propsData = {
-        createAccountUrl: 'http://localhost/account/register'
+        createAccountUrl: 'http://localhost/account/register',
+        showLoginLink: true,
+        loginUrl: '/account/register'
     };
 
     it('should be defined', () => {
@@ -33,7 +35,8 @@ describe('Registration', () => {
             const wrapper = shallowMount(Registration, {
                 propsData: {
                     createAccountUrl: 'http://localhost/account/register',
-                    showLoginLink: true
+                    showLoginLink: true,
+                    loginUrl: '/account/register'
                 }
             });
 
@@ -46,7 +49,8 @@ describe('Registration', () => {
             const wrapper = shallowMount(Registration, {
                 propsData: {
                     createAccountUrl: 'http://localhost/account/register',
-                    showLoginLink: false
+                    showLoginLink: false,
+                    loginUrl: ''
                 }
             });
 
@@ -66,7 +70,9 @@ describe('Registration', () => {
         it('should show emit VisitLoginPage event when login link is clicked.', () => {
             const wrapper = shallowMount(Registration, {
                 propsData: {
-                    createAccountUrl: 'http://localhost/account/register'
+                    createAccountUrl: 'http://localhost/account/register',
+                    showLoginLink: true,
+                    loginUrl: '/account/register'
                 }
             });
 
@@ -81,7 +87,9 @@ describe('Registration', () => {
             // Arrange
             const wrapper = shallowMount(Registration, {
                 propsData: {
-                    createAccountUrl: 'http://localhost/account/register'
+                    createAccountUrl: 'http://localhost/account/register',
+                    showLoginLink: true,
+                    loginUrl: '/account/register'
                 }
             });
 

--- a/packages/f-registration/src/components/tests/f-registration.integration.test.js
+++ b/packages/f-registration/src/components/tests/f-registration.integration.test.js
@@ -11,7 +11,9 @@ const axiosMock = new MockAdapter(axios);
 
 const propsData = {
     locale: 'en-GB',
-    createAccountUrl: 'http://localhost/consumer/uk'
+    createAccountUrl: 'http://localhost/consumer/uk',
+    showLoginLink: true,
+    loginUrl: '/account/register'
 };
 
 let wrapper;

--- a/packages/f-registration/src/tenants/da-DK.js
+++ b/packages/f-registration/src/tenants/da-DK.js
@@ -1,3 +1,0 @@
-export default {
-    locale: 'da-DK'
-};

--- a/packages/f-registration/src/tenants/en-GB.js
+++ b/packages/f-registration/src/tenants/en-GB.js
@@ -20,8 +20,7 @@ export default {
             suffix: '.'
         },
         login: {
-            text: 'Already on Just Eat?',
-            url: '/account/login'
+            text: 'Already on Just Eat?'
         }
     },
 

--- a/packages/f-registration/src/tenants/en-IE.js
+++ b/packages/f-registration/src/tenants/en-IE.js
@@ -1,3 +1,0 @@
-export default {
-    locale: 'en-IE'
-};

--- a/packages/f-registration/src/tenants/es-ES.js
+++ b/packages/f-registration/src/tenants/es-ES.js
@@ -1,3 +1,0 @@
-export default {
-    locale: 'es-ES'
-};

--- a/packages/f-registration/src/tenants/index.js
+++ b/packages/f-registration/src/tenants/index.js
@@ -1,21 +1,11 @@
 import uk from './en-GB';
 import au from './en-AU';
 import nz from './en-NZ';
-import dk from './da-DK';
-import es from './es-ES';
-import ie from './en-IE';
-import it from './it-IT';
-import no from './nb-NO';
 
 const tenantConfigs = {
     'en-GB': uk,
     'en-AU': au,
-    'en-NZ': nz,
-    'da-DK': dk,
-    'es-ES': es,
-    'en-IE': ie,
-    'it-IT': it,
-    'nb-NO': no
+    'en-NZ': nz
 };
 
 export default tenantConfigs;

--- a/packages/f-registration/src/tenants/it-IT.js
+++ b/packages/f-registration/src/tenants/it-IT.js
@@ -1,3 +1,0 @@
-export default {
-    locale: 'it-IT'
-};

--- a/packages/f-registration/src/tenants/nb-NO.js
+++ b/packages/f-registration/src/tenants/nb-NO.js
@@ -1,3 +1,0 @@
-export default {
-    locale: 'nb-NO'
-};

--- a/packages/f-registration/stories/Registration.stories.js
+++ b/packages/f-registration/stories/Registration.stories.js
@@ -1,6 +1,6 @@
-import { withKnobs, select, text } from '@storybook/addon-knobs';
-import Registration from '../src/components/Registration.vue';
+import { withKnobs, select, text, boolean } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
+import Registration from '../src/components/Registration.vue';
 
 export default {
     title: 'Components/Organisms',
@@ -16,14 +16,30 @@ export const RegistrationComponent = () => ({
         title: {
             default: text('Title', 'Create Account')
         },
+        createAccountUrl: {
+            default: text('Create Account URL', '/account/register')
+        },
         buttonText: {
             default: text('Button Text', 'Create Account')
+        },
+        showLoginLink: {
+            default: boolean('Show Login Link', true)
+        },
+        loginUrl: {
+            default: text('Login URL', '/account/register')
         }
     },
     parameters: {
         notes: 'some documentation here'
     },
-    template: '<registration :locale="locale" :title="title" :button-text="buttonText" />'
+    template: `
+        <registration
+            :locale="locale"
+            :title="title"
+            :button-text="buttonText"
+            :create-account-url="createAccountUrl"
+            :show-login-link="showLoginLink"
+            :login-url="loginUrl" />`
 });
 
 RegistrationComponent.storyName = 'f-registration';


### PR DESCRIPTION
**Problem**
- When using the "Already have an account?" link, returnURL is lost; so navigating from Offers -> Registration -> Login and signing in, means the user won't get back to offers.

### Added
- 'loginUrl' prop so that returnUrl is not lost when clicking 'Already on Just Eat' as it can be passed in by the parent

### Changed
- Updated storybook to include missing props
- Make 'showLoginLink' a required prop

### Removed
- Unsupported EU tenants
- Obselete localisation message for loginUrl

![image](https://user-images.githubusercontent.com/10741583/101624234-8ed34e80-3a11-11eb-93ba-4dfa650b7f5c.png)
