### PR TITLE
f-checkout@0.56.1 - Use comment in vue template correctly

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.57.0
+v0.56.1
 -------------------------------
 *_February 11, 2021_*
 

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.57.0
+-------------------------------
+*_February 11, 2021_*
+
+### Changed
+- Used correct comment format to prevent it being shown on UI
+
+
 v0.56.0
 -------------------------------
 *_February 11, 2021_*

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.56.1
 -------------------------------
-*_February 11, 2021_*
+*February 11, 2021*
 
 ### Changed
 - Used correct comment format to prevent it being shown on UI
@@ -14,7 +14,7 @@ v0.56.1
 
 v0.56.0
 -------------------------------
-*_February 11, 2021_*
+*February 11, 2021*
 
 ### Added
 - logging to `Checkout` and `Header` components.
@@ -23,7 +23,7 @@ v0.56.0
 
 v0.55.0
 -------------------------------
-*_February 11, 2021_*
+*February 11, 2021*
 ### Added
 - Added `vue-svg-loader` to Webpack config
 
@@ -33,7 +33,7 @@ v0.55.0
 
 v0.54.0
 -------------------------------
-*_February 10, 2021_*
+*February 10, 2021*
 
 ### Added
 - `basketTotal` and `restaurantId` to the state, being retrieved from the Basket API.
@@ -44,7 +44,7 @@ v0.54.0
 
 v0.53.0
 -------------------------------
-*_February 9, 2021_*
+*February 9, 2021*
 
 ### Added
 - Loading customer address from API endpoint if Checkout endpoint did not return it

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.57.0",
+  "version": "0.56.1",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Error.vue
+++ b/packages/components/organisms/f-checkout/src/components/Error.vue
@@ -7,7 +7,7 @@
         data-test-id="checkout-error-page-component"
         :class="[$style['c-checkout-error'], $style['c-checkout-error--verticalPadding']]"
     >
-        // TODO: Load image from CDN in future
+        <!-- TODO: Load image from CDN in future -->
         <sad-bag-icon-decorator />
 
         <h1


### PR DESCRIPTION
### Changed
- Used correct comment format to prevent it being shown on UI

Coming from React world and JSX, I used the wrong type of comment inside the Vue template, so this comment is now showing in the UI. 🙃 

![image](https://user-images.githubusercontent.com/7570492/107641437-88f52600-6c6b-11eb-98b1-2f34dace5c13.png)
