### PR TITLE
f-media-element@0.2.0 - layout +  styles + components

### DIFF
--- a/packages/components/molecules/f-media-element/CHANGELOG.md
+++ b/packages/components/molecules/f-media-element/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.2.0
+------------------------------
+*February 1, 2021*
+
+### Added
+- Add the initial start of the component, which includes styles, base component and story changes
+
+
 v0.1.0
 ------------------------------
 *January 29, 2021*

--- a/packages/components/molecules/f-media-element/package.json
+++ b/packages/components/molecules/f-media-element/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@justeat/f-media-element",
   "description": "Fozzie Media Element - provides ability to display text and an image in different orientations",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/f-media-element.umd.min.js",
   "files": [
     "dist",
-    "test-utils" 
+    "test-utils"
   ],
   "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/components/molecules/f-media-element",
   "contributors": [

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -9,20 +9,13 @@
         <div
             :class="[
                 $style['c-mediaElement-content'],
-                contentAlignClass
+                contentAlignClass,
+                fontSizeClass
             ]">
-            <h3
-                :class="[
-                    $style['c-mediaElement-title'],
-                    fontSizeClass
-                ]">
+            <h3 :class="$style['c-mediaElement-title']">
                 {{ title }}
             </h3>
-            <p
-                :class="[
-                    $style['c-mediaElement-text'],
-                    fontSizeClass
-                ]">
+            <p :class="$style['c-mediaElement-text']">
                 {{ text }}
             </p>
         </div>
@@ -34,7 +27,7 @@
             <img
                 :class="[$style['c-mediaElement-img'], 'c-mediaElement-img--override']"
                 :src="imageUrl"
-                alt="Media Element Image">
+                :alt="altText">
         </div>
     </div>
 </template>
@@ -75,6 +68,10 @@ export default {
         textSize: {
             type: String,
             default: 'md'
+        },
+        altText: {
+            type: String,
+            default: 'Media Element Image'
         }
     },
     data () {
@@ -122,17 +119,17 @@ export default {
         fontSizeClass () {
             switch (this.textSize) {
                 case FONT_SIZE.SM:
-                    return this.$style['c-mediaElement-fontSize--sm'];
+                    return this.$style['c-mediaElement--fontSizeSmall'];
                 case FONT_SIZE.MD:
-                    return this.$style['c-mediaElement-fontSize--md'];
+                    return this.$style['c-mediaElement--fontSizeMedium'];
                 case FONT_SIZE.LG:
-                    return this.$style['c-mediaElement-fontSize--lg'];
+                    return this.$style['c-mediaElement--fontSizeLarge'];
                 case FONT_SIZE.XL:
-                    return this.$style['c-mediaElement-fontSize--xl'];
+                    return this.$style['c-mediaElement--fontSizeXLarge'];
                 case FONT_SIZE.XXL:
-                    return this.$style['c-mediaElement-fontSize--xxl'];
+                    return this.$style['c-mediaElement--fontSizeXXLarge'];
                 default:
-                    return this.$style['c-mediaElement-fontSize--md'];
+                    return this.$style['c-mediaElement--fontSizeMedium'];
             }
         }
     }
@@ -141,15 +138,58 @@ export default {
 
 <style lang="scss" module>
 
+$font-sizes: (
+    fontSizeSmall: (
+        title: heading-s,
+        text: body-s,
+    ),
+    fontSizeMedium: (
+        title: heading-m,
+        text: body-l,
+    ),
+    fontSizeLarge: (
+        title: heading-l,
+        text: subheading-s,
+    ),
+    fontSizeXLarge: (
+        title: heading-xl,
+        text: subheading-s,
+    ),
+    fontSizeXXLarge: (
+        title: heading-xxl,
+        text: subheading-l,
+    )
+);
+
 .c-mediaElement {
     display: flex;
     width: 100%;
 }
+
+/**
+ * Modifier – .c-mediaElement--stack
+ *
+ * Applies flex direction column
+ */
 .c-mediaElement--stack {
     flex-direction: column;
-}
-.c-mediaElement--stack.c-mediaElement--reverse {
-    flex-direction: column-reverse;
+
+    /**
+     * Modifier – .c-mediaElement--reverse
+     *
+     * When stacked in flex col applies col-reverse
+     */
+    &.c-mediaElement--reverse {
+        flex-direction: column-reverse;
+
+        & .c-mediaElement-text {
+            margin-bottom: spacing(x3);
+        }
+    }
+
+    & .c-mediaElement-title {
+        margin-top: spacing(x3);
+    }
 }
 
 .c-mediaElement-content {
@@ -158,63 +198,31 @@ export default {
     justify-content: center;
     flex: 1 1 0;
 
-    &--center {
+    /**
+     * Modifier – .c-mediaElement-content--center
+     *
+     * Aligns the content center using flex within the container
+     */
+    &.c-mediaElement-content--center {
         align-items: center;
         text-align: center;
     }
-    &--left {
+    /**
+     * Modifier – .c-mediaElement-content--left
+     *
+     * Aligns the content left using flex within the container
+     */
+    &.c-mediaElement-content--left {
         align-items: flex-start;
     }
-    &--right {
+    /**
+     * Modifier – .c-mediaElement-content--right
+     *
+     * Aligns the content right using flex within the container
+     */
+    &.c-mediaElement-content--right {
         align-items: flex-end;
-    }
-}
-
-.c-mediaElement-title.c-mediaElement-fontSize {
-    &--sm {
-        @include font-size(heading-s);
-    }
-    &--md {
-        @include font-size(heading-m);
-    }
-    &--lg {
-        @include font-size(heading-l);
-        margin-bottom: spacing(x0.5);
-    }
-    &--xl {
-        @include font-size(heading-xl);
-        margin-bottom: spacing(x0.5);
-    }
-    &--xxl {
-        @include font-size(heading-xxl);
-        margin-bottom: spacing(x0.5);
-    }
-}
-
-.c-mediaElement--stack .c-mediaElement-title {
-    margin-top: spacing(x3);
-}
-
-.c-mediaElement-text.c-mediaElement-fontSize {
-    @include font-size(body-l);
-    margin-top: spacing(x0.5);
-    &--sm {
-        @include font-size(body-s);
-    }
-    &--md {
-        @include font-size(body-l);
-    }
-    &--lg {
-        @include font-size(subheading-s);
-        margin-bottom: spacing(x0.5);
-    }
-    &--xl {
-        @include font-size(subheading-s);
-        margin-bottom: spacing(x0.5);
-    }
-    &--xxl {
-        @include font-size(subheading-l);
-        margin-bottom: spacing(x0.5);
+        text-align: right;
     }
 }
 
@@ -223,14 +231,52 @@ export default {
     flex-direction: column;
     flex: 1 1 0;
 
-    &--center {
+    /**
+     * Modifier – .c-mediaElement-imgWrapper--center
+     *
+     * Aligns the image center using flex within the container
+     */
+    &.c-mediaElement-imgWrapper--center {
         align-items: center;
     }
-    &--left {
+    /**
+     * Modifier – .c-mediaElement-imgWrapper--left
+     *
+     * Aligns the image left using flex within the container
+     */
+    &.c-mediaElement-imgWrapper--left {
         align-items: flex-start;
     }
-    &--right {
+    /**
+     * Modifier – .c-mediaElement-imgWrapper--right
+     *
+     * Aligns the image right using flex within the container
+     */
+    &.c-mediaElement-imgWrapper--right {
         align-items: flex-end;
+    }
+}
+
+/**
+ * Modifier – .c-mediaElement--$size
+ *
+ * For each of the above map values under $font-sizes we loop over them applying the value to both title
+ * and text depending on the key using map-get()
+ */
+@each $size, $value in $font-sizes {
+    .c-mediaElement--#{$size} {
+        & .c-mediaElement-title {
+            @include font-size(map-get($value, 'title'));
+        }
+        & .c-mediaElement-text {
+            @include font-size(map-get($value, 'text'));
+            @if $size == fontSizeSmall {
+                margin-top: spacing(x0.5);
+            }
+            @else if $size == fontSizeMedium {
+                margin-top: spacing();
+            }
+        }
     }
 }
 

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -3,17 +3,17 @@
         data-test-id="mediaElement-component"
         :class="[$style['c-mediaElement'], { [$style['c-mediaElement--stack']]: stacked }, { [$style['c-mediaElement--reverse']]: reverse }]">
         <div :class="[$style['c-mediaElement-content'], contentAlignClass]">
-            <h3 :class="$style['c-mediaElement-title']">
+            <h3 :class="[$style['c-mediaElement-title'], { [$style['c-mediaElement-title--large']]: titleLarge }]">
                 {{ title }}
             </h3>
-            <p :class="$style['c-mediaElement-text']">
+            <p :class="[$style['c-mediaElement-text'], { [$style['c-mediaElement-text--large']]: textLarge }]">
                 {{ text }}
             </p>
         </div>
         <div :class="[$style['c-mediaElement-imgWrapper'], imageAlignClass]">
             <img
                 :class="$style['c-mediaBlock-img']"
-                src="https://via.placeholder.com/250"
+                :src="imageUrl"
                 alt="test image">
         </div>
     </div>
@@ -56,6 +56,14 @@ export default {
         imageAlign: {
             type: String,
             default: ALIGN.LEFT
+        },
+        titleLarge: {
+            type: Boolean,
+            default: false
+        },
+        textLarge: {
+            type: Boolean,
+            default: false
         }
     },
     data () {
@@ -124,7 +132,11 @@ export default {
 }
 
 .c-mediaElement-title {
-    @include font-size(subheading-l);
+    @include font-size(heading-m);
+    &--large {
+        @include font-size(heading-xl);
+        margin-bottom: spacing(x0.5);
+    }
 }
 
 .c-mediaElement--stack .c-mediaElement-title {
@@ -134,6 +146,9 @@ export default {
 .c-mediaElement-text {
     @include font-size(body-l);
     margin-top: spacing(x0.5);
+    &--large {
+        @include font-size(subheading-s);
+    }
 }
 
 .c-mediaElement-imgWrapper {

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -1,18 +1,93 @@
 <template>
     <div
-        :class="$style['c-mediaElement']"
-        data-test-id="mediaElement-component">
-        {{ componentName }}
+        data-test-id="mediaElement-component"
+        :class="[$style['c-mediaElement'], { [$style['c-mediaElement--stack']]: stacked }, { [$style['c-mediaElement--reverse']]: reverse }]">
+        <div :class="[$style['c-mediaElement-content'], contentAlignClass]">
+            <h3 :class="$style['c-mediaElement-title']">
+                {{ title }}
+            </h3>
+            <p :class="$style['c-mediaElement-text']">
+                {{ text }}
+            </p>
+        </div>
+        <div :class="[$style['c-mediaElement-imgWrapper'], imageAlignClass]">
+            <img
+                :class="$style['c-mediaBlock-img']"
+                src="https://via.placeholder.com/250"
+                alt="test image">
+        </div>
     </div>
 </template>
 
 <script>
 
+const ALIGN = {
+    LEFT: 'left',
+    RIGHT: 'right',
+    CENTER: 'center'
+};
+
 export default {
+    props: {
+        title: {
+            type: String,
+            required: true
+        },
+        text: {
+            type: String,
+            required: true
+        },
+        imageUrl:  {
+            type: String,
+            required: true
+        },
+        stacked: {
+            type: Boolean,
+            default: false
+        },
+        reverse: {
+            type: Boolean,
+            default: false
+        },
+        contentAlign: {
+            type: String,
+            default: ALIGN.LEFT
+        },
+        imageAlign: {
+            type: String,
+            default: ALIGN.LEFT
+        }
+    },
     data () {
         return {
             componentName: 'MediaElement'
         };
+    },
+    computed: {
+        contentAlignClass () {
+            switch (this.contentAlign) {
+                case ALIGN.LEFT:
+                    return this.$style['c-mediaElement-content--left'];
+                case ALIGN.RIGHT:
+                    return this.$style['c-mediaElement-content--right'];
+                case ALIGN.CENTER:
+                    return this.$style['c-mediaElement-content--center'];
+                default:
+                    return this.$style['c-mediaElement-content--left'];
+            }
+        },
+        imageAlignClass () {
+            switch (this.imageAlign) {
+                case ALIGN.LEFT:
+                    return this.$style['c-mediaElement-imgWrapper--left'];
+                case ALIGN.RIGHT:
+                    return this.$style['c-mediaElement-imgWrapper--right'];
+                case ALIGN.CENTER:
+                    return this.$style['c-mediaElement-imgWrapper--center'];
+                default:
+                    return this.$style['c-mediaElement-imgWrapper--left'];
+            }
+        }
     }
 };
 </script>
@@ -21,13 +96,69 @@ export default {
 
 .c-mediaElement {
     display: flex;
+    width: 100%;
+}
+.c-mediaElement--stack {
+    flex-direction: column;
+}
+.c-mediaElement--stack.c-mediaElement--reverse {
+    flex-direction: column-reverse;
+}
+
+.c-mediaElement-content {
+    display: flex;
+    flex-direction: column;
     justify-content: center;
-    min-height: 80vh;
-    width: 80vw;
-    margin: auto;
-    border: 1px solid $red;
-    font-family: $font-family-base;
-    @include font-size(heading-m);
+    flex: 1 1 0;
+
+    &--center {
+        align-items: center;
+        text-align: center;
+    }
+    &--left {
+        align-items: flex-start;
+    }
+    &--right {
+        align-items: flex-end;
+    }
+}
+
+.c-mediaElement-title {
+    @include font-size(subheading-l);
+}
+
+.c-mediaElement--stack .c-mediaElement-title {
+    margin-top: spacing(x3);
+}
+
+.c-mediaElement-text {
+    @include font-size(body-l);
+    margin-top: spacing(x0.5);
+}
+
+.c-mediaElement-imgWrapper {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 0;
+
+    &--center {
+        align-items: center;
+        .c-mediaBlock-img {
+            align-self: center;
+        }
+    }
+    &--left {
+        align-items: flex-start;
+        .c-mediaBlock-img {
+            align-self: flex-start;
+        }
+    }
+    &--right {
+        align-items: flex-end;
+        .c-mediaBlock-img {
+            align-self: flex-end;
+        }
+    }
 }
 
 </style>

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -119,17 +119,17 @@ export default {
         fontSizeClass () {
             switch (this.textSize) {
                 case FONT_SIZE.SM:
-                    return this.$style['c-mediaElement--fontSizeSmall'];
+                    return this.$style['c-mediaElement-content--fontSizeSmall'];
                 case FONT_SIZE.MD:
-                    return this.$style['c-mediaElement--fontSizeMedium'];
+                    return this.$style['c-mediaElement-content--fontSizeMedium'];
                 case FONT_SIZE.LG:
-                    return this.$style['c-mediaElement--fontSizeLarge'];
+                    return this.$style['c-mediaElement-content--fontSizeLarge'];
                 case FONT_SIZE.XL:
-                    return this.$style['c-mediaElement--fontSizeXLarge'];
+                    return this.$style['c-mediaElement-content--fontSizeXLarge'];
                 case FONT_SIZE.XXL:
-                    return this.$style['c-mediaElement--fontSizeXXLarge'];
+                    return this.$style['c-mediaElement-content--fontSizeXXLarge'];
                 default:
-                    return this.$style['c-mediaElement--fontSizeMedium'];
+                    return this.$style['c-mediaElement-content--fontSizeMedium'];
             }
         }
     }
@@ -264,7 +264,7 @@ $font-sizes: (
  * and text depending on the key using map-get()
  */
 @each $size, $value in $font-sizes {
-    .c-mediaElement--#{$size} {
+    .c-mediaElement-content--#{$size} {
         & .c-mediaElement-title {
             @include font-size(map-get($value, 'title'));
         }

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -1,26 +1,46 @@
 <template>
     <div
         data-test-id="mediaElement-component"
-        :class="[$style['c-mediaElement'], { [$style['c-mediaElement--stack']]: stacked }, { [$style['c-mediaElement--reverse']]: reverse }]">
-        <div :class="[$style['c-mediaElement-content'], contentAlignClass]">
-            <h3 :class="[$style['c-mediaElement-title'], fontSizeClass]">
+        :class="[
+            $style['c-mediaElement'],
+            (stacked ? $style['c-mediaElement--stack'] : ''),
+            (reverse ? $style['c-mediaElement--reverse'] : '')
+        ]">
+        <div
+            :class="[
+                $style['c-mediaElement-content'],
+                contentAlignClass
+            ]">
+            <h3
+                :class="[
+                    $style['c-mediaElement-title'],
+                    fontSizeClass
+                ]">
                 {{ title }}
             </h3>
-            <p :class="[$style['c-mediaElement-text'], fontSizeClass]">
+            <p
+                :class="[
+                    $style['c-mediaElement-text'],
+                    fontSizeClass
+                ]">
                 {{ text }}
             </p>
         </div>
-        <div :class="[$style['c-mediaElement-imgWrapper'], imageAlignClass]">
+        <div
+            :class="[
+                $style['c-mediaElement-imgWrapper'],
+                imageAlignClass
+            ]">
             <img
-                :class="$style['c-mediaBlock-img']"
+                :class="[$style['c-mediaElement-img'], 'c-mediaElement-img--override']"
                 :src="imageUrl"
-                alt="test image">
+                alt="Media Element Image">
         </div>
     </div>
 </template>
 
 <script>
-import { ALIGN, TEXT_SIZE } from '../config';
+import { ALIGN, FONT_SIZE } from '../constants';
 
 export default {
     props: {
@@ -101,15 +121,15 @@ export default {
          */
         fontSizeClass () {
             switch (this.textSize) {
-                case TEXT_SIZE.SM:
+                case FONT_SIZE.SM:
                     return this.$style['c-mediaElement-fontSize--sm'];
-                case TEXT_SIZE.MD:
+                case FONT_SIZE.MD:
                     return this.$style['c-mediaElement-fontSize--md'];
-                case TEXT_SIZE.LG:
+                case FONT_SIZE.LG:
                     return this.$style['c-mediaElement-fontSize--lg'];
-                case TEXT_SIZE.XL:
+                case FONT_SIZE.XL:
                     return this.$style['c-mediaElement-fontSize--xl'];
-                case TEXT_SIZE.XXL:
+                case FONT_SIZE.XXL:
                     return this.$style['c-mediaElement-fontSize--xxl'];
                 default:
                     return this.$style['c-mediaElement-fontSize--md'];
@@ -205,21 +225,12 @@ export default {
 
     &--center {
         align-items: center;
-        .c-mediaBlock-img {
-            align-self: center;
-        }
     }
     &--left {
         align-items: flex-start;
-        .c-mediaBlock-img {
-            align-self: flex-start;
-        }
     }
     &--right {
         align-items: flex-end;
-        .c-mediaBlock-img {
-            align-self: flex-end;
-        }
     }
 }
 

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -3,10 +3,10 @@
         data-test-id="mediaElement-component"
         :class="[$style['c-mediaElement'], { [$style['c-mediaElement--stack']]: stacked }, { [$style['c-mediaElement--reverse']]: reverse }]">
         <div :class="[$style['c-mediaElement-content'], contentAlignClass]">
-            <h3 :class="[$style['c-mediaElement-title'], { [$style['c-mediaElement-title--large']]: titleLarge }]">
+            <h3 :class="[$style['c-mediaElement-title'], $style['c-mediaElement-text'], textSizeClass]">
                 {{ title }}
             </h3>
-            <p :class="[$style['c-mediaElement-text'], { [$style['c-mediaElement-text--large']]: textLarge }]">
+            <p :class="[$style['c-mediaElement-text'], textSizeClass]">
                 {{ text }}
             </p>
         </div>
@@ -20,12 +20,7 @@
 </template>
 
 <script>
-
-const ALIGN = {
-    LEFT: 'left',
-    RIGHT: 'right',
-    CENTER: 'center'
-};
+import { ALIGN, TEXT_SIZE } from '../config';
 
 export default {
     props: {
@@ -57,13 +52,9 @@ export default {
             type: String,
             default: ALIGN.LEFT
         },
-        titleLarge: {
-            type: Boolean,
-            default: false
-        },
-        textLarge: {
-            type: Boolean,
-            default: false
+        textSize: {
+            type: String,
+            default: 'md'
         }
     },
     data () {
@@ -72,6 +63,10 @@ export default {
         };
     },
     computed: {
+        /**
+         * Returns the class to modify the alignment of the content based on the prop contentAlign
+         * @returns {*}
+         */
         contentAlignClass () {
             switch (this.contentAlign) {
                 case ALIGN.LEFT:
@@ -84,6 +79,10 @@ export default {
                     return this.$style['c-mediaElement-content--left'];
             }
         },
+        /**
+         * Returns the class to modify the alignment of the image based on the prop imageAlign
+         * @returns {*}
+         */
         imageAlignClass () {
             switch (this.imageAlign) {
                 case ALIGN.LEFT:
@@ -94,6 +93,26 @@ export default {
                     return this.$style['c-mediaElement-imgWrapper--center'];
                 default:
                     return this.$style['c-mediaElement-imgWrapper--left'];
+            }
+        },
+        /**
+         * Returns the class to modify the font size of the content based on the prop textSize
+         * @returns {*}
+         */
+        textSizeClass () {
+            switch (this.textSize) {
+                case TEXT_SIZE.SM:
+                    return this.$style['c-mediaElement-text--sm'];
+                case TEXT_SIZE.MD:
+                    return this.$style['c-mediaElement-text--md'];
+                case TEXT_SIZE.LG:
+                    return this.$style['c-mediaElement-text--lg'];
+                case TEXT_SIZE.XL:
+                    return this.$style['c-mediaElement-text--xl'];
+                case TEXT_SIZE.XXL:
+                    return this.$style['c-mediaElement-text--xxl'];
+                default:
+                    return this.$style['c-mediaElement-text--md'];
             }
         }
     }
@@ -131,10 +150,23 @@ export default {
     }
 }
 
-.c-mediaElement-title {
-    @include font-size(heading-m);
-    &--large {
+.c-mediaElement-title.c-mediaElement-text {
+    &--sm {
+        @include font-size(heading-s);
+    }
+    &--md {
+        @include font-size(heading-m);
+    }
+    &--lg {
+        @include font-size(heading-l);
+        margin-bottom: spacing(x0.5);
+    }
+    &--xl {
         @include font-size(heading-xl);
+        margin-bottom: spacing(x0.5);
+    }
+    &--xxl {
+        @include font-size(heading-xxl);
         margin-bottom: spacing(x0.5);
     }
 }
@@ -146,8 +178,23 @@ export default {
 .c-mediaElement-text {
     @include font-size(body-l);
     margin-top: spacing(x0.5);
-    &--large {
+    &--sm {
+        @include font-size(body-s);
+    }
+    &--md {
+        @include font-size(body-l);
+    }
+    &--lg {
         @include font-size(subheading-s);
+        margin-bottom: spacing(x0.5);
+    }
+    &--xl {
+        @include font-size(subheading-s);
+        margin-bottom: spacing(x0.5);
+    }
+    &--xxl {
+        @include font-size(subheading-l);
+        margin-bottom: spacing(x0.5);
     }
 }
 

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -3,10 +3,10 @@
         data-test-id="mediaElement-component"
         :class="[$style['c-mediaElement'], { [$style['c-mediaElement--stack']]: stacked }, { [$style['c-mediaElement--reverse']]: reverse }]">
         <div :class="[$style['c-mediaElement-content'], contentAlignClass]">
-            <h3 :class="[$style['c-mediaElement-title'], $style['c-mediaElement-text'], textSizeClass]">
+            <h3 :class="[$style['c-mediaElement-title'], fontSizeClass]">
                 {{ title }}
             </h3>
-            <p :class="[$style['c-mediaElement-text'], textSizeClass]">
+            <p :class="[$style['c-mediaElement-text'], fontSizeClass]">
                 {{ text }}
             </p>
         </div>
@@ -99,20 +99,20 @@ export default {
          * Returns the class to modify the font size of the content based on the prop textSize
          * @returns {*}
          */
-        textSizeClass () {
+        fontSizeClass () {
             switch (this.textSize) {
                 case TEXT_SIZE.SM:
-                    return this.$style['c-mediaElement-text--sm'];
+                    return this.$style['c-mediaElement-fontSize--sm'];
                 case TEXT_SIZE.MD:
-                    return this.$style['c-mediaElement-text--md'];
+                    return this.$style['c-mediaElement-fontSize--md'];
                 case TEXT_SIZE.LG:
-                    return this.$style['c-mediaElement-text--lg'];
+                    return this.$style['c-mediaElement-fontSize--lg'];
                 case TEXT_SIZE.XL:
-                    return this.$style['c-mediaElement-text--xl'];
+                    return this.$style['c-mediaElement-fontSize--xl'];
                 case TEXT_SIZE.XXL:
-                    return this.$style['c-mediaElement-text--xxl'];
+                    return this.$style['c-mediaElement-fontSize--xxl'];
                 default:
-                    return this.$style['c-mediaElement-text--md'];
+                    return this.$style['c-mediaElement-fontSize--md'];
             }
         }
     }
@@ -150,7 +150,7 @@ export default {
     }
 }
 
-.c-mediaElement-title.c-mediaElement-text {
+.c-mediaElement-title.c-mediaElement-fontSize {
     &--sm {
         @include font-size(heading-s);
     }
@@ -175,7 +175,7 @@ export default {
     margin-top: spacing(x3);
 }
 
-.c-mediaElement-text {
+.c-mediaElement-text.c-mediaElement-fontSize {
     @include font-size(body-l);
     margin-top: spacing(x0.5);
     &--sm {

--- a/packages/components/molecules/f-media-element/src/config.js
+++ b/packages/components/molecules/f-media-element/src/config.js
@@ -1,0 +1,13 @@
+export const ALIGN = {
+    LEFT: 'left',
+    RIGHT: 'right',
+    CENTER: 'center'
+};
+
+export const TEXT_SIZE = {
+    SM: 'sm',
+    MD: 'md',
+    LG: 'lg',
+    XL: 'xl',
+    XXL: 'xxl'
+};

--- a/packages/components/molecules/f-media-element/src/constants.js
+++ b/packages/components/molecules/f-media-element/src/constants.js
@@ -4,7 +4,7 @@ export const ALIGN = {
     CENTER: 'center'
 };
 
-export const TEXT_SIZE = {
+export const FONT_SIZE = {
     SM: 'sm',
     MD: 'md',
     LG: 'lg',

--- a/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
+++ b/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
@@ -26,6 +26,5 @@ MediaElementComponent.args = {
     contentAlign: 'left',
     imageAlign: 'center',
     imageUrl: 'https://via.placeholder.com/250',
-    titleLarge: true,
-    textLarge: true
+    textSize: 'xxl'
 };

--- a/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
+++ b/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
@@ -24,6 +24,7 @@ MediaElementComponent.args = {
     text: 'See the stamps you’ve collected and any discounts you’ve earned.',
     stacked: false,
     reverse: true,
+    altText: 'Test alt text',
     imageUrl: 'https://via.placeholder.com/250',
 };
 

--- a/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
+++ b/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
@@ -19,11 +19,13 @@ export const MediaElementComponent = (args, { argTypes }) => ({
 MediaElementComponent.storyName = 'f-media-element';
 
 MediaElementComponent.args = {
-    title: 'Earn',
-    text: 'Each stamp you collect from a restaurant is worth up to 15% of your order’s value and will be saved under its own StampCard.',
-    stacked: true,
+    title: 'Stampcards',
+    text: 'See the stamps you’ve collected and any discounts you’ve earned.',
+    stacked: false,
     reverse: true,
-    contentAlign: 'center',
+    contentAlign: 'left',
     imageAlign: 'center',
-    imageUrl: 'https://via.placeholder.com/250'
+    imageUrl: 'https://via.placeholder.com/250',
+    titleLarge: true,
+    textLarge: true
 };

--- a/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
+++ b/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
@@ -4,6 +4,7 @@
 // } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
 import MediaElement from '../src/components/MediaElement.vue';
+import { ALIGN, FONT_SIZE } from '../src/constants';
 
 export default {
     title: 'Components/Molecules',
@@ -23,8 +24,20 @@ MediaElementComponent.args = {
     text: 'See the stamps you’ve collected and any discounts you’ve earned.',
     stacked: false,
     reverse: true,
-    contentAlign: 'left',
-    imageAlign: 'center',
     imageUrl: 'https://via.placeholder.com/250',
-    textSize: 'xxl'
+};
+
+MediaElementComponent.argTypes = {
+    textSize: {
+        control: { type: 'select', options: [...Object.entries(FONT_SIZE).map(([, value]) => value)] },
+        defaultValue: 'xxl'
+    },
+    contentAlign: {
+        control: { type: 'select', options: [...Object.entries(ALIGN).map(([, value]) => value)] },
+        defaultValue: 'left'
+    },
+    imageAlign: {
+        control: { type: 'select', options: [...Object.entries(ALIGN).map(([, value]) => value)] },
+        defaultValue: 'center'
+    }
 };

--- a/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
+++ b/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
@@ -10,11 +10,20 @@ export default {
     decorators: [withA11y]
 };
 
-export const MediaElementComponent = () => ({
+export const MediaElementComponent = (args, { argTypes }) => ({
     components: { MediaElement },
-    props: {
-    },
-    template: `<media-element />`
+    props: Object.keys(argTypes),
+    template: '<media-element v-bind="$props" />'
 });
 
 MediaElementComponent.storyName = 'f-media-element';
+
+MediaElementComponent.args = {
+    title: 'Earn',
+    text: 'Each stamp you collect from a restaurant is worth up to 15% of your order’s value and will be saved under its own StampCard.',
+    stacked: true,
+    reverse: true,
+    contentAlign: 'center',
+    imageAlign: 'center',
+    imageUrl: 'https://via.placeholder.com/250'
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1940,14 +1940,6 @@
     "@justeat/f-services" "1.0.0"
     "@justeat/f-vue-icons" "1.11.0"
 
-"@justeat/f-form-field@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-1.7.0.tgz#0bb47182479524832766b4a7d172e73ca00550da"
-  integrity sha512-N9CYI+molFie1rPzEYB5Iq8dAk2ULZDUNILaSHuvA1KPe2mMRatU0TkTcnd/T76JYPztNljvmaZ2B+Mqlf1Ehw==
-  dependencies:
-    "@justeat/f-services" "1.0.0"
-    "@justeat/f-vue-icons" "1.11.0"
-
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-0.2.0.tgz#90ec559642c165b6325669c506c417abe09fa5dd"
@@ -2046,6 +2038,13 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.2.0.tgz#74b08c7539f3790cddc7f98df148c2642fcf0a75"
   integrity sha512-TI0Jwd2vBCVCwR26CDZhzp2Xdd35T+12sX3mkoztx14XpJ+EXJ7elR9SmI/N1vZ59o8sRP6Ix7iV+mSeAGv9Zg==
+  dependencies:
+    babel-helper-vue-jsx-merge-props "2.0.3"
+
+"@justeat/f-vue-icons@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-2.3.0.tgz#8fddbd2f48bc63efa3d162c81a4e79e22874b09a"
+  integrity sha512-bXcAy5T79LH0rS16v62Lh4VwxG7W7t8C9SlgY0KJIK99IZiV3bJS2MK+sIQvWmLMZIJi4qxNeWhUFVXHqPaTuw==
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1940,6 +1940,14 @@
     "@justeat/f-services" "1.0.0"
     "@justeat/f-vue-icons" "1.11.0"
 
+"@justeat/f-form-field@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-1.7.0.tgz#0bb47182479524832766b4a7d172e73ca00550da"
+  integrity sha512-N9CYI+molFie1rPzEYB5Iq8dAk2ULZDUNILaSHuvA1KPe2mMRatU0TkTcnd/T76JYPztNljvmaZ2B+Mqlf1Ehw==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+    "@justeat/f-vue-icons" "1.11.0"
+
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-0.2.0.tgz#90ec559642c165b6325669c506c417abe09fa5dd"


### PR DESCRIPTION
This is the start of a new media element component. It's designed to provide a component that can take in a Title, text and image and display them in a bunch of orientations and alignments. It also allows changing text size to be one from SM, MD, LG, XL, XXL. 

The component consists of two equal spaced blocks one the content the other the image, this allows for full flexibility.

I will be adding some unit tests in an additional PR to allow this to be a smaller PR. 

## UI Review Checks

Example being used:

![Screenshot 2021-02-01 at 15 51 26](https://user-images.githubusercontent.com/15876339/106482456-60b83b00-64a5-11eb-9138-efb9d0f2e1a8.png)

Some other examples: 

![Screenshot 2021-02-01 at 15 44 36](https://user-images.githubusercontent.com/15876339/106481679-94469580-64a4-11eb-976a-3f0d12f1a411.png)
![Screenshot 2021-02-01 at 15 45 11](https://user-images.githubusercontent.com/15876339/106481682-9577c280-64a4-11eb-8b4a-f9e09230c54c.png)
![Screenshot 2021-02-01 at 15 45 32](https://user-images.githubusercontent.com/15876339/106481687-96a8ef80-64a4-11eb-9c03-81147274d038.png)


## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)
