### PR TITLE
fozzie-components@v2.26.0 – Updating sass-loader, eyeglass and fozzie (v5 refs) in all packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.26.0
+------------------------------
+*December 30, 2020*
+
+### Changed
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
+
+
 v2.25.0
 ------------------------------
 *December 21, 2020*

--- a/config/sassOptions.js
+++ b/config/sassOptions.js
@@ -6,8 +6,7 @@ module.exports = function init (rootDir) {
         eyeglass: {
             root: rootDir
         },
-        includePaths: ['node_modules/'],
-        sourceMap: true
+        includePaths: ['node_modules/']
     });
 
     sassOptions.importer = [
@@ -17,5 +16,13 @@ module.exports = function init (rootDir) {
         sassOptions.importer
     ];
 
-    return sassOptions;
+    return {
+        sassOptions: {
+            eyeglass: sassOptions.eyeglass,
+            functions: sassOptions.functions,
+            includePaths: sassOptions.includePaths,
+            importer: sassOptions.importer
+        },
+        sourceMap: true
+    };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",
@@ -31,7 +31,6 @@
     "@babel/preset-env": "7.10.4",
     "@justeat/browserslist-config-fozzie": "1.1.1",
     "@justeat/eslint-config-fozzie": "3.4.1",
-    "@justeat/f-build-config": "0.3.0",
     "@justeat/f-utils": "1.0.0",
     "@justeat/fozzie": "5.0.0-beta.0",
     "@justeat/fozzie-colour-palette": "3.0.0",
@@ -64,6 +63,7 @@
     "eslint": "6.8.0",
     "eslint-import-resolver-webpack": "0.12.2",
     "eslint-plugin-vue": "6.2.2",
+    "eyeglass": "3.0.2",
     "include-media": "1.4.9",
     "jest-allure2": "1.2.3",
     "lerna": "3.22.1",
@@ -72,7 +72,7 @@
     "node-sass-magic-importer": "5.3.2",
     "npm-run-all": "4.1.5",
     "postcss-loader": "3.0.0",
-    "sass-loader": "7.3.1",
+    "sass-loader": "10.1.0",
     "stylelint": "13.7.2",
     "stylelint-scss": "3.18.0",
     "vue": "2.6.10",

--- a/packages/f-alert/CHANGELOG.md
+++ b/packages/f-alert/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (add to next release)
+------------------------------
+*December 30, 2020*
+
+### Changed
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
+
+
 v0.4.0
 ------------------------------
 *December 7, 2020*
@@ -31,9 +40,9 @@ v0.2.0
 
 ### Added
 - Stylelint added to lint styling on build.
-- data-test IDs to Alert Component 
-- Basic tests for Alert 
-- Alert Component-Object 
+- data-test IDs to Alert Component
+- Basic tests for Alert
+- Alert Component-Object
 
 
 v0.1.1

--- a/packages/f-alert/src/assets/scss/common.scss
+++ b/packages/f-alert/src/assets/scss/common.scss
@@ -3,9 +3,4 @@
 // Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
 $theme: 'jet' !default;
 
-@import '~@justeat/f-utils/src/scss/functions/index';
-@import '~@justeat/f-utils/src/scss/mixins/index';
-@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
-@import '~@justeat/fozzie/src/scss/settings/variables';
-@import '~@justeat/fozzie/src/scss/base/reset';
-@import '~@justeat/fozzie-colour-palette/src/scss/';
+@import  '~@justeat/fozzie/src/scss/fozzie';

--- a/packages/f-alert/vue.config.js
+++ b/packages/f-alert/vue.config.js
@@ -1,4 +1,7 @@
-const magicImporter = require('node-sass-magic-importer');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
@@ -9,9 +12,9 @@ module.exports = {
             .use('importer')
             .loader('sass-loader')
             .options({
-                importer: magicImporter(),
+                ...sassOptions,
                 // eslint-disable-next-line quotes
-                data: `@import "@/assets/scss/common.scss";`
+                additionalData: `@import "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/f-button/CHANGELOG.md
+++ b/packages/f-button/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (add to next release)
+------------------------------
+*December 30, 2020*
+
+### Changed
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
+
+
 v0.4.1
 ------------------------------
 *December 8, 2020*
@@ -23,7 +32,7 @@ v0.4.0
 - `o-btn--icon` modifier
 
 ### Removed
-- Margins from the button styles 
+- Margins from the button styles
 
 
 v0.3.0

--- a/packages/f-button/package.json
+++ b/packages/f-button/package.json
@@ -33,7 +33,7 @@
     "lint:style": "vue-cli-service lint:style",
     "report": "cd ../.. && yarn report",
     "storybook:serve-webdriver": "lerna run storybook:serve-static --stream",
-    "test": "vue-cli-service test:unit", 
+    "test": "vue-cli-service test:unit",
     "test-component:chrome": "run-p --race storybook:serve-webdriver webdriver:delay:chrome",
     "test:wait-for-server": "node ../../test/infrastructure/healthcheck.js",
     "webdriver:delay:chrome": "yarn test:wait-for-server && yarn webdriver:start:chrome",

--- a/packages/f-button/src/assets/scss/common.scss
+++ b/packages/f-button/src/assets/scss/common.scss
@@ -3,10 +3,5 @@
 // Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
 $theme: 'jet' !default;
 
-@import '~@justeat/f-utils/src/scss/functions/index';
-@import '~@justeat/f-utils/src/scss/mixins/index';
-@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
-@import '~@justeat/fozzie/src/scss/settings/variables';
-@import '~@justeat/fozzie/src/scss/base/reset';
-@import '~@justeat/fozzie-colour-palette/src/scss/';
+@import  '~@justeat/fozzie/src/scss/fozzie';
 

--- a/packages/f-button/vue.config.js
+++ b/packages/f-button/vue.config.js
@@ -1,4 +1,7 @@
-const magicImporter = require('node-sass-magic-importer');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
@@ -9,9 +12,9 @@ module.exports = {
             .use('importer')
             .loader('sass-loader')
             .options({
-                importer: magicImporter(),
+                ...sassOptions,
                 // eslint-disable-next-line quotes
-                data: `@import "@/assets/scss/common.scss";`
+                additionalData: `@import "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/f-card/CHANGELOG.md
+++ b/packages/f-card/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (add to next release)
+------------------------------
+*December 30, 2020*
+
+### Changed
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
+
+
 v0.9.0
 ------------------------------
 *November 18, 2020*

--- a/packages/f-card/README.md
+++ b/packages/f-card/README.md
@@ -63,11 +63,11 @@ The props that can be defined are as follows:
 
 | Prop                      | Required       | Type          | Default | Description |
 | :---                      |     :---:      |     :---:     |  :---:  | :---        |
-| locale                    | false          | `string`      | `en-GB` | Sets the locale of the component (which determines what theme and translations to use.<br><br>If the application consuming the `f-card` component is using the vue `i18n` module, then the locale from that module will be used when this prop isn't defined. When this prop is defined, it takes precedence over the locale defined by the `i18n` module.<br><br>If not defined and the `i18n` module isn't present, the default locale used is `en-GB`.|
-| isRounded                | false           | `boolean`     | `false` | When set to `true`, rounded corners are applied to the card component. |
-| hasOutline               | false           | `boolean`     | `false` | When set to `true`, an outline is applied to the card component.  |
-| isPageContentWrapper     | false           | `boolean`     | `false` | When set to `true`, applies styles to make the card act like a page content wrapper.<br><br>The card will be full width on narrow devices, and then a fixed width above a certain breakpoint width (about 480px), when the card will be centred on the page. |
-| cardHeadingPosition     | false           | `string`     | `left` | Sets the text alignment of the card component's heading.<br><br>When set to `left` the heading will aligned to the left.<br>When set to `center` the heading will be centrally aligned.<br>When set to `right` the heading will be aligned to the right. |
+| locale                    | false          | `String`      | `en-GB` | Sets the locale of the component (which determines what theme and translations to use.<br><br>If the application consuming the `f-card` component is using the vue `i18n` module, then the locale from that module will be used when this prop isn't defined. When this prop is defined, it takes precedence over the locale defined by the `i18n` module.<br><br>If not defined and the `i18n` module isn't present, the default locale used is `en-GB`.|
+| isRounded                 | false          | `Boolean`     | `false` | When set to `true`, rounded corners are applied to the card component. |
+| hasOutline                | false          | `Boolean`     | `false` | When set to `true`, an outline is applied to the card component.  |
+| isPageContentWrapper      | false          | `Boolean`     | `false` | When set to `true`, applies styles to make the card act like a page content wrapper.<br><br>The card will be full width on narrow devices, and then a fixed width above a certain breakpoint width (about 480px), when the card will be centred on the page. |
+| cardHeadingPosition      | false          | `String`     | `left` | Sets the text alignment of the card component's heading.<br><br>When set to `left` the heading will aligned to the left.<br>When set to `center` the heading will be centrally aligned.<br>When set to `right` the heading will be aligned to the right. |
 
 ## Development
 It is recommended to run the following commands at the root of the monorepo in order to install dependencies and allow you to view components in isolation via Storybook.

--- a/packages/f-card/src/assets/scss/common.scss
+++ b/packages/f-card/src/assets/scss/common.scss
@@ -3,20 +3,4 @@
 // Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
 $theme: 'jet' !default;
 
-@import '~@justeat/f-utils/src/scss/functions/index';
-@import '~@justeat/f-utils/src/scss/mixins/index';
-@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
-@import '~@justeat/fozzie/src/scss/settings/variables';
-@import '~@justeat/fozzie/src/scss/base/reset';
-@import '~@justeat/fozzie-colour-palette/src/scss/';
-
-/**
- * Component Variables
- */
-// $card-background-color          : $brand--orange;
-
-@mixin theme($type) {
-    [data-theme-card="#{$type}"] & {
-        @content;
-    }
-}
+@import  '~@justeat/fozzie/src/scss/fozzie';

--- a/packages/f-card/vue.config.js
+++ b/packages/f-card/vue.config.js
@@ -1,4 +1,7 @@
-const magicImporter = require('node-sass-magic-importer');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
@@ -9,9 +12,9 @@ module.exports = {
             .use('importer')
             .loader('sass-loader')
             .options({
-                importer: magicImporter(),
+                ...sassOptions,
                 // eslint-disable-next-line quotes
-                data: `@import "@/assets/scss/common.scss";`
+                additionalData: `@import "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/f-checkout/CHANGELOG.md
+++ b/packages/f-checkout/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (add to next release)
+------------------------------
+*December 30, 2020*
+
+### Changed
+- Updated config for latest `sass-loader`.
+- Updated fozzie dependencies in `common.scss` to pull in v5-beta.
+
+
 v0.30.0
 ------------------------------
 *December 23, 2020*

--- a/packages/f-checkout/src/assets/scss/common.scss
+++ b/packages/f-checkout/src/assets/scss/common.scss
@@ -3,20 +3,9 @@
 // Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
 $theme: 'jet' !default;
 
-@import '~@justeat/f-utils/src/scss/functions/index';
-@import '~@justeat/f-utils/src/scss/mixins/index';
-@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
-@import '~@justeat/fozzie/src/scss/settings/variables';
-@import '~@justeat/fozzie/src/scss/base/reset';
-@import '~@justeat/fozzie-colour-palette/src/scss/';
+@import  '~@justeat/fozzie/src/scss/fozzie';
 
 /**
  * Component Variables
  */
 // $checkout-background-color: $brand--orange;
-
-@mixin theme($type) {
-    [data-theme="#{$type}"] & {
-        @content;
-    }
-}

--- a/packages/f-checkout/vue.config.js
+++ b/packages/f-checkout/vue.config.js
@@ -1,4 +1,7 @@
-const magicImporter = require('node-sass-magic-importer');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
@@ -9,9 +12,9 @@ module.exports = {
             .use('importer')
             .loader('sass-loader')
             .options({
-                importer: magicImporter(),
+                ...sassOptions,
                 // eslint-disable-next-line quotes
-                data: `@import "@/assets/scss/common.scss";`
+                additionalData: `@import "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (add to next release)
+------------------------------
+*December 30, 2020*
+
+### Fixed
+- Old references to font-size keys updated.
+### Changed
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
+
+
 v2.2.0
 ------------------------------
 *December 15, 2020*

--- a/packages/f-content-cards/src/assets/scss/common.scss
+++ b/packages/f-content-cards/src/assets/scss/common.scss
@@ -3,19 +3,7 @@
 // Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
 $theme: 'jet' !default;
 
-@import '~@justeat/f-utils/src/scss/functions/index';
-@import '~@justeat/f-utils/src/scss/mixins/index';
-@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
-@import '~@justeat/fozzie/src/scss/settings/variables';
-@import '~@justeat/fozzie/src/scss/components/optional/badges';
-@import '~@justeat/fozzie/src/scss/base/reset';
-@import '~@justeat/fozzie-colour-palette/src/scss';
+@import  '~@justeat/fozzie/src/scss/fozzie';
 
 // defined separately from the $border-radius variable in order to match the radius for UI elements in OrderWeb
 $post-order-card-radius: 8px;
-
-@mixin theme($type) {
-    [data-theme-contentcards="#{$type}"] & {
-        @content;
-    }
-}

--- a/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
+++ b/packages/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
@@ -166,12 +166,12 @@ export default {
             }
 
             :global(.c-contentCards-homePromotionCard2-title) {
-                @include font-size(large);
+                @include font-size(heading-m);
                 margin-bottom: spacing();
             }
 
             :global(.c-contentCards-homePromotionCard2-text) {
-                @include font-size(mid);
+                @include font-size(subheading-s);
                 margin-top: spacing();
             }
         }

--- a/packages/f-error-message/CHANGELOG.md
+++ b/packages/f-error-message/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (add to next release)
+------------------------------
+*December 30, 2020*
+
+### Changed
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
+
+
 v0.3.1
 ------------------------------
 *November 12, 2020*

--- a/packages/f-error-message/src/assets/scss/common.scss
+++ b/packages/f-error-message/src/assets/scss/common.scss
@@ -3,14 +3,4 @@
 // Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
 $theme: 'jet' !default;
 
-@import '~@justeat/f-utils/src/scss/functions/index';
-@import '~@justeat/f-utils/src/scss/mixins/index';
-@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
-@import '~@justeat/fozzie/src/scss/settings/variables';
-@import '~@justeat/fozzie/src/scss/base/reset';
-@import '~@justeat/fozzie-colour-palette/src/scss/';
-
-/**
- * Component Variables
- */
-// $errorMessage-background-color: $brand--orange;
+@import  '~@justeat/fozzie/src/scss/fozzie';

--- a/packages/f-error-message/vue.config.js
+++ b/packages/f-error-message/vue.config.js
@@ -1,4 +1,7 @@
-const magicImporter = require('node-sass-magic-importer');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
@@ -9,9 +12,9 @@ module.exports = {
             .use('importer')
             .loader('sass-loader')
             .options({
-                importer: magicImporter(),
+                ...sassOptions,
                 // eslint-disable-next-line quotes
-                data: `@import "@/assets/scss/common.scss";`
+                additionalData: `@import "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/f-footer/CHANGELOG.md
+++ b/packages/f-footer/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (add to next release)
+------------------------------
+*December 30, 2020*
+
+### Changed
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
+
+
 v4.4.2
 ------------------------------
 *November 10, 2020*
@@ -47,7 +56,7 @@ v4.2.0
 
 ### Changed
 - 'jet' theme instead of 'je'
-- Removed typo in component test 
+- Removed typo in component test
 - Updated dependencies.
 - Updated `f-services` imports to use new variables.
 

--- a/packages/f-footer/src/assets/scss/common.scss
+++ b/packages/f-footer/src/assets/scss/common.scss
@@ -3,12 +3,7 @@
 // The theme is handled via a data-attribute on the component
 $theme: 'jet' !default;
 
-@import '~@justeat/f-utils/src/scss/functions/index';
-@import '~@justeat/f-utils/src/scss/mixins/index';
-@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
-@import '~@justeat/fozzie/src/scss/settings/variables';
-@import '~@justeat/fozzie/src/scss/base/reset';
-@import '~@justeat/fozzie-colour-palette/src/scss/index'; // specify `/index` so that this doesn't throw an error when importing with `vue-jest`
+@import  '~@justeat/fozzie/src/scss/fozzie';
 
 /**
  * Component Variables

--- a/packages/f-footer/vue.config.js
+++ b/packages/f-footer/vue.config.js
@@ -1,4 +1,7 @@
-const magicImporter = require('node-sass-magic-importer');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
@@ -9,9 +12,9 @@ module.exports = {
             .use('importer')
             .loader('sass-loader')
             .options({
-                importer: magicImporter(),
+                ...sassOptions,
                 // eslint-disable-next-line quotes
-                data: `@import "@/assets/scss/common.scss";`
+                additionalData: `@import "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/f-form-field/CHANGELOG.md
+++ b/packages/f-form-field/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (add to next release)
+------------------------------
+*December 30, 2020*
+
+### Changed
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
+
+
 v1.6.1
 ------------------------------
 *December 9, 2020*

--- a/packages/f-form-field/src/assets/scss/common.scss
+++ b/packages/f-form-field/src/assets/scss/common.scss
@@ -3,12 +3,7 @@
 // Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
 $theme: 'jet' !default;
 
-@import '~@justeat/f-utils/src/scss/functions/index';
-@import '~@justeat/f-utils/src/scss/mixins/index';
-@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
-@import '~@justeat/fozzie/src/scss/settings/variables';
-@import '~@justeat/fozzie/src/scss/base/reset';
-@import '~@justeat/fozzie-colour-palette/src/scss/';
+@import  '~@justeat/fozzie/src/scss/fozzie';
 
 /**
  * Component Variables

--- a/packages/f-form-field/src/components/FormField.vue
+++ b/packages/f-form-field/src/components/FormField.vue
@@ -65,7 +65,7 @@
 import { globalisationServices } from '@justeat/f-services';
 import FormDropdown from './FormDropdown.vue';
 import FormLabel from './FormLabel.vue';
-import Debounce from '../services/debounce';
+import debounce from '../services/debounce';
 import tenantConfigs from '../tenants';
 import {
     CUSTOM_INPUT_TYPES,
@@ -204,7 +204,7 @@ export default {
     },
 
     mounted () {
-        window.addEventListener('resize', Debounce(this.updateWidth, 100));
+        window.addEventListener('resize', debounce(this.updateWidth, 100));
         this.updateWidth();
     },
 

--- a/packages/f-form-field/vue.config.js
+++ b/packages/f-form-field/vue.config.js
@@ -1,4 +1,7 @@
-const magicImporter = require('node-sass-magic-importer');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
@@ -9,9 +12,9 @@ module.exports = {
             .use('importer')
             .loader('sass-loader')
             .options({
-                importer: magicImporter(),
+                ...sassOptions,
                 // eslint-disable-next-line quotes
-                data: `@import "@/assets/scss/common.scss";`
+                additionalData: `@import "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/f-header/CHANGELOG.md
+++ b/packages/f-header/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (add to next release)
+------------------------------
+*December 30, 2020*
+
+### Changed
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
+
+
 v4.3.0
 ------------------------------
 *December 1, 2020*

--- a/packages/f-header/src/assets/scss/common.scss
+++ b/packages/f-header/src/assets/scss/common.scss
@@ -3,12 +3,7 @@
 // The theme is handled via a data-attribute on the component
 $theme: 'jet' !default;
 
-@import '~@justeat/f-utils/src/scss/functions/index';
-@import '~@justeat/f-utils/src/scss/mixins/index';
-@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
-@import '~@justeat/fozzie/src/scss/settings/variables';
-@import '~@justeat/fozzie/src/scss/base/reset';
-@import '~@justeat/fozzie-colour-palette/src/scss/';
+@import  '~@justeat/fozzie/src/scss/fozzie';
 
 /**
  * Component Variables

--- a/packages/f-header/vue.config.js
+++ b/packages/f-header/vue.config.js
@@ -1,4 +1,7 @@
-const magicImporter = require('node-sass-magic-importer');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../config/sassOptions')(rootDir);
 const responseLoggedIn = require('./src/components/tests/__mocks__/api.account.details.json');
 const responseLoggedOut = require('./src/components/tests/__mocks__/api.account.details.loggedout.json');
 
@@ -11,9 +14,9 @@ module.exports = {
             .use('importer')
             .loader('sass-loader')
             .options({
-                importer: magicImporter(),
+                ...sassOptions,
                 // eslint-disable-next-line quotes
-                data: `@import "@/assets/scss/common.scss";`
+                additionalData: `@import "../assets/scss/common.scss";`
             });
     },
     devServer: {

--- a/packages/f-mega-modal/CHANGELOG.md
+++ b/packages/f-mega-modal/CHANGELOG.md
@@ -3,9 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-Latest (to be added to next release)
+Latest (add to next release)
 ------------------------------
-*December 10, 2020*
+*December 30, 2020*
+
+### Changed
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
 
 ### Fixed
 - Readme component reference.

--- a/packages/f-mega-modal/src/assets/scss/common.scss
+++ b/packages/f-mega-modal/src/assets/scss/common.scss
@@ -3,9 +3,4 @@
 // Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
 $theme: 'jet' !default;
 
-@import '~@justeat/f-utils/src/scss/functions/index';
-@import '~@justeat/f-utils/src/scss/mixins/index';
-@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
-@import '~@justeat/fozzie/src/scss/settings/variables';
-@import '~@justeat/fozzie/src/scss/base/reset';
-@import '~@justeat/fozzie-colour-palette/src/scss/';
+@import  '~@justeat/fozzie/src/scss/fozzie';

--- a/packages/f-mega-modal/vue.config.js
+++ b/packages/f-mega-modal/vue.config.js
@@ -1,4 +1,7 @@
-const magicImporter = require('node-sass-magic-importer');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
@@ -9,9 +12,9 @@ module.exports = {
             .use('importer')
             .loader('sass-loader')
             .options({
-                importer: magicImporter(),
+                ...sassOptions,
                 // eslint-disable-next-line quotes
-                data: `@import "@/assets/scss/common.scss";`
+                additionalData: `@import "../assets/scss/common.scss";`
             });
 
         config.externals({

--- a/packages/f-registration/CHANGELOG.md
+++ b/packages/f-registration/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.46.0
+------------------------------
+*December 30, 2020*
+
+### Changed
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
+- Updated `f-form-field` dependency.
+
+
 v0.45.0
 ------------------------------
 *December 10, 2020*
@@ -211,18 +221,21 @@ v0.31.0
 v0.30.0
 ------------------------------
 *September 29, 2020*
+
 ### Added
 - Added bag icon to registration component.
 
 
 v0.29.0
 ------------------------------
+
 ### Changed
 - Uses `JustEatBasis` font and new fozzie font size declarations.
 
 
 v0.28.0
 ------------------------------
+
 ### Removed
 - Contract tests + scripts
 

--- a/packages/f-registration/package.json
+++ b/packages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",
@@ -62,7 +62,7 @@
     "@justeat/f-button": "0.4.1",
     "@justeat/f-card": "0.7.0",
     "@justeat/f-error-message": "0.3.1",
-    "@justeat/f-form-field": "1.1.0",
+    "@justeat/f-form-field": "1.4.0",
     "@justeat/f-vue-icons": "1.10.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.5.8",

--- a/packages/f-registration/vue.config.js
+++ b/packages/f-registration/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                data: `@import "../assets/scss/common.scss";`
+                additionalData: `@import "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/f-searchbox/CHANGELOG.md
+++ b/packages/f-searchbox/CHANGELOG.md
@@ -3,9 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-Latest (to be added to next release)
+
+Latest (add to next release)
 ------------------------------
-*December 15, 2020*
+*December 30, 2020*
+
+### Changed
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
 
 ### Fixed
 - Google test from failing silently in CI.

--- a/packages/f-searchbox/src/assets/scss/common.scss
+++ b/packages/f-searchbox/src/assets/scss/common.scss
@@ -3,12 +3,7 @@
 // Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
 $theme: 'jet' !default;
 
-@import '~@justeat/f-utils/src/scss/functions/index';
-@import '~@justeat/f-utils/src/scss/mixins/index';
-@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
-@import '~@justeat/fozzie/src/scss/settings/variables';
-@import '~@justeat/fozzie/src/scss/base/reset';
-@import '~@justeat/fozzie-colour-palette/src/scss/';
+@import  '~@justeat/fozzie/src/scss/fozzie';
 
 /**
  * Component Variables

--- a/packages/f-user-message/CHANGELOG.md
+++ b/packages/f-user-message/CHANGELOG.md
@@ -4,15 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (to be added to next release)
+Latest (add to next release)
 ------------------------------
-*October 26, 2020*
-
-### Added
-- Stylelint added to lint styling on build.
+*December 30, 2020*
 
 ### Changed
 - 'jet' theme instead of 'je'
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
+
+### Added
+- Stylelint added to lint styling on build.
 
 
 v1.0.0-beta.1

--- a/packages/f-user-message/src/assets/scss/common.scss
+++ b/packages/f-user-message/src/assets/scss/common.scss
@@ -3,12 +3,7 @@
 // The theme is handled via a data-attribute on the component
 $theme: 'jet' !default;
 
-@import '~@justeat/fozzie-colour-palette/src/scss/';
-@import '~@justeat/f-utils/src/scss/functions/index';
-@import '~@justeat/f-utils/src/scss/mixins/index';
-@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
-@import '~@justeat/fozzie/src/scss/settings/variables';
-@import '~@justeat/fozzie/src/scss/base/reset';
+@import  '~@justeat/fozzie/src/scss/fozzie';
 
 /**
  * Global variables which need to be changed depending on the theme (TODO: move to separate component)

--- a/packages/f-user-message/vue.config.js
+++ b/packages/f-user-message/vue.config.js
@@ -1,4 +1,7 @@
-const magicImporter = require('node-sass-magic-importer');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../config/sassOptions')(rootDir);
 const devServer = require('./vue.config.devServer');
 
 // vue.config.js
@@ -10,9 +13,9 @@ module.exports = {
             .use('importer')
             .loader('sass-loader')
             .options({
-                importer: magicImporter(),
+                ...sassOptions,
                 // eslint-disable-next-line quotes
-                data: `@import "@/assets/scss/common.scss";`
+                additionalData: `@import "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/generator-component/CHANGELOG.md
+++ b/packages/generator-component/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.9.0
+------------------------------
+*December 30, 2020*
+
+### Changed
+- Updated config for latest `sass-loader`.
+- Switches import in `common.scss` in line with fozzie v5-beta.
+
+
 v1.8.0
 ------------------------------
 *November 26, 2020*

--- a/packages/generator-component/generators/app/templates/src/assets/scss/common.scss
+++ b/packages/generator-component/generators/app/templates/src/assets/scss/common.scss
@@ -3,12 +3,7 @@
 // Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
 $theme: 'jet' !default;
 
-@import '~@justeat/f-utils/src/scss/functions/index';
-@import '~@justeat/f-utils/src/scss/mixins/index';
-@import '~include-media/dist/include-media'; // Cleaner media query declarations – http://include-media.com
-@import '~@justeat/fozzie/src/scss/settings/variables';
-@import '~@justeat/fozzie/src/scss/base/reset';
-@import '~@justeat/fozzie-colour-palette/src/scss/';
+@import  '~@justeat/fozzie/src/scss/fozzie';
 
 /**
  * Component Variables

--- a/packages/generator-component/generators/app/templates/vue.config.js
+++ b/packages/generator-component/generators/app/templates/vue.config.js
@@ -1,4 +1,7 @@
-const magicImporter = require('node-sass-magic-importer');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
@@ -9,9 +12,9 @@ module.exports = {
             .use('importer')
             .loader('sass-loader')
             .options({
-                importer: magicImporter(),
+                ...sassOptions,
                 // eslint-disable-next-line quotes
-                data: `@import "@/assets/scss/common.scss";`
+                additionalData: `@import "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/generator-component/package.json
+++ b/packages/generator-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/generator-component",
   "description": "Generator Component – A generator for Fozzie components",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "files": [
     "generators"
   ],

--- a/packages/generator-component/vue.config.js
+++ b/packages/generator-component/vue.config.js
@@ -1,4 +1,7 @@
-const magicImporter = require('node-sass-magic-importer');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
@@ -9,9 +12,9 @@ module.exports = {
             .use('importer')
             .loader('sass-loader')
             .options({
-                importer: magicImporter(),
+                ...sassOptions,
                 // eslint-disable-next-line quotes
-                data: `@import "@/assets/scss/common.scss";`
+                additionalData: `@import "../assets/scss/common.scss";`
             });
     }
 };

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.21.0
+------------------------------
+*December 30, 2020*
+
+### Changed
+- Updated `sass-loader` config.
+
+
 v0.20.0
 ------------------------------
 *December 7, 2020*

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "scripts": {
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -s public -p 8080 -c config/storybook",
@@ -19,7 +19,6 @@
     "@storybook/addon-links": "6.0.28",
     "@storybook/vue": "6.0.28",
     "cookie-universal": "2.1.4",
-    "eyeglass": "1.4.1",
     "node-sass-magic-importer": "5.3.2",
     "npm-run-all": "4.1.5",
     "path": "0.12.7",

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -3,7 +3,6 @@ const path = require('path');
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../config/sassOptions')(rootDir);
 
-
 // vue.config.js
 module.exports = {
     chainWebpack: config => {
@@ -21,12 +20,12 @@ module.exports = {
                  * @param resourcePath
                  * @returns {string}
                  */
-                data ({ resourcePath }) {
+                additionalData (content, { resourcePath }) {
                     const levelsUpToSrc = resourcePath.split(path.sep).reverse().indexOf('src');
 
                     // Only attempt to add common styles when under a src dir
                     if (levelsUpToSrc === -1) {
-                        return '';
+                        return `${content}`;
                     }
 
                     const absPath = path.join(
@@ -41,7 +40,8 @@ module.exports = {
 @include reset();
 @include typography();
 @include links();
-@import "${relPath}";`;
+@import "${relPath}";
+${content}`;
                 }
             });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,17 +1633,6 @@
     eslint-config-airbnb-base "14.1.0"
     eslint-plugin-vue "6.2.2"
 
-"@justeat/f-build-config@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-build-config/-/f-build-config-0.3.0.tgz#15b18304e792ee031e0eb6b71f944c3d3c797c1f"
-  integrity sha512-o18SowVC+OxDFDhTcfmDJW43TRf2EsMVbuRZ5u2H5/uEHyq6YIlnrY2CwtpQ2sczjgssPEBcqX/pe6p1iI51uQ==
-  dependencies:
-    ansi-colors "3.2.4"
-    webpack "4.30.0"
-    webpack-chain "5.2.4"
-    webpack-cli "3.3.1"
-    webpack-log "2.0.0"
-
 "@justeat/f-button@0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-0.4.0.tgz#3abe0c470eaa0fc90ab9d03a4ffa86464d84f926"
@@ -1677,12 +1666,13 @@
   dependencies:
     "@justeat/f-vue-icons" "1.10.0"
 
-"@justeat/f-form-field@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-1.1.0.tgz#a9d8ba9ca65a1d5a7f016e69a079c044b5d7d8ea"
-  integrity sha512-pdvIN2OVPlFxzAatDMe2SoWH4q2n/QJ84YnLmK6P49PXg2bGPPLI8foQgVO4wUsDzuzClL8k1BJxwAMwMpmA8Q==
+"@justeat/f-form-field@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-1.4.0.tgz#4f5151996e2f80419bc74f6b126741161db7128a"
+  integrity sha512-LLiZ8McS9i8BTWrzujL0lWru7TlqDPp2JWjW3eUFCW8nUEbEIoDV5HJzQ1M21oLY7wSr0OH6wCqfNUfnRI5q/Q==
   dependencies:
     "@justeat/f-services" "1.0.0"
+    "@justeat/f-vue-icons" "1.11.0"
 
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"
@@ -5026,15 +5016,15 @@ ansi-align@^3.0.0:
   dependencies:
     string-width "^3.0.0"
 
-ansi-colors@3.2.4, ansi-colors@^3.0.0:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
-  integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
-
 ansi-colors@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+
+ansi-colors@^3.0.0:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
+  integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
 ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
@@ -7204,15 +7194,6 @@ clipboardy@^2.3.0:
     execa "^1.0.0"
     is-wsl "^2.1.1"
 
-cliui@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
-  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
-  dependencies:
-    string-width "^2.1.1"
-    strip-ansi "^4.0.0"
-    wrap-ansi "^2.0.0"
-
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
@@ -8425,7 +8406,7 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
 
-deasync@^0.1.15, deasync@^0.1.4:
+deasync@^0.1.15:
   version "0.1.21"
   resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.21.tgz#bb11eabd4466c0d8776f0d82deb8a6126460d30f"
   integrity sha512-kUmM8Y+PZpMpQ+B4AuOW9k2Pfx/mSupJtxOsLzmnHY2WqZUYRFccFn2RhzPAqt3Xb+sorK/badW2D4zNzqZz5w==
@@ -9196,7 +9177,7 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-ensure-symlink@^1.0.0:
+ensure-symlink@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ensure-symlink/-/ensure-symlink-1.0.2.tgz#58ebc26d15a9539b9e79d00aa9623f8fa65ff18d"
   integrity sha1-WOvCbRWpU5ueedAKqWI/j6Zf8Y0=
@@ -9985,23 +9966,23 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-eyeglass@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/eyeglass/-/eyeglass-1.4.1.tgz#641591720df59291690cea7c45afa64d04840838"
-  integrity sha512-StYCyE+gClI+/dw7HyujkxHZozEAVE6pYgEKfSudY9kpVrcbS9k885KZlfSQ5s6U9DESgCXd9xRAVK072/XFSA==
+eyeglass@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/eyeglass/-/eyeglass-3.0.2.tgz#4e1379df7e7d1f66785070250bdc06e9c0498e69"
+  integrity sha512-geE9DKO19RmjQQjQGfylRvJFUzwKMu7Z1en7sHzuhE4usobYvTlrOBVLKbH/1RrX79n5eAfhFOemRVkUfMotZw==
   dependencies:
     archy "^1.0.0"
-    deasync "^0.1.4"
-    debug "^2.2.0"
-    ensure-symlink "^1.0.0"
-    fs-extra "^0.30.0"
+    debug "^4.1.0"
+    ensure-symlink "^1.0.2"
+    fs-extra "^7.0.0"
     glob "^7.1.0"
+    heimdalljs "^0.2.6"
     json-stable-stringify "^1.0.1"
     lodash.includes "^4.3.0"
-    lodash.merge "^4.6.0"
-    node-sass "^4.0.0 || ^3.10.1"
-    node-sass-utils "^1.1.2"
-    semver "^5.0.3"
+    lodash.merge "^4.6.1"
+    lru-cache "^5.1.1"
+    node-sass-utils "^1.1.3"
+    semver "^5.6.0"
 
 faker@4.1.0:
   version "4.1.0"
@@ -10331,16 +10312,6 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-findup-sync@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
-  integrity sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=
-  dependencies:
-    detect-file "^1.0.0"
-    is-glob "^3.1.0"
-    micromatch "^3.0.4"
-    resolve-dir "^1.0.1"
-
 findup-sync@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
@@ -10582,7 +10553,7 @@ fs-extra@^6.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^7.0.1:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -10729,11 +10700,6 @@ gensync@^1.0.0-beta.1:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
-
-get-caller-file@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
-  integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
 get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
@@ -11434,6 +11400,13 @@ header-case@^1.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.3"
 
+heimdalljs@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.6.tgz#b0eebabc412813aeb9542f9cc622cb58dbdcd9fe"
+  integrity sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==
+  dependencies:
+    rsvp "~3.2.1"
+
 hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
@@ -12071,7 +12044,7 @@ internal-slot@^1.0.2:
     has "^1.0.3"
     side-channel "^1.0.2"
 
-interpret@^1.0.0, interpret@^1.1.0, interpret@^1.2.0:
+interpret@^1.0.0, interpret@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
@@ -12087,11 +12060,6 @@ invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
-
-invert-kv@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
-  integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -12774,7 +12742,7 @@ jasmine@^3.5.0:
     glob "^7.1.6"
     jasmine-core "~3.6.0"
 
-javascript-stringify@^2.0.0, javascript-stringify@^2.0.1:
+javascript-stringify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/javascript-stringify/-/javascript-stringify-2.0.1.tgz#6ef358035310e35d667c675ed63d3eb7c1aa19e5"
   integrity sha512-yV+gqbd5vaOYjqlbk16EG89xB5udgjqQF3C5FAORDg4f/IS1Yc5ERCv5e/57yBcfJYw05V5JyIXabhwb75Xxow==
@@ -13712,6 +13680,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+klona@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
+  integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
+
 known-css-properties@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.19.0.tgz#5d92b7fa16c72d971bda9b7fe295bdf61836ee5b"
@@ -13767,13 +13740,6 @@ lazystream@^1.0.0:
   integrity sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=
   dependencies:
     readable-stream "^2.0.5"
-
-lcid@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
-  integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
-  dependencies:
-    invert-kv "^2.0.0"
 
 left-pad@^1.3.0:
   version "1.3.0"
@@ -13925,7 +13891,7 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -14089,7 +14055,7 @@ lodash.memoize@4.x, lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.merge@^4.6.0, lodash.merge@^4.6.1:
+lodash.merge@^4.6.1:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
@@ -14351,13 +14317,6 @@ mamacro@^0.0.3:
   resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
   integrity sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==
 
-map-age-cleaner@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
-  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
-  dependencies:
-    p-defer "^1.0.0"
-
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
@@ -14524,15 +14483,6 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
-
-mem@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
-  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
-  dependencies:
-    map-age-cleaner "^0.1.1"
-    mimic-fn "^2.0.0"
-    p-is-promise "^2.0.0"
 
 memfs-or-file-map-to-github-branch@^1.1.0:
   version "1.2.0"
@@ -14758,7 +14708,7 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
-mimic-fn@^2.0.0, mimic-fn@^2.1.0:
+mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
@@ -15115,7 +15065,7 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
+neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -15296,12 +15246,12 @@ node-sass-magic-importer@5.3.2:
     postcss-scss "^2.0.0"
     resolve "^1.10.1"
 
-node-sass-utils@^1.1.2:
+node-sass-utils@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/node-sass-utils/-/node-sass-utils-1.1.3.tgz#ce99bcc7f96eec45eccbbd06f15f770d65a2d396"
   integrity sha512-zSBvzcPeI8qY3fcJPXuRVYkyKssHyt0bBLKZ9TaYBn2dskJTjooIaI0yqHL6BylgMd3WPyt9DQD91vfds75xLA==
 
-node-sass@4.14.1, "node-sass@^4.0.0 || ^3.10.1":
+node-sass@4.14.1:
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.1.tgz#99c87ec2efb7047ed638fb4c9db7f3a42e2217b5"
   integrity sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==
@@ -15774,15 +15724,6 @@ os-homedir@^2.0.0:
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-2.0.0.tgz#a0c76bb001a8392a503cbd46e7e650b3423a923c"
   integrity sha512-saRNz0DSC5C/I++gFIaJTXoFJMRwiP5zHar5vV3xQ2TkgEw6hDCcU5F272JjUylpiVgBrZNQHnfjkLabTfb92Q==
 
-os-locale@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
-  integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
-  dependencies:
-    execa "^1.0.0"
-    lcid "^2.0.0"
-    mem "^4.0.0"
-
 os-name@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-name/-/os-name-3.1.0.tgz#dec19d966296e1cd62d701a5a66ee1ddeae70801"
@@ -15819,11 +15760,6 @@ p-cancelable@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.0.0.tgz#4a3740f5bdaf5ed5d7c3e34882c6fb5d6b266a6e"
   integrity sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==
 
-p-defer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
-  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
-
 p-each-series@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-1.0.0.tgz#930f3d12dd1f50e7434457a22cd6f04ac6ad7f71"
@@ -15840,11 +15776,6 @@ p-finally@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
   integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
-
-p-is-promise@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
-  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -18561,11 +18492,6 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
-require-main-filename@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
-  integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
-
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -18876,6 +18802,11 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
+rsvp@~3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.2.1.tgz#07cb4a5df25add9e826ebc67dcc9fd89db27d84a"
+  integrity sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=
+
 run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -18964,16 +18895,16 @@ sass-graph@2.2.5:
     scss-tokenizer "^0.2.3"
     yargs "^13.3.2"
 
-sass-loader@7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.3.1.tgz#a5bf68a04bcea1c13ff842d747150f7ab7d0d23f"
-  integrity sha512-tuU7+zm0pTCynKYHpdqaPpe+MMTQ76I9TPZ7i4/5dZsigE350shQWe5EZNl5dBidM49TPET75tNqRbcsUZWeNA==
+sass-loader@10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-10.1.0.tgz#1727fcc0c32ab3eb197cda61d78adf4e9174a4b3"
+  integrity sha512-ZCKAlczLBbFd3aGAhowpYEy69Te3Z68cg8bnHHl6WnSCvnKpbM6pQrz957HWMa8LKVuhnD9uMplmMAHwGQtHeg==
   dependencies:
-    clone-deep "^4.0.1"
-    loader-utils "^1.0.1"
-    neo-async "^2.5.0"
-    pify "^4.0.1"
-    semver "^6.3.0"
+    klona "^2.0.4"
+    loader-utils "^2.0.0"
+    neo-async "^2.6.2"
+    schema-utils "^3.0.0"
+    semver "^7.3.2"
 
 sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"
@@ -19052,7 +18983,7 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "^0.10.0"
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.3, semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -20109,7 +20040,7 @@ supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.0.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
+supports-color@^5.0.0, supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -21747,14 +21678,6 @@ webpack-bundle-analyzer@^3.8.0:
     opener "^1.5.1"
     ws "^6.0.0"
 
-webpack-chain@5.2.4:
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/webpack-chain/-/webpack-chain-5.2.4.tgz#cc3665a296a6edcda738324599103ac6e215dda3"
-  integrity sha512-3g0uIbzM/EWnmf52bYhB5IZeBZiw5g9vNqF4iTBEqabpxGxcv+Aj9oL4Cvr19ujOsv/HPvpRFRPLZ/aylv10Wg==
-  dependencies:
-    deepmerge "^1.5.2"
-    javascript-stringify "^2.0.0"
-
 webpack-chain@^6.4.0:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/webpack-chain/-/webpack-chain-6.5.1.tgz#4f27284cbbb637e3c8fbdef43eef588d4d861206"
@@ -21762,23 +21685,6 @@ webpack-chain@^6.4.0:
   dependencies:
     deepmerge "^1.5.2"
     javascript-stringify "^2.0.1"
-
-webpack-cli@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.1.tgz#98b0499c7138ba9ece8898bd99c4f007db59909d"
-  integrity sha512-c2inFU7SM0IttEgF7fK6AaUsbBnORRzminvbyRKS+NlbQHVZdCtzKBlavRL5359bFsywXGRAItA5di/IruC8mg==
-  dependencies:
-    chalk "^2.4.1"
-    cross-spawn "^6.0.5"
-    enhanced-resolve "^4.1.0"
-    findup-sync "^2.0.0"
-    global-modules "^1.0.0"
-    import-local "^2.0.0"
-    interpret "^1.1.0"
-    loader-utils "^1.1.0"
-    supports-color "^5.5.0"
-    v8-compile-cache "^2.0.2"
-    yargs "^12.0.5"
 
 webpack-dev-middleware@^3.7.0, webpack-dev-middleware@^3.7.2:
   version "3.7.2"
@@ -21840,7 +21746,7 @@ webpack-hot-middleware@^2.25.0:
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
 
-webpack-log@2.0.0, webpack-log@^2.0.0:
+webpack-log@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-2.0.0.tgz#5b7928e0637593f119d32f6227c1e0ac31e1b47f"
   integrity sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==
@@ -21870,7 +21776,7 @@ webpack-virtual-modules@^0.2.2:
   dependencies:
     debug "^3.0.0"
 
-webpack@4.30.0, webpack@4.36.0, "webpack@>=4 < 4.29", webpack@^4.0.0, webpack@^4.26.0, webpack@^4.43.0:
+webpack@4.36.0, "webpack@>=4 < 4.29", webpack@^4.0.0, webpack@^4.26.0, webpack@^4.43.0:
   version "4.36.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.36.0.tgz#d49474e54acd6eed51c3aff70333cbd172f21101"
   integrity sha512-UGcu9VQMjs9CxYfDEMe7UYkMgSVx9eSgcmj8ksveJk0b7/CxPW4B0HOk+yF0CLQg8p0sxynUS4PHQtjEDSZSmg==
@@ -22046,14 +21952,6 @@ workerpool@6.0.2:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.0.2.tgz#e241b43d8d033f1beb52c7851069456039d1d438"
   integrity sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q==
 
-wrap-ansi@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
-  integrity sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=
-  dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-
 wrap-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
@@ -22215,7 +22113,7 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
+y18n@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
@@ -22256,14 +22154,6 @@ yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
-  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
@@ -22314,24 +22204,6 @@ yargs@13.3.2, yargs@^13.3.0, yargs@^13.3.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
-
-yargs@^12.0.5:
-  version "12.0.5"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
-  integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.2.0"
-    find-up "^3.0.0"
-    get-caller-file "^1.0.1"
-    os-locale "^3.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1 || ^4.0.0"
-    yargs-parser "^11.1.1"
 
 yargs@^14.2.2:
   version "14.2.3"


### PR DESCRIPTION
### Changed
- Updated config for latest `sass-loader`.
- Switches import in `common.scss` in line with fozzie v5-beta.

---

Sass loader has now been updated to the latest version (v10), with eyeglass also updated to v3. When building there will be some small warnings related to eyeglass v1 until I update a couple of other fozzie packages (coming soon).

All packages have also been updated to pull in fozzie v5 references (so just one line import instead of multiple specific files in the `common.scss`.