### PR TITLE
f-checkout@0.24.0 - Rename fulfill to fulfil

### DIFF
--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -8,7 +8,7 @@ v0.24.0
 *December 14, 2020*
 
 ### Changed
-- Renamed 'fulfill' ocurrences to 'fulfil' to keep in line with the Checkout API.
+- Renamed 'fulfill' occurrences to 'fulfil' to keep in line with the Checkout API.
 
 
 v0.23.0

--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.24.0
+------------------------------
+*December 14, 2020*
+
+### Changed
+- Renamed 'fulfill' ocurrences to 'fulfil' to keep in line with the Checkout API.
+
 
 v0.23.0
 ------------------------------

--- a/packages/f-checkout/package.json
+++ b/packages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",
@@ -34,7 +34,7 @@
     "lint:style": "vue-cli-service lint:style",
     "report": "cd ../.. && yarn report",
     "test": "vue-cli-service test:unit",
-    "storybook:serve-webdriver": "lerna run storybook:serve-static --stream", 
+    "storybook:serve-webdriver": "lerna run storybook:serve-static --stream",
     "test:coverage": "yarn test --coverage",
     "test-component:chrome": "run-p --race storybook:serve-webdriver webdriver:delay:chrome",
     "test:wait-for-server": "node ../../test/infrastructure/healthcheck.js",

--- a/packages/f-checkout/src/components/Address.vue
+++ b/packages/f-checkout/src/components/Address.vue
@@ -6,7 +6,7 @@
                 {{ $t('labels.addressGroup') }}
             </legend>
             <form-field
-                v-model="fulfillment.address.line1"
+                v-model="fulfilment.address.line1"
                 :class="$style['c-address-formField']"
                 name="address-line-1"
                 :label-text="$t('labels.line1')"
@@ -24,7 +24,7 @@
             </form-field>
 
             <form-field
-                v-model="fulfillment.address.line2"
+                v-model="fulfilment.address.line2"
                 :class="$style['c-address-formField']"
                 name="address-line-2"
                 :label-text="$t('labels.line2')"
@@ -33,7 +33,7 @@
         </fieldset>
 
         <form-field
-            v-model="fulfillment.address.city"
+            v-model="fulfilment.address.city"
             name="address-city"
             :label-text="$t('labels.city')"
             :has-error="isAddressCityEmpty">
@@ -47,7 +47,7 @@
         </form-field>
 
         <form-field
-            v-model="fulfillment.address.postcode"
+            v-model="fulfilment.address.postcode"
             name="address-postcode"
             :label-text="$t('labels.postcode')"
             :has-error="!isAddressPostcodeValid">
@@ -85,7 +85,7 @@ export default {
 
     computed: {
         ...mapState('checkout', [
-            'fulfillment'
+            'fulfilment'
         ]),
         /*
         * Validation methods return true if the validation conditions

--- a/packages/f-checkout/src/components/Checkout.vue
+++ b/packages/f-checkout/src/components/Checkout.vue
@@ -39,7 +39,7 @@
                     v-if="isCheckoutMethodDelivery"
                     data-test-id="address-block" />
 
-                <form-selector/>
+                <form-selector />
 
                 <user-note data-test-id="user-note" />
 
@@ -144,7 +144,7 @@ export default {
 
         Object.defineProperty($v, 'addressValidations', {
             enumerable: true,
-            get: () => this.$v.fulfillment.address
+            get: () => this.$v.fulfilment.address
         });
 
         return { $v };
@@ -155,7 +155,7 @@ export default {
             'id',
             'serviceType',
             'customer',
-            'fulfillment',
+            'fulfilment',
             'notes',
             'isFulfillable',
             'notices',
@@ -233,7 +233,7 @@ export default {
                 };
 
                 if (this.isCheckoutMethodDelivery) {
-                    checkoutData.address = this.fulfillment.address;
+                    checkoutData.address = this.fulfilment.address;
                 }
 
                 await this.postCheckout({
@@ -333,7 +333,7 @@ export default {
         * valid in current locale
         */
         isValidPostcode () {
-            return validations.isValidPostcode(this.fulfillment.address.postcode, this.$i18n.locale);
+            return validations.isValidPostcode(this.fulfilment.address.postcode, this.$i18n.locale);
         }
     },
 
@@ -348,7 +348,7 @@ export default {
         };
 
         if (this.isCheckoutMethodDelivery) {
-            deliveryDetails.fulfillment = {
+            deliveryDetails.fulfilment = {
                 address: {
                     line1: {
                         required

--- a/packages/f-checkout/src/components/Selector.vue
+++ b/packages/f-checkout/src/components/Selector.vue
@@ -5,7 +5,7 @@
         :class="$style['c-checkout-selector']"
         input-type="dropdown"
         :label-text="orderMethod"
-        :dropdown-options="fulfillmentTimes"
+        :dropdown-options="fulfilmentTimes"
         @input="selectionChanged" />
 </template>
 
@@ -20,7 +20,7 @@ export default {
 
     computed: {
         ...mapState('checkout', [
-            'fulfillment',
+            'fulfilment',
             'serviceType'
         ]),
 
@@ -31,24 +31,24 @@ export default {
         },
 
         /*
-        * Create an array from fulfillment times labels to
+        * Create an array from fulfilment times labels to
         * display as options in dropdown
         */
-        fulfillmentTimes () {
-            return this.fulfillment.times.map(time => time.label.text);
+        fulfilmentTimes () {
+            return this.fulfilment.times.map(time => time.label.text);
         }
     },
 
     methods: {
         /**
-        * Update all fulfillment.times.selected to false
-        * Update chosen fulfillment.times.selected to true
+        * Update all fulfilment.times.selected to false
+        * Update chosen fulfilment.times.selected to true
         *
         * @param {string} selectedTime The time emited when dropdown value is changed.
         **/
         selectionChanged (selectedTime) {
-            this.fulfillment.times.forEach(fulfillmentTime => {
-                fulfillmentTime.selected = fulfillmentTime.label.text === selectedTime;
+            this.fulfilment.times.forEach(fulfilmentTime => {
+                fulfilmentTime.selected = fulfilmentTime.label.text === selectedTime;
             });
         }
     }

--- a/packages/f-checkout/src/components/tests/Checkout.test.js
+++ b/packages/f-checkout/src/components/tests/Checkout.test.js
@@ -11,7 +11,7 @@ const localVue = createLocalVue();
 localVue.use(VueI18n);
 localVue.use(Vuex);
 
-const fulfillmentTimes = [
+const fulfilmentTimes = [
     {
         from: '2020-01-01T00:00+00:00',
         label: {
@@ -29,8 +29,8 @@ const defaultState = {
         firstName: 'John',
         mobileNumber: '+447111111111'
     },
-    fulfillment: {
-        times: fulfillmentTimes,
+    fulfilment: {
+        times: fulfilmentTimes,
         address: {
             line1: '1 Bristol Road',
             line2: 'Flat 1',
@@ -237,8 +237,8 @@ describe('Checkout', () => {
                     customer: {
                         firstName: defaultState.customer.firstName
                     },
-                    fulfillment: {
-                        times: fulfillmentTimes,
+                    fulfilment: {
+                        times: fulfilmentTimes,
                         address: {}
                     }
                 };
@@ -310,7 +310,7 @@ describe('Checkout', () => {
 
             it('should not create validations for address', () => {
                 // Assert
-                expect(wrapper.vm.$v.fulfillment).toBeUndefined();
+                expect(wrapper.vm.$v.fulfilment).toBeUndefined();
             });
         });
 
@@ -328,8 +328,8 @@ describe('Checkout', () => {
                     customer: {
                         firstName: defaultState.customer.firstName
                     },
-                    fulfillment: {
-                        times: fulfillmentTimes,
+                    fulfilment: {
+                        times: fulfilmentTimes,
                         address: {}
                     }
                 };
@@ -345,9 +345,9 @@ describe('Checkout', () => {
             it('should emit success event when all fields are populated correctly', async () => {
                 // Arrange
                 wrapper.find('[data-test-id="formfield-mobile-number-input"]').setValue(defaultState.customer.mobileNumber);
-                wrapper.find('[data-test-id="formfield-address-line-1-input"]').setValue(defaultState.fulfillment.address.line1);
-                wrapper.find('[data-test-id="formfield-address-city-input"]').setValue(defaultState.fulfillment.address.city);
-                wrapper.find('[data-test-id="formfield-address-postcode-input"]').setValue(defaultState.fulfillment.address.postcode);
+                wrapper.find('[data-test-id="formfield-address-line-1-input"]').setValue(defaultState.fulfilment.address.line1);
+                wrapper.find('[data-test-id="formfield-address-city-input"]').setValue(defaultState.fulfilment.address.city);
+                wrapper.find('[data-test-id="formfield-address-postcode-input"]').setValue(defaultState.fulfilment.address.postcode);
 
                 // Act
                 await wrapper.vm.onFormSubmit();
@@ -365,7 +365,7 @@ describe('Checkout', () => {
                 // Assert
                 expect(addressLine1EmptyMessage).toMatchSnapshot();
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
-                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment.address.line1');
+                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfilment.address.line1');
             });
 
             it('should emit failure event and display error message when city input field is empty', async () => {
@@ -376,7 +376,7 @@ describe('Checkout', () => {
                 // Assert
                 expect(addressCityEmptyMessage).toMatchSnapshot();
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
-                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment.address.city');
+                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfilment.address.city');
             });
 
             it('should emit failure event and display error message when postcode input field is empty', async () => {
@@ -387,7 +387,7 @@ describe('Checkout', () => {
                 // Assert
                 expect(addressPostcodeEmptyMessage).toMatchSnapshot();
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
-                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment.address.postcode');
+                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfilment.address.postcode');
             });
 
             it('should emit failure event and display error message when postcode contains incorrect characters', async () => {
@@ -401,7 +401,7 @@ describe('Checkout', () => {
                 // Assert
                 expect(addressPostcodeTypeErrorMessage).toMatchSnapshot();
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
-                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment.address.postcode');
+                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfilment.address.postcode');
             });
 
 
@@ -416,14 +416,14 @@ describe('Checkout', () => {
                 // Assert
                 expect(addressPostcodeTypeErrorMessage).toMatchSnapshot();
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
-                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfillment.address.postcode');
+                expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0].invalidFields).toContain('fulfilment.address.postcode');
             });
 
             it('should create validations for address', () => {
                 // Assert
-                expect(wrapper.vm.$v.fulfillment.address.line1).toBeDefined();
-                expect(wrapper.vm.$v.fulfillment.address.city).toBeDefined();
-                expect(wrapper.vm.$v.fulfillment.address.postcode).toBeDefined();
+                expect(wrapper.vm.$v.fulfilment.address.line1).toBeDefined();
+                expect(wrapper.vm.$v.fulfilment.address.city).toBeDefined();
+                expect(wrapper.vm.$v.fulfilment.address.postcode).toBeDefined();
             });
         });
     });
@@ -472,10 +472,10 @@ describe('Checkout', () => {
             });
 
             it('should set address fields', async () => {
-                expect(wrapper.find('[data-test-id="formfield-address-line-1-input"]').element.value).toBe(defaultState.fulfillment.address.line1);
-                expect(wrapper.find('[data-test-id="formfield-address-line-2-input"]').element.value).toBe(defaultState.fulfillment.address.line2);
-                expect(wrapper.find('[data-test-id="formfield-address-city-input"]').element.value).toBe(defaultState.fulfillment.address.city);
-                expect(wrapper.find('[data-test-id="formfield-address-postcode-input"]').element.value).toBe(defaultState.fulfillment.address.postcode);
+                expect(wrapper.find('[data-test-id="formfield-address-line-1-input"]').element.value).toBe(defaultState.fulfilment.address.line1);
+                expect(wrapper.find('[data-test-id="formfield-address-line-2-input"]').element.value).toBe(defaultState.fulfilment.address.line2);
+                expect(wrapper.find('[data-test-id="formfield-address-city-input"]').element.value).toBe(defaultState.fulfilment.address.city);
+                expect(wrapper.find('[data-test-id="formfield-address-postcode-input"]').element.value).toBe(defaultState.fulfilment.address.postcode);
             });
         });
     });

--- a/packages/f-checkout/src/components/tests/Selector.test.js
+++ b/packages/f-checkout/src/components/tests/Selector.test.js
@@ -10,7 +10,7 @@ const localVue = createLocalVue();
 localVue.use(VueI18n);
 localVue.use(Vuex);
 
-const fulfillmentTimes = [
+const fulfilmentTimes = [
     {
         from: '2020-01-01T00:00+00:00',
         label: {
@@ -28,8 +28,8 @@ const defaultState = {
         firstName: 'John',
         mobileNumber: '+447111111111'
     },
-    fulfillment: {
-        times: fulfillmentTimes,
+    fulfilment: {
+        times: fulfilmentTimes,
         address: {
             line1: '1 Bristol Road',
             line2: 'Flat 1',
@@ -114,8 +114,8 @@ describe('Selector', () => {
             });
         });
 
-        describe('fulfillmentTimes', () => {
-            it('should create an array of labels from `fulfillment.times` state', () => {
+        describe('fulfilmentTimes', () => {
+            it('should create an array of labels from `fulfilment.times` state', () => {
                 // Arrange && Act
                 const wrapper = shallowMount(Selector, {
                     store: createStore({ ...defaultState }),
@@ -127,14 +127,14 @@ describe('Selector', () => {
                 const expectedTimes = ['time 1'];
 
                 // Assert
-                expect(wrapper.vm.fulfillmentTimes).toEqual(expectedTimes);
+                expect(wrapper.vm.fulfilmentTimes).toEqual(expectedTimes);
             });
         });
     });
 
     describe('methods ::', () => {
         describe('selectionChanged', () => {
-            it('should update `fulfillment.times` time to be selected', () => {
+            it('should update `fulfilment.times` time to be selected', () => {
                 // Arrange
                 const wrapper = shallowMount(Selector, {
                     store: createStore({ ...defaultState }),
@@ -147,7 +147,7 @@ describe('Selector', () => {
                 wrapper.vm.selectionChanged('time 1');
 
                 // Assert
-                expect(wrapper.vm.fulfillment.times[0].selected).toBe(true);
+                expect(wrapper.vm.fulfilment.times[0].selected).toBe(true);
             });
         });
     });

--- a/packages/f-checkout/src/demo/checkout-collection.json
+++ b/packages/f-checkout/src/demo/checkout-collection.json
@@ -8,8 +8,9 @@
     "dateOfBirth": "1980-01-30",
     "emailAddress": "joe.bloggs@justeattakeaway.com"
   },
-  "fulfillment": {
-    "times": [{
+  "fulfilment": {
+    "times": [
+      {
         "label": {
           "text": "As soon as possible"
         },
@@ -37,13 +38,16 @@
   },
   "notes": [],
   "isFulfillable": true,
-  "notices": [{
-    "type": "allergy",
-    "notice": {
-      "text": "If you have a food allergy or intolerance (or someone you're ordering for has), <a href=\"https://greggs.co.uk/nutrition\" data-test-id=\"allergen-url-link\" target=\"_blank\" rel=\"noopener\">read what this restaurant has to say about allergies</a> before placing your order. Do not order if you cannot get the allergy information you need."
+  "notices": [
+    {
+      "type": "allergy",
+      "notice": {
+        "text": "If you have a food allergy or intolerance (or someone you're ordering for has), <a href=\"https://greggs.co.uk/nutrition\" data-test-id=\"allergen-url-link\" target=\"_blank\" rel=\"noopener\">read what this restaurant has to say about allergies</a> before placing your order. Do not order if you cannot get the allergy information you need."
+      }
     }
-  }],
-  "messages": [{
+  ],
+  "messages": [
+    {
       "type": "warning",
       "message": {
         "text": "Please hurry, the restaurant is closing soon"

--- a/packages/f-checkout/src/demo/checkout-delivery.json
+++ b/packages/f-checkout/src/demo/checkout-delivery.json
@@ -8,7 +8,7 @@
     "dateOfBirth": "1980-01-30",
     "emailAddress": "joe.bloggs@justeattakeaway.com"
   },
-  "fulfillment": {
+  "fulfilment": {
     "times": [
       {
         "label": {

--- a/packages/f-checkout/src/store/checkout.module.js
+++ b/packages/f-checkout/src/store/checkout.module.js
@@ -10,7 +10,7 @@ export default {
             firstName: '',
             mobileNumber: ''
         },
-        fulfillment: {
+        fulfilment: {
             times: [],
             address: {
                 line1: '',
@@ -82,7 +82,7 @@ export default {
             id,
             serviceType,
             customer,
-            fulfillment,
+            fulfilment,
             notes,
             isFulfillable,
             notices,
@@ -96,16 +96,16 @@ export default {
                 state.customer.mobileNumber = customer.phoneNumber;
             }
 
-            state.fulfillment.times = fulfillment.times;
+            state.fulfilment.times = fulfilment.times;
 
-            if (fulfillment.address) {
+            if (fulfilment.address) {
                 /* eslint-disable prefer-destructuring */
-                state.fulfillment.address.line1 = fulfillment.address.lines[0];
-                state.fulfillment.address.line2 = fulfillment.address.lines[1];
-                state.fulfillment.address.city = fulfillment.address.lines[3];
+                state.fulfilment.address.line1 = fulfilment.address.lines[0];
+                state.fulfilment.address.line2 = fulfilment.address.lines[1];
+                state.fulfilment.address.city = fulfilment.address.lines[3];
                 /* eslint-enable prefer-destructuring */
 
-                state.fulfillment.address.postcode = fulfillment.address.postalCode;
+                state.fulfilment.address.postcode = fulfilment.address.postalCode;
             }
 
             state.notes = notes;


### PR DESCRIPTION
v0.24.0
------------------------------
*December 14, 2020*

### Changed
- Renamed 'fulfill' occurrences to 'fulfil' to keep in line with the Checkout API.