### PR TITLE
f-checkout@v0.34.1 - Updated mobile number tests

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.32.1
+------------------------------
+*January 6, 2021*
+
+### Changed
+- Mobile number tests naming convention for `Checkout` component to make clear differences in tests.
+- Mobile number test for `Checkout` component to an unused number format.
+- Updated the location of the mobile number tests.
+
+
 v0.32.0
 ------------------------------
 *January 5, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/test/specs/component/f-checkout-delivery.component.spec.js
+++ b/packages/components/organisms/f-checkout/test/specs/component/f-checkout-delivery.component.spec.js
@@ -29,34 +29,6 @@ describe('f-checkout "delivery" component tests', () => {
         expect(CheckoutComponent.isFieldDisplayed('mobileNumber')).toBe(true);
     });
 
-    it('should display a "mobileNumber" error message when a number format is incorrectly entered', () => {
-        // Arrange
-        const addressDetails = {
-            mobileNumber: '+4512345678911'
-        };
-
-        // Act
-        CheckoutComponent.populateCheckoutForm(addressDetails);
-        CheckoutComponent.goToPayment();
-
-        // Assert
-        expect(CheckoutComponent.isFieldErrorDisplayed('mobileNumber')).toBe(true);
-    });
-
-    it('should not display a "mobileNumber" error message when a number is formatted correctly', () => {
-        // Arrange
-        const addressDetails = {
-            mobileNumber: '+4412345678911'
-        };
-
-        // Act
-        CheckoutComponent.populateCheckoutForm(addressDetails);
-        CheckoutComponent.goToPayment();
-
-        // Assert
-        expect(CheckoutComponent.isFieldErrorDisplayed('mobileNumber')).toBe(false);
-    });
-
     it('should prevent user from submitting a postcode with illegal characters', () => {
         // Arrange
         const addressInfo = {

--- a/packages/components/organisms/f-checkout/test/specs/component/f-checkout.component.spec.js
+++ b/packages/components/organisms/f-checkout/test/specs/component/f-checkout.component.spec.js
@@ -37,7 +37,7 @@ describe('f-checkout component tests', () => {
         // Waiting for route here, so we can grab redirect url and show form submits.
     });
 
-    it('should display a "mobileNumber" error message when an unsupported country code is used in the mobile number', () => {
+    it('should display a "mobileNumber" error message when an unsupported country code is used in the mobile number field', () => {
         // Arrange
         const addressDetails = {
             mobileNumber: '+8112345678911'

--- a/packages/components/organisms/f-checkout/test/specs/component/f-checkout.component.spec.js
+++ b/packages/components/organisms/f-checkout/test/specs/component/f-checkout.component.spec.js
@@ -37,6 +37,34 @@ describe('f-checkout component tests', () => {
         // Waiting for route here, so we can grab redirect url and show form submits.
     });
 
+    it('should display a "mobileNumber" error message when an unsupported country code is used in the mobile number', () => {
+        // Arrange
+        const addressDetails = {
+            mobileNumber: '+8112345678911'
+        };
+
+        // Act
+        CheckoutComponent.populateCheckoutForm(addressDetails);
+        CheckoutComponent.goToPayment();
+
+        // Assert
+        expect(CheckoutComponent.isFieldErrorDisplayed('mobileNumber')).toBe(true);
+    });
+
+    it('should not display a "mobileNumber" error message when a number is formatted with a supported country code', () => {
+        // Arrange
+        const addressDetails = {
+            mobileNumber: '+4412345678911'
+        };
+
+        // Act
+        CheckoutComponent.populateCheckoutForm(addressDetails);
+        CheckoutComponent.goToPayment();
+
+        // Assert
+        expect(CheckoutComponent.isFieldErrorDisplayed('mobileNumber')).toBe(false);
+    });
+
     it('should display times in ascending order, with default text "As soon as possible" showing first', () => {
         // Act
         CheckoutComponent.selectOrderTime('As soon as possible');


### PR DESCRIPTION
v0.34.1
------------------------------
*January 6, 2021*

### Changed
- Mobile number tests naming convention for `Checkout` component to make clear differences in tests.
- Mobile number test for `Checkout` component to an unused number format.
- Updated the location of the mobile number tests.