### PR TITLE
f-vue-icons@2.2.0 - new arrow icon

### DIFF
--- a/packages/tools/f-vue-icons/CHANGELOG.md
+++ b/packages/tools/f-vue-icons/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v2.2.0
+------------------------------
+*January 14, 2020*
+
+### Changed
+- Replace arrow icon to match new designs.
+
+
 v2.1.0
 ------------------------------
 *December 11, 2020*

--- a/packages/tools/f-vue-icons/icons/ArrowIcon.js
+++ b/packages/tools/f-vue-icons/icons/ArrowIcon.js
@@ -9,13 +9,29 @@ export default {
     return h("svg", _mergeJSXProps([{
       attrs: {
         xmlns: "http://www.w3.org/2000/svg",
-        viewBox: "0 0 28 28"
+        viewBox: "0 0 24 24"
       },
       "class": "c-ficon c-ficon--arrow"
-    }, ctx.data]), [h("path", {
+    }, ctx.data]), [h("defs", [h("path", {
       attrs: {
-        d: "M21.342 14l-4.838-4.838a.583.583 0 0 1 .825-.824l5.833 5.833a.583.583 0 0 1 0 .825l-5.833 5.833a.583.583 0 1 1-.825-.825l4.838-4.837H5.25a.583.583 0 0 1 0-1.167h16.092z"
+        d: "M5 11h11.167l-4.708-4.71a1 1 0 010-1.418 1 1 0 011.417 0l6.417 6.417a1 1 0 010 1.417l-6.417 6.416a1 1 0 01-1.417 0 1 1 0 010-1.416L16.167 13H5a1 1 0 010-2z",
+        id: "a"
       }
-    })]);
+    })]), h("g", {
+      attrs: {
+        fill: "none",
+        "fill-rule": "evenodd"
+      }
+    }, [h("path", {
+      attrs: {
+        d: "M24 0H0v24h24z"
+      }
+    }), h("use", {
+      attrs: {
+        fill: "#172026",
+        "fill-rule": "nonzero",
+        href: "#a"
+      }
+    })])]);
   }
 };

--- a/packages/tools/f-vue-icons/package.json
+++ b/packages/tools/f-vue-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-vue-icons",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "dist/f-vue-icons.cjs.js",
   "cdn": "dist/f-vue-icons.min.js",
   "unpkg": "dist/f-vue-icons.min.js",
@@ -47,7 +47,7 @@
     "babel-helper-vue-jsx-merge-props": "2.0.3"
   },
   "devDependencies": {
-    "@justeat/f-icons": "3.1.0",
+    "@justeat/f-icons": "3.2.0",
     "@vue/cli-plugin-babel": "4.5.8",
     "@vue/cli-plugin-eslint": "4.5.8",
     "@vue/cli-plugin-unit-jest": "4.5.8",

--- a/packages/tools/f-vue-icons/src/components/ArrowIcon.js
+++ b/packages/tools/f-vue-icons/src/components/ArrowIcon.js
@@ -10,6 +10,6 @@ export default {
         const attrs = ctx.data.attrs || {};
         ctx.data.attrs = attrs;
 
-        return <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 28" class="c-ficon c-ficon--arrow" {...ctx.data}><path d="M21.342 14l-4.838-4.838a.583.583 0 0 1 .825-.824l5.833 5.833a.583.583 0 0 1 0 .825l-5.833 5.833a.583.583 0 1 1-.825-.825l4.838-4.837H5.25a.583.583 0 0 1 0-1.167h16.092z"></path></svg>;
+        return <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--arrow" {...ctx.data}><defs><path d="M5 11h11.167l-4.708-4.71a1 1 0 010-1.418 1 1 0 011.417 0l6.417 6.417a1 1 0 010 1.417l-6.417 6.416a1 1 0 01-1.417 0 1 1 0 010-1.416L16.167 13H5a1 1 0 010-2z" id="a"></path></defs><g fill="none" fill-rule="evenodd"><path d="M24 0H0v24h24z"></path><use fill="#172026" fill-rule="nonzero" href="#a"></use></g></svg>;
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1660,10 +1660,10 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-2.3.0.tgz#473cc1ce7edeb0ce58df674c9c4ee0ebf30171d8"
   integrity sha512-KQ19RSgGyMwfAV4ZOA7SU3BjyR6h9z7Ykc0K3DBcft4EJBDh1lmvtAZIaZJyhDTwKrggrJaLq5QubEHlB6gkew==
 
-"@justeat/f-icons@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-3.1.0.tgz#16f171b0d319cc5cd648cefb36a8e5ed35338f98"
-  integrity sha512-CL7M0w8ndbU8dY13tkcbohS0DPNZpWRG7mld0QAg2YwELNCWyKb6dr5563XvkMgIapwhFnOaM9aGOM6x5f5ODg==
+"@justeat/f-icons@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-3.2.0.tgz#b42c3e4e8ab98b2771a9d5df88482b30aca9449f"
+  integrity sha512-vbAEC3w4UbXAZlyUoKqqRG6oaHPpaeByBM8G7hfzsGEQmkbC5ifshIlXZfZmlDrg/decqA7qWpcPg122xab9HQ==
 
 "@justeat/f-logger@0.8.1":
   version "0.8.1"


### PR DESCRIPTION
### Changed
- Replace arrow icon to match new designs.