### PR TITLE
f-searchbox@4.0.0-beta.25 - media query fix

### DIFF
--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v4.0.0-beta.25
+------------------------------
+*February 11, 2021*
+
+### Changed
+- Form styles for bigger than narrow media query to include 414px.
+
+
 v4.0.0-beta.24
 ------------------------------
 *February 8, 2021*

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-searchbox",
   "description": "Fozzie Searchbox – Just Eat Takeaway Global Searchbox",
-  "version": "4.0.0-beta.24",
+  "version": "4.0.0-beta.25",
   "main": "dist/f-searchbox.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-searchbox/src/components/Form.vue
+++ b/packages/components/molecules/f-searchbox/src/components/Form.vue
@@ -523,7 +523,7 @@ export default {
     width: 100%;
     max-width: 610px;
 
-    @include media('>=narrow') {
+    @include media('>narrow') {
         min-height: 90px;
     }
 }


### PR DESCRIPTION
### Changed
- Form styles for bigger than narrow media query to include 414px.