### PR TITLE
f-checkout@0.52.0 - Prop refactorings.

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.52.0
 -------------------------------
-*February 5, 2021*
+*February 9, 2021*
 
 ### Added
 - `updateCheckoutUrl` and `updateCheckoutTimeout` props.

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -10,6 +10,9 @@ v0.52.0
 ### Added
 - `updateCheckoutUrl` and `updateCheckoutTimeout` props.
 
+### Changed
+- Renamed `checkoutUrl` prop to `getCheckoutUrl`.
+
 ### Removed
 - `checkoutId` prop.
 

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.52.0
+-------------------------------
+*February 5, 2021*
+
+### Added
+- `updateCheckoutUrl` and `updateCheckoutTimeout` props.
+
+### Removed
+- `checkoutId` prop.
+
 
 v0.51.0
 -------------------------------

--- a/packages/components/organisms/f-checkout/README.md
+++ b/packages/components/organisms/f-checkout/README.md
@@ -73,7 +73,7 @@ The props that can be defined are as follows:
 | Prop  | Type  | Default | Description |
 | ----- | ----- | ------- | ----------- |
 | `updateCheckoutUrl` | `String` | - | URL for the API called to update the Checkout Data |
-| `checkoutUrl` | `String` | - | URL for the API called to load the Checkout Data.<br><br>The data returned from this API contains the serviceType, which determines if the Checkout component is created for Collection or Delivery when the user is authenticated. |
+| `getCheckoutUrl` | `String` | - | URL for the API called to load the Checkout Data.<br><br>The data returned from this API contains the serviceType, which determines if the Checkout component is created for Collection or Delivery when the user is authenticated. |
 | `checkoutAvailableFulfilmentUrl` | `String` | - | URL for the API called to load the Available Fulfilment data. |
 | `createGuestUrl` | `String` | - | URL for the API called to load the Create a Guest User. |
 | `getBasketUrl` | `String` | - | URL for the API called to get Basket Details.<br><br>The data returned from this API contains the serviceType, which determines if the Checkout component is created for Collection or Delivery when the user is not authenticated. |

--- a/packages/components/organisms/f-checkout/README.md
+++ b/packages/components/organisms/f-checkout/README.md
@@ -72,15 +72,16 @@ The props that can be defined are as follows:
 
 | Prop  | Type  | Default | Description |
 | ----- | ----- | ------- | ----------- |
-| `checkoutId` | `String` | This prop is required | Unique ID for the checkout.<br><br>Currently this is the basket ID. |
+| `updateCheckoutUrl` | `String` | - | URL for the API called to update the Checkout Details |
 | `checkoutUrl` | `String` | - | URL for the API called to load the Checkout Data.<br><br>The data returned from this API contains the serviceType, which determines if the Checkout component is created for Collection or Delivery when the user is authenticated. |
 | `checkoutAvailableFulfilmentUrl` | `String` | - | URL for the API called to load the Available Fulfilment data. |
 | `createGuestUrl` | `String` | - | URL for the API called to load the Create a Guest User. |
 | `getBasketUrl` | `String` | - | URL for the API called to get Basket Details.<br><br>The data returned from this API contains the serviceType, which determines if the Checkout component is created for Collection or Delivery when the user is not authenticated. |
 | `checkoutTimeout` | `Number` | 1000 | Timeout when submitting the checkout form. |
 | `getCheckoutTimeout` | `Number` | 1000 | Timeout when loading checkout data. |
-| `createGuestTimeout` | `Number` | 1000 | Timeout when creating a guest user.  |
-| `getBasketTimeout` | `Number` | 1000 | Timeout when loading basket data.  |
+| `createGuestTimeout` | `Number` | 1000 | Timeout when creating a guest user. |
+| `getBasketTimeout` | `Number` | 1000 | Timeout when loading basket data. |
+| `updateCheckoutTimeout` | `Number` | 1000 | Timeout when updating checkout data. |
 | `authToken` | `String` | `''` | Authorisation token used when submitting the checkout form. |
 | `loginUrl` | `String` | `-` | URL to navigate to if the user wishes to change account. |
 

--- a/packages/components/organisms/f-checkout/README.md
+++ b/packages/components/organisms/f-checkout/README.md
@@ -72,7 +72,7 @@ The props that can be defined are as follows:
 
 | Prop  | Type  | Default | Description |
 | ----- | ----- | ------- | ----------- |
-| `updateCheckoutUrl` | `String` | - | URL for the API called to update the Checkout Details |
+| `updateCheckoutUrl` | `String` | - | URL for the API called to update the Checkout Data |
 | `checkoutUrl` | `String` | - | URL for the API called to load the Checkout Data.<br><br>The data returned from this API contains the serviceType, which determines if the Checkout component is created for Collection or Delivery when the user is authenticated. |
 | `checkoutAvailableFulfilmentUrl` | `String` | - | URL for the API called to load the Available Fulfilment data. |
 | `createGuestUrl` | `String` | - | URL for the API called to load the Create a Guest User. |

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -127,7 +127,7 @@ export default {
     mixins: [validationMixin, VueGlobalisationMixin, checkoutValidationsMixin],
 
     props: {
-        checkoutUrl: {
+        getCheckoutUrl: {
             type: String,
             required: true
         },
@@ -362,7 +362,7 @@ export default {
         async loadCheckout () {
             try {
                 await this.getCheckout({
-                    url: this.checkoutUrl,
+                    url: this.getCheckoutUrl,
                     timeout: this.getCheckoutTimeout
                 });
 

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -177,7 +177,7 @@ export default {
         updateCheckoutTimeout: {
             type: Number,
             default: 1000
-        },        
+        },
 
         authToken: {
             type: String,

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -127,11 +127,6 @@ export default {
     mixins: [validationMixin, VueGlobalisationMixin, checkoutValidationsMixin],
 
     props: {
-        checkoutId: {
-            type: String,
-            required: true
-        },
-
         checkoutUrl: {
             type: String,
             required: true
@@ -148,6 +143,11 @@ export default {
         },
 
         getBasketUrl: {
+            type: String,
+            required: true
+        },
+
+        updateCheckoutUrl: {
             type: String,
             required: true
         },
@@ -173,6 +173,11 @@ export default {
             type: Number,
             default: 1000
         },
+
+        updateCheckoutTimeout: {
+            type: Number,
+            default: 1000
+        },        
 
         authToken: {
             type: String,
@@ -263,7 +268,7 @@ export default {
             'getAvailableFulfilment',
             'getBasket',
             'getCheckout',
-            'patchCheckout',
+            'updateCheckout',
             'setAuthToken',
             'updateCustomerDetails',
             'updateUserNote'
@@ -305,10 +310,10 @@ export default {
                     userNote: this.userNote
                 });
 
-                await this.patchCheckout({
-                    url: `checkout/${this.tenant}/${this.checkoutId}`,
+                await this.updateCheckout({
+                    url: this.updateCheckoutUrl,
                     data,
-                    timeout: this.checkoutTimeout
+                    timeout: this.updateCheckoutTimeout
                 });
 
                 this.$emit(EventNames.CheckoutSuccess, {

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -53,14 +53,14 @@ const $v = {
 
 describe('Checkout', () => {
     allure.feature('Checkout');
-    const checkoutId = 'abc123def456';
+    const updateCheckoutUrl = 'http://localhost/updatecheckout';
     const checkoutUrl = 'http://localhost/checkout';
     const checkoutAvailableFulfilmentUrl = 'http://localhost/checkout/fulfilment';
     const loginUrl = 'http://localhost/login';
     const createGuestUrl = 'http://localhost/createguestuser';
     const getBasketUrl = 'http://localhost/getbasket';
     const propsData = {
-        checkoutId,
+        updateCheckoutUrl,
         checkoutUrl,
         loginUrl,
         checkoutAvailableFulfilmentUrl,

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -54,14 +54,14 @@ const $v = {
 describe('Checkout', () => {
     allure.feature('Checkout');
     const updateCheckoutUrl = 'http://localhost/updatecheckout';
-    const checkoutUrl = 'http://localhost/checkout';
+    const getCheckoutUrl = 'http://localhost/checkout';
     const checkoutAvailableFulfilmentUrl = 'http://localhost/checkout/fulfilment';
     const loginUrl = 'http://localhost/login';
     const createGuestUrl = 'http://localhost/createguestuser';
     const getBasketUrl = 'http://localhost/getbasket';
     const propsData = {
         updateCheckoutUrl,
-        checkoutUrl,
+        getCheckoutUrl,
         loginUrl,
         checkoutAvailableFulfilmentUrl,
         createGuestUrl,

--- a/packages/components/organisms/f-checkout/src/components/_tests/helpers/setup.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/helpers/setup.js
@@ -46,7 +46,7 @@ const defaultState = {
 
 const defaultActions = {
     getCheckout: jest.fn(),
-    patchCheckout: jest.fn(),
+    updateCheckout: jest.fn(),
     getAvailableFulfilment: jest.fn(),
     setAuthToken: jest.fn(),
     createGuestUser: jest.fn(),

--- a/packages/components/organisms/f-checkout/src/demo/checkoutMock.js
+++ b/packages/components/organisms/f-checkout/src/demo/checkoutMock.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import checkoutDelivery from './checkout-delivery.json';
-import checkoutCollection from './checkout-collection.json';
+import getCheckoutDelivery from './checkout-delivery.json';
+import getCheckoutCollection from './checkout-collection.json';
 import checkoutAvailableFulfilment from './checkout-available-fulfilment.json';
 import createGuest from './create-guest.json';
 import getBasketDelivery from './get-basket-delivery.json';
@@ -10,16 +10,14 @@ import updateCheckout from './update-checkout.json';
 
 const mock = new MockAdapter(axios);
 
-const updateCheckoutRegex = new RegExp('checkout/[a-z]{2}/*');
-
 export default {
     setupCheckoutMethod (path) {
         switch (path) {
             case '/checkout-delivery.json':
-                mock.onGet(path).reply(200, checkoutDelivery);
+                mock.onGet(path).reply(200, getCheckoutDelivery);
                 break;
             case '/checkout-collection.json':
-                mock.onGet(path).reply(200, checkoutCollection);
+                mock.onGet(path).reply(200, getCheckoutCollection);
                 break;
             case '/checkout-available-fulfilment.json':
                 mock.onGet(path).reply(200, checkoutAvailableFulfilment);
@@ -34,7 +32,7 @@ export default {
                 mock.onGet(path).reply(200, getBasketCollection);
                 break;
             case '/update-checkout.json':
-                mock.onPatch(updateCheckoutRegex).reply(200, updateCheckout);
+                mock.onPatch(path).reply(200, updateCheckout);
                 break;
             default:
                 throw new Error(`${path} is not valid`);

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -81,7 +81,7 @@ export default {
          * @param {Object} payload - Parameter with the different configurations for the request.
          */
         // eslint-disable-next-line no-unused-vars
-        patchCheckout: async ({ commit, state }, {
+        updateCheckout: async ({ commit, state }, {
             url, data, timeout
         }) => {
             // TODO: deal with exceptions and handle this action properly (when the functionality is ready)

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -24,7 +24,7 @@ const {
     getAvailableFulfilment,
     getBasket,
     getCheckout,
-    patchCheckout,
+    updateCheckout,
     setAuthToken,
     updateAddressDetails,
     updateCustomerDetails,
@@ -253,7 +253,7 @@ describe('CheckoutModule', () => {
             });
         });
 
-        describe('patchCheckout ::', () => {
+        describe('updateCheckout ::', () => {
             payload.data = {
                 mobileNumber
             };
@@ -276,7 +276,7 @@ describe('CheckoutModule', () => {
 
             it('should post the checkout details to the backend.', async () => {
                 // Act
-                await patchCheckout({ commit, state }, payload);
+                await updateCheckout({ commit, state }, payload);
 
                 // Assert
                 expect(axios.patch).toHaveBeenCalledWith(payload.url, payload.data, config);

--- a/packages/components/organisms/f-checkout/stories/Checkout.stories.js
+++ b/packages/components/organisms/f-checkout/stories/Checkout.stories.js
@@ -18,14 +18,13 @@ export default {
 
 Vue.use(Vuex);
 
-const checkoutId = 'checkoutId';
 const deliveryUrl = '/checkout-delivery.json';
 const collectionUrl = '/checkout-collection.json';
 const checkoutAvailableFulfilmentUrl = '/checkout-available-fulfilment.json';
 const createGuestUrl = '/create-guest.json';
 const getBasketDeliveryUrl = '/get-basket-delivery.json';
 const getBasketCollectionUrl = '/get-basket-collection.json';
-const updateCheckout = '/update-checkout.json';
+const updateCheckoutUrl = '/update-checkout.json';
 
 CheckoutMock.setupCheckoutMethod(deliveryUrl);
 CheckoutMock.setupCheckoutMethod(collectionUrl);
@@ -33,7 +32,7 @@ CheckoutMock.setupCheckoutMethod(checkoutAvailableFulfilmentUrl);
 CheckoutMock.setupCheckoutMethod(createGuestUrl);
 CheckoutMock.setupCheckoutMethod(getBasketDeliveryUrl);
 CheckoutMock.setupCheckoutMethod(getBasketCollectionUrl);
-CheckoutMock.setupCheckoutMethod(updateCheckout);
+CheckoutMock.setupCheckoutMethod(updateCheckoutUrl);
 CheckoutMock.passThroughAny();
 
 export const CheckoutComponent = () => ({
@@ -42,8 +41,8 @@ export const CheckoutComponent = () => ({
         locale: {
             default: select('Locale', [ENGLISH_LOCALE])
         },
-        checkoutId: {
-            default: text('Checkout ID', checkoutId)
+        updateCheckoutUrl: {
+            default: select('Update Checkout Url', [updateCheckoutUrl], updateCheckoutUrl)
         },
         checkoutUrl: {
             default: select('Checkout Url', [deliveryUrl, collectionUrl, 'An invalid URL'], deliveryUrl)

--- a/packages/components/organisms/f-checkout/stories/Checkout.stories.js
+++ b/packages/components/organisms/f-checkout/stories/Checkout.stories.js
@@ -18,16 +18,16 @@ export default {
 
 Vue.use(Vuex);
 
-const deliveryUrl = '/checkout-delivery.json';
-const collectionUrl = '/checkout-collection.json';
+const getCheckoutDeliveryUrl = '/checkout-delivery.json';
+const getCheckoutCollectionUrl = '/checkout-collection.json';
 const checkoutAvailableFulfilmentUrl = '/checkout-available-fulfilment.json';
 const createGuestUrl = '/create-guest.json';
 const getBasketDeliveryUrl = '/get-basket-delivery.json';
 const getBasketCollectionUrl = '/get-basket-collection.json';
 const updateCheckoutUrl = '/update-checkout.json';
 
-CheckoutMock.setupCheckoutMethod(deliveryUrl);
-CheckoutMock.setupCheckoutMethod(collectionUrl);
+CheckoutMock.setupCheckoutMethod(getCheckoutDeliveryUrl);
+CheckoutMock.setupCheckoutMethod(getCheckoutCollectionUrl);
 CheckoutMock.setupCheckoutMethod(checkoutAvailableFulfilmentUrl);
 CheckoutMock.setupCheckoutMethod(createGuestUrl);
 CheckoutMock.setupCheckoutMethod(getBasketDeliveryUrl);
@@ -44,8 +44,8 @@ export const CheckoutComponent = () => ({
         updateCheckoutUrl: {
             default: select('Update Checkout Url', [updateCheckoutUrl], updateCheckoutUrl)
         },
-        checkoutUrl: {
-            default: select('Checkout Url', [deliveryUrl, collectionUrl, 'An invalid URL'], deliveryUrl)
+        getCheckoutUrl: {
+            default: select('Get Checkout Url', [getCheckoutDeliveryUrl, getCheckoutCollectionUrl, 'An invalid URL'], getCheckoutDeliveryUrl)
         },
         checkoutAvailableFulfilmentUrl: {
             default: select('Available Fulfilment Url', [checkoutAvailableFulfilmentUrl], checkoutAvailableFulfilmentUrl)
@@ -69,8 +69,8 @@ export const CheckoutComponent = () => ({
         }
     }),
     template: '<vue-checkout ' +
-        ':checkoutId="checkoutId" ' +
-        ':checkoutUrl="checkoutUrl" ' +
+        ':getCheckoutUrl="getCheckoutUrl" ' +
+        ':updateCheckoutUrl="updateCheckoutUrl" ' +
         ':checkout-available-fulfilment-url="checkoutAvailableFulfilmentUrl" ' +
         ':create-guest-url="createGuestUrl" ' +
         ':get-basket-url="getBasketUrl" ' +
@@ -78,7 +78,7 @@ export const CheckoutComponent = () => ({
         ':locale="locale" ' +
         ':loginUrl="loginUrl" ' +
         // eslint-disable-next-line no-template-curly-in-string
-        ' :key="`${locale},${checkoutId},${checkoutUrl},${checkoutAvailableFulfilmentUrl},${authToken},${createGuestUrl},${getBasketUrl}`" />'
+        ' :key="`${locale},${getCheckoutUrl},${updateCheckoutUrl},${checkoutAvailableFulfilmentUrl},${authToken},${createGuestUrl},${getBasketUrl}`" />'
 });
 
 CheckoutComponent.storyName = 'f-checkout';

--- a/packages/components/organisms/f-checkout/test/specs/component/f-checkout-collection.component.spec.js
+++ b/packages/components/organisms/f-checkout/test/specs/component/f-checkout-collection.component.spec.js
@@ -3,7 +3,7 @@ import CheckoutComponent from '../../../test-utils/component-objects/f-checkout.
 
 describe('f-checkout "collection" component tests', () => {
     before(() => {
-        browser.url('iframe.html?id=components-organisms--checkout-component&knob-Checkout%20Url=%2Fcheckout-collection.json&knob-Available%20Fulfilment%20Url=%2Fcheckout-available-fulfilment.json&knob-Create%20Guest%20Url=%2Fcreate-guest.json&knob-Auth%20token=a&knob-Login%20Url=%2Flogin&viewMode=story');
+        browser.url('iframe.html?id=components-organisms--checkout-component&knob-Get%20Checkout%20Url=%2Fcheckout-collection.json&knob-Available%20Fulfilment%20Url=%2Fcheckout-available-fulfilment.json&knob-Create%20Guest%20Url=%2Fcreate-guest.json&knob-Auth%20token=a&knob-Login%20Url=%2Flogin&viewMode=story');
         CheckoutComponent.waitForCheckoutComponent();
     });
 

--- a/packages/components/organisms/f-checkout/test/specs/component/f-checkout-delivery.component.spec.js
+++ b/packages/components/organisms/f-checkout/test/specs/component/f-checkout-delivery.component.spec.js
@@ -3,7 +3,7 @@ import CheckoutComponent from '../../../test-utils/component-objects/f-checkout.
 
 describe('f-checkout "delivery" component tests', () => {
     before(() => {
-        browser.url('iframe.html?id=components-organisms--checkout-component&knob-Checkout%20Url=%2Fcheckout-delivery.json&knob-Available%20Fulfilment%20Url=%2Fcheckout-available-fulfilment.json&knob-Create%20Guest%20Url=%2Fcreate-guest.json&knob-Get%20Basket%20Url=%2Fget-basket-delivery.json&knob-Auth%20token=a&knob-Login%20Url=%2Flogin&viewMode=story');
+        browser.url('iframe.html?id=components-organisms--checkout-component&knob-Get%20Checkout%20Url=%2Fcheckout-delivery.json&knob-Available%20Fulfilment%20Url=%2Fcheckout-available-fulfilment.json&knob-Create%20Guest%20Url=%2Fcreate-guest.json&knob-Get%20Basket%20Url=%2Fget-basket-delivery.json&knob-Auth%20token=a&knob-Login%20Url=%2Flogin&viewMode=story');
         CheckoutComponent.waitForCheckoutComponent();
     });
 

--- a/packages/components/organisms/f-checkout/test/specs/component/f-checkout-guest.component.spec.js
+++ b/packages/components/organisms/f-checkout/test/specs/component/f-checkout-guest.component.spec.js
@@ -3,7 +3,7 @@ import CheckoutComponent from '../../../test-utils/component-objects/f-checkout.
 
 describe('f-checkout component tests', () => {
     before(() => {
-        browser.url('iframe.html?id=components-organisms--checkout-component&knob-Checkout%20Url=%2Fcheckout-delivery.json&knob-Available%20Fulfilment%20Url=%2Fcheckout-available-fulfilment.json&knob-Create%20Guest%20Url=%2Fcreate-guest.json&knob-Get%20Basket%20Url=%2Fget-basket-delivery.json&knob-Auth%20token=&knob-Login%20Url=%2Flogin&viewMode=story');
+        browser.url('iframe.html?id=components-organisms--checkout-component&knob-Get%20Checkout%20Url=%2Fcheckout-delivery.json&knob-Available%20Fulfilment%20Url=%2Fcheckout-available-fulfilment.json&knob-Create%20Guest%20Url=%2Fcreate-guest.json&knob-Get%20Basket%20Url=%2Fget-basket-delivery.json&knob-Auth%20token=&knob-Login%20Url=%2Flogin&viewMode=story');
         CheckoutComponent.waitForCheckoutComponent();
     });
 

--- a/packages/components/organisms/f-checkout/test/specs/component/f-checkout.component.spec.js
+++ b/packages/components/organisms/f-checkout/test/specs/component/f-checkout.component.spec.js
@@ -2,7 +2,7 @@ import CheckoutComponent from '../../../test-utils/component-objects/f-checkout.
 
 describe('f-checkout component tests', () => {
     before(() => {
-        browser.url('iframe.html?id=components-organisms--checkout-component&knob-Checkout%20Url=%2Fcheckout-delivery.json&knob-Available%20Fulfilment%20Url=%2Fcheckout-available-fulfilment.json&knob-Create%20Guest%20Url=%2Fcreate-guest.json&knob-Auth%20token=a&knob-Login%20Url=%2Flogin&viewMode=story');
+        browser.url('iframe.html?id=components-organisms--checkout-component&knob-Get%20Checkout%20Url=%2Fcheckout-delivery.json&knob-Available%20Fulfilment%20Url=%2Fcheckout-available-fulfilment.json&knob-Create%20Guest%20Url=%2Fcreate-guest.json&knob-Auth%20token=a&knob-Login%20Url=%2Flogin&viewMode=story');
         CheckoutComponent.waitForCheckoutComponent();
     });
 


### PR DESCRIPTION
v0.52.0
-------------------------------
*February 9, 2021*

### Added
- `updateCheckoutUrl` and `updateCheckoutTimeout` props.

### Changed
- Renamed `checkoutUrl` prop to `getCheckoutUrl`.

### Removed
- `checkoutId` prop.