### PR TITLE
f-checkout@0.41.0 - Removing Accept-Tenant header

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.41.0
+-------------------------------
+*January 22, 2021*
+
+### Removed
+- `Accept-Tenant` header from requests to the `CheckoutApi`.
+
+
 v0.40.0
 -------------------------------
 *January 20, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -276,7 +276,6 @@ export default {
 
                 await this.postCheckout({
                     url: 'myPostUrl',
-                    tenant: this.tenant,
                     data: checkoutData,
                     timeout: this.checkoutTimeout
                 });
@@ -315,7 +314,6 @@ export default {
             try {
                 await this.getCheckout({
                     url: this.checkoutUrl,
-                    tenant: this.tenant,
                     timeout: this.getCheckoutTimeout
                 });
 
@@ -333,7 +331,6 @@ export default {
             try {
                 await this.getAvailableFulfilment({
                     url: this.checkoutAvailableFulfilmentUrl,
-                    tenant: this.tenant,
                     timeout: this.getCheckoutTimeout
                 });
 

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -43,7 +43,7 @@ export default {
          * @param {Object} commit - Automatically handled by Vuex to be able to commit mutations.
          * @param {Object} payload - Parameter with the different configurations for the request.
          */
-        getCheckout: async ({ commit, state }, { url, tenant, timeout }) => {
+        getCheckout: async ({ commit, state }, { url, timeout }) => {
             const authHeader = state.authToken && `Bearer ${state.authToken}`;
 
             // TODO: deal with exceptions.
@@ -51,7 +51,6 @@ export default {
                 method: 'get',
                 headers: {
                     'Content-Type': 'application/json',
-                    'Accept-Tenant': tenant,
                     ...(state.isLoggedIn && {
                         Authorization: authHeader
                     })
@@ -73,7 +72,7 @@ export default {
          */
         // eslint-disable-next-line no-unused-vars
         postCheckout: async ({ commit, state }, {
-            url, tenant, data, timeout
+            url, data, timeout
         }) => {
             // TODO: deal with exceptions and handle this action properly (when the functionality is ready)
             const authHeader = state.authToken && `Bearer ${state.authToken}`;
@@ -82,7 +81,6 @@ export default {
                 method: 'post',
                 headers: {
                     'Content-Type': 'application/json',
-                    'Accept-Tenant': tenant,
                     ...(state.isLoggedIn && {
                         Authorization: authHeader
                     })
@@ -126,13 +124,12 @@ export default {
          * @param {Object} commit - Automatically handled by Vuex to be able to commit mutations.
          * @param {Object} payload - Parameter with the different configurations for the request.
          */
-        getAvailableFulfilment: async ({ commit }, { url, tenant, timeout }) => {
+        getAvailableFulfilment: async ({ commit }, { url, timeout }) => {
             // TODO: deal with exceptions.
             const config = {
                 method: 'get',
                 headers: {
-                    'Content-Type': 'application/json',
-                    'Accept-Tenant': tenant
+                    'Content-Type': 'application/json'
                 },
                 timeout
             };

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -177,7 +177,6 @@ describe('CheckoutModule', () => {
                     method: 'get',
                     headers: {
                         'Content-Type': 'application/json',
-                        'Accept-Tenant': payload.tenant,
                         Authorization: `Bearer ${state.authToken}`
                     },
                     timeout: payload.timeout
@@ -208,8 +207,7 @@ describe('CheckoutModule', () => {
                     method: 'post',
                     headers: {
                         'Content-Type': 'application/json',
-                        Authorization: `Bearer ${authToken}`,
-                        'Accept-Tenant': payload.tenant
+                        Authorization: `Bearer ${authToken}`
                     },
                     timeout: payload.timeout
                 };
@@ -279,8 +277,7 @@ describe('CheckoutModule', () => {
                 config = {
                     method: 'get',
                     headers: {
-                        'Content-Type': 'application/json',
-                        'Accept-Tenant': payload.tenant
+                        'Content-Type': 'application/json'
                     },
                     timeout: payload.timeout
                 };


### PR DESCRIPTION
v0.41.0
-------------------------------
*January 22, 2021*

### Removed
- `Accept-Tenant` header from requests to the `CheckoutApi`.
