### PR TITLE
f-searchbox@v4.0.0-beta.18 - Allow keyboard selection events to happe…

### DIFF
--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -10,7 +10,7 @@ v4.0.0-beta.18
 ### Fixed
 - Keyboard selection event when Loqate is displaying results.
 - Tests so they pass with changes.
-- Double dropdrop flicker issue.
+- Flicker issue between suggestions drop down.
 
 
 v4.0.0-beta.17

--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.0.0-beta.18
+------------------------------
+*January 14, 2021*
+
+### Fixed
+- Keyboard selection event when Loqate is displaying results.
+- Tests so they pass with changes.
+- Double dropdrop flicker issue.
+
+
 v4.0.0-beta.17
 ------------------------------
 *January 13, 2021*

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-searchbox",
   "description": "Fozzie Searchbox – Just Eat Takeaway Global Searchbox",
-  "version": "4.0.0-beta.17",
+  "version": "4.0.0-beta.18",
   "main": "dist/f-searchbox.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-searchbox/src/components/Form.vue
+++ b/packages/components/molecules/f-searchbox/src/components/Form.vue
@@ -26,7 +26,7 @@
                 :is-compressed="isCompressed"
                 v-on="$listeners" />
 
-            <form-full-address-search-suggestions
+            <component
                 :is="setSuggestionType"
                 v-if="shouldDisplaySuggestions"
                 data-test-id="suggestions"

--- a/packages/components/molecules/f-searchbox/src/components/Form.vue
+++ b/packages/components/molecules/f-searchbox/src/components/Form.vue
@@ -4,6 +4,7 @@
         :action="formUrl"
         :class="$style['c-search']"
         method="post"
+        novalidate
         @submit.stop="submit">
         <input
             v-model="cuisine"
@@ -25,11 +26,7 @@
                 :is-compressed="isCompressed"
                 v-on="$listeners" />
 
-            <form-search-button
-                :copy="copy"
-                :is-compressed="isCompressed" />
-
-            <component
+            <form-full-address-search-suggestions
                 :is="setSuggestionType"
                 v-if="shouldDisplaySuggestions"
                 data-test-id="suggestions"
@@ -38,7 +35,11 @@
                 :copy="copy"
                 :suggestion-format="suggestionFormat"
                 :suggestions="suggestions"
-                :keyboard-suggestion-selection="keyboardSuggestionIndex" />
+                :selected="keyboardSuggestionIndex" />
+
+            <form-search-button
+                :copy="copy"
+                :is-compressed="isCompressed" />
         </div>
 
         <error-message

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
@@ -158,7 +158,7 @@ export default {
 
         /**
          * Selects an address `item` either from the `index` (clicked on)
-         * or `selected`.
+         * or `selected` (Keyboard enter event).
          *
          * 1. `getMatchedAreaAddressResults` - Returns results based on
          * the `streetLevelAddress` value.

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
@@ -61,7 +61,7 @@ export default {
             })
         },
 
-        // Prop should named `selected` for keyboard purposes.
+        // Prop should be named `selected` for keyboard purposes.
         selected: {
             type: Number,
             default: 0

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
@@ -157,7 +157,7 @@ export default {
         },
 
         /**
-         * Selects an address `item` either from the `index` (clicked on)
+         * Selects an address `suggestion` either from the `index` (clicked on)
          * or `selected` (Keyboard enter event).
          *
          * 1. `getMatchedAreaAddressResults` - Returns results based on
@@ -167,7 +167,6 @@ export default {
          * they can continue without selecting a full addresss.
          *
          * @param e
-         * @param item
          * @param index
          * @param selected
          */

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
@@ -8,10 +8,10 @@
             :ref="`suggestion${index}`"
             :class="[
                 $style.item,
-                { [$style.selected]: index === keyboardSuggestionIndex }
+                { [$style.selected]: index === selected }
             ]"
             data-test-id="suggestion-item"
-            @click="getSelectedStreetAddress($event, item, index, keyboardSuggestionIndex)">
+            @click="getSelectedStreetAddress($event, index, selected)">
             <map-pin-icon :class="$style['c-locationIcon']" />
 
             <div
@@ -61,6 +61,12 @@ export default {
             })
         },
 
+        // Prop should named `selected` for keyboard purposes.
+        selected: {
+            type: Number,
+            default: 0
+        },
+
         address: {
             type: String,
             default: ''
@@ -79,8 +85,7 @@ export default {
     computed: {
         ...mapState('searchbox', [
             'suggestions',
-            'selectedStreetLevelAddressId',
-            'keyboardSuggestionIndex'
+            'selectedStreetLevelAddressId'
         ]),
 
         /**
@@ -96,12 +101,12 @@ export default {
 
     watch: {
         /**
-         * Checks the `keyboardSuggestionIndex` value so we can scroll to the address within the
+         * Checks the `selected` value so we can scroll to the address within the
          * `fullAddressSuggestions` container, allowing keyboard navigation.
          *
          * @param {Number} value
          */
-        keyboardSuggestionIndex (value) {
+        selected (value) {
             const suggestionItem = this.$refs[`suggestion${[value]}`];
 
             if ((value || value === 0)
@@ -153,7 +158,7 @@ export default {
 
         /**
          * Selects an address `item` either from the `index` (clicked on)
-         * or `selected` (keyboard entry - @todo not working right now).
+         * or `selected`.
          *
          * 1. `getMatchedAreaAddressResults` - Returns results based on
          * the `streetLevelAddress` value.
@@ -163,18 +168,21 @@ export default {
          *
          * @param e
          * @param item
+         * @param index
+         * @param selected
          */
-        getSelectedStreetAddress (e, item) {
+        getSelectedStreetAddress (e, index, selected) {
+            const selectedAddress = this.suggestions[index || selected];
             e.preventDefault();
 
             this.getMatchedAreaAddressResults({
                 address: this.address,
-                streetLevelAddress: item.id
+                streetLevelAddress: selectedAddress.id
             });
 
             this.setContinueWithDetails({
-                postcode:  item.text,
-                street: item.description
+                postcode:  selectedAddress.text,
+                street: selectedAddress.description
             });
         }
     }

--- a/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressSearchSuggestions.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressSearchSuggestions.test.js
@@ -7,7 +7,16 @@ const localVue = createLocalVue();
 localVue.use(Vuex);
 
 const mockState = {
-    suggestions: [{ description: 'NASA' }, { postcode: 'SpaceX' }]
+    suggestions: [
+        {
+            description: 'NASA',
+            id: 'GB|RM|A|20388007',
+            text: 'AR511AR'
+        },
+        {
+            postcode: 'SpaceX'
+        }
+    ]
 };
 
 const mockActions = {
@@ -115,10 +124,11 @@ describe('`FullAddressSuggestions`', () => {
                     // Arrange
                     const { wrapper } = bootstrap();
                     const event = { preventDefault: jest.fn() };
-                    const items = [{ id: 'GB|RM|A|20388007' }];
+                    const index = 0;
+                    const selected = 0;
 
                     // Act
-                    wrapper.vm.getSelectedStreetAddress(event, items);
+                    wrapper.vm.getSelectedStreetAddress(event, index, selected);
 
                     // Assert
                     expect(event.preventDefault).toHaveBeenCalled();
@@ -128,11 +138,12 @@ describe('`FullAddressSuggestions`', () => {
                     // Arrange
                     const { wrapper } = bootstrap();
                     const event = { preventDefault: jest.fn() };
-                    const items = { id: 'GB|RM|A|20388007' };
                     const spy = jest.spyOn(wrapper.vm, 'getMatchedAreaAddressResults');
+                    const index = 0;
+                    const selected = 0;
 
                     // Act
-                    wrapper.vm.getSelectedStreetAddress(event, items);
+                    wrapper.vm.getSelectedStreetAddress(event, index, selected);
 
                     // Assert
                     expect(spy).toHaveBeenCalledWith({
@@ -145,20 +156,17 @@ describe('`FullAddressSuggestions`', () => {
                     // Arrange
                     const { wrapper } = bootstrap();
                     const event = { preventDefault: jest.fn() };
-                    const items = {
-                        id: 'GB|RM|A|20388007',
-                        text: 'AR511AR',
-                        description: 'Middle of nowhere'
-                    };
                     const spy = jest.spyOn(wrapper.vm, 'setContinueWithDetails');
+                    const index = 0;
+                    const selected = 0;
 
                     // Act
-                    wrapper.vm.getSelectedStreetAddress(event, items);
+                    wrapper.vm.getSelectedStreetAddress(event, index, selected);
 
                     // Assert
                     expect(spy).toHaveBeenCalledWith({
                         postcode: 'AR511AR',
-                        street: 'Middle of nowhere'
+                        street: 'NASA'
                     });
                 });
             });
@@ -182,7 +190,13 @@ describe('`FullAddressSuggestions`', () => {
                     const result = wrapper.vm.getAddressItems;
 
                     // Assert
-                    expect(result).toEqual([{ description: 'NASA' }]);
+                    expect(result).toEqual([
+                        {
+                            description: 'NASA',
+                            id: 'GB|RM|A|20388007',
+                            text: 'AR511AR'
+                        }
+                    ]);
                 });
             });
         });

--- a/packages/components/molecules/f-searchbox/src/store/searchbox.module.js
+++ b/packages/components/molecules/f-searchbox/src/store/searchbox.module.js
@@ -148,6 +148,7 @@ export default {
 
             if (suggestions) {
                 commit(SET_SELECTED_STREET_LEVEL_ADDRESS_ID, payload);
+                commit(SET_KEYBOARD_SUGGESTION, 0);
                 commit(SET_PARTIAL_ADDRESS_SUGGESTIONS, { suggestions, payload });
             }
         },


### PR DESCRIPTION
PR allows keyboard enter event to return further results from Loqate.

### Fixed

- Keyboard selection event when Loqate is displaying results.
- Tests so they pass with changes.
- Flicker issue between suggestions drop down.

### Video

https://www.loom.com/share/bd422b36f3fe4427940feadd7deda8cd