### PR TITLE
f-checkout@v0.56.0 - use $logger to log events

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.53.0
+-------------------------------
+*February 10, 2021*
+
+### Added
+- logging to `Checkout` and `Header` components.
+- Tests to cover changes.
+
+
 v0.52.0
 -------------------------------
 *February 9, 2021*

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -12,8 +12,9 @@ v0.56.0
 - Tests to cover changes.
 
 
-*February 11, 2021*
+v0.55.0
 -------------------------------
+*February 11, 2021*
 ### Added
 - Added `vue-svg-loader` to Webpack config
 

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.56.0
 -------------------------------
-*February 11, 2021*
+*_February 11, 2021_*
 
 ### Added
 - logging to `Checkout` and `Header` components.
@@ -14,7 +14,7 @@ v0.56.0
 
 v0.55.0
 -------------------------------
-*February 11, 2021*
+*_February 11, 2021_*
 ### Added
 - Added `vue-svg-loader` to Webpack config
 
@@ -24,7 +24,7 @@ v0.55.0
 
 v0.54.0
 -------------------------------
-*February 10, 2021*
+*_February 10, 2021_*
 
 ### Added
 - `basketTotal` and `restaurantId` to the state, being retrieved from the Basket API.

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -328,7 +328,6 @@ export default {
                     this.$store,
                     eventData
                 );
-
             } catch (thrownErrors) {
                 eventData.errors = thrownErrors;
 
@@ -463,7 +462,7 @@ export default {
             const eventData = {
                 isLoggedIn: this.isLoggedIn,
                 serviceType: this.serviceType
-            }
+            };
 
             // TODO: Review this later - even though f-registration does something similar
             if (Array.isArray(thrownErrors)) {

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -297,7 +297,6 @@ export default {
          *
          */
         async submitCheckout () {
-
             const loggerPayload = {
                 isLoggedIn: this.isLoggedIn,
                 serviceType: this.serviceType
@@ -322,11 +321,11 @@ export default {
                     timeout: this.updateCheckoutTimeout
                 });
 
-                this.$emit(EventNames.CheckoutSuccess, this.loggerPayload);
+                this.$emit(EventNames.CheckoutSuccess, loggerPayload);
 
-                this.handleLogging(
-                    'logInfo',
+                this.$logger.logInfo(
                     'Consumer Checkout Successful',
+                    this.$store,
                     loggerPayload
                 );
 
@@ -335,9 +334,9 @@ export default {
 
                 this.$emit(EventNames.CheckoutFailure, loggerPayload);
 
-                this.handleLogging(
-                    'logError',
+                this.$logger.logError(
                     'Consumer Checkout Failure',
+                    this.$store,
                     loggerPayload
                 );
             }
@@ -367,9 +366,9 @@ export default {
             } catch (thrownErrors) {
                 this.$emit(EventNames.CheckoutSetupGuestFailure, thrownErrors);
 
-                this.handleLogging(
-                    'logError',
+                this.$logger.logError(
                     'Checkout Setup Guest Failure',
+                    this.$store,
                     thrownErrors
                 );
             }
@@ -391,9 +390,9 @@ export default {
                 this.$emit(EventNames.CheckoutGetFailure, thrownErrors);
                 this.hasCheckoutLoadedSuccessfully = false;
 
-                this.handleLogging(
-                    'logError',
+                this.$logger.logError(
                     'Get Checkout Failure',
+                    this.$store,
                     thrownErrors
                 );
             }
@@ -417,9 +416,9 @@ export default {
                 this.$emit(EventNames.CheckoutBasketGetFailure, thrownErrors);
                 this.hasCheckoutLoadedSuccessfully = false;
 
-                this.handleLogging(
-                    'logError',
+                this.$logger.logError(
                     'Get Checkout Basket Failure',
+                    this.$store,
                     thrownErrors
                 );
             }
@@ -441,9 +440,9 @@ export default {
                 this.$emit(EventNames.CheckoutAvailableFulfilmentGetFailure, thrownErrors);
                 this.hasCheckoutLoadedSuccessfully = false;
 
-                this.handleLogging(
-                    'logError',
+                this.$logger.logError(
                     'Get Checkout Available Fulfilment Times Failure',
+                    this.$store,
                     thrownErrors
                 );
             }
@@ -480,9 +479,9 @@ export default {
 
                 this.$emit(EventNames.CheckoutFailure, loggerPayload);
 
-                this.handleLogging(
-                    'logError',
+                this.$logger.logError(
                     'Consumer Checkout Failure',
+                    this.$store,
                     loggerPayload
                 );
             }
@@ -498,9 +497,9 @@ export default {
                 const validationState = validations.getFormValidationState(this.$v);
                 this.$emit(EventNames.CheckoutValidationError, validationState);
 
-                this.handleLogging(
-                    'logWarn',
+                this.$logger.logWarn(
                     'Checkout Validation Error',
+                    this.$store,
                     validationState
                 );
                 return;
@@ -539,10 +538,6 @@ export default {
         */
         isValidPostcode () {
             return validations.isValidPostcode(this.address.postcode, this.$i18n.locale);
-        },
-
-        handleLogging(type, message, payload) {
-            this.$logger[type](message, this.$store, payload)
         }
     },
 

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -297,7 +297,7 @@ export default {
          *
          */
         async submitCheckout () {
-            const loggerPayload = {
+            const eventData = {
                 isLoggedIn: this.isLoggedIn,
                 serviceType: this.serviceType
             };
@@ -321,23 +321,23 @@ export default {
                     timeout: this.updateCheckoutTimeout
                 });
 
-                this.$emit(EventNames.CheckoutSuccess, loggerPayload);
+                this.$emit(EventNames.CheckoutSuccess, eventData);
 
                 this.$logger.logInfo(
                     'Consumer Checkout Successful',
                     this.$store,
-                    loggerPayload
+                    eventData
                 );
 
             } catch (thrownErrors) {
-                loggerPayload.errors = thrownErrors;
+                eventData.errors = thrownErrors;
 
-                this.$emit(EventNames.CheckoutFailure, loggerPayload);
+                this.$emit(EventNames.CheckoutFailure, eventData);
 
                 this.$logger.logError(
                     'Consumer Checkout Failure',
                     this.$store,
-                    loggerPayload
+                    eventData
                 );
             }
         },
@@ -460,7 +460,7 @@ export default {
                 thrownErrors = error.response.data.errors;
             }
 
-            const loggerPayload = {
+            const eventData = {
                 isLoggedIn: this.isLoggedIn,
                 serviceType: this.serviceType
             }
@@ -469,20 +469,20 @@ export default {
             if (Array.isArray(thrownErrors)) {
                 this.genericErrorMessage = thrownErrors[0].description || this.$t('errorMessages.genericServerError');
 
-                loggerPayload.error = thrownErrors;
+                eventData.error = thrownErrors;
 
-                this.$emit(EventNames.CheckoutFailure, loggerPayload);
+                this.$emit(EventNames.CheckoutFailure, eventData);
             } else {
                 this.genericErrorMessage = error;
 
-                loggerPayload.error = error;
+                eventData.error = error;
 
-                this.$emit(EventNames.CheckoutFailure, loggerPayload);
+                this.$emit(EventNames.CheckoutFailure, eventData);
 
                 this.$logger.logError(
                     'Consumer Checkout Failure',
                     this.$store,
-                    loggerPayload
+                    eventData
                 );
             }
         },

--- a/packages/components/organisms/f-checkout/src/components/Header.vue
+++ b/packages/components/organisms/f-checkout/src/components/Header.vue
@@ -88,6 +88,8 @@ export default {
     methods: {
         onVisitLoginPage () {
             this.$emit(EventNames.CheckoutVisitLoginPage);
+
+            this.$logger.logInfo('Consumer Visit Login Page', this.$store)
         }
     }
 };

--- a/packages/components/organisms/f-checkout/src/components/Header.vue
+++ b/packages/components/organisms/f-checkout/src/components/Header.vue
@@ -89,7 +89,7 @@ export default {
         onVisitLoginPage () {
             this.$emit(EventNames.CheckoutVisitLoginPage);
 
-            this.$logger.logInfo('Consumer Visit Login Page', this.$store)
+            this.$logger.logInfo('Consumer Visit Login Page', this.$store);
         }
     }
 };

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -1462,7 +1462,7 @@ describe('Checkout', () => {
                 const error = 'Unknown Error';
 
                 const payload = {
-                    error: error,
+                    error,
                     isLoggedIn: false,
                     serviceType: CHECKOUT_METHOD_DELIVERY
                 };

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -8,7 +8,7 @@ import VueCheckout from '../Checkout.vue';
 import EventNames from '../../event-names';
 
 import {
-    defaultState, defaultActions, i18n, createStore
+    defaultState, defaultActions, i18n, createStore, $logger
 } from './helpers/setup';
 
 const localVue = createLocalVue();
@@ -462,7 +462,10 @@ describe('Checkout', () => {
                             store: createStore({ ...defaultState, serviceType: CHECKOUT_METHOD_COLLECTION }),
                             i18n,
                             localVue,
-                            propsData
+                            propsData,
+                            mocks: {
+                                $logger
+                            }
                         });
                     });
 
@@ -487,6 +490,14 @@ describe('Checkout', () => {
                         // Assert
                         expect(wrapper.emitted(EventNames.CheckoutSuccess)[0][0]).toEqual(payload);
                     });
+
+                    it('should call `logInfo`', async () => {
+                        // Act
+                        await wrapper.vm.onFormSubmit();
+
+                        // Assert
+                        expect($logger.logInfo).toHaveBeenCalled();
+                    });
                 });
 
                 it('should show error message and emit failure event when the mobile number field is not populated', async () => {
@@ -502,7 +513,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -528,7 +542,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -555,7 +572,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -575,11 +595,40 @@ describe('Checkout', () => {
                         store: createStore({ ...defaultState, serviceType: CHECKOUT_METHOD_COLLECTION }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Assert
                     expect(wrapper.vm.$v.fulfilment).toBeUndefined();
+                });
+
+                it('should call `logWarn` if field is invalid', async () => {
+                    // Arrange
+                    wrapper = mount(VueCheckout, {
+                        store: createStore({
+                            ...defaultState,
+                            serviceType: CHECKOUT_METHOD_DELIVERY,
+                            customer: {
+                                ...defaultState.customer,
+                                mobileNumber: ''
+                            }
+                        }),
+                        i18n,
+                        localVue,
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
+                    });
+
+                    // Act
+                    await wrapper.vm.onFormSubmit();
+
+                    // Assert
+                    expect($logger.logWarn).toHaveBeenCalled();
                 });
             });
 
@@ -592,7 +641,10 @@ describe('Checkout', () => {
                             store: createStore({ ...defaultState, serviceType: CHECKOUT_METHOD_DELIVERY }),
                             i18n,
                             localVue,
-                            propsData
+                            propsData,
+                            mocks: {
+                                $logger
+                            }
                         });
                     });
 
@@ -617,6 +669,14 @@ describe('Checkout', () => {
                         // Assert
                         expect(wrapper.emitted(EventNames.CheckoutSuccess)[0][0]).toEqual(payload);
                     });
+
+                    it('should call `logInfo`', async () => {
+                        // Act
+                        await wrapper.vm.onFormSubmit();
+
+                        // Assert
+                        expect($logger.logInfo).toHaveBeenCalled();
+                    });
                 });
 
                 it('should emit failure event and display error message when address line1 input field is empty', async () => {
@@ -632,7 +692,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -658,7 +721,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -684,7 +750,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -710,7 +779,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -737,7 +809,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -756,6 +831,32 @@ describe('Checkout', () => {
                     expect(wrapper.vm.$v.address.city).toBeDefined();
                     expect(wrapper.vm.$v.address.postcode).toBeDefined();
                 });
+
+                it('should call `logWarn` if field is invalid', async () => {
+                    // Arrange
+                    wrapper = mount(VueCheckout, {
+                        store: createStore({
+                            ...defaultState,
+                            serviceType: CHECKOUT_METHOD_DELIVERY,
+                            address: {
+                                ...defaultState.address,
+                                postcode: 'EC4M 7R'
+                            }
+                        }),
+                        i18n,
+                        localVue,
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
+                    });
+
+                    // Act
+                    await wrapper.vm.onFormSubmit();
+
+                    // Assert
+                    expect($logger.logWarn).toHaveBeenCalled();
+                });
             });
 
             describe('if `isLoggedIn` set to `false`', () => {
@@ -773,7 +874,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -793,7 +897,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -818,7 +925,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -845,7 +955,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -872,7 +985,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -899,7 +1015,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -925,7 +1044,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -945,7 +1067,10 @@ describe('Checkout', () => {
                         }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Assert
@@ -984,7 +1109,10 @@ describe('Checkout', () => {
                     }),
                     i18n,
                     localVue,
-                    propsData
+                    propsData,
+                    mocks: {
+                        $logger
+                    }
                 });
 
                 // Act
@@ -999,23 +1127,41 @@ describe('Checkout', () => {
             });
 
             describe('when `createGuestUser` request fails', () => {
-                it('should emit `CheckoutSetupGuestFailure` event', async () => {
-                    // Arrange
+                let wrapper;
+
+                beforeEach(() => {
                     jest.spyOn(VueCheckout.methods, 'initialise').mockImplementation();
 
-                    const wrapper = mount(VueCheckout, {
+                    wrapper = mount(VueCheckout, {
                         store: createStore(defaultState, { ...defaultActions, createGuestUser: jest.fn(async () => Promise.reject()) }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
+                });
 
+                afterEach(() => {
+                    jest.clearAllMocks();
+                });
+
+                it('should emit `CheckoutSetupGuestFailure` event', async () => {
                     // Act
                     await wrapper.vm.setupGuestUser();
 
                     // Assert
                     expect(wrapper.emitted(EventNames.CheckoutSetupGuestSuccess)).toBeUndefined();
                     expect(wrapper.emitted(EventNames.CheckoutSetupGuestFailure).length).toBe(1);
+                });
+
+                it('should call `logError`', async () => {
+                    // Act
+                    await wrapper.vm.setupGuestUser();
+
+                    // Assert
+                    expect($logger.logError).toHaveBeenCalled();
                 });
             });
 
@@ -1028,7 +1174,10 @@ describe('Checkout', () => {
                         store: createStore(),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -1047,17 +1196,23 @@ describe('Checkout', () => {
             });
 
             describe('when `getCheckout` request fails', () => {
-                it('should emit failure event and set `hasCheckoutLoadedSuccessfully` to `false`', async () => {
-                    // Arrange
+                let wrapper;
+
+                beforeEach(() => {
                     jest.spyOn(VueCheckout.methods, 'initialise').mockImplementation();
 
-                    const wrapper = mount(VueCheckout, {
+                    wrapper = mount(VueCheckout, {
                         store: createStore(defaultState, { ...defaultActions, getCheckout: jest.fn(async () => Promise.reject()) }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
+                });
 
+                it('should emit failure event and set `hasCheckoutLoadedSuccessfully` to `false`', async () => {
                     // Act
                     await wrapper.vm.loadCheckout();
 
@@ -1065,6 +1220,14 @@ describe('Checkout', () => {
                     expect(wrapper.emitted(EventNames.CheckoutGetSuccess)).toBeUndefined();
                     expect(wrapper.emitted(EventNames.CheckoutGetFailure).length).toBe(1);
                     expect(wrapper.vm.hasCheckoutLoadedSuccessfully).toBe(false);
+                });
+
+                it('should call `logError`', async () => {
+                    // Act
+                    await wrapper.vm.loadCheckout();
+
+                    // Assert
+                    expect($logger.logError).toHaveBeenCalled();
                 });
             });
 
@@ -1077,7 +1240,10 @@ describe('Checkout', () => {
                         store: createStore(),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -1096,17 +1262,23 @@ describe('Checkout', () => {
             });
 
             describe('when `getAvailableFulfilment` request fails', () => {
-                it('should emit failure event and set `hasCheckoutLoadedSuccessfully` to `false`', async () => {
-                    // Arrange
+                let wrapper;
+
+                beforeEach(() => {
                     jest.spyOn(VueCheckout.methods, 'initialise').mockImplementation();
 
-                    const wrapper = mount(VueCheckout, {
+                    wrapper = mount(VueCheckout, {
                         store: createStore(defaultState, { ...defaultActions, getAvailableFulfilment: jest.fn(async () => Promise.reject()) }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
+                });
 
+                it('should emit failure event and set `hasCheckoutLoadedSuccessfully` to `false`', async () => {
                     // Act
                     await wrapper.vm.loadAvailableFulfilment();
 
@@ -1114,6 +1286,14 @@ describe('Checkout', () => {
                     expect(wrapper.emitted(EventNames.CheckoutAvailableFulfilmentGetSuccess)).toBeUndefined();
                     expect(wrapper.emitted(EventNames.CheckoutAvailableFulfilmentGetFailure).length).toBe(1);
                     expect(wrapper.vm.hasCheckoutLoadedSuccessfully).toBe(false);
+                });
+
+                it('should call `logError`', async () => {
+                    // Act
+                    await wrapper.vm.loadAvailableFulfilment();
+
+                    // Assert
+                    expect($logger.logError).toHaveBeenCalled();
                 });
             });
 
@@ -1126,7 +1306,10 @@ describe('Checkout', () => {
                         store: createStore(),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -1145,17 +1328,23 @@ describe('Checkout', () => {
             });
 
             describe('when `getBasket` request fails', () => {
-                it('should emit failure event and set `hasCheckoutLoadedSuccessfully` to `false`', async () => {
-                    // Arrange
+                let wrapper;
+
+                beforeEach(() => {
                     jest.spyOn(VueCheckout.methods, 'initialise').mockImplementation();
 
-                    const wrapper = mount(VueCheckout, {
+                    wrapper = mount(VueCheckout, {
                         store: createStore(defaultState, { ...defaultActions, getBasket: jest.fn(async () => Promise.reject()) }),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
+                });
 
+                it('should emit failure event and set `hasCheckoutLoadedSuccessfully` to `false`', async () => {
                     // Act
                     await wrapper.vm.loadBasket();
 
@@ -1163,6 +1352,14 @@ describe('Checkout', () => {
                     expect(wrapper.emitted(EventNames.CheckoutBasketGetFailure).length).toBe(1);
                     expect(wrapper.emitted(EventNames.CheckoutBasketGetSuccess)).toBeUndefined();
                     expect(wrapper.vm.hasCheckoutLoadedSuccessfully).toBe(false);
+                });
+
+                it('should call `logError`', async () => {
+                    // Act
+                    await wrapper.vm.loadBasket();
+
+                    // Assert
+                    expect($logger.logError).toHaveBeenCalled();
                 });
             });
 
@@ -1175,7 +1372,10 @@ describe('Checkout', () => {
                         store: createStore(),
                         i18n,
                         localVue,
-                        propsData
+                        propsData,
+                        mocks: {
+                            $logger
+                        }
                     });
 
                     // Act
@@ -1196,7 +1396,10 @@ describe('Checkout', () => {
                     store: createStore(),
                     i18n,
                     localVue,
-                    propsData
+                    propsData,
+                    mocks: {
+                        $logger
+                    }
                 });
             });
 
@@ -1247,6 +1450,7 @@ describe('Checkout', () => {
                 // Arrange
                 const error = 'Unknown Error';
 
+                // Act
                 wrapper.vm.handleErrorState(error);
 
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
@@ -1258,15 +1462,24 @@ describe('Checkout', () => {
                 const error = 'Unknown Error';
 
                 const payload = {
-                    errors: error,
+                    error: error,
                     isLoggedIn: false,
                     serviceType: CHECKOUT_METHOD_DELIVERY
                 };
 
+                // Act
                 wrapper.vm.handleErrorState(error);
 
                 expect(wrapper.emitted(EventNames.CheckoutFailure).length).toBe(1);
                 expect(wrapper.emitted(EventNames.CheckoutFailure)[0][0]).toEqual(payload);
+            });
+
+            it('should call `logError`', () => {
+                // Act
+                wrapper.vm.handleErrorState();
+
+                // Assert
+                expect($logger.logError).toHaveBeenCalled();
             });
         });
 
@@ -1368,7 +1581,8 @@ describe('Checkout', () => {
                     localVue,
                     propsData,
                     mocks: {
-                        $v
+                        $v,
+                        $logger
                     }
                 });
 
@@ -1390,7 +1604,8 @@ describe('Checkout', () => {
                     localVue,
                     propsData,
                     mocks: {
-                        $v
+                        $v,
+                        $logger
                     }
                 });
 
@@ -1415,7 +1630,8 @@ describe('Checkout', () => {
                     localVue,
                     propsData,
                     mocks: {
-                        $v
+                        $v,
+                        $logger
                     }
                 });
 
@@ -1424,6 +1640,28 @@ describe('Checkout', () => {
 
                 // Assert
                 expect(handleErrorStateSpy).toHaveBeenCalledWith(error);
+            });
+
+            it('should call `logWarn` if form is Invalid', async () => {
+                // Arrange
+                isFormValidSpy.mockReturnValue(false);
+
+                const wrapper = mount(VueCheckout, {
+                    store: createStore(),
+                    i18n,
+                    localVue,
+                    propsData,
+                    mocks: {
+                        $v,
+                        $logger
+                    }
+                });
+
+                // Act
+                await wrapper.vm.onFormSubmit();
+
+                // Assert
+                expect($logger.logWarn).toHaveBeenCalled();
             });
         });
 

--- a/packages/components/organisms/f-checkout/src/components/_tests/Header.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Header.test.js
@@ -2,7 +2,7 @@ import Vuex from 'vuex';
 import { VueI18n } from '@justeat/f-globalisation';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Header from '../Header.vue';
-import { i18n, defaultState, createStore } from './helpers/setup';
+import { i18n, defaultState, createStore, $logger } from './helpers/setup';
 import { CHECKOUT_METHOD_COLLECTION, CHECKOUT_METHOD_DELIVERY } from '../../constants';
 import EventNames from '../../event-names';
 
@@ -145,13 +145,16 @@ describe('Header', () => {
 
     describe('methods ::', () => {
         describe('onVisitLoginPage ::', () => {
-            it('should emit the `VisitLoginPage` event when switch user link is clicked.', () => {
+            it('should emit the `VisitLoginPage` event and call `logInfo` when switch user link is clicked.', () => {
                 // Arrange
                 const wrapper = shallowMount(Header, {
                     store: createStore({ ...defaultState, isLoggedIn: true }),
                     i18n,
                     localVue,
-                    propsData
+                    propsData,
+                    mocks: {
+                        $logger
+                    }
                 });
 
                 // Act
@@ -160,6 +163,7 @@ describe('Header', () => {
 
                 // Assert
                 expect(wrapper.emitted(EventNames.CheckoutVisitLoginPage).length).toBe(1);
+                expect($logger.logInfo).toHaveBeenCalled();
             });
 
             it('should emit the `VisitLoginPage` event when guest login button is clicked.', () => {
@@ -168,7 +172,10 @@ describe('Header', () => {
                     store: createStore({ ...defaultState, isLoggedIn: false }),
                     i18n,
                     localVue,
-                    propsData
+                    propsData,
+                    mocks: {
+                        $logger
+                    }
                 });
 
                 // Act
@@ -177,6 +184,7 @@ describe('Header', () => {
 
                 // Assert
                 expect(wrapper.emitted(EventNames.CheckoutVisitLoginPage).length).toBe(1);
+                expect($logger.logInfo).toHaveBeenCalled();
             });
         });
     });

--- a/packages/components/organisms/f-checkout/src/components/_tests/Header.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Header.test.js
@@ -2,7 +2,9 @@ import Vuex from 'vuex';
 import { VueI18n } from '@justeat/f-globalisation';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Header from '../Header.vue';
-import { i18n, defaultState, createStore, $logger } from './helpers/setup';
+import {
+    i18n, defaultState, createStore, $logger
+} from './helpers/setup';
 import { CHECKOUT_METHOD_COLLECTION, CHECKOUT_METHOD_DELIVERY } from '../../constants';
 import EventNames from '../../event-names';
 

--- a/packages/components/organisms/f-checkout/src/components/_tests/helpers/setup.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/helpers/setup.js
@@ -77,6 +77,12 @@ const createStore = (state = defaultState, actions = defaultActions) => new Vuex
     }
 });
 
+const $logger = {
+    logInfo: jest.fn(),
+    logWarn: jest.fn(),
+    logError: jest.fn()
+}
+
 export {
-    fulfilmentTimes, defaultState, defaultActions, i18n, createStore
+    fulfilmentTimes, defaultState, defaultActions, i18n, createStore, $logger
 };

--- a/packages/components/organisms/f-checkout/src/components/_tests/helpers/setup.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/helpers/setup.js
@@ -81,7 +81,7 @@ const $logger = {
     logInfo: jest.fn(),
     logWarn: jest.fn(),
     logError: jest.fn()
-}
+};
 
 export {
     fulfilmentTimes, defaultState, defaultActions, i18n, createStore, $logger

--- a/packages/components/organisms/f-checkout/src/components/_tests/helpers/setup.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/helpers/setup.js
@@ -85,5 +85,10 @@ const $logger = {
 };
 
 export {
-    fulfilmentTimes, defaultState, defaultActions, i18n, createStore, $logger
+    fulfilmentTimes,
+    defaultState,
+    defaultActions,
+    i18n,
+    createStore,
+    $logger
 };


### PR DESCRIPTION
### Added
- logging to `Checkout` and `Header` components.
- Tests to cover changes.
