### PR TITLE
f-content-cards@v2.2.1 - changes to fix grouping headers when 0 cards

### DIFF
--- a/packages/f-content-cards/CHANGELOG.md
+++ b/packages/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.2.1
+------------------------------
+*January 06, 2021*
+
+### Fixed
+- Fixed issue where group headers show even when content cards length was 0
+
+
 v2.2.0
 ------------------------------
 *December 15, 2020*

--- a/packages/f-content-cards/package.json
+++ b/packages/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/f-content-cards/src/components/ContentCards.vue
+++ b/packages/f-content-cards/src/components/ContentCards.vue
@@ -6,7 +6,7 @@
         <template v-if="groupCards">
             <template v-for="({ title, cards: subCards, id: groupId }, groupIndex) in cardsGrouped">
                 <h2
-                    v-if="groupId"
+                    v-if="groupId && subCards.length > 0"
                     :key="groupIndex"
                     :class="[$style['c-contentCards--group-title'], 'c-contentCards--group-title']"
                     :data-test-id="`${groupIndex}_${groupId}`"


### PR DESCRIPTION
Minor change to existing group headers on V2.2.0 to make sure the headers only show if sub card count is greater than 0