### PR TITLE
f-checkout@0.55.0 - Utilise vue svg loader for displaying SVGs

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.52.0
+-------------------------------
+*February 9, 2021*
+
+### Added
+- Utilised `vue-svg-loader` for error page SVG
+- Added `vue-svg-loader` to Webpack config
+
 
 v0.51.0
 -------------------------------

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -13,6 +13,7 @@ v0.54.0
 ### Changed
 - Utilised `vue-svg-loader` for error page SVG
 
+
 v0.53.0
 -------------------------------
 *_February 9, 2021_*

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.53.0
+-------------------------------
+*February 9, 2021*
+
+### Added
+- Added `vue-svg-loader` to Webpack config
+
+### Changed
+- Utilised `vue-svg-loader` for error page SVG
+
+
 v0.52.0
 -------------------------------
 *February 9, 2021*

--- a/packages/components/organisms/f-checkout/jest.config.js
+++ b/packages/components/organisms/f-checkout/jest.config.js
@@ -8,7 +8,8 @@ module.exports = {
     transform: {
         '^.+\\.js$': 'babel-jest',
         '^.+\\.vue$': 'vue-jest',
-        '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub'
+        '.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
+        '^.+\\.svg$': './svgTransform.js'
     },
 
     transformIgnorePatterns: [

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Error.vue
+++ b/packages/components/organisms/f-checkout/src/components/Error.vue
@@ -8,7 +8,7 @@
         :class="[$style['c-checkout-error'], $style['c-checkout-error--verticalPadding']]"
     >
         // TODO: Load image from CDN in future
-        <sad-bag-icon />
+        <sad-bag-icon-decorator />
 
         <h1
             :class="$style['c-checkout-error-heading']"
@@ -26,13 +26,13 @@
 
 <script>
 import Card from '@justeat/f-card';
-import SadBagIcon from '../assets/images/jet-sad-bag.svg';
+import SadBagIconDecorator from '../assets/images/jet-sad-bag.svg';
 import '@justeat/f-card/dist/f-card.css';
 
 export default {
     components: {
         Card,
-        SadBagIcon
+        SadBagIconDecorator
     }
 };
 </script>

--- a/packages/components/organisms/f-checkout/src/components/Error.vue
+++ b/packages/components/organisms/f-checkout/src/components/Error.vue
@@ -7,9 +7,7 @@
         data-test-id="checkout-error-page-component"
         :class="[$style['c-checkout-error'], $style['c-checkout-error--verticalPadding']]"
     >
-        <img
-            src="../assets/images/jet-sad-bag.svg"
-            alt="">
+        <sad-bag-icon />
 
         <h1
             :class="$style['c-checkout-error-heading']"
@@ -27,10 +25,14 @@
 
 <script>
 import Card from '@justeat/f-card';
+import SadBagIcon from '../assets/images/jet-sad-bag.svg';
 import '@justeat/f-card/dist/f-card.css';
 
 export default {
-    components: { Card }
+    components: {
+        Card,
+        SadBagIcon
+    }
 };
 </script>
 

--- a/packages/components/organisms/f-checkout/src/components/Error.vue
+++ b/packages/components/organisms/f-checkout/src/components/Error.vue
@@ -7,6 +7,7 @@
         data-test-id="checkout-error-page-component"
         :class="[$style['c-checkout-error'], $style['c-checkout-error--verticalPadding']]"
     >
+        // TODO: Load image from CDN in future
         <sad-bag-icon />
 
         <h1

--- a/packages/components/organisms/f-checkout/svgTransform.js
+++ b/packages/components/organisms/f-checkout/svgTransform.js
@@ -1,0 +1,14 @@
+const vueJest = require('vue-jest/lib/template-compiler');
+
+module.exports = {
+    process (content) {
+        const { render } = vueJest({
+            content,
+            attrs: {
+                functional: false
+            }
+        });
+
+        return `module.exports = { render: ${render} }`;
+    }
+};

--- a/packages/components/organisms/f-checkout/vue.config.js
+++ b/packages/components/organisms/f-checkout/vue.config.js
@@ -16,6 +16,17 @@ module.exports = {
                 // eslint-disable-next-line quotes
                 additionalData: `@import "../assets/scss/common.scss";`
             });
+
+        const svgRule = config.module.rule('svg');
+
+        svgRule.uses.clear();
+
+        svgRule
+            .use('babel-loader')
+            .loader('babel-loader')
+            .end()
+            .use('vue-svg-loader')
+            .loader('vue-svg-loader');
     },
     pluginOptions: {
         lintStyleOnBuild: true

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.25.0
+------------------------------
+*February 9, 2021*
+
+### Added
+- `vue-svg-loader` to Webpack config
 
 v0.24.0
 ------------------------------

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "scripts": {
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -s public -p 8080 -c config/storybook",

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -52,5 +52,16 @@ ${content}`;
             .use('i18n')
               .loader('@kazupon/vue-i18n-loader')
               .end();
+
+        const svgRule = config.module.rule('svg');
+
+        svgRule.uses.clear();
+
+        svgRule
+            .use('babel-loader')
+            .loader('babel-loader')
+            .end()
+            .use('vue-svg-loader')
+            .loader('vue-svg-loader');
     }
 };


### PR DESCRIPTION
### Added
- `vue-svg-loader` to Webpack config
- Utilised `vue-svg-loader` for error page SVG

Not sure if this is overkill when we have the Vue icons package, but using the path to an SVG and using it as an image was causing issues. 

Also my first PR so go easy on me ☺️

---

## UI Review Checks

![image](https://user-images.githubusercontent.com/7570492/107379030-73a1bf80-6ae4-11eb-8569-f5ece7b3ea55.png)
Not much in regards to UI except that this SVG now works when used in Core Web.

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
