### PR TITLE
f-vue-icons@v2.3.1 - Arrow icon fix.

### DIFF
--- a/packages/tools/f-vue-icons/CHANGELOG.md
+++ b/packages/tools/f-vue-icons/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v2.3.1
+------------------------------
+*January 29, 2020*
+
+### Fixed
+- Update arrow icon from f-icons in order to fix issue when using CSS fill.
+
+
 v2.3.0
 ------------------------------
 *January 18, 2020*

--- a/packages/tools/f-vue-icons/icons/ArrowIcon.js
+++ b/packages/tools/f-vue-icons/icons/ArrowIcon.js
@@ -12,26 +12,10 @@ export default {
         viewBox: "0 0 24 24"
       },
       "class": "c-ficon c-ficon--arrow"
-    }, ctx.data]), [h("defs", [h("path", {
+    }, ctx.data]), [h("path", {
       attrs: {
-        d: "M5 11h11.167l-4.708-4.71a1 1 0 010-1.418 1 1 0 011.417 0l6.417 6.417a1 1 0 010 1.417l-6.417 6.416a1 1 0 01-1.417 0 1 1 0 010-1.416L16.167 13H5a1 1 0 010-2z",
-        id: "a"
+        d: "M5 11h11.167l-4.708-4.71a1 1 0 010-1.418 1 1 0 011.417 0l6.417 6.417a1 1 0 010 1.417l-6.417 6.416a1 1 0 01-1.417 0 1 1 0 010-1.416L16.167 13H5a1 1 0 010-2z"
       }
-    })]), h("g", {
-      attrs: {
-        fill: "none",
-        "fill-rule": "evenodd"
-      }
-    }, [h("path", {
-      attrs: {
-        d: "M24 0H0v24h24z"
-      }
-    }), h("use", {
-      attrs: {
-        fill: "#172026",
-        "fill-rule": "nonzero",
-        href: "#a"
-      }
-    })])]);
+    })]);
   }
 };

--- a/packages/tools/f-vue-icons/package.json
+++ b/packages/tools/f-vue-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-vue-icons",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "main": "dist/f-vue-icons.cjs.js",
   "cdn": "dist/f-vue-icons.min.js",
   "unpkg": "dist/f-vue-icons.min.js",
@@ -47,7 +47,7 @@
     "babel-helper-vue-jsx-merge-props": "2.0.3"
   },
   "devDependencies": {
-    "@justeat/f-icons": "3.3.0",
+    "@justeat/f-icons": "3.3.1",
     "@vue/cli-plugin-babel": "4.5.8",
     "@vue/cli-plugin-eslint": "4.5.8",
     "@vue/cli-plugin-unit-jest": "4.5.8",

--- a/packages/tools/f-vue-icons/src/components/ArrowIcon.js
+++ b/packages/tools/f-vue-icons/src/components/ArrowIcon.js
@@ -10,6 +10,6 @@ export default {
         const attrs = ctx.data.attrs || {};
         ctx.data.attrs = attrs;
 
-        return <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--arrow" {...ctx.data}><defs><path d="M5 11h11.167l-4.708-4.71a1 1 0 010-1.418 1 1 0 011.417 0l6.417 6.417a1 1 0 010 1.417l-6.417 6.416a1 1 0 01-1.417 0 1 1 0 010-1.416L16.167 13H5a1 1 0 010-2z" id="a"></path></defs><g fill="none" fill-rule="evenodd"><path d="M24 0H0v24h24z"></path><use fill="#172026" fill-rule="nonzero" href="#a"></use></g></svg>;
+        return <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--arrow" {...ctx.data}><path d="M5 11h11.167l-4.708-4.71a1 1 0 010-1.418 1 1 0 011.417 0l6.417 6.417a1 1 0 010 1.417l-6.417 6.416a1 1 0 01-1.417 0 1 1 0 010-1.416L16.167 13H5a1 1 0 010-2z"></path></svg>;
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1947,10 +1947,10 @@
   dependencies:
     vue-i18n "8.0.0"
 
-"@justeat/f-icons@3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-3.3.0.tgz#ffcdc8e6bb9879fe1008a0af0e56a1142ed4a0f1"
-  integrity sha512-5mcxbk6Xb5ja19oY9BOUWtPf1KDBsAmJGw8IWaqLIrc0oG/JTkM+AbEUEWSa/mi+OcEfRrV7+I5t1BdD/LyakQ==
+"@justeat/f-icons@3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-3.3.1.tgz#28b7fb405ffc0d5285391449faa6806668b3f6ed"
+  integrity sha512-dj4jwA5vV1lJJBz7vfwPGobdY0UNP27oMotxhNPGQMbcDHDlOMIIKs+tKnAEdOQS7+wz2WSnk+CCcLNP2nzcwA==
 
 "@justeat/f-logger@0.8.1":
   version "0.8.1"


### PR DESCRIPTION
### Fixed
- Update arrow icon from f-icons in order to fix issue when using CSS fill.