### PR TITLE
f-searchbox@v4.0.0-beta.24 - Save full address as cased.

### DIFF
--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.0.0-beta.24
+------------------------------
+*February 8, 2021*
+
+### Changed
+- Full address keys saves as capitalisation.
+
+
 v4.0.0-beta.23
 ------------------------------
 *February 4, 2021*

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-searchbox",
   "description": "Fozzie Searchbox – Just Eat Takeaway Global Searchbox",
-  "version": "4.0.0-beta.23",
+  "version": "4.0.0-beta.24",
   "main": "dist/f-searchbox.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-searchbox/src/store/searchbox.module.js
+++ b/packages/components/molecules/f-searchbox/src/store/searchbox.module.js
@@ -453,15 +453,15 @@ export default {
                     line5,
                     postcode
                 }) => ({
-                    city,
-                    field1,
-                    field2,
-                    line1,
-                    line2,
-                    line3,
-                    line4,
-                    line5,
-                    postcode,
+                    City: city,
+                    Field1: field1,
+                    Field2: field2,
+                    Line1: line1,
+                    Line2: line2,
+                    Line3: line3,
+                    Line4: line4,
+                    Line5: line5,
+                    PostalCode: postcode,
                     searchBoxAddress: address
                 }));
             }


### PR DESCRIPTION
Saves full address to a format CW UK is already setup to read. We can revert this change once v4.0.0 is rolled out. It will be tricky to rollout CW UK & a new version of f-searchbox at the same time (considering legacy f-searchbox will be live too) so this change removes the need to make any CW UK changes when v4.0.0 goes live.

### Changed

- Full address keys saves as capitalisation.