### PR TITLE
f-tabs@0.2.0 - First changes, adds styles, layout and components

### DIFF
--- a/packages/components/molecules/f-tabs/CHANGELOG.md
+++ b/packages/components/molecules/f-tabs/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.2.0
+------------------------------
+*January 28, 2021*
+
+### Added
+- Added the first version of tabs with Tab and Tabs vue component
+
+
 v0.1.0
 ------------------------------
 *January 21, 2021*

--- a/packages/components/molecules/f-tabs/README.md
+++ b/packages/components/molecules/f-tabs/README.md
@@ -29,15 +29,20 @@
 
 2.  Import the component
 
+    This component has two exports `Tab.vue` and `Tabs.vue`. The reasoning behind this is that due to the ability to
+    register a tab with provide / inject, you may wish in a particular circumstance create your own tab and register
+    it manually, therefore removing the need to import `Tab.vue`.
+
     You can import it in your Vue SFC like this (please note that styles have to be imported separately):
 
     ```
-    import VueTabs from '@justeat/f-tabs';
+    import { Tabs, Tab } from '@justeat/f-tabs';
     import '@justeat/f-tabs/dist/f-tabs.css';
 
     export default {
         components: {
-            VueTabs
+            Tabs,
+            Tab
         }
     }
     ```

--- a/packages/components/molecules/f-tabs/package.json
+++ b/packages/components/molecules/f-tabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-tabs",
   "description": "Fozzie Tabs – Switchable slots for content&#34;",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/f-tabs.umd.min.js",
   "files": [
     "dist",
@@ -32,6 +32,7 @@
     "lint:fix": "yarn lint --fix",
     "lint:style": "vue-cli-service lint:style",
     "report": "cd ../../../tools && yarn report",
+    "test": "vue-cli-service test:unit",
     "test-component:chrome": "wdio ../../../../wdio.conf.js --suite component",
     "test-a11y:chrome": "wdio ../../../../wdio.conf.js --suite a11y"
   },

--- a/packages/components/molecules/f-tabs/src/components/Tab.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tab.vue
@@ -1,0 +1,123 @@
+<template>
+    <transition
+        v-if="animateTab"
+        :name="transitionName">
+        <div
+            v-show="isActive"
+            :class="[$style['c-tab']]">
+            <slot />
+        </div>
+    </transition>
+    <div v-else>
+        <div
+            v-show="isActive"
+            :class="[$style['c-tab']]">
+            <slot />
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'Tab',
+    props: {
+        title: {
+            required: true,
+            type: String
+        },
+        name: {
+            required: true,
+            type: String
+        },
+        selected: {
+            required: false,
+            type: Boolean,
+            default: false
+        }
+    },
+    inject: ['register', 'tabsComponent'],
+    computed: {
+        isActive () {
+            return this.tabsComponent.activeTab === this.name;
+        },
+        transitionName () {
+            return this.tabsComponent.animationDirection === 'LEFT' ?
+                this.$style['fade-in-right'] : this.$style['fade-in-left'];
+        },
+        animateTab () {
+            return this.tabsComponent.animate;
+        }
+    },
+    created () {
+        this.register({
+            name: this.name,
+            title: this.title,
+            selected: this.selected
+        });
+    }
+};
+</script>
+
+<style lang="scss" module>
+/* stylelint-disable -- does not understand syntax. */
+.c-tab {
+    padding: spacing() 0;
+    left: 0;
+    top: 0;
+    grid-area: 1/1;
+}
+@keyframes fadeInLeft {
+    from {
+        transform: translate3d(-40px, 0, 0);
+    }
+
+    to {
+        transform: translate3d(0, 0, 0);
+        opacity: 1;
+    }
+}
+
+.fade-in-left {
+    &:global(-enter-to) {
+        opacity: 0;
+        animation-duration: 0.7s;
+        animation-fill-mode: both;
+        animation-name: fadeInLeft;
+    }
+    &:global(-enter) {
+        opacity: 0;
+        transform: translate3d(-40px, 0, 0);
+    }
+    &:global(-leave-to) {
+        opacity: 0;
+        transition: opacity 0.3s;
+    }
+}
+@keyframes fadeInRight {
+    from {
+        transform: translate3d(40px, 0, 0);
+    }
+
+    to {
+        transform: translate3d(0, 0, 0);
+        opacity: 1;
+    }
+}
+
+.fade-in-right {
+    &:global(-enter-to) {
+        opacity: 0;
+        animation-duration: 0.7s;
+        animation-fill-mode: both;
+        animation-name: fadeInRight;
+    }
+    &:global(-enter) {
+        opacity: 0;
+        transform: translate3d(40px, 0, 0);
+    }
+    &:global(-leave-to) {
+        opacity: 0;
+        transition: opacity 0.3s;
+    }
+}
+</style>

--- a/packages/components/molecules/f-tabs/src/components/Tab.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tab.vue
@@ -30,7 +30,6 @@ export default {
             type: String
         },
         selected: {
-            required: false,
             type: Boolean,
             default: false
         }

--- a/packages/components/molecules/f-tabs/src/components/Tab.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tab.vue
@@ -4,20 +4,22 @@
         :name="transitionName">
         <div
             v-show="isActive"
-            :class="[$style['c-tab']]">
+            :class="$style['c-tab']">
             <slot />
         </div>
     </transition>
     <div v-else>
         <div
             v-show="isActive"
-            :class="[$style['c-tab']]">
+            :class="$style['c-tab']">
             <slot />
         </div>
     </div>
 </template>
 
 <script>
+import { DIRECTION } from '../constants';
+
 export default {
     name: 'Tab',
     props: {
@@ -40,7 +42,7 @@ export default {
             return this.tabsComponent.activeTab === this.name;
         },
         transitionName () {
-            return this.tabsComponent.animationDirection === 'LEFT' ?
+            return this.tabsComponent.animationDirection === DIRECTION.LEFT ?
                 this.$style['fade-in-right'] : this.$style['fade-in-left'];
         },
         animateTab () {
@@ -58,16 +60,22 @@ export default {
 </script>
 
 <style lang="scss" module>
-/* stylelint-disable -- does not understand syntax. */
+
+$fade-out-transition-duration: 0.3s;
+$fade-in-transition-duration: 0.7s;
+$fade-in-transition-distance: 40px;
+
+
 .c-tab {
     padding: spacing() 0;
     left: 0;
     top: 0;
     grid-area: 1/1;
 }
+
 @keyframes fadeInLeft {
     from {
-        transform: translate3d(-40px, 0, 0);
+        transform: translate3d(-#{$fade-in-transition-distance}, 0, 0);
     }
 
     to {
@@ -77,24 +85,27 @@ export default {
 }
 
 .fade-in-left {
+    /* stylelint-disable -- does not understand syntax. */
     &:global(-enter-to) {
         opacity: 0;
-        animation-duration: 0.7s;
+        animation-duration: $fade-in-transition-duration;
         animation-fill-mode: both;
         animation-name: fadeInLeft;
     }
     &:global(-enter) {
         opacity: 0;
-        transform: translate3d(-40px, 0, 0);
+        transform: translate3d(-#{$fade-in-transition-distance}, 0, 0);
     }
     &:global(-leave-to) {
         opacity: 0;
-        transition: opacity 0.3s;
+        transition: opacity $fade-out-transition-duration;
     }
+    /* stylelint-enable */
 }
+
 @keyframes fadeInRight {
     from {
-        transform: translate3d(40px, 0, 0);
+        transform: translate3d($fade-in-transition-distance, 0, 0);
     }
 
     to {
@@ -104,19 +115,21 @@ export default {
 }
 
 .fade-in-right {
+    /* stylelint-disable -- does not understand syntax. */
     &:global(-enter-to) {
         opacity: 0;
-        animation-duration: 0.7s;
+        animation-duration: $fade-in-transition-duration;
         animation-fill-mode: both;
         animation-name: fadeInRight;
     }
     &:global(-enter) {
         opacity: 0;
-        transform: translate3d(40px, 0, 0);
+        transform: translate3d($fade-in-transition-distance, 0, 0);
     }
     &:global(-leave-to) {
         opacity: 0;
-        transition: opacity 0.3s;
+        transition: opacity $fade-out-transition-duration;
     }
+    /* stylelint-enable */
 }
 </style>

--- a/packages/components/molecules/f-tabs/src/components/Tabs.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tabs.vue
@@ -1,46 +1,140 @@
 <template>
-    <div
-        :class="$style['c-tabs']"
-        data-test-id='tabs-component'>
-        {{ copy.text }}
+    <div :class="$style['c-tabs']">
+        <div :class="$style['c-tabs-header']">
+            <div :class="$style['c-tabs-buttons']">
+                <button
+                    v-for="({ name, title }, i) in tabs"
+                    :key="i"
+                    :class="[{ [$style['c-tabs-button--active']]: activeTab === name }, $style['c-tabs-button']]"
+                    @click="selectTabIndex(name)"
+                >
+                    {{ title }}
+                </button>
+            </div>
+        </div>
+        <div :class="$style['c-tabs-body']">
+            <slot />
+        </div>
     </div>
 </template>
 
 <script>
-import { globalisationServices } from '@justeat/f-services';
-import tenantConfigs from '../tenants';
+
+const DIRECTION = {
+    LEFT: 'LEFT',
+    RIGHT: 'RIGHT'
+};
 
 export default {
-    name: 'VueTabs',
+    name: 'Tabs',
     components: {},
     props: {
         locale: {
             type: String,
             default: ''
+        },
+        animate: {
+            type: Boolean,
+            default: false
         }
     },
-    data () {
-        const locale = globalisationServices.getLocale(tenantConfigs, this.locale, this.$i18n);
-        const localeConfig = tenantConfigs[locale];
-
+    data: () => ({
+        direction: null,
+        activeTab: '',
+        tabs: []
+    }),
+    computed: {},
+    provide () {
+        const component = this;
+        const tabsComponent = {};
+        Object.defineProperty(tabsComponent, 'activeTab', {
+            enumerable: true,
+            get: () => this.activeTab
+        });
+        Object.defineProperty(tabsComponent, 'animationDirection', {
+            enumerable: true,
+            get: () => this.direction
+        });
+        Object.defineProperty(tabsComponent, 'animate', {
+            enumerable: true,
+            get: () => this.animate
+        });
         return {
-            copy: { ...localeConfig }
+            register (tab) {
+                component.addTab(tab);
+            },
+            tabsComponent
         };
+    },
+    methods: {
+        selectTabIndex (name) {
+            const previousIndex = this.tabs.findIndex(t => t.name === this.activeTab);
+            const newIndex = this.tabs.findIndex(t => t.name === name);
+            if (newIndex > previousIndex) {
+                this.direction = DIRECTION.RIGHT;
+            } else {
+                this.direction = DIRECTION.LEFT;
+            }
+            this.activeTab = name;
+        },
+        addTab (tab) {
+            if (tab.selected) {
+                this.activeTab = tab.name;
+            }
+            this.tabs = [...this.tabs, tab];
+        }
     }
 };
 </script>
 
 <style lang="scss" module>
 
+$tabs-link-colour         : $grey--darkest;
+$tabs-link-font-weight    : $font-weight-bold;
+$tabs-link-border-colour  : $brand--orange;
+
 .c-tabs {
+    width: 100%;
+    height: 100%;
+}
+.c-tabs-header {
+    width: 100%;
+    height: 42px;
+}
+.c-tabs-buttons {
     display: flex;
-    justify-content: center;
-    min-height: 80vh;
-    width: 80vw;
-    margin: auto;
-    border: 1px solid $red;
-    font-family: $font-family-base;
-    @include font-size(heading-m);
+    align-items: center;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    height: 100%;
+
+    @include media('<narrowMid') {
+        width:100%;
+    }
+
+}
+.c-tabs-button {
+    padding: spacing(x1.5) spacing(x2);
+    cursor: pointer;
+    color: $tabs-link-colour;
+    border: none;
+    background-color: transparent;
+    outline: none;
+
+    @include media('<narrowMid') {
+        flex: 1 1 0px;// important px for IE
+    }
+
+}
+.c-tabs-button--active {
+    border-bottom: 2px solid $tabs-link-border-colour;
+    font-weight: $tabs-link-font-weight;
+}
+.c-tabs-body {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr;
 }
 
 </style>

--- a/packages/components/molecules/f-tabs/src/components/Tabs.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tabs.vue
@@ -7,7 +7,10 @@
                 <button
                     v-for="({ name, title }, i) in tabs"
                     :key="i"
-                    :class="[{ [$style['c-tabs-button--active']]: activeTab === name }, $style['c-tabs-button']]"
+                    :class="[
+                        { [$style['c-tabs-button--active']]: activeTab === name },
+                        $style['c-tabs-button']
+                    ]"
                     @click="selectTabIndex(name)"
                 >
                     {{ title }}
@@ -22,18 +25,11 @@
 
 <script>
 
-const DIRECTION = {
-    LEFT: 'LEFT',
-    RIGHT: 'RIGHT'
-};
+import { DIRECTION } from '../constants';
 
 export default {
     name: 'Tabs',
     props: {
-        locale: {
-            type: String,
-            default: ''
-        },
         animate: {
             type: Boolean,
             default: false
@@ -67,6 +63,11 @@ export default {
         };
     },
     methods: {
+        /**
+         * This function is used to select the tab index and set the active tab while applying the correct animation
+         * uses the tab name to select index
+         * @param name
+         */
         selectTabIndex (name) {
             const previousIndex = this.tabs.findIndex(t => t.name === this.activeTab);
             const newIndex = this.tabs.findIndex(t => t.name === name);
@@ -77,6 +78,10 @@ export default {
             }
             this.activeTab = name;
         },
+        /**
+         * This function adds a tab that is calling the register tab callback
+         * @param tab
+         */
         addTab (tab) {
             if (tab.selected) {
                 this.activeTab = tab.name;

--- a/packages/components/molecules/f-tabs/src/components/Tabs.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tabs.vue
@@ -29,7 +29,6 @@ const DIRECTION = {
 
 export default {
     name: 'Tabs',
-    components: {},
     props: {
         locale: {
             type: String,
@@ -45,7 +44,6 @@ export default {
         activeTab: '',
         tabs: []
     }),
-    computed: {},
     provide () {
         const component = this;
         const tabsComponent = {};

--- a/packages/components/molecules/f-tabs/src/components/Tabs.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tabs.vue
@@ -1,5 +1,7 @@
 <template>
-    <div :class="$style['c-tabs']">
+    <div
+        data-test-id="tabs-component"
+        :class="$style['c-tabs']">
         <div :class="$style['c-tabs-header']">
             <div :class="$style['c-tabs-buttons']">
                 <button

--- a/packages/components/molecules/f-tabs/src/components/Tabs.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tabs.vue
@@ -110,7 +110,7 @@ $tabs-link-border-colour  : $brand--orange;
     height: 100%;
 
     @include media('<narrowMid') {
-        width:100%;
+        width: 100%;
     }
 
 }
@@ -123,7 +123,9 @@ $tabs-link-border-colour  : $brand--orange;
     outline: none;
 
     @include media('<narrowMid') {
+        /* stylelint-disable */
         flex: 1 1 0px;// important px for IE
+        /* stylelint-enable */
     }
 
 }

--- a/packages/components/molecules/f-tabs/src/constants.js
+++ b/packages/components/molecules/f-tabs/src/constants.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line import/prefer-default-export
+export const DIRECTION = {
+    LEFT: 'LEFT',
+    RIGHT: 'RIGHT'
+};

--- a/packages/components/molecules/f-tabs/src/index.js
+++ b/packages/components/molecules/f-tabs/src/index.js
@@ -6,13 +6,15 @@
 
 
 // Import vue component
-import VueTabs from '@/components/Tabs.vue';
+import Tabs from '@/components/Tabs.vue';
+import Tab from '@/components/Tab.vue';
 
 // Declare install function executed by Vue.use()
 export function install (Vue) {
     if (install.installed) return;
     install.installed = true;
-    Vue.component('VueTabs', VueTabs);
+    Vue.component('Tabs', Tabs);
+    Vue.component('Tab', Tab);
 }
 
 // Create module definition for Vue.use()
@@ -32,4 +34,7 @@ if (GlobalVue) {
 }
 
 // To allow use as module (npm/webpack/etc.) export component
-export default VueTabs;
+export {
+    Tabs,
+    Tab
+};

--- a/packages/components/molecules/f-tabs/stories/Tabs.stories.js
+++ b/packages/components/molecules/f-tabs/stories/Tabs.stories.js
@@ -3,24 +3,32 @@
 //     withKnobs, select, boolean
 // } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
-import VueTabs from '../src/components/Tabs.vue';
+import Tabs from '../src/components/Tabs.vue';
+import Tab from '../src/components/Tab.vue';
 
 export default {
-    title: 'Components',
+    title: 'Components/Molecules',
     decorators: [withA11y]
 };
 
 export const VueTabsComponent = () => ({
-    components: { VueTabs },
-    // props: {
-    //     buttonType: {
-    //         default: select('Button Type', ['primary', 'primaryAlt', 'secondary', 'tertiary', 'link'])
-    //     },
-    //     fullWidth: {
-    //         default: boolean('fullWidth', false)
-    //     }
-    // },
-    template: '<vue-tabs />'
+    components: { Tabs, Tab },
+    template: `
+        <tabs :animate="true">
+            <tab name="a" title="Your Stampcards" :selected="true">
+                Lorem ipsum dolor sit amet consectetur adipisicing elit. Corrupti
+                temporibus deleniti quas dolor eos et delectus eveniet sequi dolore,
+                minus vel ad nesciunt voluptatibus numquam nulla distinctio modi,
+                voluptas exercitationem?
+            </tab>
+            <tab name="b" title="How it works">
+                Lorem ipsum, dolor sit amet consectetur adipisicing elit. Commodi eaque
+                dicta quisquam voluptate inventore repellendus ut itaque, animi, magni
+                consectetur dolore, sapiente error! Eos cupiditate harum quidem sit illo
+                dicta!
+            </tab>
+        </tabs>
+    `
 });
 
 VueTabsComponent.storyName = 'f-tabs';

--- a/packages/components/molecules/f-tabs/test/specs/component/f-tabs.component.spec.js
+++ b/packages/components/molecules/f-tabs/test/specs/component/f-tabs.component.spec.js
@@ -2,7 +2,7 @@ import TabsComponent from '../../../test-utils/component-objects/f-tabs.componen
 
 describe('f-tabs component tests', () => {
     beforeEach(() => {
-        browser.url('?path=/story/components--vue-tabs-component');
+        browser.url('?path=/story/components-molecules--vue-tabs-component');
         browser.switchToFrame(0);
         TabsComponent.waitForTabsComponent();
     });


### PR DESCRIPTION
This is the beginning of a tabs component, at a high level it is required to accomplish part of a design in the new stamp cards page. The component consists of two new components `Tab` and `Tabs`. 

The underlying choice of how to handle the way the tabs worked was made based on a few points.

	1. The tabs should be allowed to animate if needed
	2. Only `Tab` ’s should be allowed to be registered as a tab within the `Tabs` slot. 
	3. It must not be complicated to implement.

Based on this I decided not to use`$children` as an option for accessing the slot contents. It’s removed in the next version of vue and it’s also very painful to work with `<transition>` elements.   

I have therefore used`provide/inject` to inject a callback function for the `Tab` component to register itself with the parent `Tabs` component.  This way we have access to more data on the child component / `Tab` as it is able to send tab data when registering, so we can then use the title prop to add the text to the tab button. 

For this PR I am not including unit tests and will add in a later PR to reduce the PR size. 

All style choices are made based on the design given and until we need to modify this e.g we have a PIE design for tabs then I thought best to style tabs buttons according to design. 

Animation can be applied by adding `:animate=“true”` to the `Tabs` component.

## UI Review Checks

![Screenshot 2021-01-28 at 14 36 04](https://user-images.githubusercontent.com/15876339/106153562-95ab5180-6176-11eb-9c05-0dc62d9ffdc7.png)

![Screenshot 2021-01-28 at 14 36 42](https://user-images.githubusercontent.com/15876339/106153397-685ea380-6176-11eb-8381-a610d5b89d56.png)

Below is snippet from design file.

![Screenshot 2021-01-28 at 14 43 56](https://user-images.githubusercontent.com/15876339/106154245-4dd8fa00-6177-11eb-9c32-dd9fe02a4a35.png)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)
