### PR TITLE
generator-component@v2.0.1 – README fixes

### DIFF
--- a/packages/tools/generator-component/CHANGELOG.md
+++ b/packages/tools/generator-component/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.0.1
+------------------------------
+*February 10, 2021*
+
+### Fixed
+- Couple of path updates in the `README` and closing tag for `h1` removed.
+
+
 v2.0.0
 ------------------------------
 *January 27, 2021*

--- a/packages/tools/generator-component/generators/app/templates/README.md
+++ b/packages/tools/generator-component/generators/app/templates/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# f-<%= name.default %></h1>
+# f-<%= name.default %>
 
 <img width="125" alt="Fozzie Bear" src="../../../../bear.png" />
 
@@ -100,7 +100,7 @@ $ cd packages/components/<%= componentCategory %>/<%= name.component %>
 ### Unit, Integration and Contract
 
 To test all components, run from root directory.
-To test only `f-<%= name.default %>`, run from the `./fozzie-components/packages/f-<%= name.default %>` directory.
+To test only `f-<%= name.default %>`, run from the `./fozzie-components/<%= componentFolder %>f-<%= name.default %>` directory.
 
 ```sh
 yarn test
@@ -123,7 +123,7 @@ OR
 ```bash
 # Run Component tests for f-<%= name.default %>
 # Note: Ensure Storybook is not running when running the following commands
-cd ./fozzie-components/packages/f-<%= name.default %>
+cd ./fozzie-components/<%= componentFolder %>f-<%= name.default %>
 yarn test-component:chrome
 ```
 ## Documentation to be completed once module is in stable state.

--- a/packages/tools/generator-component/package.json
+++ b/packages/tools/generator-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/generator-component",
   "description": "Generator Component – A generator for Fozzie components",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "files": [
     "generators"
   ],


### PR DESCRIPTION
### Fixed
- Couple of path updates in the `README` and closing tag for `h1` removed.