### PR TITLE
f-globalisation@1.0.0 - Adding support for dateTimeFormats.

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -10,11 +10,11 @@ if (!isTrivial) {
     const modifiedFiles = danger.git.modified_files;
 
     // Get an array of files in the root monorepo that have changed
-    const modifiedRootFiles = modifiedFiles.filter(filepath => !filepath.startsWith('packages/') && filepath !== 'yarn.lock');
+    const modifiedRootFiles = modifiedFiles.filter(filepath => (!filepath.startsWith('packages/') || !filepath.startsWith('services/')) && filepath !== 'yarn.lock');
 
-    // Get an array of packages that have changed, then make that array unique
-    const modifiedPackages = modifiedFiles.filter(filepath => filepath.startsWith('packages/'))
+    const modifiedPackages = modifiedFiles.filter(filepath => filepath.startsWith('packages/') || filepath.startsWith('services/'))
         .map(filepath => filepath.split('/')[1]);
+
     const uniqueModifiedPackages = new Set(modifiedPackages);
     const modifiedRootPackage = modifiedPackages.includes('');
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -10,11 +10,11 @@ if (!isTrivial) {
     const modifiedFiles = danger.git.modified_files;
 
     // Get an array of files in the root monorepo that have changed
-    const modifiedRootFiles = modifiedFiles.filter(filepath => (!filepath.startsWith('packages/') || !filepath.startsWith('services/')) && filepath !== 'yarn.lock');
+    const modifiedRootFiles = modifiedFiles.filter(filepath => !filepath.startsWith('packages/') && filepath !== 'yarn.lock');
 
-    const modifiedPackages = modifiedFiles.filter(filepath => filepath.startsWith('packages/') || filepath.startsWith('services/'))
+    // Get an array of packages that have changed, then make that array unique
+    const modifiedPackages = modifiedFiles.filter(filepath => filepath.startsWith('packages/'))
         .map(filepath => filepath.split('/')[1]);
-
     const uniqueModifiedPackages = new Set(modifiedPackages);
     const modifiedRootPackage = modifiedPackages.includes('');
 

--- a/services/f-globalisation/CHANGELOG.md
+++ b/services/f-globalisation/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.3.0
+------------------------------
+*December 16, 2020*
+
+### Added
+- Support for `dateTimeFormats`, ensuring backwards compatibility.
+
+
 v0.2.0
 ------------------------------
 *November 10, 2020*

--- a/services/f-globalisation/CHANGELOG.md
+++ b/services/f-globalisation/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.0.0
 ------------------------------
-*December 16, 2020*
+*December 17, 2020*
 
 ### Added
 - Support for `dateTimeFormats`, which requires a change in the structure of the tenancy files.

--- a/services/f-globalisation/CHANGELOG.md
+++ b/services/f-globalisation/CHANGELOG.md
@@ -3,12 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v0.3.0
+v1.0.0
 ------------------------------
 *December 16, 2020*
 
 ### Added
-- Support for `dateTimeFormats`, ensuring backwards compatibility.
+- Support for `dateTimeFormats`, which requires a change in the structure of the tenancy files.
 
 
 v0.2.0

--- a/services/f-globalisation/package.json
+++ b/services/f-globalisation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-globalisation",
   "description": "Fozzie Globalisation – A utility which wires up vue-i18n within your Smart Component",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "main": "dist/f-globalisation.umd.min.js",
   "files": [
     "dist"

--- a/services/f-globalisation/package.json
+++ b/services/f-globalisation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-globalisation",
   "description": "Fozzie Globalisation – A utility which wires up vue-i18n within your Smart Component",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/f-globalisation.umd.min.js",
   "files": [
     "dist"

--- a/services/f-globalisation/src/mixins/globalisation.mixin.vue
+++ b/services/f-globalisation/src/mixins/globalisation.mixin.vue
@@ -26,13 +26,8 @@ export default {
         setupLocale (locale, applyLocale = false) {
             const localeConfig = this.tenantConfigs[locale];
 
-            const messages = localeConfig.messages || localeConfig; // Backwards compatibility if a tenant file only has messages without the new structure.
-
-            this.$i18n.setLocaleMessage(locale, messages);
-
-            if (localeConfig.dateTimeFormats) {
-                this.$i18n.setDateTimeFormat(locale, localeConfig.dateTimeFormats);
-            }
+            this.$i18n.setLocaleMessage(locale, localeConfig.messages);
+            this.$i18n.setDateTimeFormat(locale, localeConfig.dateTimeFormats);
 
             if (applyLocale) {
                 this.$i18n.locale = locale;

--- a/services/f-globalisation/src/mixins/globalisation.mixin.vue
+++ b/services/f-globalisation/src/mixins/globalisation.mixin.vue
@@ -25,7 +25,14 @@ export default {
     methods: {
         setupLocale (locale, applyLocale = false) {
             const localeConfig = this.tenantConfigs[locale];
-            this.$i18n.setLocaleMessage(locale, localeConfig);
+
+            const messages = localeConfig.messages || localeConfig; // Backwards compatibility if a tenant file only has messages without the new structure.
+
+            this.$i18n.setLocaleMessage(locale, messages);
+
+            if (localeConfig.dateTimeFormats) {
+                this.$i18n.setDateTimeFormat(locale, localeConfig.dateTimeFormats);
+            }
 
             if (applyLocale) {
                 this.$i18n.locale = locale;

--- a/services/f-globalisation/src/mixins/tests/globalisation.mixin.test.js
+++ b/services/f-globalisation/src/mixins/tests/globalisation.mixin.test.js
@@ -15,7 +15,12 @@ const defaultData = {
             test: 'Test message (EN)'
         },
         [ALTERNATIVE_LOCALE]: {
-            test: 'Test message (ES)'
+            messages: {
+                test: 'Test message (ES)'
+            },
+            dateTimeFormats: {
+                short: { hour: 'numeric' }
+            }
         }
     }
 };
@@ -169,12 +174,14 @@ describe('Globalisation', () => {
 
         describe('setupLocale', () => {
             let setLocaleMessageMock;
+            let setDateTimeFormatMock;
 
             beforeEach(() => {
                 setLocaleMessageMock = jest.spyOn(i18n, 'setLocaleMessage');
+                setDateTimeFormatMock = jest.spyOn(i18n, 'setDateTimeFormat');
             });
 
-            it('should set the messages for the provided locale and update the current i18n locale when `applyLocale` is `true`', () => {
+            it('should set the messages and datetime formats for the provided locale and update the current i18n locale when `applyLocale` is `true`', () => {
                 // Arrange
                 const wrapper = shallowMount(component, {
                     data () {
@@ -188,11 +195,13 @@ describe('Globalisation', () => {
 
                 // Assert
                 expect(setLocaleMessageMock).toHaveBeenCalledTimes(1);
-                expect(setLocaleMessageMock).toHaveBeenCalledWith(ALTERNATIVE_LOCALE, defaultData.tenantConfigs[ALTERNATIVE_LOCALE]);
+                expect(setLocaleMessageMock).toHaveBeenCalledWith(ALTERNATIVE_LOCALE, defaultData.tenantConfigs[ALTERNATIVE_LOCALE].messages);
+                expect(setDateTimeFormatMock).toHaveBeenCalledTimes(1);
+                expect(setDateTimeFormatMock).toHaveBeenCalledWith(ALTERNATIVE_LOCALE, defaultData.tenantConfigs[ALTERNATIVE_LOCALE].dateTimeFormats);
                 expect(i18n.locale).toBe(ALTERNATIVE_LOCALE);
             });
 
-            it('should set the messages for the provided locale and not update the current i18n locale when `applyLocale` is `false`', () => {
+            it('should set the messages and datetime formats for the provided locale and not update the current i18n locale when `applyLocale` is `false`', () => {
                 // Arrange
                 const wrapper = shallowMount(component, {
                     data () {
@@ -206,8 +215,45 @@ describe('Globalisation', () => {
 
                 // Assert
                 expect(setLocaleMessageMock).toHaveBeenCalledTimes(1);
-                expect(setLocaleMessageMock).toHaveBeenCalledWith(ALTERNATIVE_LOCALE, defaultData.tenantConfigs[ALTERNATIVE_LOCALE]);
+                expect(setLocaleMessageMock).toHaveBeenCalledWith(ALTERNATIVE_LOCALE, defaultData.tenantConfigs[ALTERNATIVE_LOCALE].messages);
+                expect(setDateTimeFormatMock).toHaveBeenCalledTimes(1);
+                expect(setDateTimeFormatMock).toHaveBeenCalledWith(ALTERNATIVE_LOCALE, defaultData.tenantConfigs[ALTERNATIVE_LOCALE].dateTimeFormats);
                 expect(i18n.locale).toBe(DEFAULT_LOCALE);
+            });
+
+            describe('legacy tenancy file support to ensure backwards compatibility', () => {
+                it('should not set the datetime formats if its not available in the tenancy file', () => {
+                    // Arrange
+                    const wrapper = shallowMount(component, {
+                        data () {
+                            return defaultData;
+                        },
+                        i18n
+                    });
+
+                    // Act
+                    wrapper.vm.setupLocale(DEFAULT_LOCALE, false);
+
+                    // Assert
+                    expect(setDateTimeFormatMock).toHaveBeenCalledTimes(0);
+                });
+
+                it('should set the messages if it\'s the only thing the tenancy file has', () => {
+                    // Arrange
+                    const wrapper = shallowMount(component, {
+                        data () {
+                            return defaultData;
+                        },
+                        i18n
+                    });
+
+                    // Act
+                    wrapper.vm.setupLocale(DEFAULT_LOCALE, false);
+
+                    // Assert
+                    expect(setLocaleMessageMock).toHaveBeenCalledTimes(1);
+                    expect(setLocaleMessageMock).toHaveBeenCalledWith(DEFAULT_LOCALE, defaultData.tenantConfigs[DEFAULT_LOCALE]);
+                });
             });
         });
     });

--- a/services/f-globalisation/src/mixins/tests/globalisation.mixin.test.js
+++ b/services/f-globalisation/src/mixins/tests/globalisation.mixin.test.js
@@ -12,7 +12,12 @@ const ALTERNATIVE_LOCALE = 'es-ES';
 const defaultData = {
     tenantConfigs: {
         [DEFAULT_LOCALE]: {
-            test: 'Test message (EN)'
+            messages: {
+                test: 'Test message (EN)'
+            },
+            dateTimeFormats: {
+                short: { hour: 'numeric' }
+            }
         },
         [ALTERNATIVE_LOCALE]: {
             messages: {
@@ -219,41 +224,6 @@ describe('Globalisation', () => {
                 expect(setDateTimeFormatMock).toHaveBeenCalledTimes(1);
                 expect(setDateTimeFormatMock).toHaveBeenCalledWith(ALTERNATIVE_LOCALE, defaultData.tenantConfigs[ALTERNATIVE_LOCALE].dateTimeFormats);
                 expect(i18n.locale).toBe(DEFAULT_LOCALE);
-            });
-
-            describe('legacy tenancy file support to ensure backwards compatibility', () => {
-                it('should not set the datetime formats if its not available in the tenancy file', () => {
-                    // Arrange
-                    const wrapper = shallowMount(component, {
-                        data () {
-                            return defaultData;
-                        },
-                        i18n
-                    });
-
-                    // Act
-                    wrapper.vm.setupLocale(DEFAULT_LOCALE, false);
-
-                    // Assert
-                    expect(setDateTimeFormatMock).toHaveBeenCalledTimes(0);
-                });
-
-                it('should set the messages if it\'s the only thing the tenancy file has', () => {
-                    // Arrange
-                    const wrapper = shallowMount(component, {
-                        data () {
-                            return defaultData;
-                        },
-                        i18n
-                    });
-
-                    // Act
-                    wrapper.vm.setupLocale(DEFAULT_LOCALE, false);
-
-                    // Assert
-                    expect(setLocaleMessageMock).toHaveBeenCalledTimes(1);
-                    expect(setLocaleMessageMock).toHaveBeenCalledWith(DEFAULT_LOCALE, defaultData.tenantConfigs[DEFAULT_LOCALE]);
-                });
             });
         });
     });


### PR DESCRIPTION
v1.0.0
------------------------------
*December 17, 2020*

### Added
- Support for `dateTimeFormats`, ensuring backwards compatibility.