### PR TITLE
f-footer@4.8.3 - small style bug fix for f-footer #trivial

### DIFF
--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -4,9 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.8.3
+------------------------------
+*February 9, 2021*
+
+### Added
+- All tenants to a tenant prop for storybook f-footer story
+- New modifier css class to fix footer items alignment 
+
+
 v4.8.2
 ------------------------------
-_February 04, 2021_
+*February 4, 2021*
 
 ### Changed
 - AUS Menulog footer links update

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-footer/src/components/Footer.vue
+++ b/packages/components/organisms/f-footer/src/components/Footer.vue
@@ -45,7 +45,7 @@
 
         <div
             :class="['c-footer-container c-footer-row c-footer-row--combined c-footer-row--notEqualTopAndBottomPad c-footer-row--noPadBelowWide',
-                     { 'c-footer-row--rightAlignedOnDesktopView': !showCountrySelector }]">
+                     { 'c-footer-row--rightAlignedAboveWide': !showCountrySelector }]">
             <country-selector
                 v-if="showCountrySelector"
                 data-test-id="country-selector"
@@ -56,7 +56,7 @@
 
             <legal-field
                 v-if="metaLegalFieldEnabled"
-                :class="[{ 'c-footer-row-item--fullWidthOnDesktopView': !showCountrySelector }]"
+                :class="[{ 'c-footer-row-item--fullWidthAboveWide': !showCountrySelector }]"
                 :info="copy.metaLegalField" />
 
             <icon-list
@@ -215,7 +215,7 @@ $footer-heading-font-size: 'heading-s';
     padding-bottom: 0;
 }
 
-.c-footer-row--rightAlignedOnDesktopView {
+.c-footer-row--rightAlignedAboveWide {
     justify-content: flex-end;
 
     @include media('<wide') {
@@ -223,7 +223,7 @@ $footer-heading-font-size: 'heading-s';
     }
 }
 
-.c-footer-row-item--fullWidthOnDesktopView {
+.c-footer-row-item--fullWidthAboveWide {
     @include media('>=wide') {
         flex: 1;
     }

--- a/packages/components/organisms/f-footer/src/components/Footer.vue
+++ b/packages/components/organisms/f-footer/src/components/Footer.vue
@@ -56,6 +56,7 @@
 
             <legal-field
                 v-if="metaLegalFieldEnabled"
+                :class="[{ 'c-footer-row-item--fullWidthOnDesktopView': !showCountrySelector }]"
                 :info="copy.metaLegalField" />
 
             <icon-list
@@ -219,6 +220,12 @@ $footer-heading-font-size: 'heading-s';
 
     @include media('<wide') {
         justify-content: flex-start;
+    }
+}
+
+.c-footer-row-item--fullWidthOnDesktopView {
+    @include media('>=wide') {
+        flex: 1;
     }
 }
 

--- a/packages/components/organisms/f-footer/stories/footer.stories.js
+++ b/packages/components/organisms/f-footer/stories/footer.stories.js
@@ -22,13 +22,20 @@ export const FooterComponent = () => ({
     components: { VueFooter },
     props: {
         locale: {
-            default: select('Locale', ['en-GB', 'en-AU'])
+            default: select('Locale', ['en-GB', 'en-AU', 'da-DK', 'en-IE', 'en-NZ', 'es-ES', 'it-IT', 'nb-NO'])
         },
         showCourierLinks: {
             default: boolean('Show courier links', false)
+        },
+        showCountrySelector: {
+            default: boolean('Show country selector', false)
         }
     },
-    template: '<vue-footer :showCourierLinks="showCourierLinks" :locale="locale" />'
+    template: `
+        <vue-footer
+            :showCourierLinks="showCourierLinks"
+            :locale="locale"
+            :showCountrySelector="showCountrySelector" />`
 });
 
 FooterComponent.storyName = 'f-footer';

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+To be added to the latest release
+------------------------------
+*Fabruary 9, 2021*
+
+### Added
+- All tenants to a tenant prop for storybook f-footer story
+
+
 v4.6.0
 ------------------------------
 *January 27, 2021*

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -9,7 +9,7 @@ To be added to the latest release
 *Fabruary 9, 2021*
 
 ### Added
-- All tenants to a tenant prop for storybook f-footer story
+- All tenants to a tenant prop for storybook f-header story
 
 
 v4.6.0

--- a/packages/components/organisms/f-header/stories/header.stories.js
+++ b/packages/components/organisms/f-header/stories/header.stories.js
@@ -25,7 +25,7 @@ export const HeaderComponent = () => ({
     components: { VueHeader },
     props: {
         locale: {
-            default: select('Locale', ['en-GB', 'en-AU'])
+            default: select('Locale', ['en-GB', 'en-AU', 'da-DK', 'en-IE', 'en-NZ', 'es-ES', 'it-IT', 'nb-NO'])
         },
         showOffersLink: {
             default: boolean('Show offers link', false)


### PR DESCRIPTION
### Added
- New modifier css class to fix footer items alignment for ES and IT
- All tenants to a tenant prop for storybook f-footer story

Before:
![Screen Shot 2021-02-09 at 11 02 56](https://user-images.githubusercontent.com/19548183/107354947-b81e6280-6ac6-11eb-9d2b-9d77cc0d058a.png)
![Screen Shot 2021-02-09 at 11 03 33](https://user-images.githubusercontent.com/19548183/107355006-ca989c00-6ac6-11eb-9d27-68653e3e65e6.png)

After:
![Screen Shot 2021-02-09 at 11 00 14](https://user-images.githubusercontent.com/19548183/107354970-c0769d80-6ac6-11eb-818e-66c5aa5e5fe7.png)
![Screen Shot 2021-02-09 at 11 00 32](https://user-images.githubusercontent.com/19548183/107354985-c5d3e800-6ac6-11eb-8c42-e14b2637cfab.png)
