### PR TITLE
f-content-cards@3.1.1 - some style changes for home promo cards

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v3.1.1
+------------------------------
+*February 10, 2020*
+
+### Changed
+- Some style changes for home promotion cards
+
+
 v3.1.0
 ------------------------------
 *February 9, 2020*
@@ -20,6 +29,7 @@ v3.0.0-beta.1
 
 ### Fixed
 - Old references to font-size keys updated.
+
 ### Changed
 - Updated config for latest `sass-loader`.
 - Switches import in `common.scss` in line with fozzie v5-beta.

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.1",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
@@ -141,7 +141,7 @@ export default {
         align-items: center;
         justify-content: center;
         width: 100%;
-        margin-bottom: spacing(x3);
+        margin-bottom: spacing(x2);
 
         @include media('>mid') {
             width: 50%;
@@ -159,6 +159,7 @@ export default {
 
         @include media('>mid') {
             display: unset;
+            @include font-size(heading-m);
         }
     }
 
@@ -168,13 +169,10 @@ export default {
 
     .c-contentCards-homePromotionCard1-innerCard {
         width: 100%;
-        padding-left: spacing(x2);
-        padding-right: spacing(x2);
+        padding: 0;
 
         @include media('>mid') {
             width: 50%;
-            padding-left: 0;
-            padding-right: spacing(x4);
 
             :global(.c-contentCards-homePromotionCard2) {
                 padding-left: spacing(x5);

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
@@ -119,7 +119,7 @@ export default {
         width: 100%;
         box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
         border-radius: 4px;
-        padding: spacing(x2) calc(35% + 8px) spacing(x2) spacing(x2);
+        padding: spacing(x2) calc(35% + #{spacing()}) spacing(x2) spacing(x2);
         max-width: 800px; //to replicate max-width of searchbox
         margin: auto;
 

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
@@ -118,14 +118,18 @@ export default {
         display: block;
         width: 100%;
         box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-        border-radius: $post-order-card-radius;
-        padding: spacing(x3) calc(35% + 8px) spacing(x3) spacing(x3);
+        border-radius: 4px;
+        padding: spacing(x2) calc(35% + 8px) spacing(x2) spacing(x2);
+        max-width: 800px; //to replicate max-width of searchbox
+        margin: auto;
 
         @include media('>narrow') {
             padding-right: 208px;
+            width: 95%; //to replicate width of searchbox
         }
 
         .c-contentCards-homePromotionCard2-link {
+            @include font-size('body-l', false);
             text-decoration: none;
             font-weight: $font-weight-bold;
 
@@ -154,6 +158,14 @@ export default {
             .c-contentCards-homePromotionCard2-title {
                 color: $grey--lighter;
             }
+        }
+    }
+
+    .c-contentCards-homePromotionCard2-title {
+        @include font-size(heading-m);
+
+        @include media('<=narrow') {
+            @include font-size(heading-m, true, narrow);
         }
     }
 


### PR DESCRIPTION
### Changed
- Some style changes for home promotion cards

**Before:**
**Card1:**
desktop:
![Screen Shot 2021-02-10 at 15 59 37](https://user-images.githubusercontent.com/19548183/107535816-02800c00-6bb9-11eb-9239-c16081941c7b.png)

tablet:
![Screen Shot 2021-02-10 at 15 59 31](https://user-images.githubusercontent.com/19548183/107535822-03b13900-6bb9-11eb-9f87-a3b4d0b203ad.png)

mobile:
![Screen Shot 2021-02-10 at 15 59 23](https://user-images.githubusercontent.com/19548183/107535834-06ac2980-6bb9-11eb-861d-41ff274fa7e4.png)


**Card2:**
desktop:
![Screen Shot 2021-02-10 at 15 57 27](https://user-images.githubusercontent.com/19548183/107535627-d2d10400-6bb8-11eb-9a3d-5d92c4e2f977.png)

tablet:
![Screen Shot 2021-02-10 at 15 57 37](https://user-images.githubusercontent.com/19548183/107535635-d49ac780-6bb8-11eb-9074-9c5a0836eabf.png)

mobile:
![Screen Shot 2021-02-10 at 15 57 50](https://user-images.githubusercontent.com/19548183/107535641-d5cbf480-6bb8-11eb-9e98-6a2801f3023f.png)


**After:**
**Card1:**
desktop:
![Screen Shot 2021-02-10 at 15 48 37](https://user-images.githubusercontent.com/19548183/107534134-8afdad00-6bb7-11eb-9bbb-30825cd049d0.png)

tablet:
![Screen Shot 2021-02-10 at 15 48 48](https://user-images.githubusercontent.com/19548183/107534143-8cc77080-6bb7-11eb-88e3-a4cbfe70ff1a.png)

mobile:
![Screen Shot 2021-02-10 at 15 49 03](https://user-images.githubusercontent.com/19548183/107534150-8df89d80-6bb7-11eb-8111-b426af65c1a0.png)

**Card2:**
desktop:
![Screen Shot 2021-02-10 at 15 50 20](https://user-images.githubusercontent.com/19548183/107534379-bed8d280-6bb7-11eb-8250-edfdd3c4c7cd.png)

tablet:
![Screen Shot 2021-02-10 at 15 50 13](https://user-images.githubusercontent.com/19548183/107534352-baacb500-6bb7-11eb-8bd0-ca49dbdd364e.png)

mobile:
![Screen Shot 2021-02-10 at 15 50 03](https://user-images.githubusercontent.com/19548183/107534394-c13b2c80-6bb7-11eb-8200-6291c32b8f5d.png)


