### PR TITLE
#trivial - Add readme info for non vue sites.

### DIFF
--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+(To be rolled into the next release)
+------------------------------
+*January 27, 2021*
+
+### Added
+- Readme information on how to render f-searchbox in non-vue instances.
+
+
 v4.0.0-beta.20
 ------------------------------
 *January 22, 2021*

--- a/packages/components/molecules/f-searchbox/README.md
+++ b/packages/components/molecules/f-searchbox/README.md
@@ -250,10 +250,10 @@ the store module using `this.$store.hasModule('searchbox')`, `hasModule` was add
 </head>
 <body>
     <div data-app>
-        <Vue-Searchbox locale="en-GB" />
+        <vue-Searchbox locale="en-GB" />
     </div>
     <script src="https://unpkg.com/vue@2.6.11/dist/vue.js"></script>
-    <script src="https://unpkg.com/vuex@3.2.0"></script>
+    <script src="https://unpkg.com/vuex@3.2.0/dist/vuex.js"></script>
     <script src="https://unpkg.com/@justeat/f-searchbox/dist/f-searchbox.umd.min.js"></script>
     <script>
         (function() {

--- a/packages/components/molecules/f-searchbox/README.md
+++ b/packages/components/molecules/f-searchbox/README.md
@@ -238,8 +238,7 @@ NOTE: You need to provide Vue with an instance of Vuex for f-searchbox to work c
 added after Vue has been included. Including the `unpkg` Vuex script, like the below example, will automatically install Vuex.
 
 The version of Vuex required must be no earlier than `vuex@3.2.0` as f-searchbox under the hood registers
-the store module using `this.$store.hasModule('searchbox')`, `hasModule` was added in `v3.2.0`, earlier Vuex versions
-will break store registration.
+the store module using `this.$store.hasModule('searchbox')`, `hasModule` was added in `v3.2.0`, earlier Vuex versions will break store registration.
 
 
 ```html

--- a/packages/components/molecules/f-searchbox/README.md
+++ b/packages/components/molecules/f-searchbox/README.md
@@ -227,3 +227,48 @@ const copyOverrides = {
     // ...
 }
 ```
+
+### Non-Vue Applications
+
+This module can be ran as a micro front-end for applications that don't make use of the Vue framework.
+
+The following rudimentary example can be used as a guide for implementing this component in an existing static application.
+
+NOTE: You need to provide Vue with an instance of Vuex for f-searchbox to work correctly. This should be
+added after Vue has been included. Including the `unpkg` Vuex script, like the below example, will automatically install Vuex.
+
+The version of Vuex required must be no earlier than `vuex@3.2.0` as f-searchbox under the hood registers
+the store module using `this.$store.hasModule('searchbox')`, `hasModule` was added in `v3.2.0`, earlier Vuex versions
+will break store registration.
+
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+    <title>f-searchbox example standalone</title>
+    <link rel="stylesheet" href="https://unpkg.com/@justeat/f-searchbox/dist/f-searchbox.css">
+</head>
+<body>
+    <div data-app>
+        <Vue-Searchbox locale="en-GB" />
+    </div>
+    <script src="https://unpkg.com/vue@2.6.11/dist/vue.js"></script>
+    <script src="https://unpkg.com/vuex@3.2.0"></script>
+    <script src="https://unpkg.com/@justeat/f-searchbox/dist/f-searchbox.umd.min.js"></script>
+    <script>
+        (function() {
+            if (typeof Vue === 'undefined') return null;
+
+            Vue.config.devtools = false;
+            Vue.config.productionTip = false;
+
+            return new Vue({
+                store: new Vuex.Store({}), // init empty Vuex store here.
+                el: '[data-app]'
+            });
+    	})();
+    </script>
+</body>
+</html>
+```


### PR DESCRIPTION
### Added

- Readme information on how to render f-searchbox in non-vue instances.