### PR TITLE
f-cookie-banner@v0.1.1 - Move legacy banner out of overlay.

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.1.1
+------------------------------
+*February 11, 2021*
+
+### Changed
+- Amend class name on legacy banner
+- Move legacy banner out of overlay
+- Include hide class for legacy banner
+- Wrap `navigator` call in conditional for `process.browser`
 
 v0.1.0
 ------------------------------

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -1,5 +1,6 @@
 <template>
     <div
+        v-if="!legacyBanner"
         ref="cookieBanner"
         :class="[
             $style['c-cookieBanner'],
@@ -10,7 +11,6 @@
         data-test-id="cookieBanner-component"
         :aria-hidden="shouldHideBanner">
         <div
-            v-if="!legacyBanner"
             :class="[
                 $style['c-cookieBanner-card'],
                 { [$style['c-cookieBanner-ios']]: isIosBrowser() }
@@ -64,11 +64,12 @@
                 </button-component>
             </div>
         </div>
-        <legacy-banner
-            v-else
-            @hide-legacy-banner="hideBanner"
-        />
     </div>
+    <legacy-banner
+        v-else
+        :should-hide-legacy-banner="shouldHideBanner"
+        @hide-legacy-banner="hideBanner"
+    />
 </template>
 
 <script>
@@ -249,7 +250,10 @@ export default {
          * @returns {Bool}
          */
         isIosBrowser () {
-            return /(iPhone|iPad).*Safari/.test(navigator.userAgent);
+            if (process.browser) {
+                return /(iPhone|iPad).*Safari/.test(navigator.userAgent);
+            }
+            return false;
         },
         /**
          * Resend GTM events

--- a/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
@@ -1,6 +1,8 @@
 <template>
     <div>
-        <div :class="[$style['c-cookieWarning'], { [$style['c-cookieBanner--hidden']]: hideBanner }]">
+        <div
+            :class="[$style['c-cookieWarning'], { [$style['c-cookieWarning--is-hidden']]: shouldHideLegacyBanner }]"
+            :aria-hidden="shouldHideLegacyBanner">
             <div :class="$style['c-cookieWarning-inner']">
                 <p>
                     {{ $t('legacyBannerText') }}
@@ -39,10 +41,11 @@ export default {
         ButtonComponent,
         CrossIcon
     },
-    data () {
-        return {
-            hideBanner: false
-        };
+    props: {
+        shouldHideLegacyBanner: {
+            type: Boolean,
+            default: false
+        }
     }
 };
 </script>
@@ -52,6 +55,8 @@ export default {
         box-sizing: border-box;
         background-color: $grey--darkest;
         position: fixed;
+        left: 0;
+        right: 0;
         bottom: 0;
         width: 100%;
         z-index: 99999990;
@@ -89,5 +94,9 @@ export default {
                 border: none;
                 cursor: pointer;
             }
+    }
+
+    .c-cookieWarning--is-hidden {
+        display: none;
     }
 </style>

--- a/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
@@ -2,7 +2,8 @@
     <div>
         <div
             :class="[$style['c-cookieWarning'], { [$style['c-cookieWarning--is-hidden']]: shouldHideLegacyBanner }]"
-            :aria-hidden="shouldHideLegacyBanner">
+            :aria-hidden="shouldHideLegacyBanner"
+            data-test-id="cookieBanner-component">
             <div :class="$style['c-cookieWarning-inner']">
                 <p>
                     {{ $t('legacyBannerText') }}


### PR DESCRIPTION
---

Move the legacy banner out of the overlay, as it doesn't need the modal behaviour, and a couple of other minor tweaks

---

