### PR TITLE
f-form-field@1.7.0 Fix Axe accessibility violation

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -4,13 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (add to next release)
+v1.7.0
 ------------------------------
-*December 30, 2020*
+*January 14, 2021*
 
 ### Changed
 - Updated config for latest `sass-loader`.
 - Switches import in `common.scss` in line with fozzie v5-beta.
+
+### Fixed
+- Axe accessibility violation: `Ensures every form element has a label`
 
 
 v1.6.1

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
@@ -6,7 +6,7 @@
             :class="$style['c-formDropdown-icon']"
             :data-test-id="testId.icon" />
         <select
-            id="time-selection"
+            :id="$attrs.id"
             :class="$style['c-formDropdown-select']"
             :data-test-id="testId.select"
             v-bind="attributes"
@@ -29,6 +29,8 @@ export default {
     components: {
         CaretIcon
     },
+
+    inheritAttrs: false,
 
     props: {
         attributes: {


### PR DESCRIPTION
### Fixed
-  Axe accessibility violation: `Ensures every form element has a label'

Once published f-checkout will require an update to the latest f-form-field version to remove the Axe violation.