### PR TITLE
generator-component@v2.0.2 – Fixing couple of README paths

### DIFF
--- a/packages/tools/generator-component/CHANGELOG.md
+++ b/packages/tools/generator-component/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v2.0.2
+------------------------------
+*February 10, 2021*
+
+### Fixed
+- Couple more `README` path and name updates.
+
+
 v2.0.1
 ------------------------------
 *February 10, 2021*

--- a/packages/tools/generator-component/generators/app/templates/README.md
+++ b/packages/tools/generator-component/generators/app/templates/README.md
@@ -89,10 +89,10 @@ $ cd fozzie-components
 $ yarn
 ```
 
-Change directory to the `<%= name.component %>` package:
+Change directory to the `f-<%= name.default %>` package:
 
 ```sh
-$ cd packages/components/<%= componentCategory %>/<%= name.component %>
+$ cd <%= componentFolder %>f-<%= name.default %>
 ```
 
 ## Testing

--- a/packages/tools/generator-component/package.json
+++ b/packages/tools/generator-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/generator-component",
   "description": "Generator Component – A generator for Fozzie components",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "files": [
     "generators"
   ],


### PR DESCRIPTION
### Fixed
- Couple more `README` path and name updates.