### PR TITLE
storybook@v0.22.0 – Updating storybook theming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.9.0
+------------------------------
+*February 4, 2021*
+
+### Changed
+- Re-organisation of the `/stories` folder.
+
+### Fixed
+- Danger not checking `storybook` package changes correctly, because path wasn't present in directory match.
+
+
 v3.8.0
 ------------------------------
 *February 4, 2021*
 
 ### Added
-- `f-wdio-utils` package in the services folder - for the `page-object` file and other webdriverio utils. 
+- `f-wdio-utils` package in the services folder - for the `page-object` file and other webdriverio utils.
 
 
 v3.7.1

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -12,7 +12,8 @@ if (!isTrivial) {
         'packages/components/molecules/',
         'packages/components/organisms/',
         'packages/services/',
-        'packages/tools/'
+        'packages/tools/',
+        'packages/'
     ];
     const modifiedFiles = danger.git.modified_files;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -4,6 +4,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.22.0
+------------------------------
+*February 4, 2021*
+
+### Fixed
+- `ul` bullet styling updated to show in mdx files.
+- `stories` glob updated to find stories within subfolders of the `stories/` directory.
+
+### Changed
+- Base theme config added to mdx files (including `JustEatBasis` font).
+- Font size and margins for sidebar subheadings has been decreased.
+- Story ordering added to Storybook config (via `storySort` object in `preview.js`).
+- Documentation stories moved into sub-folder structure.
+
+
 v0.21.0
 ------------------------------
 *December 30, 2020*

--- a/packages/storybook/config/storybook/main.js
+++ b/packages/storybook/config/storybook/main.js
@@ -1,7 +1,7 @@
 module.exports = {
     stories: [
         '../../../**/*.stories.@(js|mdx)',
-        '../../../../stories/*.stories.@(js|mdx)'
+        '../../../../stories/**/*.stories.@(js|mdx)'
     ],
     addons: [
         '@storybook/addon-essentials',

--- a/packages/storybook/config/storybook/manager-head.html
+++ b/packages/storybook/config/storybook/manager-head.html
@@ -1,6 +1,7 @@
 <link rel="shortcut icon" href="/storybook.ico" type="image/x-icon">
 
-<link rel="preload" href="https://d30v2pzvrfyzpo.cloudfront.net/fonts/JustEatBasis-Regular-optimised.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://d30v2pzvrfyzpo.cloudfront.net/fonts/JustEatBasis-Regular-optimised.woff2" as="font"
+    type="font/woff2" crossorigin>
 
 <script>
     (function () {
@@ -84,7 +85,7 @@
 
     [data-title] a {
         color: #fff;
-        font-size: 16px;
-        margin-bottom: 8px;
+        font-size: 14px;
+        margin-bottom: 4px;
     }
 </style>

--- a/packages/storybook/config/storybook/preview-head.html
+++ b/packages/storybook/config/storybook/preview-head.html
@@ -1,22 +1,16 @@
-<link rel="preload" href="https://d30v2pzvrfyzpo.cloudfront.net/fonts/JustEatBasis-Regular-optimised.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://d30v2pzvrfyzpo.cloudfront.net/fonts/JustEatBasis-Regular-optimised.woff2" as="font"
+    type="font/woff2" crossorigin>
 
 <style>
     @font-face {
         font-family: JustEatBasis;
-        src: url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JustEatBasis-Regular-optimised.woff2') format("woff2"),
-            url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JustEatBasis-Regular-optimised.woff') format("woff");
+        src: url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JustEatBasis-Regular-optimised.woff2') format('woff2'),
+            url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JustEatBasis-Regular-optimised.woff') format('woff');
         font-weight: 400;
         font-display: swap;
     }
 
     body {
-        font-feature-settings: "tnum"; /* Enable tabular numbers */
-    }
-
-    /*
-     * Remove default list style type
-     */
-    ul.sbdocs-ul {
-        list-style-type: none;
+        font-feature-settings: 'tnum'; /* Enable tabular numbers */
     }
 </style>

--- a/packages/storybook/config/storybook/preview.js
+++ b/packages/storybook/config/storybook/preview.js
@@ -1,6 +1,30 @@
+/* eslint-disable import/prefer-default-export */
 import Vue from 'vue';
 import setupContext from '../../context';
+import jetPieThemeDark from './jetPieThemeDark';
 
 setupContext();
 
 Vue.config.devtools = true;
+
+export const parameters = {
+    docs: {
+        theme: jetPieThemeDark
+    },
+    options: {
+        storySort: {
+            order: ['Documentation',
+                [
+                    'Getting Started',
+                    [
+                        'Intro',
+                        'Development Principles',
+                        'Troubleshooting'
+                    ],
+                    'Standards',
+                    'Setup Guides'
+                ],
+                'Components']
+        }
+    }
+};

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "scripts": {
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -s public -p 8080 -c config/storybook",

--- a/stories/getting-started/getting-started.stories.mdx
+++ b/stories/getting-started/getting-started.stories.mdx
@@ -1,4 +1,4 @@
-<Meta title="Documentation/Getting-Started"/>
+<Meta title="Documentation/Getting Started/Intro"/>
 
 # Getting Started
 

--- a/stories/getting-started/troubleshooting.stories.mdx
+++ b/stories/getting-started/troubleshooting.stories.mdx
@@ -1,4 +1,4 @@
-<Meta title="Documentation/Troubleshooting"/>
+<Meta title="Documentation/Getting Started/Troubleshooting"/>
 
 # Troubleshooting
 Looking to get involved in the mono repo but running into issues? Read on to find out how to fix them!

--- a/stories/guides/typography.stories.mdx
+++ b/stories/guides/typography.stories.mdx
@@ -1,4 +1,4 @@
-<Meta title="Documentation/Typography"/>
+<Meta title="Documentation/Setup Guides/Typography"/>
 
 # Typography
 


### PR DESCRIPTION
### Fixed
- `ul` bullet styling updated to show in mdx files.
- `stories` glob updated to find stories within subfolders of the `stories/` directory.

### Changed
- Base theme config added to mdx files (including `JustEatBasis` font).
- Font size and margins for sidebar subheadings has been decreased.
- Story ordering added to Storybook config (via `storySort` object in `preview.js`).
- Documentation stories moved into sub-folder structure.

---

## UI Review Checks

<img width="1663" alt="Screen Shot 2021-02-04 at 12 50 58" src="https://user-images.githubusercontent.com/805184/106895050-ab28fa00-66e7-11eb-8c42-5867e748199f.png">

- [x] README and/or UI Documentation has been updated

