### PR TITLE
f-button@0.6.0 - forward `$listeners` prop

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.6.0
+------------------------------
+*January 25, 2021*
+
+### Added
+- Forward `$listeners` prop to button component to be able to add events listeners to it without `.native`
+
+
 v0.5.0
 ------------------------------
 *January 21, 2021*
@@ -11,11 +19,6 @@ v0.5.0
 ### Added
 - `Action` component for standard buttons.
 - `Link` component for links styled as buttons.
-
-
-Latest (add to next release)
-------------------------------
-*December 30, 2020*
 
 ### Changed
 - Updated config for latest `sass-loader`.

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "dist/f-button.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -9,7 +9,8 @@
         ]"
         :attributes="$attrs"
         :action-type="buttonActionType"
-        :data-test-id="`${componentType}-component`">
+        :data-test-id="`${componentType}-component`"
+        v-on="$listeners">
         <slot />
     </component>
 </template>


### PR DESCRIPTION
### Changed
- Forward `$listeners` prop to button component to be able to add events listeners without `.native`