### PR TITLE
f-checkout@0.31.0 - Storybook component tests updated

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -8,7 +8,7 @@ v0.31.0
 -------------------------------
 *January 5, 2021*
 
-### Changed	### Changed
+### Changed
 - Updated skipped tests to work with Storybook component tests.
 
 ### Added

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,8 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (add to next release)
-------------------------------
+v0.31.0
+-------------------------------
+*January 5, 2021*
+
+
+### Changed	### Changed
+- Updated skipped tests to work with Storybook component tests.
+
+### Added
+- New `clearCheckoutForm` function added to clear the fields in tests in the `f-checkout-component.js` file.
+
 *December 30, 2020*
 
 ### Changed

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -8,7 +8,6 @@ v0.31.0
 -------------------------------
 *January 5, 2021*
 
-
 ### Changed	### Changed
 - Updated skipped tests to work with Storybook component tests.
 

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout-selectors.js
+++ b/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout-selectors.js
@@ -4,6 +4,8 @@ export const ORDER_TIME_DROPDOWN = '[data-test-id="formfield-order-time-dropdown
 export const ORDER_TIME_DROPDOWN_OPTIONS = '[data-test-id="formfield-order-time-dropdown-select"] option';
 export const USER_NOTE_INPUT = '[data-test-id="user-note"] textarea';
 export const GO_TO_PAYMENT_BUTTON = '[data-test-id="confirm-payment-submit-button"]';
+export const KNOB_BUTTON = '[id$="tabbutton-knobs"]';
+export const KNOB_CHECKOUT_DROPDOWN = '[name="Checkout Url"]';
 
 export const FIELDS = {
     mobileNumber: {
@@ -36,7 +38,7 @@ export const FIELDS = {
 export default {
     ALLERGEN_LINK,
     CHECKOUT_COMPONENT,
-    ORDER_TIME_DROPDOWN, 
+    ORDER_TIME_DROPDOWN,
     ORDER_TIME_DROPDOWN_OPTIONS,
     USER_NOTE_INPUT,
     GO_TO_PAYMENT_BUTTON,

--- a/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout.component.js
+++ b/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout.component.js
@@ -7,7 +7,9 @@ import {
     ORDER_TIME_DROPDOWN_OPTIONS,
     USER_NOTE_INPUT,
     GO_TO_PAYMENT_BUTTON,
-    FIELDS
+    FIELDS,
+    KNOB_CHECKOUT_DROPDOWN,
+    KNOB_BUTTON
 } from './f-checkout-selectors';
 
 const { doesElementExist } = require('../../../../../../test/utils/webdriverio-extensions')(browser);
@@ -18,11 +20,13 @@ const checkoutComponent = () => $(CHECKOUT_COMPONENT);
 
 const orderTimeDropdown = () => $(ORDER_TIME_DROPDOWN);
 const orderTimeDropdownOptions = () => $$(ORDER_TIME_DROPDOWN_OPTIONS);
+const knobCheckoutDropdown = () => $(KNOB_CHECKOUT_DROPDOWN);
 
 // Buttons
 
 const allergenLink = () => $(ALLERGEN_LINK);
 const goToPaymentButton = () => $(GO_TO_PAYMENT_BUTTON);
+const knobButton = () => $(KNOB_BUTTON);
 
 // Form Fields
 
@@ -56,6 +60,21 @@ const fields = {
     }
 };
 
+/**
+ * @description
+ * Changes checkout page to reflect checkout method to either delivery or collection depending on index given.
+ *
+ * @param {string} method The collection type: either 'delivery' or 'collection'
+ */
+
+exports.changeCheckoutMethod = method => {
+    const file = `/checkout-${method}.json`;
+    knobButton().click();
+    knobCheckoutDropdown().selectByVisibleText(file);
+};
+
+
+
 exports.isFieldErrorDisplayed = fieldName => fields[fieldName].error().isDisplayed();
 exports.isFieldDisplayed = fieldName => fields[fieldName].input().isDisplayed();
 exports.isFieldTypeErrorDisplayed = fieldName => fields[fieldName].typeError().isDisplayed();
@@ -87,6 +106,37 @@ exports.populateCheckoutForm = addressInfo => {
     fields.addressPostcode.input().setValue(addressInfo.postcode);
     fields.userNote.input().setValue(addressInfo.note);
 };
+
+/**
+ * @description
+ * Adds a space and backspaces to clear the value of the form field.
+ * For more information on this, you can check out the link below:
+ * https://github.com/webdriverio/webdriverio/issues/530#issuecomment-229435909
+ *
+ * @param {String} fieldName The name of the field input it is clearing
+ */
+exports.clearField = fieldName => {
+    const BACKSPACE_UNICODE = '\uE003';
+    fields[fieldName].input().setValue([' ', BACKSPACE_UNICODE]);
+};
+
+/**
+ * @description
+ * Adds a space and backspaces to clear the value of the form field.
+ *
+ * @param {String} fields Grabs the fields of the above object and runs a forEach loop to get the keys
+ */
+exports.clearCheckoutForm = () => {
+    exports.waitForCheckoutComponent();
+    Object.keys(fields).forEach(exports.clearField);
+};
+
+exports.populateCollectionCheckoutForm = addressInfo => {
+    exports.waitForCheckoutComponent();
+    fields.mobileNumber.input().setValue(addressInfo.mobileNumber);
+    fields.userNote.input().setValue(addressInfo.note);
+};
+
 /**
  * @description
  * Sets the value of the order time in dropdown based on visible text.
@@ -96,6 +146,7 @@ exports.populateCheckoutForm = addressInfo => {
 exports.selectOrderTime = orderTime => {
     orderTimeDropdown().selectByVisibleText(orderTime);
 };
+
 /**
  * @description
  * The time of the order should increase when a higher index is applied.
@@ -103,6 +154,7 @@ exports.selectOrderTime = orderTime => {
  * @param {Number} index The index of the `orderTimeDropdownOptions` array
  */
 exports.getOrderTimeOptionText = index => orderTimeDropdownOptions()[index].getText();
+
 /**
  * @description
  * Sets the value of the user note.
@@ -113,6 +165,7 @@ exports.getOrderTimeOptionText = index => orderTimeDropdownOptions()[index].getT
 exports.inputUserNote = addressInfo => {
     fields.userNote.input().setValue(addressInfo.note);
 };
+
 /**
  * @description
  * Grabs the length of characters of the user note.
@@ -120,13 +173,14 @@ exports.inputUserNote = addressInfo => {
  * @returns {number} The length of the user note
  */
 exports.getUserNoteLength = () => userNoteInput().getValue().length;
+
 /**
  * @description
  *Submit the checkout form.
  */
-exports.submit = () => {
+exports.goToPayment = () => {
     goToPaymentButton().click();
 };
 
 exports.doesErrorMessageExist = errorMessage => doesElementExist(FIELDS[errorMessage].error);
-exports.doesInputFieldExist = inputField => doesElementExist(FIELDS[inputField].input);
+exports.doesFieldExist = inputField => doesElementExist(FIELDS[inputField].input);

--- a/packages/components/organisms/f-checkout/test/specs/component/f-checkout-collection.component.spec.js
+++ b/packages/components/organisms/f-checkout/test/specs/component/f-checkout-collection.component.spec.js
@@ -1,38 +1,35 @@
 import forEach from 'mocha-each';
-import DemoControls from '../../../test-utils/component-objects/demo-controls';
 import CheckoutComponent from '../../../test-utils/component-objects/f-checkout.component';
 
 describe('f-checkout "collection" component tests', () => {
-      beforeEach(() => {
+    before(() => {
         browser.url('?path=/story/components-organisms--checkout-component');
+        CheckoutComponent.changeCheckoutMethod('collection');
         browser.switchToFrame(0);
         CheckoutComponent.waitForCheckoutComponent();
     });
 
-    it.skip('should display "mobileNumber" error message when collection method is set', () => {
+    it('should display "mobileNumber" error message when collection method is set and number is incorrect', () => {
         // Arrange
-        DemoControls.selectCheckoutMethod('collection');
+        const addressDetails = {
+            mobileNumber: '1234'
+        };
 
         // Act
-        CheckoutComponent.submit();
+        CheckoutComponent.populateCollectionCheckoutForm(addressDetails);
+        CheckoutComponent.goToPayment();
 
         // Assert
         expect(CheckoutComponent.isFieldErrorDisplayed('mobileNumber')).toBe(true);
     });
 
     forEach(['addressLine1', 'addressLine2', 'addressCity', 'addressPostcode'])
-    .it.skip('address fields should not exist', field => {
-        // Arrange
-        DemoControls.selectCheckoutMethod('collection');
-
+    .it('address fields should not exist', field => {
         // Assert
-        expect(CheckoutComponent.doesInputFieldExist(field)).toBe(false);
+        expect(CheckoutComponent.doesFieldExist(field)).toBe(false);
     });
 
-    it.skip('should display the mandatory "mobileNumber" field', () => {
-        // Arrange
-        DemoControls.selectCheckoutMethod('collection');
-
+    it('should display the mandatory "mobileNumber" field', () => {
         // Assert
         expect(CheckoutComponent.isFieldDisplayed('mobileNumber')).toBe(true);
     });

--- a/packages/components/organisms/f-checkout/test/specs/component/f-checkout-delivery.component.spec.js
+++ b/packages/components/organisms/f-checkout/test/specs/component/f-checkout-delivery.component.spec.js
@@ -2,33 +2,34 @@ import forEach from 'mocha-each';
 import CheckoutComponent from '../../../test-utils/component-objects/f-checkout.component';
 
 describe('f-checkout "delivery" component tests', () => {
-    beforeEach(() => {
+    before(() => {
         browser.url('?path=/story/components-organisms--checkout-component');
         browser.switchToFrame(0);
         CheckoutComponent.waitForCheckoutComponent();
     });
 
     forEach(['mobileNumber', 'addressLine1', 'addressCity', 'addressPostcode'])
-    .it.skip('each fields error message should be displayed', field => {
+    .it('each fields error message should be displayed', field => {
         // Act
-        CheckoutComponent.submit();
+        CheckoutComponent.clearCheckoutForm();
+        CheckoutComponent.goToPayment();
 
         // Assert
         expect(CheckoutComponent.isFieldErrorDisplayed(field)).toBe(true);
     });
 
     forEach(['addressLine1', 'addressLine2', 'addressCity', 'addressPostcode'])
-    .it.skip('address fields should exist', field => {
+    .it('address fields should exist', field => {
         // Assert
-        expect(CheckoutComponent.doesInputFieldExist(field)).toBe(true);
+        expect(CheckoutComponent.doesFieldExist(field)).toBe(true);
     });
 
-    it.skip('should display the mandatory fields', () => {
+    it('should display the mandatory fields', () => {
         // Assert
         expect(CheckoutComponent.isFieldDisplayed('mobileNumber')).toBe(true);
     });
 
-    it.skip('should display a "mobileNumber" error message when a number format is incorrectly entered', () => {
+    it('should display a "mobileNumber" error message when a number format is incorrectly entered', () => {
         // Arrange
         const addressDetails = {
             mobileNumber: '+4512345678911'
@@ -36,13 +37,13 @@ describe('f-checkout "delivery" component tests', () => {
 
         // Act
         CheckoutComponent.populateCheckoutForm(addressDetails);
-        CheckoutComponent.submit();
+        CheckoutComponent.goToPayment();
 
         // Assert
         expect(CheckoutComponent.isFieldErrorDisplayed('mobileNumber')).toBe(true);
     });
 
-    it.skip('should not display a "mobileNumber" error message when a number is formatted correctly', () => {
+    it('should not display a "mobileNumber" error message when a number is formatted correctly', () => {
         // Arrange
         const addressDetails = {
             mobileNumber: '+4412345678911'
@@ -50,7 +51,7 @@ describe('f-checkout "delivery" component tests', () => {
 
         // Act
         CheckoutComponent.populateCheckoutForm(addressDetails);
-        CheckoutComponent.submit();
+        CheckoutComponent.goToPayment();
 
         // Assert
         expect(CheckoutComponent.isFieldErrorDisplayed('mobileNumber')).toBe(false);
@@ -64,11 +65,11 @@ describe('f-checkout "delivery" component tests', () => {
 
         // Act
         CheckoutComponent.populateCheckoutForm(addressInfo);
-        CheckoutComponent.submit();
+        CheckoutComponent.goToPayment();
 
         // Assert
         expect(CheckoutComponent.isFieldTypeErrorDisplayed('addressPostcode')).toBe(true);
-    }); 
+    });
 
     it('should enable a user to submit a postcode with correct characters', () => {
         // Arrange
@@ -78,7 +79,7 @@ describe('f-checkout "delivery" component tests', () => {
 
         // Act
         CheckoutComponent.populateCheckoutForm(addressInfo);
-        CheckoutComponent.submit();
+        CheckoutComponent.goToPayment();
 
         // Assert
         expect(CheckoutComponent.isFieldTypeErrorDisplayed('addressPostcode')).toBe(false);

--- a/packages/components/organisms/f-checkout/test/specs/component/f-checkout.component.spec.js
+++ b/packages/components/organisms/f-checkout/test/specs/component/f-checkout.component.spec.js
@@ -1,18 +1,18 @@
 import CheckoutComponent from '../../../test-utils/component-objects/f-checkout.component';
 
 describe('f-checkout component tests', () => {
-    beforeEach(() => {
+    before(() => {
         browser.url('?path=/story/components-organisms--checkout-component');
         browser.switchToFrame(0);
         CheckoutComponent.waitForCheckoutComponent();
     });
 
-    it.skip('should display the f-checkout component', () => {
+    it('should display the f-checkout component', () => {
         // Assert
         expect(CheckoutComponent.isCheckoutComponentDisplayed()).toBe(true);
     });
 
-    it.skip('should display the allergen link', () => {
+    it('should display the allergen link', () => {
         // Assert
         expect(CheckoutComponent.isAllergenLinkDisplayed()).toBe(true);
     });
@@ -30,26 +30,26 @@ describe('f-checkout component tests', () => {
 
         // Act
         CheckoutComponent.populateCheckoutForm(addressInfo);
-        CheckoutComponent.selectOrderTime('Monday 00:15');
-        CheckoutComponent.submit();
+        CheckoutComponent.selectOrderTime('Wednesday 00:30');
+        CheckoutComponent.goToPayment();
 
         // Assert
         // Waiting for route here, so we can grab redirect url and show form submits.
     });
 
-    it.skip('should display times in ascending order, with default text "As soon as possible" showing first', () => {
-        // Act 
+    it('should display times in ascending order, with default text "As soon as possible" showing first', () => {
+        // Act
         CheckoutComponent.selectOrderTime('As soon as possible');
 
         // Assert
         expect(CheckoutComponent.isOrderTimeDropdownDisplayed()).toBe(true);
         expect(CheckoutComponent.getOrderTimeOptionText(0)).toBe('As soon as possible');
-        expect(CheckoutComponent.getOrderTimeOptionText(1)).toBe('Monday 00:15');
-        expect(CheckoutComponent.getOrderTimeOptionText(2)).toBe('Monday 00:30');
+        expect(CheckoutComponent.getOrderTimeOptionText(1)).toBe('Wednesday 00:30');
+        expect(CheckoutComponent.getOrderTimeOptionText(2)).toBe('Wednesday 00:45');
     });
 
-    it.skip('should prevent user from writing a note of over 200 characters', () => {
-        // Arrange 
+    it('should prevent user from writing a note of over 200 characters', () => {
+        // Arrange
         const userNote = 'A';
         const addressInfo = {
             note: userNote.repeat(300)
@@ -75,8 +75,8 @@ describe('f-checkout component tests', () => {
 
         // Act
         CheckoutComponent.populateCheckoutForm(addressInfo);
-        CheckoutComponent.selectOrderTime('Monday 00:30');
-        CheckoutComponent.submit();
+        CheckoutComponent.selectOrderTime('Wednesday 00:30');
+        CheckoutComponent.goToPayment();
 
         // Assert
         // Waiting for route here, so we can grab redirect url and show form submits.

--- a/packages/components/organisms/f-checkout/test/specs/component/f-checkout.component.spec.js
+++ b/packages/components/organisms/f-checkout/test/specs/component/f-checkout.component.spec.js
@@ -48,7 +48,7 @@ describe('f-checkout component tests', () => {
         expect(CheckoutComponent.getOrderTimeOptionText(2)).toBe('Wednesday 00:45');
     });
 
-    it('should prevent user from writing a note of over 200 characters', () => {
+    it('should prevent a user from writing a note of over 200 characters', () => {
         // Arrange
         const userNote = 'A';
         const addressInfo = {


### PR DESCRIPTION
This is an updated PR to incorporate the new fozzie changes. The original PR can be found [here](https://github.com/justeat/fozzie-components/pull/546).

v0.31.0
-------------------------------
*January 5, 2021*

### Changed
- Updated skipped tests to work with Storybook component tests.

### Added
- New `clearCheckoutForm` function added to clear the fields in tests in the `f-checkout-component.js` file.