### PR TITLE
f-checkout@0.45.0 - Only call the Checkout `GET` endpoint when the user is logged in

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -5,6 +5,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.44.0
 -------------------------------
+*January 27, 2021*
+
+### Changed
+- Only call the Checkout `GET` endpoint when the user is logged in.
+- Refactored tests.
+
+
+v0.44.0
+-------------------------------
 *January 25, 2021*
 
 ### Added

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v0.44.0
+v0.45.0
 -------------------------------
 *January 27, 2021*
 

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -256,17 +256,17 @@ export default {
          *
          */
         async initialise () {
+            const initialLoadPromises = [this.loadAvailableFulfilment()];
+
             this.setAuthToken(this.authToken);
 
-            if (!this.isLoggedIn) {
+            if (this.isLoggedIn) {
+                initialLoadPromises.push(this.loadCheckout());
+            } else {
                 await this.loadBasket();
             }
 
-            const promises = this.isLoggedIn
-                ? [this.loadCheckout(), this.loadAvailableFulfilment()]
-                : [this.loadAvailableFulfilment()];
-
-            await Promise.all(promises);
+            await Promise.all(initialLoadPromises);
         },
 
         /**

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -262,7 +262,11 @@ export default {
                 await this.loadBasket();
             }
 
-            await Promise.all([this.loadCheckout(), this.loadAvailableFulfilment()]);
+            const promises = this.isLoggedIn
+                ? [this.loadCheckout(), this.loadAvailableFulfilment()]
+                : [this.loadAvailableFulfilment()];
+
+            await Promise.all(promises);
         },
 
         /**

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -256,17 +256,17 @@ export default {
          *
          */
         async initialise () {
-            const initialLoadPromises = [this.loadAvailableFulfilment()];
-
             this.setAuthToken(this.authToken);
 
-            if (this.isLoggedIn) {
-                initialLoadPromises.push(this.loadCheckout());
-            } else {
+            if (!this.isLoggedIn) {
                 await this.loadBasket();
             }
 
-            await Promise.all(initialLoadPromises);
+            const promises = this.isLoggedIn
+                ? [this.loadCheckout(), this.loadAvailableFulfilment()]
+                : [this.loadAvailableFulfilment()];
+
+            await Promise.all(promises);
         },
 
         /**

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -317,6 +317,7 @@ describe('Checkout', () => {
                     propsData: propsDataWithAuthToken
                 });
 
+                // Assert
                 expect(setAuthTokenSpy).toHaveBeenCalledWith(propsDataWithAuthToken.authToken);
             });
 
@@ -332,6 +333,7 @@ describe('Checkout', () => {
                 });
                 await flushPromises();
 
+                // Assert
                 expect(loadAvailableFulfilmentSpy).toHaveBeenCalled();
             });
 
@@ -348,6 +350,7 @@ describe('Checkout', () => {
                     });
                     await flushPromises();
 
+                    // Assert
                     expect(loadBasketSpy).toHaveBeenCalled();
                 });
 
@@ -363,6 +366,7 @@ describe('Checkout', () => {
                     });
                     await flushPromises();
 
+                    // Assert
                     expect(loadCheckoutSpy).not.toHaveBeenCalled();
                 });
             });

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -380,6 +380,7 @@ describe('Checkout', () => {
                     });
                     await flushPromises();
 
+                    // Assert
                     expect(loadBasketSpy).not.toHaveBeenCalled();
                 });
 
@@ -395,6 +396,7 @@ describe('Checkout', () => {
                     });
                     await flushPromises();
 
+                    // Assert
                     expect(loadCheckoutSpy).toHaveBeenCalled();
                 });
             });

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -320,21 +320,6 @@ describe('Checkout', () => {
                 expect(setAuthTokenSpy).toHaveBeenCalledWith(propsDataWithAuthToken.authToken);
             });
 
-            it('should call `loadCheckout`', async () => {
-                // Arrange & Act
-                const loadCheckoutSpy = jest.spyOn(VueCheckout.methods, 'loadCheckout');
-
-                shallowMount(VueCheckout, {
-                    store: createStore(),
-                    i18n,
-                    localVue,
-                    propsData
-                });
-                await flushPromises();
-
-                expect(loadCheckoutSpy).toHaveBeenCalled();
-            });
-
             it('should call `loadAvailableFulfilment`', async () => {
                 // Arrange & Act
                 const loadAvailableFulfilmentSpy = jest.spyOn(VueCheckout.methods, 'loadAvailableFulfilment');
@@ -365,6 +350,21 @@ describe('Checkout', () => {
 
                     expect(loadBasketSpy).toHaveBeenCalled();
                 });
+
+                it('should not call `loadCheckout`', async () => {
+                    // Arrange & Act
+                    const loadCheckoutSpy = jest.spyOn(VueCheckout.methods, 'loadCheckout');
+
+                    shallowMount(VueCheckout, {
+                        store: createStore(),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+                    await flushPromises();
+
+                    expect(loadCheckoutSpy).not.toHaveBeenCalled();
+                });
             });
 
             describe('if isLoggedIn set to `true`', () => {
@@ -381,6 +381,21 @@ describe('Checkout', () => {
                     await flushPromises();
 
                     expect(loadBasketSpy).not.toHaveBeenCalled();
+                });
+
+                it('should call `loadCheckout`', async () => {
+                    // Arrange & Act
+                    const loadCheckoutSpy = jest.spyOn(VueCheckout.methods, 'loadCheckout');
+
+                    shallowMount(VueCheckout, {
+                        store: createStore({ ...defaultState, isLoggedIn: true }),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+                    await flushPromises();
+
+                    expect(loadCheckoutSpy).toHaveBeenCalled();
                 });
             });
         });
@@ -912,37 +927,47 @@ describe('Checkout', () => {
         });
 
         describe('loadCheckout ::', () => {
-            describe('when `getCheckout` request fails', () => {
-                let wrapper;
+            afterEach(() => {
+                jest.clearAllMocks();
+            });
 
-                beforeEach(async () => {
-                    wrapper = mount(VueCheckout, {
+            describe('when `getCheckout` request fails', () => {
+                it('should emit failure event', async () => {
+                    // Arrange
+                    jest.spyOn(VueCheckout.methods, 'initialise').mockImplementation();
+
+                    const wrapper = mount(VueCheckout, {
                         store: createStore(defaultState, { ...defaultActions, getCheckout: jest.fn(async () => Promise.reject()) }),
                         i18n,
                         localVue,
                         propsData
                     });
-                });
 
-                it('should emit failure event', async () => {
+                    // Act
+                    await wrapper.vm.loadCheckout();
+
+                    // Assert
                     expect(wrapper.emitted(EventNames.CheckoutGetSuccess)).toBeUndefined();
                     expect(wrapper.emitted(EventNames.CheckoutGetFailure).length).toBe(1);
                 });
             });
 
             describe('when `getCheckout` request succeeds', () => {
-                let wrapper;
+                it('should emit success event', async () => {
+                    // Arrange
+                    jest.spyOn(VueCheckout.methods, 'initialise').mockImplementation();
 
-                beforeEach(async () => {
-                    wrapper = mount(VueCheckout, {
+                    const wrapper = mount(VueCheckout, {
                         store: createStore(),
                         i18n,
                         localVue,
                         propsData
                     });
-                });
 
-                it('should emit success event', async () => {
+                    // Act
+                    await wrapper.vm.loadCheckout();
+
+                    // Assert
                     expect(wrapper.emitted(EventNames.CheckoutGetSuccess).length).toBe(1);
                     expect(wrapper.emitted(EventNames.CheckoutGetFailure)).toBeUndefined();
                 });
@@ -950,37 +975,47 @@ describe('Checkout', () => {
         });
 
         describe('loadAvailableFulfilment ::', () => {
-            describe('when `getAvailableFulfilment` request fails', () => {
-                let wrapper;
+            afterEach(() => {
+                jest.clearAllMocks();
+            });
 
-                beforeEach(async () => {
-                    wrapper = mount(VueCheckout, {
+            describe('when `getAvailableFulfilment` request fails', () => {
+                it('should emit failure event', async () => {
+                    // Arrange
+                    jest.spyOn(VueCheckout.methods, 'initialise').mockImplementation();
+
+                    const wrapper = mount(VueCheckout, {
                         store: createStore(defaultState, { ...defaultActions, getAvailableFulfilment: jest.fn(async () => Promise.reject()) }),
                         i18n,
                         localVue,
                         propsData
                     });
-                });
 
-                it('should emit failure event', async () => {
+                    // Act
+                    await wrapper.vm.loadAvailableFulfilment();
+
+                    // Assert
                     expect(wrapper.emitted(EventNames.CheckoutAvailableFulfilmentGetSuccess)).toBeUndefined();
                     expect(wrapper.emitted(EventNames.CheckoutAvailableFulfilmentGetFailure).length).toBe(1);
                 });
             });
 
             describe('when `getAvailableFulfilment` request succeeds', () => {
-                let wrapper;
+                it('should emit success event', async () => {
+                    // Arrange
+                    jest.spyOn(VueCheckout.methods, 'initialise').mockImplementation();
 
-                beforeEach(async () => {
-                    wrapper = mount(VueCheckout, {
+                    const wrapper = mount(VueCheckout, {
                         store: createStore(),
                         i18n,
                         localVue,
                         propsData
                     });
-                });
 
-                it('should emit success event', async () => {
+                    // Act
+                    await wrapper.vm.loadAvailableFulfilment();
+
+                    // Assert
                     expect(wrapper.emitted(EventNames.CheckoutAvailableFulfilmentGetSuccess).length).toBe(1);
                     expect(wrapper.emitted(EventNames.CheckoutAvailableFulfilmentGetFailure)).toBeUndefined();
                 });
@@ -988,36 +1023,48 @@ describe('Checkout', () => {
         });
 
         describe('loadBasket ::', () => {
+            afterEach(() => {
+                jest.clearAllMocks();
+            });
+
             describe('when `getBasket` request fails', () => {
-                const wrapper = mount(VueCheckout, {
-                    store: createStore(defaultState, { ...defaultActions, getBasket: jest.fn(async () => Promise.reject()) }),
-                    i18n,
-                    localVue,
-                    propsData
-                });
-
                 it('should emit failure event', async () => {
-                    expect(wrapper.emitted(EventNames.CheckoutBasketGetFailure).length).toBe(1);
-                });
+                    // Arrange
+                    jest.spyOn(VueCheckout.methods, 'initialise').mockImplementation();
 
-                it('should not emit success event', async () => {
+                    const wrapper = mount(VueCheckout, {
+                        store: createStore(defaultState, { ...defaultActions, getBasket: jest.fn(async () => Promise.reject()) }),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+
+                    // Act
+                    await wrapper.vm.loadBasket();
+
+                    // Assert
+                    expect(wrapper.emitted(EventNames.CheckoutBasketGetFailure).length).toBe(1);
                     expect(wrapper.emitted(EventNames.CheckoutBasketGetSuccess)).toBeUndefined();
                 });
             });
 
             describe('when `getBasket` request succeeds', () => {
-                const wrapper = mount(VueCheckout, {
-                    store: createStore(),
-                    i18n,
-                    localVue,
-                    propsData
-                });
-
                 it('should emit success event', async () => {
-                    expect(wrapper.emitted(EventNames.CheckoutBasketGetSuccess).length).toBe(1);
-                });
+                    // Arrange
+                    jest.spyOn(VueCheckout.methods, 'initialise').mockImplementation();
 
-                it('should not emit failure event', async () => {
+                    const wrapper = mount(VueCheckout, {
+                        store: createStore(),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+
+                    // Act
+                    await wrapper.vm.loadBasket();
+
+                    // Assert
+                    expect(wrapper.emitted(EventNames.CheckoutBasketGetSuccess).length).toBe(1);
                     expect(wrapper.emitted(EventNames.CheckoutBasketGetFailure)).toBeUndefined();
                 });
             });


### PR DESCRIPTION
v0.45.0
-------------------------------
*January 27, 2021*

### Changed
- Only call the Checkout `GET` endpoint when the user is logged in.
- Refactored tests.