### PR TITLE
f-checkout@0.23.0 f-button component

### DIFF
--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -11,6 +11,16 @@ v0.22.0
 - Webdriver tests for postcode format in `f-checkout-delivery`.
 
 
+v0.22.0
+------------------------------
+*December 10, 2020*
+
+### Changed
+- Moved justeat packages to the dev dependencies
+- Updated f-button component to the latest (0.4.1)
+- Renamed button-component to f-button for concistency between projects
+
+
 v0.21.0
 ------------------------------
 *December 10, 2020*

--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -3,22 +3,23 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.23.0
+------------------------------
+*December 11, 2020*
+
+### Changed
+- Moved justeat packages to the dev dependencies
+- Updated f-button component to the latest (0.4.1)
+- Renamed button-component to f-button for concistency between projects
+
+
 v0.22.0
 ------------------------------
 *December 11, 2020*
 
 ### Added
 - Webdriver tests for postcode format in `f-checkout-delivery`.
-
-
-v0.22.0
-------------------------------
-*December 10, 2020*
-
-### Changed
-- Moved justeat packages to the dev dependencies
-- Updated f-button component to the latest (0.4.1)
-- Renamed button-component to f-button for concistency between projects
 
 
 v0.21.0

--- a/packages/f-checkout/package.json
+++ b/packages/f-checkout/package.json
@@ -62,17 +62,17 @@
     "vuex": "3.5.1"
   },
   "devDependencies": {
+    "@justeat/f-alert": "0.4.0",
+    "@justeat/f-button": "0.4.1",
+    "@justeat/f-card": "0.8.0",
+    "@justeat/f-error-message": "0.3.0",
+    "@justeat/f-form-field": "1.6.1",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
     "@vue/test-utils": "1.0.3",
     "node-sass-magic-importer": "5.3.2",
-    "vuex": "3.5.1",
-    "@justeat/f-alert": "0.1.1",
-    "@justeat/f-button": "0.4.1",
-    "@justeat/f-card": "0.8.0",
-    "@justeat/f-error-message": "0.3.0",
-    "@justeat/f-form-field": "1.6.1"
+    "vuex": "3.5.1"
   }
 }

--- a/packages/f-checkout/package.json
+++ b/packages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/f-checkout/package.json
+++ b/packages/f-checkout/package.json
@@ -51,11 +51,6 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-alert": "0.1.1",
-    "@justeat/f-button": "0.3.0",
-    "@justeat/f-card": "0.8.0",
-    "@justeat/f-error-message": "0.3.0",
-    "@justeat/f-form-field": "1.6.1",
     "@justeat/f-globalisation": "0.2.0",
     "@justeat/f-services": "1.7.0",
     "axios": "0.20.0",
@@ -73,6 +68,11 @@
     "@vue/cli-plugin-unit-jest": "4.4.6",
     "@vue/test-utils": "1.0.3",
     "node-sass-magic-importer": "5.3.2",
-    "vuex": "3.5.1"
+    "vuex": "3.5.1",
+    "@justeat/f-alert": "0.1.1",
+    "@justeat/f-button": "0.4.1",
+    "@justeat/f-card": "0.8.0",
+    "@justeat/f-error-message": "0.3.0",
+    "@justeat/f-form-field": "1.6.1"
   }
 }

--- a/packages/f-checkout/src/components/Checkout.vue
+++ b/packages/f-checkout/src/components/Checkout.vue
@@ -43,21 +43,21 @@
 
                 <user-note data-test-id="user-note" />
 
-                <button-component
+                <f-button
                     :class="$style['c-checkout-allergyButton']"
                     button-type="link"
                     data-test-id="allergy-button">
                     {{ $t('allergyText') }}
-                </button-component>
+                </f-button>
 
-                <button-component
+                <f-button
                     :class="$style['c-checkout-submitButton']"
                     button-type="primary"
                     button-size="large"
                     is-full-width
                     data-test-id="confirm-payment-submit-button">
                     {{ $t('buttonText') }}
-                </button-component>
+                </f-button>
             </form>
         </card>
     </div>
@@ -69,7 +69,7 @@ import { required } from 'vuelidate/lib/validators';
 
 import Alert from '@justeat/f-alert';
 import '@justeat/f-alert/dist/f-alert.css';
-import ButtonComponent from '@justeat/f-button';
+import FButton from '@justeat/f-button';
 import '@justeat/f-button/dist/f-button.css';
 import { validations } from '@justeat/f-services';
 import { VueGlobalisationMixin } from '@justeat/f-globalisation';
@@ -98,7 +98,7 @@ export default {
     components: {
         AddressBlock,
         Alert,
-        ButtonComponent,
+        FButton,
         Card,
         ErrorMessage,
         FormField,

--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.45.0
+------------------------------
+*December 10, 2020*
+
+### Changed
+- Moved justeat packages to the dev dependencies
+- Updated f-button component to the latest (0.4.1)
+- Renamed button-component to f-button for concistency between projects
+
+
 v0.44.1
 ------------------------------
 *December 10, 2020*

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -59,6 +59,11 @@
     "@justeat/browserslist-config-fozzie": ">=1.1.1"
   },
   "devDependencies": {
+    "@justeat/f-button": "0.4.1",
+    "@justeat/f-card": "0.7.0",
+    "@justeat/f-error-message": "0.3.1",
+    "@justeat/f-form-field": "1.1.0",
+    "@justeat/f-vue-icons": "1.10.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.5.8",
     "@vue/cli-plugin-eslint": "3.9.2",
@@ -66,11 +71,6 @@
     "@vue/test-utils": "1.1.1",
     "axios-mock-adapter": "1.19.0",
     "flush-promises": "1.0.2",
-    "node-sass-magic-importer": "5.3.2",
-    "@justeat/f-button": "0.4.1",
-    "@justeat/f-card": "0.7.0",
-    "@justeat/f-error-message": "0.3.1",
-    "@justeat/f-form-field": "1.1.0",
-    "@justeat/f-vue-icons": "1.10.0"
+    "node-sass-magic-importer": "5.3.2"
   }
 }

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",
@@ -51,12 +51,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-button": "0.2.0",
-    "@justeat/f-card": "0.7.0",
-    "@justeat/f-error-message": "0.3.1",
-    "@justeat/f-form-field": "1.1.0",
     "@justeat/f-services": "1.4.0",
-    "@justeat/f-vue-icons": "1.10.0",
     "axios": "0.21.0",
     "vuelidate": "0.7.6"
   },
@@ -71,6 +66,11 @@
     "@vue/test-utils": "1.1.1",
     "axios-mock-adapter": "1.19.0",
     "flush-promises": "1.0.2",
-    "node-sass-magic-importer": "5.3.2"
+    "node-sass-magic-importer": "5.3.2",
+    "@justeat/f-button": "0.4.1",
+    "@justeat/f-card": "0.7.0",
+    "@justeat/f-error-message": "0.3.1",
+    "@justeat/f-form-field": "1.1.0",
+    "@justeat/f-vue-icons": "1.10.0"
   }
 }

--- a/packages/f-registration/src/components/Registration.vue
+++ b/packages/f-registration/src/components/Registration.vue
@@ -135,7 +135,7 @@
                     </template>
                 </form-field>
 
-                <button-component
+                <f-button
                     :class="$style['c-registration-submit']"
                     data-test-id="create-account-submit-button"
                     button-type="primary"
@@ -143,7 +143,7 @@
                     is-full-width
                     :disabled="shouldDisableCreateAccountButton">
                     {{ copy.labels.createAccountBtn }}
-                </button-component>
+                </f-button>
             </form>
             <p :class="$style['c-registration-link']">
                 {{ copy.navLinks.termsAndConditions.prefix }}
@@ -176,7 +176,7 @@ import {
     maxLength
 } from 'vuelidate/lib/validators';
 import { BagCelebrateIcon } from '@justeat/f-vue-icons';
-import ButtonComponent from '@justeat/f-button';
+import FButton from '@justeat/f-button';
 import '@justeat/f-button/dist/f-button.css';
 import CardComponent from '@justeat/f-card';
 import '@justeat/f-card/dist/f-card.css';
@@ -219,7 +219,7 @@ export default {
     name: 'Registration',
 
     components: {
-        ButtonComponent,
+        FButton,
         CardComponent,
         FormField,
         BagCelebrateIcon,

--- a/packages/f-searchbox/CHANGELOG.md
+++ b/packages/f-searchbox/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v4.0.0-beta.11
+------------------------------
+*December 10, 2020*
+
+### Changed
+- Moved justeat packages to the dev dependencies
+- Updated f-button component to the latest (0.4.1)
+
+
 v4.0.0-beta.10
 ------------------------------
 *December 10, 2020*

--- a/packages/f-searchbox/package.json
+++ b/packages/f-searchbox/package.json
@@ -60,7 +60,10 @@
     "vuex": "3.5.1"
   },
   "devDependencies": {
+    "@justeat/f-button": "0.4.1",
+    "@justeat/f-error-message": "0.3.1",
     "@justeat/f-globalisation": "0.2.0",
+    "@justeat/f-vue-icons": "1.13.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
@@ -68,9 +71,6 @@
     "@vue/test-utils": "1.0.3",
     "node-sass-magic-importer": "5.3.2",
     "vue": "2.6.10",
-    "vuex": "3.5.1",
-    "@justeat/f-button": "0.4.1",
-    "@justeat/f-error-message": "0.3.1",
-    "@justeat/f-vue-icons": "1.13.0"
+    "vuex": "3.5.1"
   }
 }

--- a/packages/f-searchbox/package.json
+++ b/packages/f-searchbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-searchbox",
   "description": "Fozzie Searchbox – Just Eat Takeaway Global Searchbox",
-  "version": "4.0.0-beta.10",
+  "version": "4.0.0-beta.11",
   "main": "dist/f-searchbox.umd.min.js",
   "files": [
     "dist",
@@ -50,10 +50,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-button": "0.2.0",
-    "@justeat/f-error-message": "0.3.1",
     "@justeat/f-services": "1.0.0",
-    "@justeat/f-vue-icons": "1.13.0",
     "axios": "0.19.2",
     "lodash.debounce": "4.0.8"
   },
@@ -71,6 +68,9 @@
     "@vue/test-utils": "1.0.3",
     "node-sass-magic-importer": "5.3.2",
     "vue": "2.6.10",
-    "vuex": "3.5.1"
+    "vuex": "3.5.1",
+    "@justeat/f-button": "0.4.1",
+    "@justeat/f-error-message": "0.3.1",
+    "@justeat/f-vue-icons": "1.13.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,14 +1633,6 @@
     eslint-config-airbnb-base "14.1.0"
     eslint-plugin-vue "6.2.2"
 
-"@justeat/f-alert@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@justeat/f-alert/-/f-alert-0.1.1.tgz#3ea11276f6c5931670c1f85f6810c1133601490b"
-  integrity sha512-Y1qpZwNiRuFkmwGtlgUmCRY1yyoSh5cI9bdPkFwfg+l8ToACbCkU/kGfwqNTfmUoOLCwrM5HMvK/NIcnwVXS2A==
-  dependencies:
-    "@justeat/f-services" "1.0.0"
-    "@justeat/f-vue-icons" "1.4.0"
-
 "@justeat/f-build-config@0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-build-config/-/f-build-config-0.3.0.tgz#15b18304e792ee031e0eb6b71f944c3d3c797c1f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1652,16 +1652,6 @@
     webpack-cli "3.3.1"
     webpack-log "2.0.0"
 
-"@justeat/f-button@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-0.2.0.tgz#fc60c21ada40557aa894dd54ec26be1b5a5dc6f7"
-  integrity sha512-+bWE9+hxNlzpJhIesShTwzm0lJ/nm3iXZC7LWAipMX5CtgQ0xOpwrOBMr0nPP4rKCV54QW8qHG4/4AjnghUuEw==
-
-"@justeat/f-button@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-0.3.0.tgz#2bd258023bb57160a64c91a690f1e0a188ce9c1b"
-  integrity sha512-ed72BvakNr8eDXRGNDht3VnVlS0VkdozVRn52iwWJ9HHz8w440+AO/dZIBBSgIdOgIN4MaHf5QORhgRiY0T8cg==
-
 "@justeat/f-button@0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-0.4.0.tgz#3abe0c470eaa0fc90ab9d03a4ffa86464d84f926"


### PR DESCRIPTION
## f-checkout@0.23.0

### Changed
- Moved justeat packages to the dev dependencies
- Updated f-button component to the latest (0.4.1)
- Renamed button-component to f-button for concistency between projects

## f-registration@0.45.0

### Changed
- Moved justeat packages to the dev dependencies
- Updated f-button component to the latest (0.4.1)
- Renamed button-component to f-button for concistency between projects

## f-searchbox@4.0.0-beta.11

### Changed
- Moved justeat packages to the dev dependencies
- Updated f-button component to the latest (0.4.1)