### PR TITLE
f-content-cards@v2.2.0 🚀 Corrects HPC styling and storybook

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.2.0
+------------------------------
+*December 15, 2020*
+
+### Fixed
+- Styles to match designs in HPC 1&2
+- Correct stories for HPC 1&2
+
+### Updated
+- Dynamically change HPC1 subtitle and HPC2 title and text between light/dark based on
+  luminosity of BG colour(s)
+- Tests to check above behave correctly
+
+
 v2.2.0-beta.9
 ------------------------------
 *December 03, 2020*

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "2.2.0-beta.9",
+  "version": "2.2.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"
@@ -45,13 +45,14 @@
     "vue": "2.x"
   },
   "devDependencies": {
+    "@justeat/f-metadata": "3.0.0-beta.7",
     "@justeat/f-vue-icons": "1.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
-    "@justeat/f-metadata": "3.0.0-beta.7",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
     "@vue/test-utils": "1.0.3",
+    "color": "3.1.3",
     "copy-to-clipboard": "3.3.1",
     "crypto-js": "4.0.0",
     "faker": "4.1.0",

--- a/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
@@ -7,14 +7,14 @@
             :data-test-id="containerTestId"
             :class="['l-container', 'c-contentCards-homePromotionCard1-container', $style['c-contentCards-homePromotionCard1-container']]"
             :style="{ maxWidth: `${containerMaxWidth}px` }">
-            <div :class="['c-contentCards-homePromotionCard1-icon', $style['c-contentCards-homePromotionCard1-icon']]">
+            <div :class="['c-contentCards-homePromotionCard1-iconPane', $style['c-contentCards-homePromotionCard1-iconPane']]">
                 <img
-                    :class="[$style['c-contentCards-homePromotionCard1-icon-img']]"
+                    :class="[$style['c-contentCards-homePromotionCard1-icon']]"
                     :src="icon"
                     alt="">
                 <h3
-                    :class="[$style['c-contentCards-homePromotionCard1-icon-subtitle'], {
-                        [$style['c-contentCards-homePromotionCard1-icon-subtitle--light']]: isLightSubtitle
+                    :class="[$style['c-contentCards-homePromotionCard1-subtitle'], {
+                        [$style['c-contentCards-homePromotionCard1-subtitle--light']]: isLightSubtitle
                     }]"
                 >
                     {{ subtitle }}
@@ -120,7 +120,7 @@ export default {
         margin: 0 auto;
     }
 
-    .c-contentCards-homePromotionCard1-icon {
+    .c-contentCards-homePromotionCard1-iconPane {
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -134,20 +134,20 @@ export default {
         }
     }
 
-        .c-contentCards-homePromotionCard1-icon-img {
-            max-height: 88px;
-            max-width: 100%;
+    .c-contentCards-homePromotionCard1-icon {
+        max-height: 88px;
+        max-width: 100%;
+    }
+
+    .c-contentCards-homePromotionCard1-subtitle {
+        display: none;
+
+        @include media('>mid') {
+            display: unset;
         }
+    }
 
-        .c-contentCards-homePromotionCard1-icon-subtitle {
-            display: none;
-
-            @include media('>mid') {
-                display: unset;
-            }
-        }
-
-        .c-contentCards-homePromotionCard1-icon-subtitle--light {
+        .c-contentCards-homePromotionCard1-subtitle--light {
             color: $white;
         }
 
@@ -161,16 +161,16 @@ export default {
             padding-left: 0;
             padding-right: spacing(x4);
 
-            .c-contentCards-homePromotionCard2 {
+            :global(.c-contentCards-homePromotionCard2) {
                 padding-left: spacing(x5);
             }
 
-            h3 {
+            :global(.c-contentCards-homePromotionCard2-title) {
                 @include font-size(large);
                 margin-bottom: spacing();
             }
 
-            p {
+            :global(.c-contentCards-homePromotionCard2-text) {
                 @include font-size(mid);
                 margin-top: spacing();
             }

--- a/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
@@ -9,8 +9,16 @@
             :style="{ maxWidth: `${containerMaxWidth}px` }">
             <div :class="['c-contentCards-homePromotionCard1-icon', $style['c-contentCards-homePromotionCard1-icon']]">
                 <img
+                    :class="[$style['c-contentCards-homePromotionCard1-icon-img']]"
                     :src="icon"
                     alt="">
+                <h3
+                    :class="[$style['c-contentCards-homePromotionCard1-icon-subtitle'], {
+                        [$style['c-contentCards-homePromotionCard1-icon-subtitle--light']]: isLightSubtitle
+                    }]"
+                >
+                    {{ subtitle }}
+                </h3>
             </div>
             <div :class="['c-contentCards-homePromotionCard1-innerCard', $style['c-contentCards-homePromotionCard1-innerCard']]">
                 <home-promotion-card2 :card="card" />
@@ -20,6 +28,7 @@
 </template>
 
 <script>
+import Color from 'color';
 import HomePromotionCard2 from './HomePromotionCard2.vue';
 
 export default {
@@ -51,7 +60,8 @@ export default {
             icon,
             title,
             url,
-            description
+            description,
+            subtitle
         } = this.card;
 
         return {
@@ -64,7 +74,8 @@ export default {
             type,
             icon,
             url,
-            description
+            description,
+            subtitle
         };
     },
     computed: {
@@ -74,6 +85,20 @@ export default {
 
         containerTestId () {
             return this.testId ? `${this.testId}--container` : false;
+        },
+
+        /**
+         * If background colour is set *and* dark, then use a light text colour for the subtitle for A11y
+         * @return {boolean}
+         */
+        isLightSubtitle () {
+            try {
+                return this.backgroundColor
+                    ? (new Color(this.backgroundColor)).isDark()
+                    : false;
+            } catch {
+                return false;
+            }
         }
     }
 };
@@ -97,21 +122,34 @@ export default {
 
     .c-contentCards-homePromotionCard1-icon {
         display: flex;
+        flex-direction: column;
         align-items: center;
         justify-content: center;
         width: 100%;
         margin-bottom: spacing(x3);
-
-        img {
-            max-height: 65px;
-            max-width: 100%;
-        }
 
         @include media('>mid') {
             width: 50%;
             margin-bottom: 0;
         }
     }
+
+        .c-contentCards-homePromotionCard1-icon-img {
+            max-height: 88px;
+            max-width: 100%;
+        }
+
+        .c-contentCards-homePromotionCard1-icon-subtitle {
+            display: none;
+
+            @include media('>mid') {
+                display: unset;
+            }
+        }
+
+        .c-contentCards-homePromotionCard1-icon-subtitle--light {
+            color: $white;
+        }
 
     .c-contentCards-homePromotionCard1-innerCard {
         width: 100%;
@@ -122,6 +160,20 @@ export default {
             width: 50%;
             padding-left: 0;
             padding-right: spacing(x4);
+
+            .c-contentCards-homePromotionCard2 {
+                padding-left: spacing(x5);
+            }
+
+            h3 {
+                @include font-size(large);
+                margin-bottom: spacing();
+            }
+
+            p {
+                @include font-size(mid);
+                margin-top: spacing();
+            }
         }
     }
 </style>

--- a/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
@@ -1,7 +1,9 @@
 <template>
     <div
         :data-test-id="testId"
-        :class="['c-contentCards-homePromotionCard2', $style['c-contentCards-homePromotionCard2']]"
+        :class="['c-contentCards-homePromotionCard2', $style['c-contentCards-homePromotionCard2'], {
+            [$style['c-contentCards-homePromotionCard2--light']]: isLightText
+        }]"
         :style="{ background: contentBackgroundColor }">
         <div
             :class="['c-contentCards-homePromotionCard2-image', $style['c-contentCards-homePromotionCard2-image']]"
@@ -23,6 +25,8 @@
 </template>
 
 <script>
+import Color from 'color';
+
 export default {
     props: {
         card: {
@@ -38,6 +42,7 @@ export default {
         const {
             image,
             ctaText,
+            backgroundColor,
             contentBackgroundColor,
             title,
             url,
@@ -46,6 +51,7 @@ export default {
 
         return {
             title,
+            backgroundColor,
             contentBackgroundColor,
             image,
             ctaText,
@@ -56,6 +62,27 @@ export default {
     computed: {
         ctaTestId () {
             return this.testId ? `${this.testId}--cta` : false;
+        },
+
+        /**
+         * If background colour is set *and* dark, then use a light text colour for the title and text for A11y
+         * @return {boolean}
+         */
+        isLightText () {
+            if (this.contentBackgroundColor) {
+                try {
+                    return new Color(this.contentBackgroundColor).isDark();
+                } catch {
+                    // Fall through and try with backgroundColor from surrounding HPC1
+                }
+            }
+            try {
+                return this.backgroundColor
+                    ? (new Color(this.backgroundColor)).isDark()
+                    : false;
+            } catch {
+                return false;
+            }
         }
     }
 };
@@ -72,6 +99,37 @@ export default {
 
         @include media('>narrow') {
             padding-right: 208px;
+        }
+
+        a {
+            & {
+                color: $color-link-default;
+            }
+
+            &:hover, &:focus {
+                color: $color-link-hover;
+            }
+
+            &:active {
+                color: $color-link-active;
+            }
+
+            text-decoration: none;
+            font-weight: $font-weight-bold;
+        }
+
+        p {
+            color: $grey--dark;
+        }
+
+        &.c-contentCards-homePromotionCard2--light {
+            p {
+                color: $white;
+            }
+
+            h3 {
+                color: $grey--lighter;
+            }
         }
     }
 

--- a/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
@@ -8,10 +8,14 @@
         <div
             :class="['c-contentCards-homePromotionCard2-image', $style['c-contentCards-homePromotionCard2-image']]"
             :style="{ backgroundImage: `url('${image}')` }" />
-        <h3>{{ title }}</h3>
+        <h3
+            :class="['c-contentCards-homePromotionCard2-title', $style['c-contentCards-homePromotionCard2-title']]">
+            {{ title }}
+        </h3>
         <template v-for="(textItem, textIndex) in description">
             <p
-                :key="textIndex">
+                :key="textIndex"
+                :class="['c-contentCards-homePromotionCard2-text', $style['c-contentCards-homePromotionCard2-text']]">
                 {{ textItem }}
             </p>
         </template>
@@ -19,7 +23,13 @@
             <a
                 :href="url"
                 :data-test-id="ctaTestId"
-                class="o-link--full o-link--bold u-color-link u-text-left">{{ ctaText }}</a>
+                :class="[
+                    'o-link--full',
+                    'o-link--bold',
+                    'u-color-link',
+                    'u-text-left',
+                    $style['c-contentCards-homePromotionCard2-link']
+                ]">{{ ctaText }}</a>
         </p>
     </div>
 </template>
@@ -101,7 +111,10 @@ export default {
             padding-right: 208px;
         }
 
-        a {
+        .c-contentCards-homePromotionCard2-link {
+            text-decoration: none;
+            font-weight: $font-weight-bold;
+
             & {
                 color: $color-link-default;
             }
@@ -113,21 +126,18 @@ export default {
             &:active {
                 color: $color-link-active;
             }
-
-            text-decoration: none;
-            font-weight: $font-weight-bold;
         }
 
-        p {
+        .c-contentCards-homePromotionCard2-text {
             color: $grey--dark;
         }
 
         &.c-contentCards-homePromotionCard2--light {
-            p {
+            .c-contentCards-homePromotionCard2-text {
                 color: $white;
             }
 
-            h3 {
+            .c-contentCards-homePromotionCard2-title {
                 color: $grey--lighter;
             }
         }

--- a/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard1.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard1.test.js
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+import Color from 'color';
 import HomePromotionCard1 from '../HomePromotionCard1.vue';
 
 const testId = '__TEST_ID__';
@@ -32,5 +33,254 @@ describe('contentCards › HomePromotionCard1', () => {
 
         // Assert
         expect(styles.indexOf(`max-width: ${containerMaxWidth}px;`)).toBe(0);
+    });
+
+    describe('when `backgroundColor` is "#000" ::', () => {
+        it('should set the `background` css property appropriately in a style attribute', () => {
+            // Arrange
+            const backgroundColor = '#000';
+            const card = {
+                backgroundColor
+            };
+            const expectedColour = new Color(backgroundColor);
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard1, {
+                propsData: {
+                    testId,
+                    card
+                }
+            });
+
+            // Assert
+            const styles = wrapper.find(`[data-test-id="${testId}"]`).attributes('style');
+            const [, backgroundColour] = styles.match(/background: ([^;]+);/);
+
+            // Check contrast is 1 - e.g. colour is identical
+            expect(expectedColour.contrast(new Color(backgroundColour))).toBe(1);
+        });
+    });
+
+    describe('when `backgroundColor` is undefined ::', () => {
+        it('should not set the `background` css property in a style attribute', () => {
+            // Arrange
+            const card = {};
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard1, {
+                propsData: {
+                    testId,
+                    card
+                }
+            });
+
+            // Assert
+            const styles = wrapper.find(`[data-test-id="${testId}"]`).attributes('style') || '';
+            expect(styles.match(/background: ([^;]+);/)).toBeNull();
+        });
+    });
+
+    describe('when `backgroundColor` is `#000` ::', () => {
+        it('should add the light subtitle class', () => {
+            // Arrange
+            const backgroundColor = '#000';
+            const card = {
+                backgroundColor
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard1, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            expect(lightSubtitle.exists()).toBe(true);
+        });
+    });
+
+    describe('when `backgroundColor` is "#fff" ::', () => {
+        it('should NOT add the light subtitle class', () => {
+            // Arrange
+            const backgroundColor = '#fff';
+            const card = {
+                backgroundColor
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard1, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            expect(lightSubtitle.exists()).toBe(false);
+        });
+    });
+
+    describe('when `backgroundColor` is "black" ::', () => {
+        it('should add the light subtitle class', () => {
+            // Arrange
+            const backgroundColor = 'black';
+            const card = {
+                backgroundColor
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard1, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            expect(lightSubtitle.exists()).toBe(true);
+        });
+    });
+
+    describe('when `backgroundColor` is "white" ::', () => {
+        it('should NOT add the light subtitle class', () => {
+            // Arrange
+            const backgroundColor = 'white';
+            const card = {
+                backgroundColor
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard1, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            expect(lightSubtitle.exists()).toBe(false);
+        });
+    });
+
+    describe('when `backgroundColor` is "#f05b14" ::', () => {
+        it('should add the light subtitle class', () => {
+            // Arrange
+            const backgroundColor = '#f05b14';
+            const card = {
+                backgroundColor
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard1, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            expect(lightSubtitle.exists()).toBe(true);
+        });
+    });
+
+    describe('when `backgroundColor` is "#f05c14" ::', () => {
+        it('should NOT add the light subtitle class', () => {
+            // Arrange
+            const backgroundColor = '#f05c14';
+            const card = {
+                backgroundColor
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard1, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            expect(lightSubtitle.exists()).toBe(false);
+        });
+    });
+
+    describe('when `backgroundColor` is undefined ::', () => {
+        it('should NOT add the light subtitle class', () => {
+            // Arrange
+            const card = {};
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard1, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            expect(lightSubtitle.exists()).toBeFalsy();
+        });
+    });
+
+    describe('when `backgroundColor` is "invalid" ::', () => {
+        it('should NOT add the light subtitle class', () => {
+            // Arrange
+            const card = {
+                backgroundColor: 'invalid'
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard1, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            expect(lightSubtitle.exists()).toBeFalsy();
+        });
     });
 });

--- a/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard1.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard1.test.js
@@ -95,13 +95,13 @@ describe('contentCards › HomePromotionCard1', () => {
                 },
                 mocks: {
                     $style: {
-                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                        'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
                 }
             });
 
             // Assert
-            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-subtitle--light');
             expect(lightSubtitle.exists()).toBe(true);
         });
     });
@@ -121,13 +121,13 @@ describe('contentCards › HomePromotionCard1', () => {
                 },
                 mocks: {
                     $style: {
-                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                        'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
                 }
             });
 
             // Assert
-            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-subtitle--light');
             expect(lightSubtitle.exists()).toBe(false);
         });
     });
@@ -147,13 +147,13 @@ describe('contentCards › HomePromotionCard1', () => {
                 },
                 mocks: {
                     $style: {
-                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                        'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
                 }
             });
 
             // Assert
-            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-subtitle--light');
             expect(lightSubtitle.exists()).toBe(true);
         });
     });
@@ -173,13 +173,13 @@ describe('contentCards › HomePromotionCard1', () => {
                 },
                 mocks: {
                     $style: {
-                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                        'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
                 }
             });
 
             // Assert
-            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-subtitle--light');
             expect(lightSubtitle.exists()).toBe(false);
         });
     });
@@ -199,13 +199,13 @@ describe('contentCards › HomePromotionCard1', () => {
                 },
                 mocks: {
                     $style: {
-                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                        'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
                 }
             });
 
             // Assert
-            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-subtitle--light');
             expect(lightSubtitle.exists()).toBe(true);
         });
     });
@@ -225,13 +225,13 @@ describe('contentCards › HomePromotionCard1', () => {
                 },
                 mocks: {
                     $style: {
-                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                        'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
                 }
             });
 
             // Assert
-            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-subtitle--light');
             expect(lightSubtitle.exists()).toBe(false);
         });
     });
@@ -248,13 +248,13 @@ describe('contentCards › HomePromotionCard1', () => {
                 },
                 mocks: {
                     $style: {
-                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                        'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
                 }
             });
 
             // Assert
-            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-subtitle--light');
             expect(lightSubtitle.exists()).toBeFalsy();
         });
     });
@@ -273,13 +273,13 @@ describe('contentCards › HomePromotionCard1', () => {
                 },
                 mocks: {
                     $style: {
-                        'c-contentCards-homePromotionCard1-icon-subtitle--light': 'c-contentCards-homePromotionCard1-icon-subtitle--light'
+                        'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
                 }
             });
 
             // Assert
-            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-icon-subtitle--light');
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard1-subtitle--light');
             expect(lightSubtitle.exists()).toBeFalsy();
         });
     });

--- a/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard2.test.js
+++ b/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard2.test.js
@@ -5,11 +5,6 @@ const testId = '__TEST_ID__';
 const ctaText = '__CTA_TEXT__';
 const url = '__URL__';
 
-const card = {
-    ctaText,
-    url
-};
-
 describe('contentCards › HomePromotionCard2', () => {
     it('should apply the given test ID', () => {
         // Arrange & Act
@@ -24,7 +19,13 @@ describe('contentCards › HomePromotionCard2', () => {
     });
 
     it('should display a CTA link and label', () => {
-        // Arrange & Act
+        // Arrange
+        const card = {
+            ctaText,
+            url
+        };
+
+        // Act
         const wrapper = shallowMount(HomePromotionCard2, {
             propsData: {
                 card,
@@ -37,5 +38,211 @@ describe('contentCards › HomePromotionCard2', () => {
         // Assert
         expect(cta.text()).toBe(ctaText);
         expect(cta.attributes('href')).toBe(url);
+    });
+
+    // Check contentBackgroundColour is the dominant factor
+    describe('when `contentBackgroundColor` is "#000" and `backgroundColor` is "#fff" ::', () => {
+        it('should add the light subtitle class', () => {
+            // Arrange
+            const card = {
+                backgroundColor: '#fff',
+                contentBackgroundColor: '#000'
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard2, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard2--light');
+            expect(lightSubtitle.exists()).toBe(true);
+        });
+    });
+
+    describe('when `contentBackgroundColor` is "#fff" and `backgroundColor` is "#000" ::', () => {
+        it('should NOT add the light subtitle class', () => {
+            // Arrange
+            const card = {
+                backgroundColor: '#000',
+                contentBackgroundColor: '#fff'
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard2, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard2--light');
+            expect(lightSubtitle.exists()).toBe(false);
+        });
+    });
+
+    // Check fallback to backgroundColour
+    describe('when `contentBackgroundColor` is undefined and `backgroundColor` is "#fff" ::', () => {
+        it('should NOT add the light subtitle class', () => {
+            // Arrange
+            const card = {
+                backgroundColor: '#fff'
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard2, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard2--light');
+            expect(lightSubtitle.exists()).toBe(false);
+        });
+    });
+
+    describe('when `contentBackgroundColor` is undefined and `backgroundColor` is "#000" ::', () => {
+        it('should add the light subtitle class', () => {
+            // Arrange
+            const card = {
+                backgroundColor: '#000'
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard2, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard2--light');
+            expect(lightSubtitle.exists()).toBe(true);
+        });
+    });
+
+    // Edge case checking luminosity differentiation between this and below case
+    describe('when `contentBackgroundColor` is "#f05b14" and `backgroundColor` is undefined ::', () => {
+        it('should add the light subtitle class', () => {
+            // Arrange
+            const card = {
+                contentBackgroundColor: '#f05b14'
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard2, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard2--light');
+            expect(lightSubtitle.exists()).toBe(true);
+        });
+    });
+
+    describe('when `contentBackgroundColor` is "#f05c14" and `backgroundColor` is undefined ::', () => {
+        it('should NOT add the light subtitle class', () => {
+            // Arrange
+            const card = {
+                contentBackgroundColor: '#f05c14'
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard2, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard2--light');
+            expect(lightSubtitle.exists()).toBe(false);
+        });
+    });
+
+    // Check default is dark
+    describe('when `contentBackgroundColor` is undefined and `backgroundColor` is undefined ::', () => {
+        it('should NOT add the light subtitle class', () => {
+            // Arrange
+            const card = {};
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard2, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard2--light');
+            expect(lightSubtitle.exists()).toBe(false);
+        });
+    });
+
+    // Check default is used when colours are invalid
+    describe('when `contentBackgroundColor` is "invalid" and `backgroundColor` is "invalid" ::', () => {
+        it('should NOT add the light subtitle class', () => {
+            // Arrange
+            const card = {
+                backgroundColor: 'invalid',
+                contentBackgroundColor: 'invalid'
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard2, {
+                propsData: {
+                    card
+                },
+                mocks: {
+                    $style: {
+                        'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
+                    }
+                }
+            });
+
+            // Assert
+            const lightSubtitle = wrapper.find('.c-contentCards-homePromotionCard2--light');
+            expect(lightSubtitle.exists()).toBe(false);
+        });
     });
 });

--- a/packages/f-content-cards/stories/HomePromotionCard1.stories.js
+++ b/packages/f-content-cards/stories/HomePromotionCard1.stories.js
@@ -6,16 +6,42 @@ import image from './images/burger-placeholder.jpg';
 export default {
     title: 'Components/Atoms/f-content-cards',
     argTypes: {
-        title: { control: { type: 'text' } },
-        description: { control: { type: 'array', separator: '--' } },
-        image: { control: { type: 'text' } },
-        icon: { control: { type: 'text' } },
-        ctaText: { control: { type: 'text' } },
-        backgroundColor: { control: { type: 'text' } },
-        contentBackgroundColor: { control: { type: 'text' } },
-        subtitle: { control: { type: 'text' } },
-        url: { control: { type: 'text' } },
-        tenant: { control: { type: 'radio', options: ['uk', 'au', 'nz'] } }
+        title: {
+            control: { type: 'text' },
+            description: 'Title text for the inner card'
+        },
+        description: {
+            control: { type: 'array', separator: '--' },
+            description: 'Individual lines for the text in the inner card, lines separated by "--"'
+        },
+        image: {
+            control: { type: 'text' },
+            description: 'If given, a URL of the image used for the inner card'
+        },
+        icon: {
+            control: { type: 'text' },
+            description: 'If given, a URL for an icon that appears in the left/top portion of the card'
+        },
+        ctaText: {
+            control: { type: 'text' },
+            description: 'Display text used for the CTA link'
+        },
+        backgroundColor: {
+            control: { type: 'text' },
+            description: 'A custom css-compatible colour value given from CRM via braze for the left/top portion of the card'
+        },
+        contentBackgroundColor: {
+            control: { type: 'text' },
+            description: 'A custom css-compatible colour value given from CRM via braze for the right/inner portion of the card'
+        },
+        subtitle: {
+            control: { type: 'text' },
+            description: 'The subtitle that appears below the icon on mid-breakpoint and above only'
+        },
+        url: {
+            control: { type: 'text' },
+            description: 'The url that the CTA directs to'
+        }
     }
 };
 
@@ -54,9 +80,8 @@ export const HomePromotionCard1Component = (args, { argTypes }) => ({
     template: '<home-promotion-card'
         // Setting key as per below forces re-render of the component when the supplied controls change
         // eslint-disable-next-line no-template-curly-in-string
-        + ' :key="`${title},${backgroundColor},${contentBackgroundColor},${ctaText},${description},${image},${icon},${url},${subtitle},${tenant}`"'
+        + ' :key="`${title},${backgroundColor},${contentBackgroundColor},${ctaText},${description},${image},${icon},${url},${subtitle}`"'
         + ' :card="{title, backgroundColor, contentBackgroundColor, ctaText, description, image, icon, url, subtitle}"'
-        + ' :tenant="tenant"'
     + '/>'
 });
 
@@ -75,6 +100,5 @@ HomePromotionCard1Component.args = {
     icon,
     ctaText: 'Purchase now',
     subtitle: 'Only from Just Eat',
-    url: '#',
-    tenant: 'uk'
+    url: '#'
 };

--- a/packages/f-content-cards/stories/HomePromotionCard1.stories.js
+++ b/packages/f-content-cards/stories/HomePromotionCard1.stories.js
@@ -7,12 +7,13 @@ export default {
     title: 'Components/Atoms/f-content-cards',
     argTypes: {
         title: { control: { type: 'text' } },
-        description: { control: { type: 'text' } },
+        description: { control: { type: 'array', separator: '--' } },
         image: { control: { type: 'text' } },
         icon: { control: { type: 'text' } },
         ctaText: { control: { type: 'text' } },
         backgroundColor: { control: { type: 'text' } },
-        contentContainerBackground: { control: { type: 'text' } },
+        contentBackgroundColor: { control: { type: 'text' } },
+        subtitle: { control: { type: 'text' } },
         url: { control: { type: 'text' } },
         tenant: { control: { type: 'radio', options: ['uk', 'au', 'nz'] } }
     }
@@ -50,7 +51,13 @@ export const HomePromotionCard1Component = (args, { argTypes }) => ({
         };
     },
 
-    template: '<home-promotion-card :card="{title, backgroundColor, contentContainerBackground, ctaText, description, image, icon, url}" :tenant="tenant" />'
+    template: '<home-promotion-card'
+        // Setting key as per below forces re-render of the component when the supplied controls change
+        // eslint-disable-next-line no-template-curly-in-string
+        + ' :key="`${title},${backgroundColor},${contentBackgroundColor},${ctaText},${description},${image},${icon},${url},${subtitle},${tenant}`"'
+        + ' :card="{title, backgroundColor, contentBackgroundColor, ctaText, description, image, icon, url, subtitle}"'
+        + ' :tenant="tenant"'
+    + '/>'
 });
 
 HomePromotionCard1Component.storyName = 'home-promotion-card-1';
@@ -58,11 +65,16 @@ HomePromotionCard1Component.storyName = 'home-promotion-card-1';
 HomePromotionCard1Component.args = {
     title: 'Treat them with a Just Eat gift card',
     backgroundColor: '#da0006',
-    contentContainerBackground: 'white',
-    description: 'Whether you want to treat Mum to her Friday night favourite, or surprise your mate with a ‘KFC on me’, show them you care – the tasty way.',
+    contentBackgroundColor: 'white',
+    description: [
+        'Whether you want to treat Mum to her Friday night favourite ',
+        ' or surprise your mate with a ‘KFC on me’ ',
+        ' show them you care – the tasty way.'
+    ],
     image,
     icon,
     ctaText: 'Purchase now',
+    subtitle: 'Only from Just Eat',
     url: '#',
     tenant: 'uk'
 };

--- a/packages/f-content-cards/stories/HomePromotionCard2.stories.js
+++ b/packages/f-content-cards/stories/HomePromotionCard2.stories.js
@@ -6,7 +6,7 @@ export default {
     title: 'Components/Atoms/f-content-cards',
     argTypes: {
         title: { control: { type: 'text' } },
-        description: { control: { type: 'text' } },
+        description: { control: { type: 'array', separator: '--' } },
         image: { control: { type: 'text' } },
         icon: { control: { type: 'text' } },
         ctaText: { control: { type: 'text' } },
@@ -49,15 +49,25 @@ export const HomePromotionCard2Component = (args, { argTypes }) => ({
         };
     },
 
-    template: '<home-promotion-card :card="{title, backgroundColor, contentContainerBackground, ctaText, description, image, icon, url}" :tenant="tenant" />'
+    template: '<home-promotion-card'
+        // Setting key as per below forces re-render of the component when the supplied controls change
+        // eslint-disable-next-line no-template-curly-in-string
+        + ' :key="`${title},${backgroundColor},${contentBackgroundColor},${ctaText},${description},${image},${url},${tenant}`"'
+        + ' :card="{title, backgroundColor, contentBackgroundColor, ctaText, description, image, url}"'
+        + ' :tenant="tenant" '
+    + '/>'
 });
 
 HomePromotionCard2Component.storyName = 'home-promotion-card-2';
 
 HomePromotionCard2Component.args = {
     title: 'Treat them with a Just Eat gift card',
-    contentContainerBackground: 'white',
-    description: 'Whether you want to treat Mum to her Friday night favourite, or surprise your mate with a ‘KFC on me’, show them you care – the tasty way.',
+    contentBackgroundColor: 'white',
+    description: [
+        'Whether you want to treat Mum to her Friday night favourite ',
+        ' or surprise your mate with a ‘KFC on me’ ',
+        ' show them you care – the tasty way.'
+    ],
     image,
     ctaText: 'Purchase now',
     url: '#',

--- a/packages/f-content-cards/stories/HomePromotionCard2.stories.js
+++ b/packages/f-content-cards/stories/HomePromotionCard2.stories.js
@@ -5,15 +5,30 @@ import image from './images/burger-placeholder.jpg';
 export default {
     title: 'Components/Atoms/f-content-cards',
     argTypes: {
-        title: { control: { type: 'text' } },
-        description: { control: { type: 'array', separator: '--' } },
-        image: { control: { type: 'text' } },
-        icon: { control: { type: 'text' } },
-        ctaText: { control: { type: 'text' } },
-        backgroundColor: { control: { type: 'text' } },
-        contentContainerBackground: { control: { type: 'text' } },
-        url: { control: { type: 'text' } },
-        tenant: { control: { type: 'radio', options: ['uk', 'au', 'nz'] } }
+        title: {
+            control: { type: 'text' },
+            description: 'Title text for the inner card'
+        },
+        description: {
+            control: { type: 'array', separator: '--' },
+            description: 'Individual lines for the text in the inner card, lines separated by "--"'
+        },
+        image: {
+            control: { type: 'text' },
+            description: 'If given, a URL of the image used for the inner card'
+        },
+        ctaText: {
+            control: { type: 'text' },
+            description: 'Display text used for the CTA link'
+        },
+        contentBackgroundColor: {
+            control: { type: 'text' },
+            description: 'A custom css-compatible colour value given from CRM via braze for the right/inner portion of the card'
+        },
+        url: {
+            control: { type: 'text' },
+            description: 'The url that the CTA directs to'
+        }
     }
 };
 
@@ -52,9 +67,8 @@ export const HomePromotionCard2Component = (args, { argTypes }) => ({
     template: '<home-promotion-card'
         // Setting key as per below forces re-render of the component when the supplied controls change
         // eslint-disable-next-line no-template-curly-in-string
-        + ' :key="`${title},${backgroundColor},${contentBackgroundColor},${ctaText},${description},${image},${url},${tenant}`"'
-        + ' :card="{title, backgroundColor, contentBackgroundColor, ctaText, description, image, url}"'
-        + ' :tenant="tenant" '
+        + ' :key="`${title},${contentBackgroundColor},${ctaText},${description},${image},${url}`"'
+        + ' :card="{title, contentBackgroundColor, ctaText, description, image, url}"'
     + '/>'
 });
 
@@ -70,6 +84,5 @@ HomePromotionCard2Component.args = {
     ],
     image,
     ctaText: 'Purchase now',
-    url: '#',
-    tenant: 'uk'
+    url: '#'
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1771,6 +1771,14 @@
     lodash-es "4.17.15"
     window-or-global "1.0.1"
 
+"@justeat/f-services@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-1.6.0.tgz#1c6afb320b398c8120a9400b50a7761f892def99"
+  integrity sha512-LT0FUXDh1JGpkvfSQPuNIzImUTA9X52NMyvjZ9OCMVNtzGPmEEg++1BLwIfugpt6ezcCSF9HtiS218IGlqzffA==
+  dependencies:
+    lodash-es "4.17.15"
+    window-or-global "1.0.1"
+
 "@justeat/f-utils@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-1.0.0.tgz#d4f38f6c2b2992fefa39789f1ce742dc083798b1"
@@ -7372,6 +7380,14 @@ color-string@^1.5.4:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
+color@3.1.3, color@^3.0.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.1.3.tgz#ca67fb4e7b97d611dcde39eceed422067d91596e"
+  integrity sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.4"
+
 color@^0.11.0:
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/color/-/color-0.11.4.tgz#6d7b5c74fb65e841cd48792ad1ed5e07b904d764"
@@ -7380,14 +7396,6 @@ color@^0.11.0:
     clone "^1.0.2"
     color-convert "^1.3.0"
     color-string "^0.3.0"
-
-color@^3.0.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/color/-/color-3.1.3.tgz#ca67fb4e7b97d611dcde39eceed422067d91596e"
-  integrity sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==
-  dependencies:
-    color-convert "^1.9.1"
-    color-string "^1.5.4"
 
 colorette@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
f-content-cards@v2.2.0
------------------------------
*December 15, 2020*

### Fixed
- Styles to match designs in HPC 1&2
- Correct stories for HPC 1&2

### Updated
- Dynamically change HPC1 subtitle and HPC2 title and text between light/dark based on
  luminosity of BG colour(s)
- Tests to check above behave correctly

---

## UI Review Checks

HPC1:
![image](https://user-images.githubusercontent.com/6674452/102212529-47473980-3ecd-11eb-9da7-1194a2d3de27.png)

With dynamically adjusting text colour:
![image](https://user-images.githubusercontent.com/6674452/102212721-8b3a3e80-3ecd-11eb-9782-7c7548bb46fc.png)

HPC2:
![image](https://user-images.githubusercontent.com/6674452/102212755-9d1be180-3ecd-11eb-9853-3d6c1449c8ff.png)

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
