### PR TITLE
f-button@v0.7.0 — Update button focus styles.

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.7.0
+------------------------------
+*January 28, 2021*
+
+### Changed
+- Updated focus styles to provide more control over when focus outlines are displayed. See this article for more info - https://matthiasott.com/notes/focus-visible-is-here.
+- Updated focus style to match the style used in the Fozzie SCSS.
+- Updated package URL to match new structure.
+
+
 v0.6.1
 ------------------------------
 *January 25, 2021*

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "main": "dist/f-button.umd.min.js",
   "files": [
     "dist",
     "test-utils"
   ],
-  "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/f-button",
+  "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/components/atoms/f-button",
   "contributors": [
     "Github contributors <https://github.com/justeat/fozzie-components/graphs/contributors>"
   ],
@@ -45,7 +45,6 @@
   "browserslist": [
     "extends @justeat/browserslist-config-fozzie"
   ],
-  "dependencies": {},
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1"
   },

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -144,7 +144,7 @@ $btn-sizeXSmall-lineHeight      : 1;
 
     // Show focus styles on keyboard focus.
     &:focus-visible {
-        outline: 2px solid $btn-default-outline-color;
+        outline: 2px dotted $btn-default-outline-color;
     }
 
     &:hover,

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -137,14 +137,20 @@ $btn-sizeXSmall-lineHeight      : 1;
         background-color: $btn-default-bgColor--hover;
     }
 
-    &:focus {
-        outline: 2px dotted $btn-default-outline-color;
+    // Hide focus styles if they're not needed, for example, when an element receives focus via the mouse.
+    &:focus:not(:focus-visible) {
+        outline: 0;
+    }
+
+    // Show focus styles on keyboard focus.
+    &:focus-visible {
+        outline: 2px solid $btn-default-outline-color;
     }
 
     &:hover,
     &:active {
         &:not(.o-btnLink) {
-            outline: none; // no need as already has a focus/active state
+            outline: 0; // no need as already has a focus/active state
         }
     }
 


### PR DESCRIPTION
### Changed

- Updated focus styles to provide more control over when focus outlines are displayed. This allows us to only show the focus outlines when using a keyboard. See this article for more info - https://matthiasott.com/notes/focus-visible-is-here.
- Updated package URL to match new structure.