### PR TITLE
f-breadcrumbs@0.2.0 - style + layout + component

### DIFF
--- a/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
+++ b/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.2.0
+------------------------------
+*February 02, 2021*
+
+### Added
+- Added styles, component structure and updated story.
+
+
 v0.1.0
 ------------------------------
 *January 20, 2021*

--- a/packages/components/molecules/f-breadcrumbs/package.json
+++ b/packages/components/molecules/f-breadcrumbs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-breadcrumbs",
   "description": "Fozzie Bread Crumbs – Provides clickable paths back to previous pages",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/f-breadcrumbs.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
+++ b/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
@@ -48,6 +48,11 @@ export default {
         }
     },
     methods: {
+        /**
+       * Function to add active class to the last link
+       * @param index
+       * @returns {*|string}
+       */
         linkActiveClass (index) {
             return index === this.links.length - 1 ? this.$style['c-breadcrumbs-link--active'] : '';
         }
@@ -81,7 +86,8 @@ $breadcrumbs-active-font-weight: $font-weight-base;
         padding: spacing(x0.5) spacing(x2) spacing(x0.5) spacing();
     }
 }
-.c-breadcrumbs-item, .c-breadcrumbs-separator {
+.c-breadcrumbs-item,
+.c-breadcrumbs-separator {
     @include media('<narrowMid') {
         display: none;
         &:nth-last-child(-n+4):not(:nth-last-child(-n+2)) {

--- a/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
+++ b/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
@@ -1,7 +1,7 @@
 <template>
     <div :class="$style['c-breadcrumbs']">
         <ul :class="$style['c-breadcrumbs-list']">
-            <template v-for="(link, index) in links">
+            <template v-for="({ name, url }, index) in links">
                 <li
                     v-if="index !== 0"
                     :key="`${index}_link`"
@@ -11,7 +11,18 @@
                 <li
                     :key="`${index}_separator`"
                     :class="$style['c-breadcrumbs-item']">
-                    <a :class="[$style['c-breadcrumbs-link'], { [$style['c-breadcrumbs-link--active']]: index === links.length - 1 }]">{{ link }}</a>
+                    <router-link
+                        v-if="routerLinks"
+                        :to="url"
+                        :class="[$style['c-breadcrumbs-link'], linkActiveClass(index)]">
+                        {{ name }}
+                    </router-link>
+                    <a
+                        v-else
+                        :href="url"
+                        :class="[$style['c-breadcrumbs-link'], linkActiveClass(index)]">
+                        {{ name }}
+                    </a>
                 </li>
             </template>
         </ul>
@@ -19,29 +30,23 @@
 </template>
 
 <script>
-import { globalisationServices } from '@justeat/f-services';
-import tenantConfigs from '../tenants';
 
 export default {
     name: 'Breadcrumbs',
-    components: {},
     props: {
-        locale: {
-            type: String,
-            default: ''
-        },
         links: {
             type: Array,
             default: () => []
+        },
+        routerLinks: {
+            type: Boolean,
+            default: true
         }
     },
-    data () {
-        const locale = globalisationServices.getLocale(tenantConfigs, this.locale, this.$i18n);
-        const localeConfig = tenantConfigs[locale];
-
-        return {
-            copy: { ...localeConfig }
-        };
+    methods: {
+        linkActiveClass (index) {
+            return index === this.links.length - 1 ? this.$style['c-breadcrumbs-link--active'] : '';
+        }
     }
 };
 </script>
@@ -84,6 +89,7 @@ $breadcrumbs-active-font-weight: $font-weight-base;
     color: $breadcrumbs-text-colour;
     font-weight: $breadcrumbs-not-active-font-weight;
     cursor: pointer;
+    text-decoration: none;
     &:hover {
         text-decoration: underline;
         color: $breadcrumbs-text-colour;

--- a/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
+++ b/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
@@ -3,7 +3,7 @@
         data-test-id="breadcrumbs-component"
         :class="$style['c-breadcrumbs']">
         <ul :class="$style['c-breadcrumbs-list']">
-            <template v-for="({ name, url }, index) in links">
+            <template v-for="({ name, url, routerLink }, index) in links">
                 <li
                     v-if="index !== 0"
                     :key="`${index}_link`"
@@ -14,7 +14,7 @@
                     :key="`${index}_separator`"
                     :class="$style['c-breadcrumbs-item']">
                     <router-link
-                        v-if="routerLinks"
+                        v-if="routerLink"
                         :to="url"
                         :class="[
                             $style['c-breadcrumbs-link'],
@@ -45,10 +45,6 @@ export default {
         links: {
             type: Array,
             default: () => []
-        },
-        routerLinks: {
-            type: Boolean,
-            default: true
         }
     },
     methods: {

--- a/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
+++ b/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
@@ -1,21 +1,19 @@
 <template>
     <div :class="$style['c-breadcrumbs']">
         <ul :class="$style['c-breadcrumbs-list']">
-            <li :class="$style['c-breadcrumbs-item']">
-                <a :class="$style['c-breadcrumbs-link']">Home</a>
-            </li>
-            <li :class="$style['c-breadcrumbs-separator']">
-                >
-            </li>
-            <li :class="$style['c-breadcrumbs-item']">
-                <a :class="$style['c-breadcrumbs-link']">For You</a>
-            </li>
-            <li :class="$style['c-breadcrumbs-separator']">
-                >
-            </li>
-            <li :class="$style['c-breadcrumbs-item']">
-                <a :class="[$style['c-breadcrumbs-link'], $style['c-breadcrumbs-link--active']]">Stamp Cards</a>
-            </li>
+            <template v-for="(link, index) in links">
+                <li
+                    v-if="index !== 0"
+                    :key="`${index}_link`"
+                    :class="$style['c-breadcrumbs-separator']">
+                    >
+                </li>
+                <li
+                    :key="`${index}_separator`"
+                    :class="$style['c-breadcrumbs-item']">
+                    <a :class="[$style['c-breadcrumbs-link'], { [$style['c-breadcrumbs-link--active']]: index === links.length - 1 }]">{{ link }}</a>
+                </li>
+            </template>
         </ul>
     </div>
 </template>
@@ -66,7 +64,6 @@ $breadcrumbs-active-font-weight: $font-weight-base;
     margin: 0;
     padding: 0;
     display: flex;
-    flex-flow: row;
     align-items: center;
 }
 .c-breadcrumbs-item {
@@ -89,6 +86,7 @@ $breadcrumbs-active-font-weight: $font-weight-base;
     cursor: pointer;
     &:hover {
         text-decoration: underline;
+        color: $breadcrumbs-text-colour;
     }
 }
 .c-breadcrumbs-separator {

--- a/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
+++ b/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
@@ -1,5 +1,7 @@
 <template>
-    <div :class="$style['c-breadcrumbs']">
+    <div
+        data-test-id="breadcrumbs-component"
+        :class="$style['c-breadcrumbs']">
         <ul :class="$style['c-breadcrumbs-list']">
             <template v-for="({ name, url }, index) in links">
                 <li

--- a/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
+++ b/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
@@ -73,7 +73,7 @@ $breadcrumbs-active-font-weight: $font-weight-base;
     }
 }
 .c-breadcrumbs-item, .c-breadcrumbs-separator {
-    @include media('<narrowMid'){
+    @include media('<narrowMid') {
         display: none;
         &:nth-last-child(-n+4):not(:nth-last-child(-n+2)) {
             display: block;

--- a/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
+++ b/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
@@ -14,13 +14,19 @@
                     <router-link
                         v-if="routerLinks"
                         :to="url"
-                        :class="[$style['c-breadcrumbs-link'], linkActiveClass(index)]">
+                        :class="[
+                            $style['c-breadcrumbs-link'],
+                            linkActiveClass(index)
+                        ]">
                         {{ name }}
                     </router-link>
                     <a
                         v-else
                         :href="url"
-                        :class="[$style['c-breadcrumbs-link'], linkActiveClass(index)]">
+                        :class="[
+                            $style['c-breadcrumbs-link'],
+                            linkActiveClass(index)
+                        ]">
                         {{ name }}
                     </a>
                 </li>

--- a/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
+++ b/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
@@ -1,8 +1,22 @@
 <template>
-    <div
-        :class="$style['c-breadcrumbs']"
-        data-test-id="breadcrumbs-component">
-        {{ copy.text }}
+    <div :class="$style['c-breadcrumbs']">
+        <ul :class="$style['c-breadcrumbs-list']">
+            <li :class="$style['c-breadcrumbs-item']">
+                <a :class="$style['c-breadcrumbs-link']">Home</a>
+            </li>
+            <li :class="$style['c-breadcrumbs-separator']">
+                >
+            </li>
+            <li :class="$style['c-breadcrumbs-item']">
+                <a :class="$style['c-breadcrumbs-link']">For You</a>
+            </li>
+            <li :class="$style['c-breadcrumbs-separator']">
+                >
+            </li>
+            <li :class="$style['c-breadcrumbs-item']">
+                <a :class="[$style['c-breadcrumbs-link'], $style['c-breadcrumbs-link--active']]">Stamp Cards</a>
+            </li>
+        </ul>
     </div>
 </template>
 
@@ -17,6 +31,10 @@ export default {
         locale: {
             type: String,
             default: ''
+        },
+        links: {
+            type: Array,
+            default: () => []
         }
     },
     data () {
@@ -32,15 +50,58 @@ export default {
 
 <style lang="scss" module>
 
+$breadcrumbs-text-colour: $white;
+$breadcrumbs-background-colour: rgba($black, 0.6);
+$breadcrumbs-border-radius: 16px;
+$breadcrumbs-not-active-font-weight: $font-weight-bold;
+$breadcrumbs-active-font-weight: $font-weight-base;
+
 .c-breadcrumbs {
     display: flex;
-    justify-content: center;
-    min-height: 80vh;
-    width: 80vw;
-    margin: auto;
-    border: 1px solid $red;
-    font-family: $font-family-base;
-    @include font-size(heading-m);
+}
+.c-breadcrumbs-list {
+    list-style: none;
+    background-color: $breadcrumbs-background-colour;
+    border-radius: $breadcrumbs-border-radius;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-flow: row;
+    align-items: center;
+}
+.c-breadcrumbs-item {
+    padding: spacing(x0.5) spacing(x2);
+    @include media('<narrowMid') {
+        padding: spacing(x0.5) spacing(x2) spacing(x0.5) spacing();
+    }
+}
+.c-breadcrumbs-item, .c-breadcrumbs-separator {
+    @include media('<narrowMid'){
+        display: none;
+        &:nth-last-child(-n+4):not(:nth-last-child(-n+2)) {
+            display: block;
+        }
+    }
+}
+.c-breadcrumbs-link {
+    color: $breadcrumbs-text-colour;
+    font-weight: $breadcrumbs-not-active-font-weight;
+    cursor: pointer;
+    &:hover {
+        text-decoration: underline;
+    }
+}
+.c-breadcrumbs-separator {
+    color: $breadcrumbs-text-colour;
+    transform: scale(0.6, 1.2);
+    @include media('<narrowMid') {
+        margin-left: spacing(x1.5);
+        transform: scale(0.6, 1.2) rotate(180deg);
+        margin-top: 2px;
+    }
+}
+.c-breadcrumbs-link--active {
+    font-weight: $breadcrumbs-active-font-weight;
 }
 
 </style>

--- a/packages/components/molecules/f-breadcrumbs/stories/Breadcrumbs.stories.js
+++ b/packages/components/molecules/f-breadcrumbs/stories/Breadcrumbs.stories.js
@@ -20,7 +20,10 @@ export const BreadcrumbsComponent = () => ({
     //         default: boolean('fullWidth', false)
     //     }
     // },
-    template: '<breadcrumbs />'
+    template: '<breadcrumbs :links="links" />',
+    data: () => ({
+        links: ['Home', 'For you', 'Stamp Cards']
+    })
 });
 
 BreadcrumbsComponent.storyName = 'f-breadcrumbs';

--- a/packages/components/molecules/f-breadcrumbs/stories/Breadcrumbs.stories.js
+++ b/packages/components/molecules/f-breadcrumbs/stories/Breadcrumbs.stories.js
@@ -6,7 +6,7 @@ import { withA11y } from '@storybook/addon-a11y';
 import Breadcrumbs from '../src/components/Breadcrumbs.vue';
 
 export default {
-    title: 'Components',
+    title: 'Components/molecules',
     decorators: [withA11y]
 };
 

--- a/packages/components/molecules/f-breadcrumbs/stories/Breadcrumbs.stories.js
+++ b/packages/components/molecules/f-breadcrumbs/stories/Breadcrumbs.stories.js
@@ -10,20 +10,32 @@ export default {
     decorators: [withA11y]
 };
 
-export const BreadcrumbsComponent = () => ({
+export const BreadcrumbsComponent = (args, { argTypes }) => ({
     components: { Breadcrumbs },
-    // props: {
-    //     buttonType: {
-    //         default: select('Button Type', ['primary', 'primaryAlt', 'secondary', 'tertiary', 'link'])
-    //     },
-    //     fullWidth: {
-    //         default: boolean('fullWidth', false)
-    //     }
-    // },
-    template: '<breadcrumbs :links="links" />',
-    data: () => ({
-        links: ['Home', 'For you', 'Stamp Cards']
-    })
+    props: Object.keys(argTypes),
+    template: '<breadcrumbs v-bind="$props" />'
 });
 
 BreadcrumbsComponent.storyName = 'f-breadcrumbs';
+
+/**
+ * Arguments without specified controls
+ * @type {{routerLinks: boolean}}
+ */
+BreadcrumbsComponent.args = {
+    links: [
+        {
+            name: 'Home',
+            url: '/'
+        },
+        {
+            name: 'For You',
+            url: '/offers'
+        },
+        {
+            name: 'Stampcards',
+            url: '/offers/stamp-cards'
+        }
+    ],
+    routerLinks: false
+};

--- a/packages/components/molecules/f-breadcrumbs/stories/Breadcrumbs.stories.js
+++ b/packages/components/molecules/f-breadcrumbs/stories/Breadcrumbs.stories.js
@@ -26,16 +26,18 @@ BreadcrumbsComponent.args = {
     links: [
         {
             name: 'Home',
-            url: '/'
+            url: '/',
+            routerLink: false
         },
         {
             name: 'For You',
-            url: '/offers'
+            url: '/offers',
+            routerLink: false
         },
         {
             name: 'Stampcards',
-            url: '/offers/stamp-cards'
+            url: '/offers/stamp-cards',
+            routerLink: false
         }
-    ],
-    routerLinks: false
+    ]
 };

--- a/packages/components/molecules/f-breadcrumbs/stories/Breadcrumbs.stories.js
+++ b/packages/components/molecules/f-breadcrumbs/stories/Breadcrumbs.stories.js
@@ -6,7 +6,7 @@ import { withA11y } from '@storybook/addon-a11y';
 import Breadcrumbs from '../src/components/Breadcrumbs.vue';
 
 export default {
-    title: 'Components/molecules',
+    title: 'Components/Molecules',
     decorators: [withA11y]
 };
 

--- a/packages/components/molecules/f-breadcrumbs/test/specs/component/f-breadcrumbs.component.spec.js
+++ b/packages/components/molecules/f-breadcrumbs/test/specs/component/f-breadcrumbs.component.spec.js
@@ -2,7 +2,7 @@ import BreadcrumbsComponent from '../../../test-utils/component-objects/f-breadc
 
 describe('f-breadcrumbs component tests', () => {
     beforeEach(() => {
-        browser.url('/?path=/story/components--breadcrumbs-component');
+        browser.url('/?path=/story/components-molecules--breadcrumbs-component');
         browser.switchToFrame(0);
         BreadcrumbsComponent.waitForBreadcrumbsComponent();
     });


### PR DESCRIPTION
This is the beginning of the breadcrumbs component, I have added the option to switch between normal `a` tag and router links. Style is based on the current breadcrumbs on https://www.just-eat.co.uk/takeaway/nearme/sushi for example. It's been slightly modified in the new design to have bold text before the last breadcrumb. 

When on mobile it only shows the next up from last breadcrumb. I will add unit tests in a separate PR to keep the PR size smaller. 

## UI Review Checks

![Screenshot 2021-02-02 at 11 51 13](https://user-images.githubusercontent.com/15876339/106596551-17bbc180-654d-11eb-8641-07d958438d9e.png)
![Screenshot 2021-02-02 at 11 51 25](https://user-images.githubusercontent.com/15876339/106596556-1a1e1b80-654d-11eb-965c-67d9373fc83c.png)


## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)
