### PR TITLE
f-checkout@v0.42.0 - Upgrade f-button and update header text

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.42.0
+-------------------------------
+*January 22, 2021*
+
+### Changed
+- `f-button` version.
+- `Header` component `login` button to use `f-button`.
+
+
 v0.41.0
 -------------------------------
 *January 22, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@justeat/f-alert": "0.4.0",
-    "@justeat/f-button": "0.4.1",
+    "@justeat/f-button": "0.5.0",
     "@justeat/f-card": "0.8.0",
     "@justeat/f-error-message": "0.3.1",
     "@justeat/f-form-field": "1.7.0",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -9,6 +9,7 @@
             :heading="$t('errorMessages.errorHeading')">
             {{ genericErrorMessage }}
         </alert>
+
         <card
             is-rounded
             has-outline
@@ -39,6 +40,7 @@
                         </error-message>
                     </template>
                 </form-field>
+
                 <address-block
                     v-if="isCheckoutMethodDelivery"
                     data-test-id="address-block" />
@@ -52,6 +54,7 @@
                     button-type="primary"
                     button-size="large"
                     is-full-width
+                    action-type="submit"
                     data-test-id="confirm-payment-submit-button">
                     {{ $t('buttonText') }}
                 </f-button>
@@ -66,14 +69,12 @@
 <script>
 import { validationMixin } from 'vuelidate';
 import { required, email } from 'vuelidate/lib/validators';
+import { mapState, mapActions } from 'vuex';
 
 import Alert from '@justeat/f-alert';
 import '@justeat/f-alert/dist/f-alert.css';
 import FButton from '@justeat/f-button';
 import '@justeat/f-button/dist/f-button.css';
-import { validations } from '@justeat/f-services';
-import { VueGlobalisationMixin } from '@justeat/f-globalisation';
-
 import Card from '@justeat/f-card';
 import '@justeat/f-card/dist/f-card.css';
 import ErrorMessage from '@justeat/f-error-message';
@@ -81,7 +82,9 @@ import '@justeat/f-error-message/dist/f-error-message.css';
 import FormField from '@justeat/f-form-field';
 import '@justeat/f-form-field/dist/f-form-field.css';
 
-import { mapState, mapActions } from 'vuex';
+import { validations } from '@justeat/f-services';
+import { VueGlobalisationMixin } from '@justeat/f-globalisation';
+
 import AddressBlock from './Address.vue';
 import CheckoutHeader from './Header.vue';
 import CheckoutTermsAndConditions from './TermsAndConditions.vue';
@@ -90,11 +93,11 @@ import GuestBlock from './Guest.vue';
 import UserNote from './UserNote.vue';
 
 import { CHECKOUT_METHOD_DELIVERY, TENANT_MAP, VALIDATIONS } from '../constants';
-import tenantConfigs from '../tenants';
-import EventNames from '../event-names';
-
 import checkoutModule from '../store/checkout.module';
 import checkoutValidationsMixin from '../mixins/validations.mixin';
+import EventNames from '../event-names';
+import tenantConfigs from '../tenants';
+
 
 export default {
     name: 'VueCheckout',
@@ -470,7 +473,7 @@ export default {
 }
 
 .c-checkout-form {
-    margin-top: spacing(x3);
+    margin-top: spacing(x2);
 }
 
 .c-checkout-alert {

--- a/packages/components/organisms/f-checkout/src/components/Header.vue
+++ b/packages/components/organisms/f-checkout/src/components/Header.vue
@@ -26,13 +26,16 @@
                 {{ $t('checkoutHeader.guest.guestTitle') }}
             </h2>
 
-            <a
-                :href="loginUrl"
-                data-test-id="guest-login-button"
+            <f-button
+                button-type="primary"
+                button-size="large"
+                is-full-width
                 :class="$style['c-checkoutHeader-loginButton']"
-                @click="onVisitLoginPage">
+                data-test-id="guest-login-button"
+                :href="loginUrl"
+                @click.native="onVisitLoginPage">
                 {{ $t('checkoutHeader.guest.loginButton') }}
-            </a>
+            </f-button>
 
             <div
                 :class="$style['c-checkoutHeader-option']">
@@ -43,18 +46,26 @@
                 {{ $t('checkoutHeader.guest.guestTitle') }}
             </h2>
 
-            <p :class="$style['c-checkoutHeader-confirmation']">
-                {{ $t('checkoutHeader.guest.confirmation') }}
+            <p
+                :class="$style['c-checkoutHeader-confirmation']"
+                data-test-id="service-type-confirmation">
+                {{ $t('checkoutHeader.guest.confirmation', { serviceType }) }}
             </p>
         </div>
     </div>
 </template>
 
 <script>
+import FButton from '@justeat/f-button';
+import '@justeat/f-button/dist/f-button.css';
 import { mapState } from 'vuex';
 import EventNames from '../event-names';
 
 export default {
+    components: {
+        FButton
+    },
+
     props: {
         loginUrl: {
             type: String,
@@ -65,7 +76,8 @@ export default {
     computed: {
         ...mapState('checkout', [
             'customer',
-            'isLoggedIn'
+            'isLoggedIn',
+            'serviceType'
         ]),
 
         name () {
@@ -92,36 +104,8 @@ export default {
     @include font-size('heading-s');
 }
 
-// TODO: Add link button to f-button
 .c-checkoutHeader-loginButton {
-    display: inline-block;
-    width: 100%;
-    background-color: $orange;
-    padding: spacing(x2) 0;
     margin-top: spacing(x2);
-    border: 1px solid transparent;
-    border-radius: $border-radius;
-    text-align: center;
-    font-weight: $font-weight-bold;
-    @include font-size('body-l');
-    text-decoration: none;
-    color: $white;
-    cursor: pointer;
-
-    &:hover,
-    &:active,
-    &:focus {
-        color: $white;
-    }
-
-    &:hover,
-    &:focus {
-        background-color: $orange--dark;
-    }
-
-    &:active {
-        background-color: $orange--darkest;
-    }
 }
 
 .c-checkoutHeader-confirmation {

--- a/packages/components/organisms/f-checkout/src/components/_tests/Header.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Header.test.js
@@ -3,6 +3,7 @@ import { VueI18n } from '@justeat/f-globalisation';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Header from '../Header.vue';
 import { i18n, defaultState, createStore } from './helpers/setup';
+import { CHECKOUT_METHOD_COLLECTION, CHECKOUT_METHOD_DELIVERY } from '../../constants';
 import EventNames from '../../event-names';
 
 const localVue = createLocalVue();
@@ -58,7 +59,7 @@ describe('Header', () => {
 
                     // Assert
                     expect(loginLink).toBeDefined();
-                    expect(loginLink.text()).toBe(`Not ${defaultState.customer.firstName}? Click here.`);
+                    expect(loginLink.text()).toBe(`Not ${defaultState.customer.firstName}? Click here`);
                 });
             });
 
@@ -112,6 +113,32 @@ describe('Header', () => {
 
                 // Assert
                 expect(name).toEqual('Joe');
+            });
+        });
+
+        describe('serviceType ::', () => {
+            it.each([
+                [CHECKOUT_METHOD_DELIVERY],
+                [CHECKOUT_METHOD_COLLECTION]
+            ])('should update serviceType confirmation with the %s service type', serviceType => {
+                // Arrange
+                const wrapper = shallowMount(Header, {
+                    store: createStore({
+                        ...defaultState,
+                        isLoggedIn: false,
+                        serviceType
+                    }),
+                    i18n,
+                    localVue,
+                    propsData
+                });
+
+                // Act
+                const confirmation = wrapper.find("[data-test-id='service-type-confirmation']");
+                const received = `Please confirm your ${serviceType} details`;
+
+                // Assert
+                expect(confirmation.text()).toEqual(received);
             });
         });
     });

--- a/packages/components/organisms/f-checkout/src/tenants/en-GB.js
+++ b/packages/components/organisms/f-checkout/src/tenants/en-GB.js
@@ -61,14 +61,14 @@ const messages = {
     checkoutHeader: {
         user: {
             title: '{name}, confirm your details',
-            switchUser: 'Not {name}? Click here.'
+            switchUser: 'Not {name}? Click here'
         },
         guest: {
             loginTitle: 'How do you want to continue?',
             loginButton: 'Log in or sign up',
             option: 'or',
             guestTitle: 'Checkout as a guest',
-            confirmation: 'Please confirm your delivery details'
+            confirmation: 'Please confirm your {serviceType} details'
         }
     },
 


### PR DESCRIPTION
### Changed
- `f-button` version.
- `Header` component `login` button to use `f-button`.

## UI Review Checks

| Guest | User |
| --- |--- |
|  **Delivery** ![image](https://user-images.githubusercontent.com/24740015/105499781-dc520500-5cb9-11eb-80e7-1669f824b3e7.png) | ![image](https://user-images.githubusercontent.com/24740015/105499809-e542d680-5cb9-11eb-8aa7-542a4860dd37.png) |
| **Collection** ![image](https://user-images.githubusercontent.com/24740015/105499949-1ae7bf80-5cba-11eb-97ad-fb8faf9e2f9e.png) | |
