### PR TITLE
f-checkout@0.39.0 Send authentication token with GET request

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.39.0
+-------------------------------
+*January 18, 2021*
+
+### Changed
+- `getCheckout` store method passes authentication token to the api endpoint.
+
+
 v0.38.0
 -------------------------------
 *January 15, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -43,13 +43,18 @@ export default {
          * @param {Object} commit - Automatically handled by Vuex to be able to commit mutations.
          * @param {Object} payload - Parameter with the different configurations for the request.
          */
-        getCheckout: async ({ commit }, { url, tenant, timeout }) => {
+        getCheckout: async ({ commit, state }, { url, tenant, timeout }) => {
+            const authHeader = state.authToken && `Bearer ${state.authToken}`;
+
             // TODO: deal with exceptions.
             const config = {
                 method: 'get',
                 headers: {
                     'Content-Type': 'application/json',
-                    'Accept-Tenant': tenant
+                    'Accept-Tenant': tenant,
+                    ...(state.isLoggedIn && {
+                        Authorization: authHeader
+                    })
                 },
                 timeout
             };

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -177,7 +177,8 @@ describe('CheckoutModule', () => {
                     method: 'get',
                     headers: {
                         'Content-Type': 'application/json',
-                        'Accept-Tenant': payload.tenant
+                        'Accept-Tenant': payload.tenant,
+                        Authorization: `Bearer ${state.authToken}`
                     },
                     timeout: payload.timeout
                 };
@@ -187,7 +188,7 @@ describe('CheckoutModule', () => {
 
             it('should get the checkout details from the backend and call `UPDATE_STATE` mutation.', async () => {
                 // Act
-                await getCheckout({ commit }, payload);
+                await getCheckout({ commit, state }, payload);
 
                 // Assert
                 expect(axios.get).toHaveBeenCalledWith(payload.url, config);


### PR DESCRIPTION
Main Checkout API GET request requires auth token in the Authorize header.

---

## UI Review Checks
No UI changes

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
