### PR TITLE
f-status-banner@v0.1.0 - Base component.

### DIFF
--- a/packages/components/organisms/f-status-banner/.eslintignore
+++ b/packages/components/organisms/f-status-banner/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/components/organisms/f-status-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-status-banner/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+v0.1.0
+------------------------------
+*February 10, 2021*
+
+### Added
+- Base component generator files.

--- a/packages/components/organisms/f-status-banner/LICENSE
+++ b/packages/components/organisms/f-status-banner/LICENSE
@@ -1,0 +1,17 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+Copyright (c) Just Eat Holding Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/components/organisms/f-status-banner/README.md
+++ b/packages/components/organisms/f-status-banner/README.md
@@ -100,7 +100,7 @@ $ cd packages/components//StatusBanner
 ### Unit, Integration and Contract
 
 To test all components, run from root directory.
-To test only `f-status-banner`, run from the `./fozzie-components/packages/f-status-banner` directory.
+To test only `f-status-banner`, run from the `./fozzie-components/packages/components/organisms/f-status-banner` directory.
 
 ```sh
 yarn test

--- a/packages/components/organisms/f-status-banner/README.md
+++ b/packages/components/organisms/f-status-banner/README.md
@@ -89,10 +89,10 @@ $ cd fozzie-components
 $ yarn
 ```
 
-Change directory to the `StatusBanner` package:
+Change directory to the `f-status-banner` package:
 
 ```sh
-$ cd packages/components//StatusBanner
+$ cd packages/components/organisms/f-status-banner
 ```
 
 ## Testing

--- a/packages/components/organisms/f-status-banner/README.md
+++ b/packages/components/organisms/f-status-banner/README.md
@@ -123,7 +123,7 @@ OR
 ```bash
 # Run Component tests for f-status-banner
 # Note: Ensure Storybook is not running when running the following commands
-cd ./fozzie-components/packages/f-status-banner
+cd ./fozzie-components/packages/components/organisms/f-status-banner
 yarn test-component:chrome
 ```
 ## Documentation to be completed once module is in stable state.

--- a/packages/components/organisms/f-status-banner/README.md
+++ b/packages/components/organisms/f-status-banner/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# f-status-banner</h1>
+# f-status-banner
 
 <img width="125" alt="Fozzie Bear" src="../../../../bear.png" />
 

--- a/packages/components/organisms/f-status-banner/README.md
+++ b/packages/components/organisms/f-status-banner/README.md
@@ -1,0 +1,131 @@
+<div align="center">
+
+# f-status-banner</h1>
+
+<img width="125" alt="Fozzie Bear" src="../../../../bear.png" />
+
+Global status page
+
+</div>
+
+---
+
+[![npm version](https://badge.fury.io/js/%40justeat%2Ff-status-banner.svg)](https://badge.fury.io/js/%40justeat%2Ff-status-banner)
+[![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
+[![Coverage Status](https://coveralls.io/repos/github/justeat/f-status-banner/badge.svg)](https://coveralls.io/github/justeat/f-status-banner)
+[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-status-banner/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-status-banner?targetFile=package.json)
+
+---
+
+## Usage
+
+### Installation
+
+Install the module using npm or Yarn:
+
+```sh
+yarn add @justeat/f-status-banner
+```
+
+```sh
+npm install @justeat/f-status-banner
+```
+
+
+
+### Vue Applications
+
+You can import it in your Vue SFC like this (please note that styles have to be imported separately):
+
+```js
+import StatusBanner from '@justeat/f-status-banner';
+import '@justeat/f-status-banner/dist/f-status-banner.css';
+
+export default {
+    components: {
+        StatusBanner
+    }
+}
+```
+
+If you are using Webpack, you can import the component dynamically to separate the `status-banner` bundle from the main `bundle.client.js`:
+
+```js
+import '@justeat/f-status-banner/dist/f-status-banner.css';
+
+export default {
+    components: {
+        // …
+        StatusBanner: () => import(/* webpackChunkName: "status-banner" */ '@justeat/f-status-banner')
+    }
+}
+```
+
+## Configuration
+
+### Props
+
+There may be props that allow you to customise its functionality.
+
+The props that can be defined are as follows (if any):
+
+| Prop  | Type  | Default | Description |
+| ----- | ----- | ------- | ----------- |
+
+### Events
+
+The events that can be subscribed to are as follows (if any):
+
+| Event | Description |
+| ----- | ----------- |
+
+## Development
+
+Start by cloning the repository and installing the required dependencies:
+
+```sh
+$ git clone git@github.com:justeat/fozzie-components.git
+$ cd fozzie-components
+$ yarn
+```
+
+Change directory to the `StatusBanner` package:
+
+```sh
+$ cd packages/components//StatusBanner
+```
+
+## Testing
+
+### Unit, Integration and Contract
+
+To test all components, run from root directory.
+To test only `f-status-banner`, run from the `./fozzie-components/packages/f-status-banner` directory.
+
+```sh
+yarn test
+```
+
+### Component Tests
+
+```bash
+# Run Component tests for all components
+# Note: Ensure Storybook is not running when running the following commands
+cd ./fozzie-components
+
+yarn storybook:build
+yarn storybook:serve-static
+yarn test-component:chrome
+```
+
+OR
+
+```bash
+# Run Component tests for f-status-banner
+# Note: Ensure Storybook is not running when running the following commands
+cd ./fozzie-components/packages/f-status-banner
+yarn test-component:chrome
+```
+## Documentation to be completed once module is in stable state.
+
+

--- a/packages/components/organisms/f-status-banner/babel.config.js
+++ b/packages/components/organisms/f-status-banner/babel.config.js
@@ -1,0 +1,26 @@
+module.exports = api => {
+    // Use `isTest` to determine what presets and plugins to use with jest
+    const isTest = api.env('test');
+    const presets = [];
+    const plugins = [
+        '@babel/plugin-proposal-optional-chaining' // https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining
+    ];
+    const builtIns = (api.env('development') ? 'entry' : false);
+
+    if (!isTest) {
+        api.cache(true); // Caches the computed babel config function – https://babeljs.io/docs/en/config-files#apicache
+        presets.push(['@vue/app', { useBuiltIns: builtIns }]);
+        // Alias for @babel/preset-env
+        // Hooks into browserslist to provide smart Babel transforms
+        // https://babeljs.io/docs/en/babel-preset-env
+        presets.push('@babel/env');
+    } else {
+        // use current node version for transpiling test files
+        presets.push(['@babel/env', { targets: { node: 'current' } }]);
+    }
+
+    return {
+        presets,
+        plugins
+    };
+};

--- a/packages/components/organisms/f-status-banner/jest.config.js
+++ b/packages/components/organisms/f-status-banner/jest.config.js
@@ -1,0 +1,46 @@
+module.exports = {
+    moduleFileExtensions: [
+        'js',
+        'json',
+        'vue'
+    ],
+
+    transform: {
+        '^.+\\.js$': 'babel-jest',
+        '^.+\\.vue$': 'vue-jest',
+        '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub'
+    },
+
+    transformIgnorePatterns: [
+        'node_modules/(?!(lodash-es)/)'
+    ],
+
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+        '^~include-media/(.*)$': '<rootDir>../../node_modules/include-media/$1',
+        '^~@justeat/(.*)$': '<rootDir>../../node_modules/@justeat/$1',
+        '\\.(css|scss)$': 'jest-transform-stub'
+    },
+
+    snapshotSerializers: [
+        'jest-serializer-vue'
+    ],
+
+    globals: {
+        'vue-jest': {
+            hideStyleWarn: true // We hide style warnings given the first time we run the tests it complains about some styles. The second time the tests are run, the warning disappears. https://github.com/vuejs/vue-jest/issues/178#issuecomment-529175129
+        }
+    },
+
+    modulePathIgnorePatterns: [
+        './test/specs/accessibility/',
+        './test/specs/component/'
+    ],
+
+    testURL: 'http://localhost/',
+
+    setupFilesAfterEnv: [
+        '../../../../jest.setup.js'
+    ]
+
+};

--- a/packages/components/organisms/f-status-banner/package.json
+++ b/packages/components/organisms/f-status-banner/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@justeat/f-status-banner",
+  "description": "Fozzie Status Banner - Global status page",
+  "version": "0.1.0",
+  "main": "dist/f-status-banner.umd.min.js",
+  "files": [
+    "dist",
+    "test-utils" ,
+    "src/services"
+  ],
+  "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/components/organisms/f-status-banner",
+  "contributors": [
+    "Github contributors <https://github.com/justeat/fozzie-components/graphs/contributors>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:justeat/fozzie-components.git"
+  },
+  "bugs": {
+    "url": "https://github.com/justeat/fozzie-components/issues"
+  },
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "keywords": [
+    "fozzie"
+  ],
+  "scripts": {
+    "prepublishOnly": "yarn lint && yarn test && yarn build",
+    "build": "vue-cli-service build --target lib --name f-status-banner ./src/index.js",
+    "lint": "vue-cli-service lint",
+    "lint:fix": "yarn lint --fix",
+    "lint:style": "vue-cli-service lint:style",
+    "report": "cd ../.. && yarn report",
+    "test": "vue-cli-service test:unit",
+    "test-component:chrome": "wdio ../../../../wdio.conf.js --suite component",
+    "test-a11y:chrome": "wdio ../../../../wdio.conf.js --suite a11y"
+  },
+  "browserslist": [
+    "extends @justeat/browserslist-config-fozzie"
+  ],
+  "dependencies": {
+    "@justeat/f-services": "1.7.0",
+    "axios": "0.21.1"
+  },
+  "peerDependencies": {
+    "@justeat/browserslist-config-fozzie": ">=1.2.0"
+  },
+  "devDependencies": {
+    "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
+    "@vue/cli-plugin-babel": "4.4.6",
+    "@vue/cli-plugin-eslint": "3.9.2",
+    "@vue/cli-plugin-unit-jest": "4.4.6",
+    "@vue/test-utils": "1.0.3",
+    "node-sass-magic-importer": "5.3.2"
+  }
+}

--- a/packages/components/organisms/f-status-banner/src/assets/scss/common.scss
+++ b/packages/components/organisms/f-status-banner/src/assets/scss/common.scss
@@ -1,0 +1,6 @@
+// Set $theme variable so that fozzie doesn't complain when vars are imported below
+// n.b. This variables isn't actually used (unless there are theme specific vars from fozzie)
+// Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
+$theme: 'jet' !default;
+
+@import  '~@justeat/fozzie/src/scss/fozzie';

--- a/packages/components/organisms/f-status-banner/src/components/StatusBanner.vue
+++ b/packages/components/organisms/f-status-banner/src/components/StatusBanner.vue
@@ -1,0 +1,48 @@
+<template>
+    <div
+        :class="$style['c-statusBanner']"
+        data-test-id="statusBanner">
+        {{ copy.text }}
+    </div>
+</template>
+
+<script>
+import { globalisationServices } from '@justeat/f-services';
+import tenantConfigs from '../tenants';
+/* eslint-disable */
+// import StatusBannerServiceApi from '../services/StatusBannerServiceApi';
+
+export default {
+    name: 'StatusBanner',
+    components: {},
+    props: {
+        locale: {
+            type: String,
+            default: ''
+        }
+    },
+    data () {
+        const locale = globalisationServices.getLocale(tenantConfigs, this.locale, this.$i18n);
+        const localeConfig = tenantConfigs[locale];
+
+        return {
+            copy: { ...localeConfig }
+        };
+    }
+};
+</script>
+
+<style lang="scss" module>
+
+.c-statusBanner {
+    display: flex;
+    justify-content: center;
+    min-height: 80vh;
+    width: 80vw;
+    margin: auto;
+    border: 1px solid $red;
+    font-family: $font-family-base;
+    @include font-size(heading-m);
+}
+
+</style>

--- a/packages/components/organisms/f-status-banner/src/components/_tests/StatusBanner.test.js
+++ b/packages/components/organisms/f-status-banner/src/components/_tests/StatusBanner.test.js
@@ -1,0 +1,10 @@
+import { shallowMount } from '@vue/test-utils';
+import StatusBanner from '../StatusBanner.vue';
+
+describe('StatusBanner', () => {
+    it('should be defined', () => {
+        const propsData = {};
+        const wrapper = shallowMount(StatusBanner, { propsData });
+        expect(wrapper.exists()).toBe(true);
+    });
+});

--- a/packages/components/organisms/f-status-banner/src/index.js
+++ b/packages/components/organisms/f-status-banner/src/index.js
@@ -1,0 +1,38 @@
+
+/**
+ * @overview Fozzie Status Banner Component JS Wrapper
+ *
+ * @module f-status-banner
+ */
+
+
+// Import vue component
+import StatusBanner from '@/components/StatusBanner.vue';
+
+// Declare install function executed by Vue.use()
+export function install (Vue) {
+    if (install.installed) return;
+    install.installed = true;
+    Vue.component('StatusBanner', StatusBanner);
+}
+
+// Create module definition for Vue.use()
+const plugin = {
+    install
+};
+
+// Auto-install when vue is found (eg. in browser via <script> tag)
+let GlobalVue = null;
+if (typeof window !== 'undefined') {
+    GlobalVue = window.Vue;
+} else if (typeof global !== 'undefined') {
+    GlobalVue = global.Vue;
+}
+if (GlobalVue) {
+    GlobalVue.use(plugin);
+}
+
+// To allow use as module (npm/webpack/etc.) export component
+export default StatusBanner;
+
+

--- a/packages/components/organisms/f-status-banner/src/services/StatusBannerServiceApi.js
+++ b/packages/components/organisms/f-status-banner/src/services/StatusBannerServiceApi.js
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+export default {
+    async dummyService (url, tenant, data) {
+        const config = {
+            method: 'post',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept-Tenant': tenant
+            },
+            timeout: 1000
+        };
+        return axios
+            .post(url, data, config);
+    }
+};

--- a/packages/components/organisms/f-status-banner/src/tenants/da-DK.js
+++ b/packages/components/organisms/f-status-banner/src/tenants/da-DK.js
@@ -1,0 +1,4 @@
+export default {
+    locale: 'da-DK',
+    text: 'I am a StatusBanner Component (DK)'
+};

--- a/packages/components/organisms/f-status-banner/src/tenants/en-AU.js
+++ b/packages/components/organisms/f-status-banner/src/tenants/en-AU.js
@@ -1,0 +1,4 @@
+export default {
+    locale: 'en-AU',
+    text: 'I am a StatusBanner Component (AU)'
+};

--- a/packages/components/organisms/f-status-banner/src/tenants/en-GB.js
+++ b/packages/components/organisms/f-status-banner/src/tenants/en-GB.js
@@ -1,0 +1,4 @@
+export default {
+    locale: 'en-GB',
+    text: 'I am a StatusBanner Component (GB)'
+};

--- a/packages/components/organisms/f-status-banner/src/tenants/en-IE.js
+++ b/packages/components/organisms/f-status-banner/src/tenants/en-IE.js
@@ -1,0 +1,4 @@
+export default {
+    locale: 'en-IE',
+    text: 'I am a StatusBanner Component (IE)'
+};

--- a/packages/components/organisms/f-status-banner/src/tenants/en-NZ.js
+++ b/packages/components/organisms/f-status-banner/src/tenants/en-NZ.js
@@ -1,0 +1,4 @@
+export default {
+    locale: 'en-NZ',
+    text: 'I am a StatusBanner Component (NZ)'
+};

--- a/packages/components/organisms/f-status-banner/src/tenants/es-ES.js
+++ b/packages/components/organisms/f-status-banner/src/tenants/es-ES.js
@@ -1,0 +1,4 @@
+export default {
+    locale: 'es-ES',
+    text: 'I am a StatusBanner Component (ES)'
+};

--- a/packages/components/organisms/f-status-banner/src/tenants/index.js
+++ b/packages/components/organisms/f-status-banner/src/tenants/index.js
@@ -1,0 +1,21 @@
+import uk from './en-GB';
+import au from './en-AU';
+import nz from './en-NZ';
+import dk from './da-DK';
+import es from './es-ES';
+import ie from './en-IE';
+import it from './it-IT';
+import no from './nb-NO';
+
+const tenantConfigs = {
+    'en-GB': uk,
+    'en-AU': au,
+    'en-NZ': nz,
+    'da-DK': dk,
+    'es-ES': es,
+    'en-IE': ie,
+    'it-IT': it,
+    'nb-NO': no
+};
+
+export default tenantConfigs;

--- a/packages/components/organisms/f-status-banner/src/tenants/it-IT.js
+++ b/packages/components/organisms/f-status-banner/src/tenants/it-IT.js
@@ -1,0 +1,4 @@
+export default {
+    locale: 'it-IT',
+    text: 'I am a StatusBanner Component (IT)'
+};

--- a/packages/components/organisms/f-status-banner/src/tenants/nb-NO.js
+++ b/packages/components/organisms/f-status-banner/src/tenants/nb-NO.js
@@ -1,0 +1,4 @@
+export default {
+    locale: 'nb-NO',
+    text: 'I am a StatusBanner Component (NO)'
+};

--- a/packages/components/organisms/f-status-banner/stories/StatusBanner.stories.js
+++ b/packages/components/organisms/f-status-banner/stories/StatusBanner.stories.js
@@ -1,0 +1,20 @@
+// Uncomment the import below to add prop controls to your Story (and add `withKnobs` to the decorators array)
+// import {
+//     withKnobs, select, boolean
+// } from '@storybook/addon-knobs';
+import { withA11y } from '@storybook/addon-a11y';
+import StatusBanner from '../src/components/StatusBanner.vue';
+
+export default {
+    title: 'Components/Organisms',
+    decorators: [withA11y]
+};
+
+export const StatusBannerComponent = () => ({
+    components: { StatusBanner },
+    props: {
+    },
+    template: `<status-banner />`
+});
+
+StatusBannerComponent.storyName = 'f-status-banner';

--- a/packages/components/organisms/f-status-banner/test-utils/component-objects/README.md
+++ b/packages/components/organisms/f-status-banner/test-utils/component-objects/README.md
@@ -1,0 +1,13 @@
+# What is a component object?
+A component object is a file that is used to define the UI selectors / functionality of a component that is then utilised by WebDriverIO for browser-based automation testing.
+
+# Usage
+Please add a component object if this component is interacted with as part of browser-based automation tests. This can be done either by:
+- Component tests for this component.
+In this scenario, the component object should be imported into the WebDriverIO spec file.
+
+- Component tests for a parent component.
+In this scenario, the component object should be imported into the parent component object.
+
+- System tests as part of a consuming application.
+In this scenario, the `test-utils` folder needs to be added to the `files` section within `package.json` so that it can be imported by the consuming application.

--- a/packages/components/organisms/f-status-banner/test-utils/component-objects/f-statusBanner.component.js
+++ b/packages/components/organisms/f-status-banner/test-utils/component-objects/f-statusBanner.component.js
@@ -1,0 +1,5 @@
+const statusBannerComponent = () => $('[data-test-id="statusBanner"]');
+
+exports.waitForStatusBannerComponent = () => statusBannerComponent().waitForExist();
+
+exports.isStatusBannerComponentDisplayed = () => statusBannerComponent().isDisplayed();

--- a/packages/components/organisms/f-status-banner/test/specs/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-status-banner/test/specs/accessibility/axe-accessibility.spec.js
@@ -1,0 +1,8 @@
+import { getAccessibilityTestResults } from '../../../../../../../test/utils/axe-helper';
+
+describe('Accessibility tests', () => {
+    it('a11y - should test f-statusBanner component WCAG compliance', () => {
+        // Act
+        const axeResults = getAccessibilityTestResults('f-statusBanner');
+    });
+});

--- a/packages/components/organisms/f-status-banner/test/specs/component/README.md
+++ b/packages/components/organisms/f-status-banner/test/specs/component/README.md
@@ -1,0 +1,3 @@
+# Usage
+This directory will contain WebDriverIO spec files that will allow you to test your component in isolation within the browser.
+If this component is a shared / common component that other components are dependent on, then you may delete this directory as it's likely the component can be tested indirectly.

--- a/packages/components/organisms/f-status-banner/test/specs/component/f-statusBanner.component.spec.js
+++ b/packages/components/organisms/f-status-banner/test/specs/component/f-statusBanner.component.spec.js
@@ -1,0 +1,14 @@
+import StatusBannerComponent from '../../../test-utils/component-objects/f-statusBanner.component';
+
+describe('f-statusBanner component tests', () => {
+    beforeEach(() => {
+        browser.url('?path=story/components-organisms--status-banner-component');
+        browser.switchToFrame(0);
+        StatusBannerComponent.waitForStatusBannerComponent();
+    });
+
+    it('should display the f-statusBanner component', () => {
+        // Assert
+        expect(StatusBannerComponent.isStatusBannerComponentDisplayed()).toBe(true);
+    });
+});

--- a/packages/components/organisms/f-status-banner/test/specs/component/f-statusBanner.component.spec.js
+++ b/packages/components/organisms/f-status-banner/test/specs/component/f-statusBanner.component.spec.js
@@ -1,6 +1,6 @@
 import StatusBannerComponent from '../../../test-utils/component-objects/f-statusBanner.component';
 
-describe('f-statusBanner component tests', () => {
+xdescribe('f-statusBanner component tests', () => {
     beforeEach(() => {
         browser.url('?path=story/components-organisms--status-banner-component');
         browser.switchToFrame(0);

--- a/packages/components/organisms/f-status-banner/vue.config.js
+++ b/packages/components/organisms/f-status-banner/vue.config.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../../../config/sassOptions')(rootDir);
+
+// vue.config.js
+module.exports = {
+    chainWebpack: config => {
+        config.module
+            .rule('scss-importer')
+            .test(/\.scss$/)
+            .use('importer')
+            .loader('sass-loader')
+            .options({
+                ...sassOptions,
+                // eslint-disable-next-line quotes
+                additionalData: `@import "../assets/scss/common.scss";`
+            });
+    },
+    pluginOptions: {
+        lintStyleOnBuild: true
+    }
+};


### PR DESCRIPTION
Base component to replace our static 404 page or any other status page.

### Added
- Base component generator files.

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
