### PR TITLE
f-form-field@1.8.0 - Separate text and value for dropdownOptions

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.8.0
+------------------------------
+*January 27, 2021*
+
+### Changed
+- `dropdownOptions` prop should now be an array of objects with the properties `text` and `value` rather than an array of strings.
+
+
 v1.7.0
 ------------------------------
 *January 14, 2021*

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
@@ -15,7 +15,7 @@
                 v-for="(option, index) in dropdownOptions"
                 :key="index"
                 :data-test-id="`${testId.option}-${index}`"
-                :value="option">{{ option }}</option>
+                :value="option.value">{{ option.text }}</option>
         </select>
     </div>
 </template>

--- a/packages/components/atoms/f-form-field/src/components/_tests/FormDropdown.test.js
+++ b/packages/components/atoms/f-form-field/src/components/_tests/FormDropdown.test.js
@@ -3,11 +3,11 @@ import FormDropdown from '../FormDropdown.vue';
 
 describe('FormDropdown', () => {
     const dropdownOptions = [
-        {text: 'text 0', value: 'value 0'},
-        {text: 'text 1', value: 'value 1'},
-        {text: 'text 2', value: 'value 2'},
-        {text: 'text 3', value: 'value 3'},
-        {text: 'text 4', value: 'value 4'}
+        { text: 'text 0', value: 'value 0' },
+        { text: 'text 1', value: 'value 1' },
+        { text: 'text 2', value: 'value 2' },
+        { text: 'text 3', value: 'value 3' },
+        { text: 'text 4', value: 'value 4' }
     ];
 
     it('should be defined', () => {

--- a/packages/components/atoms/f-form-field/src/components/_tests/FormDropdown.test.js
+++ b/packages/components/atoms/f-form-field/src/components/_tests/FormDropdown.test.js
@@ -2,7 +2,13 @@ import { shallowMount } from '@vue/test-utils';
 import FormDropdown from '../FormDropdown.vue';
 
 describe('FormDropdown', () => {
-    const dropdownOptions = ['option 0', 'option 1', 'option 2', 'option 3', 'option 4'];
+    const dropdownOptions = [
+        {text: 'text 0', value: 'value 0'},
+        {text: 'text 1', value: 'value 1'},
+        {text: 'text 2', value: 'value 2'},
+        {text: 'text 3', value: 'value 3'},
+        {text: 'text 4', value: 'value 4'}
+    ];
 
     it('should be defined', () => {
         const propsData = {};
@@ -13,17 +19,18 @@ describe('FormDropdown', () => {
     describe('props ::', () => {
         describe('dropdownOptions ::', () => {
             it('should populate `<option>` tags', () => {
-                // Arrange && Act
+                // Arrange & Act
                 const propsData = { dropdownOptions };
                 const wrapper = shallowMount(FormDropdown, { propsData });
                 const option = wrapper.find('[data-test-id="formfield-dropdown-option-0"]');
 
                 // Assert
-                expect(option.text()).toEqual('option 0');
+                expect(option.element.text).toEqual('text 0');
+                expect(option.element.value).toEqual('value 0');
             });
 
             it('should display an empty `<select>`', () => {
-                // Arrange && Act
+                // Arrange & Act
                 const propsData = {};
                 const wrapper = shallowMount(FormDropdown, { propsData });
                 const option = wrapper.find('[data-test-id="formfield-dropdown-option-0"]');

--- a/packages/components/atoms/f-form-field/stories/FormField.stories.js
+++ b/packages/components/atoms/f-form-field/stories/FormField.stories.js
@@ -1,5 +1,5 @@
 import {
-    withKnobs, select, text, boolean, array
+    withKnobs, select, text, boolean, object
 } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
 import FormField from '../src/components/FormField.vue';
@@ -29,7 +29,10 @@ export const FormFieldComponent = () => ({
             default: boolean('hasError', false)
         },
         dropdownOptions: {
-            default: array('Dropdown Options', ['As soon as possible', 'Today in 5 minutes'], ',')
+            default: object('Dropdown Options', [
+                { text: 'As soon as possible', value: '2021-01-01T01:00:00.000Z' },
+                { text: 'Today in 5 minutes', value: '2021-01-01T01:05:00.000Z' }
+            ])
         },
         isGrouped: {
             default: boolean('isGrouped', false)


### PR DESCRIPTION
### Changed
- `dropdownOptions` prop should now be an array of objects with the properties `text` and `value` rather than an array of strings.

---

## UI Review Checks
- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested
- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)