### PR TITLE
f-checkout@v0.34.0 - Create a guest user when submitting checkout form and the user is not authenticated

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.34.0
+-------------------------------
+*January 6, 2021*
+
+### Added
+
+-  Call to create a guest user when submitting checkout form and the user is not authenticated
+
 
 v0.33.0
 ------------------------------

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -188,15 +188,15 @@ export default {
 
     computed: {
         ...mapState('checkout', [
-            'id',
-            'serviceType',
             'customer',
             'fulfilment',
-            'notes',
+            'id',
             'isFulfillable',
-            'notices',
+            'isLoggedIn',
             'messages',
-            'isLoggedIn'
+            'notes',
+            'notices',
+            'serviceType'
         ]),
 
         name () {
@@ -255,11 +255,11 @@ export default {
 
     methods: {
         ...mapActions('checkout', [
+            'createGuestUser',
+            'getAvailableFulfilment',
             'getCheckout',
             'postCheckout',
-            'getAvailableFulfilment',
-            'setAuthToken',
-            'createGuestUser'
+            'setAuthToken'
         ]),
 
         onVisitLoginPage () {

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -281,19 +281,7 @@ export default {
                 }
 
                 if (!this.isLoggedIn) {
-                    const createGuestData = {
-                        emailAddress: this.customer.email,
-                        firstName: this.customer.firstName,
-                        lastName: this.customer.lastName,
-                        registrationSource: 'Guest'
-                    };
-
-                    this.createGuestUser({
-                        url: this.createGuestUrl,
-                        tenant: this.tenant,
-                        data: createGuestData,
-                        timeout: this.createGuestTimeout
-                    });
+                    await this.setupGuestUser();
                 }
 
                 await this.postCheckout({
@@ -307,6 +295,22 @@ export default {
             } catch (thrownErrors) {
                 this.$emit(EventNames.CheckoutFailure, thrownErrors);
             }
+        },
+
+        async setupGuestUser() {
+            const createGuestData = {
+                emailAddress: this.customer.email,
+                firstName: this.customer.firstName,
+                lastName: this.customer.lastName,
+                registrationSource: 'Guest'
+            };
+
+            this.createGuestUser({
+                url: this.createGuestUrl,
+                tenant: this.tenant,
+                data: createGuestData,
+                timeout: this.createGuestTimeout
+            });
         },
 
         /**

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -130,6 +130,11 @@ export default {
             required: true
         },
 
+        createGuestUrl: {
+            type: String,
+            required: true
+        },
+
         checkoutTimeout: {
             type: Number,
             required: false,
@@ -139,6 +144,11 @@ export default {
         getCheckoutTimeout: {
             type: Number,
             required: false,
+            default: 1000
+        },
+
+        createGuestTimeout: {
+            type: Number,
             default: 1000
         },
 
@@ -185,7 +195,8 @@ export default {
             'notes',
             'isFulfillable',
             'notices',
-            'messages'
+            'messages',
+            'isLoggedIn'
         ]),
 
         name () {
@@ -247,7 +258,8 @@ export default {
             'getCheckout',
             'postCheckout',
             'getAvailableFulfilment',
-            'setAuthToken'
+            'setAuthToken',
+            'createGuestUser'
         ]),
 
         onVisitLoginPage () {
@@ -266,6 +278,22 @@ export default {
 
                 if (this.isCheckoutMethodDelivery) {
                     checkoutData.address = this.fulfilment.address;
+                }
+
+                if (!this.isLoggedIn) {
+                    const createGuestData = {
+                        emailAddress: 'pawel.kedziora+test1@just-eat.com',
+                        firstName: 'Pawel',
+                        lastName: 'Kedziora',
+                        registrationSource: 'Guest'
+                    };
+
+                    this.createGuestUser({
+                        url: this.createGuestUrl,
+                        tenant: this.tenant,
+                        data: createGuestData,
+                        timeout: this.createGuestTimeout
+                    });
                 }
 
                 await this.postCheckout({

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -305,7 +305,7 @@ export default {
                 registrationSource: 'Guest'
             };
 
-            this.createGuestUser({
+            await this.createGuestUser({
                 url: this.createGuestUrl,
                 tenant: this.tenant,
                 data: createGuestData,

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -297,7 +297,7 @@ export default {
             }
         },
 
-        async setupGuestUser() {
+        async setupGuestUser () {
             const createGuestData = {
                 emailAddress: this.customer.email,
                 firstName: this.customer.firstName,

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -297,6 +297,10 @@ export default {
             }
         },
 
+        /**
+         * Setup a new guest user account. This method will be called when isLoggedIn is false.
+         *
+         */
         async setupGuestUser () {
             const createGuestData = {
                 emailAddress: this.customer.email,

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -282,9 +282,9 @@ export default {
 
                 if (!this.isLoggedIn) {
                     const createGuestData = {
-                        emailAddress: 'pawel.kedziora+test1@just-eat.com',
-                        firstName: 'Pawel',
-                        lastName: 'Kedziora',
+                        emailAddress: this.customer.email,
+                        firstName: this.customer.firstName,
+                        lastName: this.customer.lastName,
                         registrationSource: 'Guest'
                     };
 

--- a/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
@@ -382,7 +382,6 @@ describe('Checkout', () => {
     });
 
     describe('methods ::', () => {
-
         afterEach(() => {
             jest.clearAllMocks();
         });

--- a/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
@@ -157,6 +157,7 @@ describe('Checkout', () => {
         describe('authToken ::', () => {
             it('should store auth token', async () => {
                 // Arrange
+                    createGuestUrl
                 const setAuthToken = jest.fn();
 
                 // Act

--- a/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
@@ -48,7 +48,13 @@ describe('Checkout', () => {
     const checkoutAvailableFulfilmentUrl = 'http://localhost/checkout/fulfilment';
     const loginUrl = 'http://dummy-login.example.com';
     const createGuestUrl = 'http://localhost/createguestuser';
-    const propsData = { checkoutUrl, loginUrl, checkoutAvailableFulfilmentUrl , createGuestUrl };
+    const propsData = {
+        checkoutUrl,
+        loginUrl,
+        checkoutAvailableFulfilmentUrl,
+        createGuestUrl
+    };
+
     it('should be defined', () => {
         const wrapper = shallowMount(VueCheckout, {
             i18n,
@@ -157,7 +163,6 @@ describe('Checkout', () => {
         describe('authToken ::', () => {
             it('should store auth token', async () => {
                 // Arrange
-
                 const setAuthToken = jest.fn();
 
                 // Act
@@ -334,7 +339,6 @@ describe('Checkout', () => {
 
             const propsDataWithAuthToken = {
                 ...propsData,
-                createGuestUrl,
                 authToken: 'mytoken'
             };
 

--- a/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
@@ -577,6 +577,95 @@ describe('Checkout', () => {
                     expect(wrapper.vm.$v.fulfilment.address.postcode).toBeDefined();
                 });
             });
+
+            describe('if isLoggedIn set to false', () => {
+                afterEach(() => {
+                    jest.clearAllMocks();
+                });
+
+                it('should call `setupGuestUser`', async () => {
+                    const state = {
+                        ...defaultState,
+                        isLoggedIn: false
+                    };
+
+                    const setupGuestUserSpy = jest.spyOn(VueCheckout.methods, 'setupGuestUser');
+
+                    const wrapper = shallowMount(VueCheckout, {
+                        store: createStore(state),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+
+                    await wrapper.vm.onFormSubmit();
+
+                    expect(setupGuestUserSpy).toHaveBeenCalled();
+                });
+
+                it('should call `createGuestUser`', async () => {
+                    const state = {
+                        ...defaultState,
+                        isLoggedIn: false
+                    };
+
+                    const createGuestUserSpy = jest.spyOn(VueCheckout.methods, 'createGuestUser');
+
+                    const wrapper = shallowMount(VueCheckout, {
+                        store: createStore(state),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+
+                    await wrapper.vm.onFormSubmit();
+
+                    expect(createGuestUserSpy).toHaveBeenCalled();
+                });
+            });
+
+            describe('if isLoggedIn set to true', () => {
+                it('should not call `setupGuestUser`', async () => {
+                    const state = {
+                        ...defaultState,
+                        authToken: 'sampleToken',
+                        isLoggedIn: true
+                    };
+
+                    const setupGuestUserSpy = jest.spyOn(VueCheckout.methods, 'setupGuestUser');
+
+                    const wrapper = shallowMount(VueCheckout, {
+                        store: createStore(state),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+
+                    await wrapper.vm.onFormSubmit();
+
+                    expect(setupGuestUserSpy).not.toHaveBeenCalled();
+                });
+
+                it('should not call `createGuestUser`', async () => {
+                    const state = {
+                        ...defaultState,
+                        isLoggedIn: true
+                    };
+
+                    const createGuestUserSpy = jest.spyOn(VueCheckout.methods, 'createGuestUser');
+
+                    const wrapper = shallowMount(VueCheckout, {
+                        store: createStore(state),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+
+                    await wrapper.vm.onFormSubmit();
+
+                    expect(createGuestUserSpy).not.toHaveBeenCalled();
+                });
+            });
         });
 
         describe('loadCheckout ::', () => {

--- a/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
@@ -585,113 +585,89 @@ describe('Checkout', () => {
                 });
 
                 it('should call `setupGuestUser`', async () => {
+                    // Arrange
                     const state = {
                         ...defaultState,
                         isLoggedIn: false
                     };
-
                     const setupGuestUserSpy = jest.spyOn(VueCheckout.methods, 'setupGuestUser');
 
+                    // Act
                     const wrapper = shallowMount(VueCheckout, {
                         store: createStore(state),
                         i18n,
                         localVue,
                         propsData
                     });
-
                     await wrapper.vm.onFormSubmit();
 
+                    // Assert
                     expect(setupGuestUserSpy).toHaveBeenCalled();
                 });
             });
 
             describe('if `isLoggedIn` set to `true`', () => {
                 it('should not call `setupGuestUser`', async () => {
+                    // Arrange
                     const state = {
                         ...defaultState,
                         authToken: 'sampleToken',
                         isLoggedIn: true
                     };
-
                     const setupGuestUserSpy = jest.spyOn(VueCheckout.methods, 'setupGuestUser');
 
+                    // Act
                     const wrapper = shallowMount(VueCheckout, {
                         store: createStore(state),
                         i18n,
                         localVue,
                         propsData
                     });
-
                     await wrapper.vm.onFormSubmit();
 
+                    // Assert
                     expect(setupGuestUserSpy).not.toHaveBeenCalled();
                 });
             });
         });
 
         describe('setupGuestUser ::', () => {
-            describe('if `isLoggedIn` set to `false`', () => {
-                it('should call `createGuestUser`', async () => {
-                    const customer = {
-                        firstName: 'Joe',
-                        lastName: 'Bloggs',
-                        email: 'joe@test.com',
-                        mobileNumber: '+447111111111'
-                    };
+            it('should call `createGuestUser`', async () => {
+                // Arrange
+                const customer = {
+                    firstName: 'Joe',
+                    lastName: 'Bloggs',
+                    email: 'joe@test.com',
+                    mobileNumber: '+447111111111'
+                };
+                const state = {
+                    ...defaultState,
+                    customer
+                };
+                const createGuestUserSpy = jest.spyOn(VueCheckout.methods, 'createGuestUser');
 
-                    const state = {
-                        ...defaultState,
-                        customer,
-                        isLoggedIn: false
-                    };
-
-                    const createGuestUserSpy = jest.spyOn(VueCheckout.methods, 'createGuestUser');
-
-                    const wrapper = shallowMount(VueCheckout, {
-                        store: createStore(state),
-                        i18n,
-                        localVue,
-                        propsData
-                    });
-
-                    const expected = {
-                        url: createGuestUrl,
-                        tenant: wrapper.vm.tenant,
-                        data: {
-                            firstName: customer.firstName,
-                            lastName: customer.lastName,
-                            emailAddress: customer.email,
-                            registrationSource: 'Guest'
-                        },
-                        timeout: 1000
-                    };
-
-                    await wrapper.vm.onFormSubmit();
-
-                    expect(createGuestUserSpy).toHaveBeenCalledWith(expected);
+                // Act
+                const wrapper = shallowMount(VueCheckout, {
+                    store: createStore(state),
+                    i18n,
+                    localVue,
+                    propsData
                 });
-            });
+                await wrapper.vm.setupGuestUser();
 
-            describe('if `isLoggedIn` set to `true`', () => {
-                it('should not call `createGuestUser`', async () => {
-                    const state = {
-                        ...defaultState,
-                        isLoggedIn: true
-                    };
-
-                    const createGuestUserSpy = jest.spyOn(VueCheckout.methods, 'createGuestUser');
-
-                    const wrapper = shallowMount(VueCheckout, {
-                        store: createStore(state),
-                        i18n,
-                        localVue,
-                        propsData
-                    });
-
-                    await wrapper.vm.onFormSubmit();
-
-                    expect(createGuestUserSpy).not.toHaveBeenCalled();
-                });
+                // Assert
+                const expected = {
+                    url: createGuestUrl,
+                    tenant: wrapper.vm.tenant,
+                    data: {
+                        firstName: customer.firstName,
+                        lastName: customer.lastName,
+                        emailAddress: customer.email,
+                        registrationSource: 'Guest'
+                    },
+                    timeout: 1000
+                };
+                expect(createGuestUserSpy).toHaveBeenCalledWith(expected);
             });
         });
 

--- a/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
@@ -590,19 +590,18 @@ describe('Checkout', () => {
 
                 it('should call `setupGuestUser`', async () => {
                     // Arrange
-                    const state = {
-                        ...defaultState,
-                        isLoggedIn: false
-                    };
                     const setupGuestUserSpy = jest.spyOn(VueCheckout.methods, 'setupGuestUser');
-
-                    // Act
                     const wrapper = shallowMount(VueCheckout, {
-                        store: createStore(state),
+                        store: createStore({
+                            ...defaultState,
+                            isLoggedIn: false
+                        }),
                         i18n,
                         localVue,
                         propsData
                     });
+
+                    // Act
                     await wrapper.vm.onFormSubmit();
 
                     // Assert
@@ -613,20 +612,19 @@ describe('Checkout', () => {
             describe('if `isLoggedIn` set to `true`', () => {
                 it('should not call `setupGuestUser`', async () => {
                     // Arrange
-                    const state = {
-                        ...defaultState,
-                        authToken: 'sampleToken',
-                        isLoggedIn: true
-                    };
                     const setupGuestUserSpy = jest.spyOn(VueCheckout.methods, 'setupGuestUser');
-
-                    // Act
                     const wrapper = shallowMount(VueCheckout, {
-                        store: createStore(state),
+                        store: createStore({
+                            ...defaultState,
+                            authToken: 'sampleToken',
+                            isLoggedIn: true
+                        }),
                         i18n,
                         localVue,
                         propsData
                     });
+
+                    // Act
                     await wrapper.vm.onFormSubmit();
 
                     // Assert
@@ -644,10 +642,6 @@ describe('Checkout', () => {
                     email: 'joe@test.com',
                     mobileNumber: '+447111111111'
                 };
-                const state = {
-                    ...defaultState,
-                    customer
-                };
                 const expected = {
                     url: createGuestUrl,
                     tenant: TENANT_MAP[i18n.locale],
@@ -661,7 +655,10 @@ describe('Checkout', () => {
                 };
                 const createGuestUserSpy = jest.spyOn(VueCheckout.methods, 'createGuestUser');
                 const wrapper = shallowMount(VueCheckout, {
-                    store: createStore(state),
+                    store: createStore({
+                        ...defaultState,
+                        customer
+                    }),
                     i18n,
                     localVue,
                     propsData

--- a/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
@@ -157,7 +157,7 @@ describe('Checkout', () => {
         describe('authToken ::', () => {
             it('should store auth token', async () => {
                 // Arrange
-                    createGuestUrl
+
                 const setAuthToken = jest.fn();
 
                 // Act
@@ -579,7 +579,7 @@ describe('Checkout', () => {
                 });
             });
 
-            describe('if isLoggedIn set to false', () => {
+            describe('if `isLoggedIn` set to `false`', () => {
                 afterEach(() => {
                     jest.clearAllMocks();
                 });
@@ -603,29 +603,9 @@ describe('Checkout', () => {
 
                     expect(setupGuestUserSpy).toHaveBeenCalled();
                 });
-
-                it('should call `createGuestUser`', async () => {
-                    const state = {
-                        ...defaultState,
-                        isLoggedIn: false
-                    };
-
-                    const createGuestUserSpy = jest.spyOn(VueCheckout.methods, 'createGuestUser');
-
-                    const wrapper = shallowMount(VueCheckout, {
-                        store: createStore(state),
-                        i18n,
-                        localVue,
-                        propsData
-                    });
-
-                    await wrapper.vm.onFormSubmit();
-
-                    expect(createGuestUserSpy).toHaveBeenCalled();
-                });
             });
 
-            describe('if isLoggedIn set to true', () => {
+            describe('if `isLoggedIn` set to `true`', () => {
                 it('should not call `setupGuestUser`', async () => {
                     const state = {
                         ...defaultState,
@@ -646,7 +626,53 @@ describe('Checkout', () => {
 
                     expect(setupGuestUserSpy).not.toHaveBeenCalled();
                 });
+            });
+        });
 
+        describe('setupGuestUser ::', () => {
+            describe('if `isLoggedIn` set to `false`', () => {
+                it('should call `createGuestUser`', async () => {
+                    const customer = {
+                        firstName: 'Joe',
+                        lastName: 'Bloggs',
+                        email: 'joe@test.com',
+                        mobileNumber: '+447111111111'
+                    };
+
+                    const state = {
+                        ...defaultState,
+                        customer,
+                        isLoggedIn: false
+                    };
+
+                    const createGuestUserSpy = jest.spyOn(VueCheckout.methods, 'createGuestUser');
+
+                    const wrapper = shallowMount(VueCheckout, {
+                        store: createStore(state),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+
+                    const expected = {
+                        url: createGuestUrl,
+                        tenant: wrapper.vm.tenant,
+                        data: {
+                            firstName: customer.firstName,
+                            lastName: customer.lastName,
+                            emailAddress: customer.email,
+                            registrationSource: 'Guest'
+                        },
+                        timeout: 1000
+                    };
+
+                    await wrapper.vm.onFormSubmit();
+
+                    expect(createGuestUserSpy).toHaveBeenCalledWith(expected);
+                });
+            });
+
+            describe('if `isLoggedIn` set to `true`', () => {
                 it('should not call `createGuestUser`', async () => {
                     const state = {
                         ...defaultState,

--- a/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
@@ -47,7 +47,8 @@ describe('Checkout', () => {
     const checkoutUrl = 'http://localhost/checkout';
     const checkoutAvailableFulfilmentUrl = 'http://localhost/checkout/fulfilment';
     const loginUrl = 'http://dummy-login.example.com';
-    const propsData = { checkoutUrl, loginUrl, checkoutAvailableFulfilmentUrl };
+    const createGuestUrl = 'http://localhost/createguestuser';
+    const propsData = { checkoutUrl, loginUrl, checkoutAvailableFulfilmentUrl , createGuestUrl };
     it('should be defined', () => {
         const wrapper = shallowMount(VueCheckout, {
             i18n,
@@ -82,6 +83,7 @@ describe('Checkout', () => {
 
         it('should register the `checkout` module if it doesn\'t exist in the store', () => {
             // Arrange
+
             const store = new Vuex.Store({});
 
             const registerModuleSpy = jest.spyOn(store, 'registerModule');
@@ -331,6 +333,7 @@ describe('Checkout', () => {
 
             const propsDataWithAuthToken = {
                 ...propsData,
+                createGuestUrl,
                 authToken: 'mytoken'
             };
 

--- a/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/tests/Checkout.test.js
@@ -2,7 +2,7 @@ import { shallowMount, mount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import { VueI18n } from '@justeat/f-globalisation';
 import { validations } from '@justeat/f-services';
-import { CHECKOUT_METHOD_DELIVERY, CHECKOUT_METHOD_COLLECTION } from '../../constants';
+import { CHECKOUT_METHOD_DELIVERY, CHECKOUT_METHOD_COLLECTION, TENANT_MAP } from '../../constants';
 import VueCheckout from '../Checkout.vue';
 import EventNames from '../../event-names';
 
@@ -644,21 +644,9 @@ describe('Checkout', () => {
                     ...defaultState,
                     customer
                 };
-                const createGuestUserSpy = jest.spyOn(VueCheckout.methods, 'createGuestUser');
-
-                // Act
-                const wrapper = shallowMount(VueCheckout, {
-                    store: createStore(state),
-                    i18n,
-                    localVue,
-                    propsData
-                });
-                await wrapper.vm.setupGuestUser();
-
-                // Assert
                 const expected = {
                     url: createGuestUrl,
-                    tenant: wrapper.vm.tenant,
+                    tenant: TENANT_MAP[i18n.locale],
                     data: {
                         firstName: customer.firstName,
                         lastName: customer.lastName,
@@ -667,6 +655,18 @@ describe('Checkout', () => {
                     },
                     timeout: 1000
                 };
+                const createGuestUserSpy = jest.spyOn(VueCheckout.methods, 'createGuestUser');
+                const wrapper = shallowMount(VueCheckout, {
+                    store: createStore(state),
+                    i18n,
+                    localVue,
+                    propsData
+                });
+
+                // Act
+                await wrapper.vm.setupGuestUser();
+
+                // Assert
                 expect(createGuestUserSpy).toHaveBeenCalledWith(expected);
             });
         });

--- a/packages/components/organisms/f-checkout/src/components/tests/helpers/setup.js
+++ b/packages/components/organisms/f-checkout/src/components/tests/helpers/setup.js
@@ -41,7 +41,9 @@ const defaultState = {
     notes: [],
     isFulfillable: true,
     notices: [],
-    messages: []
+    messages: [],
+    authToken: '',
+    isLoggedIn: false
 };
 
 const defaultActions = {

--- a/packages/components/organisms/f-checkout/src/components/tests/helpers/setup.js
+++ b/packages/components/organisms/f-checkout/src/components/tests/helpers/setup.js
@@ -18,6 +18,8 @@ const defaultState = {
     serviceType: CHECKOUT_METHOD_DELIVERY,
     customer: {
         firstName: 'John',
+        lastName: 'Smith',
+        email: 'john@test.com',
         mobileNumber: '+447111111111'
     },
     fulfilment: {
@@ -46,7 +48,8 @@ const defaultActions = {
     getCheckout: jest.fn(),
     postCheckout: jest.fn(),
     getAvailableFulfilment: jest.fn(),
-    setAuthToken: jest.fn()
+    setAuthToken: jest.fn(),
+    createGuestUser: jest.fn()
 };
 
 const i18n = {

--- a/packages/components/organisms/f-checkout/src/demo/checkoutMock.js
+++ b/packages/components/organisms/f-checkout/src/demo/checkoutMock.js
@@ -21,5 +21,9 @@ export default {
             default:
                 throw new Error(`${path} is not valid`);
         }
+    },
+
+    passThroughAny () {
+        mock.onAny().passThrough();
     }
 };

--- a/packages/components/organisms/f-checkout/src/demo/checkoutMock.js
+++ b/packages/components/organisms/f-checkout/src/demo/checkoutMock.js
@@ -3,6 +3,7 @@ import MockAdapter from 'axios-mock-adapter';
 import checkoutDelivery from './checkout-delivery.json';
 import checkoutCollection from './checkout-collection.json';
 import checkoutAvailableFulfilment from './checkout-available-fulfilment.json';
+import createGuest from './create-guest.json';
 
 const mock = new MockAdapter(axios);
 
@@ -17,6 +18,9 @@ export default {
                 break;
             case '/checkout-available-fulfilment.json':
                 mock.onGet(path).reply(200, checkoutAvailableFulfilment);
+                break;
+            case '/create-guest.json':
+                mock.onPost(path).reply(200, createGuest);
                 break;
             default:
                 throw new Error(`${path} is not valid`);

--- a/packages/components/organisms/f-checkout/src/demo/create-guest.json
+++ b/packages/components/organisms/f-checkout/src/demo/create-guest.json
@@ -1,0 +1,4 @@
+{
+  "token": "c6e882a90d9b9c0c3d5807ec435bdcd7",
+  "type": "otac"
+}

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -8,6 +8,8 @@ export default {
         serviceType: '',
         customer: {
             firstName: '',
+            lastName: '',
+            email: '',
             mobileNumber: ''
         },
         fulfilment: {
@@ -106,8 +108,9 @@ export default {
                 },
                 timeout
             };
-
+            debugger;
             const response = await axios.post(url, data, config);
+            // eslint-disable-next-line no-unused-vars
             let otac = response.data.token;
             console.log(otac);
             // TODO: Use otac to log the user in

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -98,11 +98,8 @@ export default {
         createGuestUser: async ({ commit, state }, {
             url, tenant, data, timeout
         }) => {
-            console.log('entering createGuestUser');
             const config = {
                 method: 'post',
-                crossDomain: true,
-                withCredentials: true,
                 headers: {
                     'Content-Type': 'application/json',
                     'Accept-Tenant': tenant
@@ -110,13 +107,10 @@ export default {
                 timeout
             };
 
-            try {
-                // eslint-disable-next-line no-unused-vars
-                const response = await axios.post(url, data, config);
-                console.log(response);
-            } catch (err) {
-                console.log(err);
-            }
+            const response = await axios.post(url, data, config);
+            let otac = response.data.token;
+            console.log(otac);
+            // TODO: Use otac to log the user in
         },
 
         /**

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -88,6 +88,38 @@ export default {
         },
 
         /**
+         * Post the guest user details to the backend.
+         *
+         * @param {Object} commit - Automatically handled by Vuex to be able to commit mutations.
+         * @param {Object} state - Automatically handled by Vuex to be able to retrieve state.
+         * @param {Object} payload - Parameter with the different configurations for the request.
+         */
+        // eslint-disable-next-line no-unused-vars
+        createGuestUser: async ({ commit, state }, {
+            url, tenant, data, timeout
+        }) => {
+            console.log('entering createGuestUser');
+            const config = {
+                method: 'post',
+                crossDomain: true,
+                withCredentials: true,
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept-Tenant': tenant
+                },
+                timeout
+            };
+
+            try {
+                // eslint-disable-next-line no-unused-vars
+                const response = await axios.post(url, data, config);
+                console.log(response);
+            } catch (err) {
+                console.log(err);
+            }
+        },
+
+        /**
          * Get the fulfilment details from the backend and update the state.
          *
          * @param {Object} commit - Automatically handled by Vuex to be able to commit mutations.

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -108,11 +108,10 @@ export default {
                 },
                 timeout
             };
-            debugger;
+
             const response = await axios.post(url, data, config);
             // eslint-disable-next-line no-unused-vars
-            let otac = response.data.token;
-            console.log(otac);
+            const otac = response.data.token;
             // TODO: Use otac to log the user in
         },
 

--- a/packages/components/organisms/f-checkout/src/store/tests/__snapshots__/checkout.module.test.js.snap
+++ b/packages/components/organisms/f-checkout/src/store/tests/__snapshots__/checkout.module.test.js.snap
@@ -8,7 +8,9 @@ Object {
     "times": Array [],
   },
   "customer": Object {
+    "email": "",
     "firstName": "Joe",
+    "lastName": "",
     "mobileNumber": "+447111111111",
   },
   "fulfilment": Object {

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -184,14 +184,13 @@ describe('CheckoutModule', () => {
         });
 
         describe('createGuestUser ::', () => {
+            let config;
             payload.url = 'http://localhost/account/createguest';
             payload.data = {
                 firstName: 'Joe',
                 lastName: 'Bloggs',
                 email: 'joe@test.com'
             };
-
-            let config;
 
             beforeEach(() => {
                 config = {

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -12,6 +12,8 @@ const defaultState = {
     serviceType: '',
     customer: {
         firstName: '',
+        lastName: '',
+        email: '',
         mobileNumber: ''
     },
     fulfilment: {

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -42,7 +42,7 @@ const defaultState = {
 
 const { updateState, updateAuth, updateAvailableFulfilment } = CheckoutModule.mutations;
 const {
-    getCheckout, postCheckout, setAuthToken, getAvailableFulfilment
+    getCheckout, postCheckout, createGuestUser, setAuthToken, getAvailableFulfilment
 } = CheckoutModule.actions;
 let state = CheckoutModule.state();
 
@@ -177,6 +177,44 @@ describe('CheckoutModule', () => {
             it('should post the checkout details to the backend.', async () => {
                 // Act
                 await postCheckout({ commit, state }, payload);
+
+                // Assert
+                expect(axios.post).toHaveBeenCalledWith(payload.url, payload.data, config);
+            });
+        });
+
+        describe('createGuestUser ::', () => {
+            payload.url = 'http://localhost/account/createguest';
+            payload.data = {
+                firstName: 'Joe',
+                lastName: 'Bloggs',
+                email: 'joe@test.com'
+            };
+
+            let config;
+
+            beforeEach(() => {
+                config = {
+                    method: 'post',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Accept-Tenant': payload.tenant
+                    },
+                    timeout: payload.timeout
+                };
+
+                axios.post = jest.fn(() => Promise.resolve({
+                    status: 200,
+                    data: {
+                        token: 'otacToken',
+                        type: 'otac'
+                    }
+                }));
+            });
+
+            it('should post the create guest user request to the backend.', async () => {
+                // Act
+                await createGuestUser({ commit, state }, payload);
 
                 // Assert
                 expect(axios.post).toHaveBeenCalledWith(payload.url, payload.data, config);

--- a/packages/components/organisms/f-checkout/stories/Checkout.stories.js
+++ b/packages/components/organisms/f-checkout/stories/Checkout.stories.js
@@ -55,11 +55,12 @@ export const CheckoutComponent = () => ({
     template: '<vue-checkout ' +
         ':checkoutUrl="checkoutUrl" ' +
         ':checkout-available-fulfilment-url="checkoutAvailableFulfilmentUrl" ' +
+        ':create-guest-url="createGuestUrl" ' +
         ':authToken="authToken" ' +
         ':locale="locale" ' +
         ':loginUrl="loginUrl" ' +
         // eslint-disable-next-line no-template-curly-in-string
-        ' :key="`${locale},${checkoutUrl},${checkoutAvailableFulfilmentUrl},${authToken}`" />'
+        ' :key="`${locale},${checkoutUrl},${checkoutAvailableFulfilmentUrl},${authToken},${createGuestUrl}`" />'
 });
 
 CheckoutComponent.storyName = 'f-checkout';

--- a/packages/components/organisms/f-checkout/stories/Checkout.stories.js
+++ b/packages/components/organisms/f-checkout/stories/Checkout.stories.js
@@ -16,10 +16,12 @@ Vue.use(Vuex);
 const deliveryUrl = '/checkout-delivery.json';
 const collectionUrl = '/checkout-collection.json';
 const checkoutAvailableFulfilmentUrl = '/checkout-available-fulfilment.json';
+const createGuestUrl = '/create-guest.json';
 
 CheckoutMock.setupCheckoutMethod(deliveryUrl);
 CheckoutMock.setupCheckoutMethod(collectionUrl);
 CheckoutMock.setupCheckoutMethod(checkoutAvailableFulfilmentUrl);
+CheckoutMock.setupCheckoutMethod(createGuestUrl);
 CheckoutMock.passThroughAny();
 
 export default {
@@ -40,7 +42,7 @@ export const CheckoutComponent = () => ({
             default: select('Available Fulfilment Url', [checkoutAvailableFulfilmentUrl], checkoutAvailableFulfilmentUrl)
         },
         createGuestUrl: {
-            default: text('Create Guest Url', 'https://smartgateway.staging-uk.je-labs.com/consumers/uk')
+            default: text('Create Guest Url', createGuestUrl)
         },
         authToken: {
             default: text('Auth token', '')

--- a/packages/components/organisms/f-checkout/stories/Checkout.stories.js
+++ b/packages/components/organisms/f-checkout/stories/Checkout.stories.js
@@ -20,6 +20,7 @@ const checkoutAvailableFulfilmentUrl = '/checkout-available-fulfilment.json';
 CheckoutMock.setupCheckoutMethod(deliveryUrl);
 CheckoutMock.setupCheckoutMethod(collectionUrl);
 CheckoutMock.setupCheckoutMethod(checkoutAvailableFulfilmentUrl);
+CheckoutMock.passThroughAny();
 
 export default {
     title: 'Components/Organisms',
@@ -39,7 +40,7 @@ export const CheckoutComponent = () => ({
             default: select('Available Fulfilment Url', [checkoutAvailableFulfilmentUrl], checkoutAvailableFulfilmentUrl)
         },
         createGuestUrl: {
-            default: text('Create Guest Url', 'https://uk.api.just-eat.io/consumers/uk')
+            default: text('Create Guest Url', 'https://smartgateway.staging-uk.je-labs.com/consumers/uk')
         },
         authToken: {
             default: text('Auth token', '')

--- a/packages/components/organisms/f-checkout/stories/Checkout.stories.js
+++ b/packages/components/organisms/f-checkout/stories/Checkout.stories.js
@@ -38,6 +38,9 @@ export const CheckoutComponent = () => ({
         checkoutAvailableFulfilmentUrl: {
             default: select('Available Fulfilment Url', [checkoutAvailableFulfilmentUrl], checkoutAvailableFulfilmentUrl)
         },
+        createGuestUrl: {
+            default: text('Create Guest Url', 'https://uk.api.just-eat.io/consumers/uk')
+        },
         authToken: {
             default: text('Auth token', '')
         },


### PR DESCRIPTION
Added a call to create a guest user when submitting checkout form and the user is not authenticated.
The resulting one time access token (otac) will be used later to log the user in

---

## UI Review Checks

No UI changes

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
