### PR TITLE
f-checkout@0.53.0 Loading customer address from API endpoint if Checkout endpoint did not return it. Part 1

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.53.0
+-------------------------------
+*_February 9, 2021_*
+
+### Added
+- Loading customer address from API endpoint if Checkout endpoint did not return it
+
+
 v0.52.0
 -------------------------------
 *February 9, 2021*
@@ -15,14 +23,6 @@ v0.52.0
 
 ### Removed
 - `checkoutId` prop.
-
-
-v0.52.0
--------------------------------
-*_February 9, 2021_*
-
-### Added
-- Loading customer address from API endpoint if Checkout endpoint did not return it
 
 
 v0.51.0

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -17,6 +17,15 @@ v0.52.0
 - `checkoutId` prop.
 
 
+## v0.52.0
+
+_February 9, 2021_
+
+### Added
+
+-   Loading customer address from API endpoint if Checkout endpoint did not return it
+
+
 v0.51.0
 -------------------------------
 *February 5, 2021*

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -17,13 +17,12 @@ v0.52.0
 - `checkoutId` prop.
 
 
-## v0.52.0
-
-_February 9, 2021_
+v0.52.0
+-------------------------------
+*_February 9, 2021_*
 
 ### Added
-
--   Loading customer address from API endpoint if Checkout endpoint did not return it
+- Loading customer address from API endpoint if Checkout endpoint did not return it
 
 
 v0.51.0

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -259,6 +259,12 @@ export default {
 
         tenant () {
             return TENANT_MAP[this.$i18n.locale];
+        },
+
+        shouldLoadAddress () {
+            return this.isLoggedIn &&
+            this.isCheckoutMethodDelivery &&
+            (!this.address || !this.address.line1);
         }
     },
 
@@ -302,20 +308,11 @@ export default {
 
             await Promise.all(promises);
 
-            if (this.shouldLoadAddress()) {
+            if (this.shouldLoadAddress) {
                 await this.loadAddress();
             }
         },
 
-        /**
-         * Check if address should be loaded from a getAddress API endpoint
-         *
-         */
-        shouldLoadAddress () {
-            return this.isLoggedIn &&
-            this.isCheckoutMethodDelivery &&
-            (!this.address || !this.address.line1);
-        },
         /**
          * Submit the checkout details while emitting events to communicate its success or failure.
          *

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -187,6 +187,16 @@ export default {
         loginUrl: {
             type: String,
             required: true
+        },
+
+        getAddressUrl: {
+            type: String,
+            required: true
+        },
+
+        getAddressTimeout: {
+            type: Number,
+            default: 1000
         }
     },
 
@@ -266,6 +276,7 @@ export default {
         ...mapActions('checkout', [
             'createGuestUser',
             'getAvailableFulfilment',
+            'getAddress',
             'getBasket',
             'getCheckout',
             'updateCheckout',
@@ -290,8 +301,21 @@ export default {
                 : [this.loadAvailableFulfilment()];
 
             await Promise.all(promises);
+
+            if (this.shouldLoadAddress()) {
+                await this.loadAddress();
+            }
         },
 
+        /**
+         * Check if address should be loaded from a getAddress API endpoint
+         *
+         */
+        shouldLoadAddress () {
+            return this.isLoggedIn &&
+            this.isCheckoutMethodDelivery &&
+            (!this.address || !this.address.line1);
+        },
         /**
          * Submit the checkout details while emitting events to communicate its success or failure.
          *
@@ -407,6 +431,26 @@ export default {
                 this.$emit(EventNames.CheckoutAvailableFulfilmentGetSuccess);
             } catch (thrownErrors) {
                 this.$emit(EventNames.CheckoutAvailableFulfilmentGetFailure, thrownErrors);
+                this.hasCheckoutLoadedSuccessfully = false;
+            }
+        },
+
+        /**
+         * Load the customer address while emitting events to communicate its success or failure.
+         *
+         */
+        async loadAddress () {
+            debugger;
+            try {
+                await this.getAddress({
+                    url: this.getAddressUrl,
+                    language: this.$i18n.locale,
+                    timeout: this.getAddressTimeout
+                });
+
+                this.$emit(EventNames.CheckoutAddressGetSuccess);
+            } catch (thrownErrors) {
+                this.$emit(EventNames.CheckoutAddressGetFailure, thrownErrors);
                 this.hasCheckoutLoadedSuccessfully = false;
             }
         },

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -440,7 +440,6 @@ export default {
          *
          */
         async loadAddress () {
-            debugger;
             try {
                 await this.getAddress({
                     url: this.getAddressUrl,

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -390,7 +390,7 @@ describe('Checkout', () => {
                     // Arrange & Act
                     const loadAddressSpy = jest.spyOn(VueCheckout.methods, 'loadAddress');
                     const shouldLoadAddressSpy = jest.spyOn(VueCheckout.methods, 'shouldLoadAddress');
-                    shouldLoadAddressSpy.mockReturnValue(false);
+                    shouldLoadAddressSpy.mockReturnValueOnce(false);
 
                     shallowMount(VueCheckout, {
                         store: createStore(),
@@ -410,7 +410,7 @@ describe('Checkout', () => {
                     // Arrange & Act
                     const loadAddressSpy = jest.spyOn(VueCheckout.methods, 'loadAddress');
                     const shouldLoadAddressSpy = jest.spyOn(VueCheckout.methods, 'shouldLoadAddress');
-                    shouldLoadAddressSpy.mockReturnValue(true);
+                    shouldLoadAddressSpy.mockReturnValueOnce(true);
 
                     shallowMount(VueCheckout, {
                         store: createStore(),
@@ -1227,6 +1227,81 @@ describe('Checkout', () => {
                     expect(wrapper.emitted(EventNames.CheckoutBasketGetSuccess).length).toBe(1);
                     expect(wrapper.emitted(EventNames.CheckoutBasketGetFailure)).toBeUndefined();
                 });
+            });
+        });
+
+        describe('shouldLoadAddress ::', () => {
+            it('should return `true` for delivery order without address when user is not logged in', () => {
+                const wrapper = shallowMount(VueCheckout, {
+                    store: createStore({
+                        ...defaultState,
+                        isLoggedIn: true,
+                        serviceType: CHECKOUT_METHOD_DELIVERY,
+                        address: {}
+                    }),
+                    i18n,
+                    localVue,
+                    propsData
+                });
+
+                // Act
+                const result = wrapper.vm.shouldLoadAddress();
+
+                // Assert
+                expect(result).toBe(true);
+            });
+
+            it('should return `false` if `isLoggedIn` is `false`', () => {
+                const wrapper = shallowMount(VueCheckout, {
+                    store: createStore({
+                        ...defaultState,
+                        isLoggedIn: false,
+                        serviceType: CHECKOUT_METHOD_DELIVERY,
+                        address: {}
+                    }),
+                    i18n,
+                    localVue,
+                    propsData
+                });
+
+                // Act
+                const result = wrapper.vm.shouldLoadAddress();
+
+                // Assert
+                expect(result).toBe(false);
+            });
+
+            it('should return `false` if `serviceType` is `collection`', async () => {
+                const wrapper = shallowMount(VueCheckout, {
+                    store: createStore(),
+                    i18n,
+                    localVue,
+                    propsData
+                });
+                const result = await wrapper.vm.shouldLoadAddress();
+
+                // Assert
+                expect(result).toBe(false);
+            });
+
+            it('should return `false` if address is set', () => {
+                const wrapper = shallowMount(VueCheckout, {
+                    store: createStore({
+                        ...defaultState,
+                        isLoggedIn: true,
+                        serviceType: CHECKOUT_METHOD_DELIVERY,
+                        address: { line1: 'Fleet Place House', postcode: 'EC4M 7RF', city: 'London' }
+                    }),
+                    i18n,
+                    localVue,
+                    propsData
+                });
+
+                // Act
+                const result = wrapper.vm.shouldLoadAddress();
+
+                // Assert
+                expect(result).toBe(false);
             });
         });
 

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -59,13 +59,15 @@ describe('Checkout', () => {
     const loginUrl = 'http://localhost/login';
     const createGuestUrl = 'http://localhost/createguestuser';
     const getBasketUrl = 'http://localhost/getbasket';
+    const getAddressUrl = 'http://localhost/getaddress';
     const propsData = {
         updateCheckoutUrl,
         getCheckoutUrl,
         loginUrl,
         checkoutAvailableFulfilmentUrl,
         createGuestUrl,
-        getBasketUrl
+        getBasketUrl,
+        getAddressUrl
     };
 
     it('should be defined', () => {

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -319,6 +319,90 @@ describe('Checkout', () => {
                 expect(wrapper.vm.tenant).toEqual(tenant);
             });
         });
+
+        describe('shouldLoadAddress ::', () => {
+            it('should return `true` for delivery order without address when user is logged in', () => {
+                // Arrange
+                const wrapper = shallowMount(VueCheckout, {
+                    store: createStore({
+                        ...defaultState,
+                        isLoggedIn: true,
+                        serviceType: CHECKOUT_METHOD_DELIVERY,
+                        address: {}
+                    }),
+                    i18n,
+                    localVue,
+                    propsData
+                });
+
+                // Act
+                const result = wrapper.vm.shouldLoadAddress;
+
+                // Assert
+                expect(result).toBe(true);
+            });
+
+            it('should return `false` if `isLoggedIn` is `false`', () => {
+                // Arrange
+                const wrapper = shallowMount(VueCheckout, {
+                    store: createStore({
+                        ...defaultState,
+                        isLoggedIn: false,
+                        serviceType: CHECKOUT_METHOD_DELIVERY,
+                        address: {}
+                    }),
+                    i18n,
+                    localVue,
+                    propsData
+                });
+
+                // Act
+                const result = wrapper.vm.shouldLoadAddress;
+
+                // Assert
+                expect(result).toBe(false);
+            });
+
+            it('should return `false` if `serviceType` is `collection`', async () => {
+                // Arrange
+                const wrapper = shallowMount(VueCheckout, {
+                    store: createStore({
+                        ...defaultState,
+                        isLoggedIn: true,
+                        serviceType: CHECKOUT_METHOD_COLLECTION,
+                        address: {}
+                    }),
+                    i18n,
+                    localVue,
+                    propsData
+                });
+                const result = await wrapper.vm.shouldLoadAddress;
+
+                // Assert
+                expect(result).toBe(false);
+            });
+
+            it('should return `false` if address is set', () => {
+                // Arrange
+                const wrapper = shallowMount(VueCheckout, {
+                    store: createStore({
+                        ...defaultState,
+                        isLoggedIn: true,
+                        serviceType: CHECKOUT_METHOD_DELIVERY,
+                        address: { line1: 'Fleet Place House', postcode: 'EC4M 7RF', city: 'London' }
+                    }),
+                    i18n,
+                    localVue,
+                    propsData
+                });
+
+                // Act
+                const result = wrapper.vm.shouldLoadAddress;
+
+                // Assert
+                expect(result).toBe(false);
+            });
+        });
     });
 
     describe('mounted ::', () => {
@@ -389,7 +473,7 @@ describe('Checkout', () => {
                 it('should not call `loadAddress`', async () => {
                     // Arrange & Act
                     const loadAddressSpy = jest.spyOn(VueCheckout.methods, 'loadAddress');
-                    jest.spyOn(VueCheckout.methods, 'shouldLoadAddress').mockReturnValueOnce(false);
+                    jest.spyOn(VueCheckout.computed, 'shouldLoadAddress').mockReturnValueOnce(false);
 
                     shallowMount(VueCheckout, {
                         store: createStore(),
@@ -408,7 +492,7 @@ describe('Checkout', () => {
                 it('should call `loadAddress`', async () => {
                     // Arrange & Act
                     const loadAddressSpy = jest.spyOn(VueCheckout.methods, 'loadAddress');
-                    jest.spyOn(VueCheckout.methods, 'shouldLoadAddress').mockReturnValueOnce(true);
+                    jest.spyOn(VueCheckout.computed, 'shouldLoadAddress').mockReturnValueOnce(true);
 
                     shallowMount(VueCheckout, {
                         store: createStore(),
@@ -1270,90 +1354,6 @@ describe('Checkout', () => {
                     expect(wrapper.emitted(EventNames.CheckoutAddressGetSuccess).length).toBe(1);
                     expect(wrapper.emitted(EventNames.CheckoutAddressGetFailure)).toBeUndefined();
                 });
-            });
-        });
-
-        describe('shouldLoadAddress ::', () => {
-            it('should return `true` for delivery order without address when user is not logged in', () => {
-                // Arrange
-                const wrapper = shallowMount(VueCheckout, {
-                    store: createStore({
-                        ...defaultState,
-                        isLoggedIn: true,
-                        serviceType: CHECKOUT_METHOD_DELIVERY,
-                        address: {}
-                    }),
-                    i18n,
-                    localVue,
-                    propsData
-                });
-
-                // Act
-                const result = wrapper.vm.shouldLoadAddress();
-
-                // Assert
-                expect(result).toBe(true);
-            });
-
-            it('should return `false` if `isLoggedIn` is `false`', () => {
-                // Arrange
-                const wrapper = shallowMount(VueCheckout, {
-                    store: createStore({
-                        ...defaultState,
-                        isLoggedIn: false,
-                        serviceType: CHECKOUT_METHOD_DELIVERY,
-                        address: {}
-                    }),
-                    i18n,
-                    localVue,
-                    propsData
-                });
-
-                // Act
-                const result = wrapper.vm.shouldLoadAddress();
-
-                // Assert
-                expect(result).toBe(false);
-            });
-
-            it('should return `false` if `serviceType` is `collection`', async () => {
-                // Arrange
-                const wrapper = shallowMount(VueCheckout, {
-                    store: createStore({
-                        ...defaultState,
-                        isLoggedIn: true,
-                        serviceType: CHECKOUT_METHOD_COLLECTION,
-                        address: {}
-                    }),
-                    i18n,
-                    localVue,
-                    propsData
-                });
-                const result = await wrapper.vm.shouldLoadAddress();
-
-                // Assert
-                expect(result).toBe(false);
-            });
-
-            it('should return `false` if address is set', () => {
-                // Arrange
-                const wrapper = shallowMount(VueCheckout, {
-                    store: createStore({
-                        ...defaultState,
-                        isLoggedIn: true,
-                        serviceType: CHECKOUT_METHOD_DELIVERY,
-                        address: { line1: 'Fleet Place House', postcode: 'EC4M 7RF', city: 'London' }
-                    }),
-                    i18n,
-                    localVue,
-                    propsData
-                });
-
-                // Act
-                const result = wrapper.vm.shouldLoadAddress();
-
-                // Assert
-                expect(result).toBe(false);
             });
         });
 

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -1230,6 +1230,51 @@ describe('Checkout', () => {
             });
         });
 
+        describe('loadAddress ::', () => {
+            afterEach(() => {
+                jest.clearAllMocks();
+            });
+
+            describe('when `getAddress` request fails', () => {
+                it('should emit failure event and set `hasCheckoutLoadedSuccessfully` to `false`', async () => {
+                    // Arrange
+                    const wrapper = mount(VueCheckout, {
+                        store: createStore(defaultState, { ...defaultActions, getAddress: jest.fn(async () => Promise.reject()) }),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+
+                    // Act
+                    await wrapper.vm.loadAddress();
+
+                    // Assert
+                    expect(wrapper.emitted(EventNames.CheckoutAddressGetFailure).length).toBe(1);
+                    expect(wrapper.emitted(EventNames.CheckoutAddressGetSuccess)).toBeUndefined();
+                    expect(wrapper.vm.hasCheckoutLoadedSuccessfully).toBe(false);
+                });
+            });
+
+            describe('when `getAddress` request succeeds', () => {
+                it('should emit success event', async () => {
+                    // Arrange
+                    const wrapper = mount(VueCheckout, {
+                        store: createStore(),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+
+                    // Act
+                    await wrapper.vm.loadAddress();
+
+                    // Assert
+                    expect(wrapper.emitted(EventNames.CheckoutAddressGetSuccess).length).toBe(1);
+                    expect(wrapper.emitted(EventNames.CheckoutAddressGetFailure)).toBeUndefined();
+                });
+            });
+        });
+
         describe('shouldLoadAddress ::', () => {
             it('should return `true` for delivery order without address when user is not logged in', () => {
                 const wrapper = shallowMount(VueCheckout, {

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -389,8 +389,7 @@ describe('Checkout', () => {
                 it('should not call `loadAddress`', async () => {
                     // Arrange & Act
                     const loadAddressSpy = jest.spyOn(VueCheckout.methods, 'loadAddress');
-                    const shouldLoadAddressSpy = jest.spyOn(VueCheckout.methods, 'shouldLoadAddress');
-                    shouldLoadAddressSpy.mockReturnValueOnce(false);
+                    jest.spyOn(VueCheckout.methods, 'shouldLoadAddress').mockReturnValueOnce(false);
 
                     shallowMount(VueCheckout, {
                         store: createStore(),
@@ -409,8 +408,7 @@ describe('Checkout', () => {
                 it('should call `loadAddress`', async () => {
                     // Arrange & Act
                     const loadAddressSpy = jest.spyOn(VueCheckout.methods, 'loadAddress');
-                    const shouldLoadAddressSpy = jest.spyOn(VueCheckout.methods, 'shouldLoadAddress');
-                    shouldLoadAddressSpy.mockReturnValueOnce(true);
+                    jest.spyOn(VueCheckout.methods, 'shouldLoadAddress').mockReturnValueOnce(true);
 
                     shallowMount(VueCheckout, {
                         store: createStore(),
@@ -1277,6 +1275,7 @@ describe('Checkout', () => {
 
         describe('shouldLoadAddress ::', () => {
             it('should return `true` for delivery order without address when user is not logged in', () => {
+                // Arrange
                 const wrapper = shallowMount(VueCheckout, {
                     store: createStore({
                         ...defaultState,
@@ -1297,6 +1296,7 @@ describe('Checkout', () => {
             });
 
             it('should return `false` if `isLoggedIn` is `false`', () => {
+                // Arrange
                 const wrapper = shallowMount(VueCheckout, {
                     store: createStore({
                         ...defaultState,
@@ -1317,8 +1317,14 @@ describe('Checkout', () => {
             });
 
             it('should return `false` if `serviceType` is `collection`', async () => {
+                // Arrange
                 const wrapper = shallowMount(VueCheckout, {
-                    store: createStore(),
+                    store: createStore({
+                        ...defaultState,
+                        isLoggedIn: true,
+                        serviceType: CHECKOUT_METHOD_COLLECTION,
+                        address: {}
+                    }),
                     i18n,
                     localVue,
                     propsData
@@ -1330,6 +1336,7 @@ describe('Checkout', () => {
             });
 
             it('should return `false` if address is set', () => {
+                // Arrange
                 const wrapper = shallowMount(VueCheckout, {
                     store: createStore({
                         ...defaultState,

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -385,6 +385,46 @@ describe('Checkout', () => {
                 expect(loadAvailableFulfilmentSpy).toHaveBeenCalled();
             });
 
+            describe('if shouldLoadAddress returns `false`', () => {
+                it('should not call `loadAddress`', async () => {
+                    // Arrange & Act
+                    const loadAddressSpy = jest.spyOn(VueCheckout.methods, 'loadAddress');
+                    const shouldLoadAddressSpy = jest.spyOn(VueCheckout.methods, 'shouldLoadAddress');
+                    shouldLoadAddressSpy.mockReturnValue(false);
+
+                    shallowMount(VueCheckout, {
+                        store: createStore(),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+                    await flushPromises();
+
+                    // Assert
+                    expect(loadAddressSpy).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('if shouldLoadAddress returns `true`', () => {
+                it('should call `loadAddress`', async () => {
+                    // Arrange & Act
+                    const loadAddressSpy = jest.spyOn(VueCheckout.methods, 'loadAddress');
+                    const shouldLoadAddressSpy = jest.spyOn(VueCheckout.methods, 'shouldLoadAddress');
+                    shouldLoadAddressSpy.mockReturnValue(true);
+
+                    shallowMount(VueCheckout, {
+                        store: createStore(),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+                    await flushPromises();
+
+                    // Assert
+                    expect(loadAddressSpy).toHaveBeenCalled();
+                });
+            });
+
             describe('if isLoggedIn set to `false`', () => {
                 it('should call `loadBasket`', async () => {
                     // Arrange & Act

--- a/packages/components/organisms/f-checkout/src/components/_tests/helpers/setup.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/helpers/setup.js
@@ -53,7 +53,8 @@ const defaultActions = {
     updateAddressDetails: jest.fn(),
     updateCustomerDetails: jest.fn(),
     updateFulfilmentTime: jest.fn(),
-    getBasket: jest.fn()
+    getBasket: jest.fn(),
+    getAddress: jest.fn()
 };
 
 const i18n = {

--- a/packages/components/organisms/f-checkout/src/demo/checkoutMock.js
+++ b/packages/components/organisms/f-checkout/src/demo/checkoutMock.js
@@ -7,6 +7,7 @@ import createGuest from './create-guest.json';
 import getBasketDelivery from './get-basket-delivery.json';
 import getBasketCollection from './get-basket-collection.json';
 import updateCheckout from './update-checkout.json';
+import getAddress from './get-address.json';
 
 const mock = new MockAdapter(axios);
 
@@ -33,6 +34,9 @@ export default {
                 break;
             case '/update-checkout.json':
                 mock.onPatch(path).reply(200, updateCheckout);
+                break;
+            case '/get-address.json':
+                mock.onGet(path).reply(200, getAddress);
                 break;
             default:
                 throw new Error(`${path} is not valid`);

--- a/packages/components/organisms/f-checkout/src/demo/get-address.json
+++ b/packages/components/organisms/f-checkout/src/demo/get-address.json
@@ -1,0 +1,22 @@
+{
+  "Addresses": [
+    {
+      "City": "London",
+      "ZipCode": "EC4M 7RF",
+      "AddressName": "EC4M 7RF",
+      "IsDefault": true,
+      "Line1": "Fleet Place House",
+      "Line2": "Farringdon",
+      "Line3": null
+    },
+    {
+      "City": "Area 51",
+      "ZipCode": "AR51 7AR",
+      "AddressName": "AR51 7AR",
+      "IsDefault": false,
+      "Line1": "Test St 1",
+      "Line2": "Test House",
+      "Line3": null
+    }
+  ]
+}

--- a/packages/components/organisms/f-checkout/src/event-names.js
+++ b/packages/components/organisms/f-checkout/src/event-names.js
@@ -10,6 +10,8 @@ const CheckoutBasketGetFailure = 'checkout-basket-get-failure';
 const CheckoutSetupGuestSuccess = 'checkout-setup-guest-success';
 const CheckoutSetupGuestFailure = 'checkout-setup-guest-failure';
 const CheckoutValidationError = 'checkout-validation-error';
+const CheckoutAddressGetSuccess = 'checkout-address-get-success';
+const CheckoutAddressGetFailure = 'checkout-address-get-failure';
 
 export default {
     CheckoutSuccess,
@@ -23,5 +25,7 @@ export default {
     CheckoutBasketGetFailure,
     CheckoutSetupGuestSuccess,
     CheckoutSetupGuestFailure,
-    CheckoutValidationError
+    CheckoutValidationError,
+    CheckoutAddressGetSuccess,
+    CheckoutAddressGetFailure
 };

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -190,7 +190,6 @@ export default {
             timeout
         }) => {
             const authHeader = state.authToken && `Bearer ${state.authToken}`;
-            debugger;
             const config = {
                 headers: {
                     'Content-Type': 'application/json',

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -178,6 +178,45 @@ export default {
             commit(UPDATE_BASKET_DETAILS, basketDetails);
         },
 
+        /**
+         * Get the address details from the backend and update the state.
+         *
+         * @param {Object} context - Vuex context object, this is the standard first parameter for actions
+         * @param {Object} payload - Parameter with the different configurations for the request.
+         */
+        getAddress: async ({ commit, state }, {
+            url,
+            language,
+            timeout
+        }) => {
+            const authHeader = state.authToken && `Bearer ${state.authToken}`;
+            debugger;
+            const config = {
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept-Language': language,
+                    ...(state.isLoggedIn && {
+                        Authorization: authHeader
+                    })
+                },
+                timeout
+            };
+
+            const { data } = await axios.get(url, config);
+
+            // TODO: Implement logic to select best address. For now, select the first address
+            const [selectedAddress] = data.Addresses;
+
+            const addressDetails = {
+                line1: selectedAddress.Line1,
+                line2: selectedAddress.Line2,
+                city: selectedAddress.City,
+                postcode: selectedAddress.ZipCode
+            };
+
+            commit(UPDATE_FULFILMENT_ADDRESS, addressDetails);
+        },
+
         setAuthToken: ({ commit }, authToken) => {
             commit(UPDATE_AUTH, authToken);
         },

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -3,6 +3,7 @@ import CheckoutModule from '../checkout.module';
 import checkoutDelivery from '../../demo/checkout-delivery.json';
 import basketDelivery from '../../demo/get-basket-delivery.json';
 import checkoutAvailableFulfilment from '../../demo/checkout-available-fulfilment.json';
+import customerAddresses from '../../demo/get-address.json';
 
 import {
     UPDATE_AUTH,
@@ -21,6 +22,7 @@ const { actions, mutations } = CheckoutModule;
 
 const {
     createGuestUser,
+    getAddress,
     getAvailableFulfilment,
     getBasket,
     getCheckout,
@@ -249,6 +251,35 @@ describe('CheckoutModule', () => {
                 expect(axios.get).toHaveBeenCalledWith(payload.url, config);
                 expect(commit).toHaveBeenCalledWith(UPDATE_BASKET_DETAILS, {
                     serviceType: basketDelivery.ServiceType.toLowerCase()
+                });
+            });
+        });
+
+        describe('getAddress ::', () => {
+            it(`should get the address details from the backend and call ${UPDATE_FULFILMENT_ADDRESS} mutation.`, async () => {
+                // Arrange
+                const config = {
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Accept-Language': payload.language,
+                        Authorization: `Bearer ${state.authToken}`
+                    },
+                    timeout: payload.timeout
+                };
+
+                axios.get = jest.fn(() => Promise.resolve({ data: customerAddresses }));
+                const [exptectedAddress] = customerAddresses.Addresses;
+
+                // Act
+                await getAddress({ commit, state }, payload);
+
+                // Assert
+                expect(axios.get).toHaveBeenCalledWith(payload.url, config);
+                expect(commit).toHaveBeenCalledWith(UPDATE_FULFILMENT_ADDRESS, {
+                    line1: exptectedAddress.Line1,
+                    line2: exptectedAddress.Line2,
+                    city: exptectedAddress.City,
+                    postcode: exptectedAddress.ZipCode
                 });
             });
         });

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -268,7 +268,7 @@ describe('CheckoutModule', () => {
                 };
 
                 axios.get = jest.fn(() => Promise.resolve({ data: customerAddresses }));
-                const [exptectedAddress] = customerAddresses.Addresses;
+                const [expectedAddress] = customerAddresses.Addresses;
 
                 // Act
                 await getAddress({ commit, state }, payload);
@@ -276,10 +276,10 @@ describe('CheckoutModule', () => {
                 // Assert
                 expect(axios.get).toHaveBeenCalledWith(payload.url, config);
                 expect(commit).toHaveBeenCalledWith(UPDATE_FULFILMENT_ADDRESS, {
-                    line1: exptectedAddress.Line1,
-                    line2: exptectedAddress.Line2,
-                    city: exptectedAddress.City,
-                    postcode: exptectedAddress.ZipCode
+                    line1: expectedAddress.Line1,
+                    line2: expectedAddress.Line2,
+                    city: expectedAddress.City,
+                    postcode: expectedAddress.ZipCode
                 });
             });
         });

--- a/packages/components/organisms/f-checkout/stories/Checkout.stories.js
+++ b/packages/components/organisms/f-checkout/stories/Checkout.stories.js
@@ -25,6 +25,7 @@ const createGuestUrl = '/create-guest.json';
 const getBasketDeliveryUrl = '/get-basket-delivery.json';
 const getBasketCollectionUrl = '/get-basket-collection.json';
 const updateCheckoutUrl = '/update-checkout.json';
+const getAddressUrl = '/get-address.json';
 
 CheckoutMock.setupCheckoutMethod(getCheckoutDeliveryUrl);
 CheckoutMock.setupCheckoutMethod(getCheckoutCollectionUrl);
@@ -33,6 +34,7 @@ CheckoutMock.setupCheckoutMethod(createGuestUrl);
 CheckoutMock.setupCheckoutMethod(getBasketDeliveryUrl);
 CheckoutMock.setupCheckoutMethod(getBasketCollectionUrl);
 CheckoutMock.setupCheckoutMethod(updateCheckoutUrl);
+CheckoutMock.setupCheckoutMethod(getAddressUrl);
 CheckoutMock.passThroughAny();
 
 export const CheckoutComponent = () => ({
@@ -61,6 +63,9 @@ export const CheckoutComponent = () => ({
         },
         loginUrl: {
             default: text('Login Url', '/login')
+        },
+        getAddressUrl: {
+            default: text('Get Address Url', getAddressUrl)
         }
     },
     store: new Vuex.Store({
@@ -77,8 +82,9 @@ export const CheckoutComponent = () => ({
         ':authToken="authToken" ' +
         ':locale="locale" ' +
         ':loginUrl="loginUrl" ' +
+        ':getAddressUrl="getAddressUrl" ' +
         // eslint-disable-next-line no-template-curly-in-string
-        ' :key="`${locale},${getCheckoutUrl},${updateCheckoutUrl},${checkoutAvailableFulfilmentUrl},${authToken},${createGuestUrl},${getBasketUrl}`" />'
+        ' :key="`${locale},${getCheckoutUrl},${updateCheckoutUrl},${checkoutAvailableFulfilmentUrl},${authToken},${createGuestUrl},${getBasketUrl},${getAddressUrl}`" />'
 });
 
 CheckoutComponent.storyName = 'f-checkout';


### PR DESCRIPTION
When Checkout GET endpoint does not return an address and the user is logged in and order type is delivery, request the address from Address api endpoint. 

Address API endpoint returns a list of addresses. In this PR, the first address is selected.
In the next PR I will implement proper selection logic based on last searched post code

---

## UI Review Checks

No UI changes

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
