### PR TITLE
fozzie-components@v3.13.0 – Contributing and Dependency guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.13.0
+------------------------------
+*February 12, 2021*
+
+### Added
+- `Contributing Guide` to Storybook docs.
+- `Dependencies Guide` to Storybook docs.
+
+### Changed
+- `Getting Started` guide updated with links to new sections.
+- `CONTRIBUTING.md` updated with new info to be in-line with the Storybook docs.
+
+### Fixed
+- Image path in `Typography Setup Guide`.
+
+
 v3.12.0
 ------------------------------
 *February 8, 2021*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,9 @@
 # Contributing
 
+*_[This contributing guide can also be viewed in our Storybook documentation](https://justeat.github.io/fozzie-components/@justeat/storybook/index.html?path=/story/documentation-getting-started-contributing--page)_*
+
 - Before creating a new component, please discuss it with us in #help-web
-- New components should use [generator-component](https://github.com/justeat/fozzie-components/tree/master/packages/generator-component) to create the base structure of the component. It's usually a good idea to PR this base structure as a `v0.1.0` before adding any significant custom component code.
+- New components should use [generator-component](https://github.com/justeat/fozzie-components/tree/master/packages/tools/generator-component) to create the base structure of the component. It's usually a good idea to PR this base structure as a `v0.1.0` before adding any significant custom component code.
 
 ## Background Reading
 
@@ -14,9 +16,9 @@ Our Open Source development guide | https://fozzie.just-eat.com/documentation/op
 Fozzie CSS Naming Scheme | https://fozzie.just-eat.com/documentation/css/css-naming
 Fozzie Accessibility Guide | https://fozzie.just-eat.com/documentation/general/accessibility/
 
-## Pull Request Process
+## Pull Requests
 
-When raising a PR in the `fozzie-components` repo, please follow these guidelines.
+When raising a PR in the mono-repo, please follow these guidelines.
 
 ### PR Title
 
@@ -33,15 +35,24 @@ When raising a PR in the `fozzie-components` repo, please follow these guideline
 ### PR Checks/Reviews
 
 - All PRs get checked by a tool called [Danger.js](https://danger.systems/js/), which runs the following [checks against your PR](https://github.com/justeat/fozzie-components/blob/master/dangerfile.js). If you miss a version number or `CHANGELOG` entry, it will leave a comment on your PR to add them to your changes.
+- Use draft PRs when it's appropriate (for example, to share code with a colleague or get early feedback on some changes).
 - Test your changes using Storybook (and ensure any modified/added props are added to the components story).
 - Always consider if your change warrants adding/amending the components README. If you're changing or adding props, it will do.
 - You need two reviews on your PR and all of the Danger.js and CircleCI build checks should pass.
 - Please don't add any links to internal facing tools or wikis anywhere in this repo – so that's in the PR title and description, code, comments, commit titles and branch names.
 
+### Useful PR tags
 
-## Useful PR tags
+By default, all PRs are checked by our automated Danger.js checks, which check that any packages that have been changed also have version bumps and `CHANGELOG` entries.
 
-These tags are read by Danger.js and will allow you to bypass certain checks if you are making only documentation or configuration changes. These tags should be added as part of the PRs title.
+The following tags are read by Danger.js and will allow you to bypass certain checks if you are making only documentation or configuration changes. These tags should be added as part of the PRs title.
 
-- `#trivial` – If you are making changes that do not need a version bump in any part of the repo (usually, only documentation related changes), then you can use this tag to skip the Danger.js checks on your PR.
-- `#globalconfig` – If you are making configuration changes to a number of packages (such as updating linting or test config), then you can simply bump the package version at the root of the mono-repo (as well as adding a CHANGELOG entry at the root describing the changes) and add the `#globalconfig` tag to your PR. This will then only run the Danger.js checks on the root of the mono-repo, and not for packages located in the `/packages` folder. It's generally good practice to also add a `CHANGELOG` entry to the individual packages that have been modified using the title `Latest (changes to be rolled into next release)`.
+#### `#globalconfig`
+
+If you are making configuration changes to a number of packages (such as updating linting or test config), then you can simply bump the package version at the root of the mono-repo (as well as adding a CHANGELOG entry at the root describing the changes) and add the `#globalconfig` tag to your PR. This will then only run the Danger.js checks on the root of the mono-repo, and not for packages located in the `/packages` folder.
+
+It's generally good practice to also add a `CHANGELOG` entry to the individual packages that have been modified using the title `Latest (changes to be rolled into next release)`.
+
+#### `#trivial`
+
+If you are making changes that do not need a version bump in any part of the repo (usually, only documentation related changes), then you can use this tag to skip the Danger.js checks on your PR.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,12 +3,23 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.26.0
+------------------------------
+*February 9, 2021*
+
+### Fixed
+- Storybook helper popup now visible (previously had black text on black bg).
+- Link styling in Storybook content updated so the links are clearly visible.
+
+
 v0.25.0
 ------------------------------
 *February 9, 2021*
 
 ### Added
 - `vue-svg-loader` to Webpack config
+
 
 v0.24.0
 ------------------------------

--- a/packages/storybook/config/storybook/manager-head.html
+++ b/packages/storybook/config/storybook/manager-head.html
@@ -88,4 +88,12 @@
         font-size: 14px;
         margin-bottom: 4px;
     }
+
+    /* Theme dropdown overlay in storybook */
+    div.css-16n0kwd {
+        border-bottom-color: #fff;
+    }
+    div.css-wmj67n {
+        background: #fff;
+    }
 </style>

--- a/packages/storybook/config/storybook/preview-head.html
+++ b/packages/storybook/config/storybook/preview-head.html
@@ -25,6 +25,14 @@
         padding-bottom: 8px;
     }
 
+    .sbdocs-content .sbdocs-a {
+        color: #125fca;
+        text-decoration: underline;
+    }
+    .sbdocs-content .sbdocs-a:hover {
+        color: #0f4fa9;
+    }
+
     .os-content {
         background-color: #333;
     }

--- a/packages/storybook/config/storybook/preview.js
+++ b/packages/storybook/config/storybook/preview.js
@@ -19,6 +19,7 @@ export const parameters = {
                     [
                         'Intro',
                         'Development Principles',
+                        'Contributing',
                         'Troubleshooting'
                     ],
                     'Standards',

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "scripts": {
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -s public -p 8080 -c config/storybook",

--- a/stories/getting-started/contributing-guide.stories.mdx
+++ b/stories/getting-started/contributing-guide.stories.mdx
@@ -1,0 +1,101 @@
+<Meta title="Documentation/Getting Started/Contributing"/>
+
+# Contributing Guide
+
+Before creating a new component, please discuss it with us in #help-web or via Github discussions.
+
+New components should use [generator-component](https://github.com/justeat/fozzie-components/tree/master/packages/tools/generator-component) to create the base structure of the component. It's usually a good idea to PR this base structure as a `v0.1.0` before adding any significant custom component code.
+
+All of our components and services are published to NPM, so that they can be consumed as versioned packages. More information on versioning and publishing a component can be found below.
+
+## Versioning
+
+We use [Semantic Versioning](http://semver.org/spec/v2.0.0.html) to publish all of our npm packages.
+
+The basic premise of semantic versioning is that given a version number MAJOR.MINOR.PATCH, you should increment the:
+
+- MAJOR version when you make incompatible API changes,
+- MINOR version when you add functionality in a backwards compatible manner, and
+- PATCH version when you make backwards compatible bug fixes.
+
+
+## Publishing via npm
+
+To publish a package to **npm**, please first ensure that you have registered an account on [npmjs.com](https://www.npmjs.com/).
+
+Internal contributors (JET Employees) should request to be added to the Just Eat npm organisation by asking in the #guild-ui Slack channel and providing your npm username. This will then allow you to publish the packages in our mono-repo.
+
+External contributors should raise a pull request and the release will be handled for you once approved.
+
+Once you are happy that the package is ready to be published, ensure you are on the correct branch — typically the `master`/`main` branch with the latest changes pulled. Then run `npm publish` on the command line.
+
+
+## Publishing beta releases
+
+It can be useful to publish a package under a beta or alpha tag, prior to publishing it on the default release tag. For example, when working on a major version release that can be used by some consuming applications, but should not be made fully available for consumption.
+
+To do this, we use npm tags and separate release branches.
+
+As an example, if the current version of `@justeat/f-header` was currently `2.5.0` and I wanted to publish version 3 as a beta release, I would do the following.
+
+1. Create a branch off the main repository branch to be used for my beta changes. All subsequent PRs should be merged into this branch until the release branch is merged back into the `main`/`master` repository branch, so that other teams can continue to work on version 2 of the component if needed.
+2. Update the components version in its `package.json` to be `3.0.0-beta.0`. Subsequent v3 beta releases will increment this integer suffix `-beta.x`
+3. Once a PR has been merged into the v3 release branch, the package should be published using the following command: `npm publish --tag beta`.
+   This publishes the package using the tag `beta` ensuring that it doesn't get tagged as the `latest` version of the package.
+4. When the package is ready for full release as v3, the `package.json` of the component should be updated to `3.0.0` in its `package.json` and a PR from the v3 release branch should be made back into the `main`/`master` branch. When this has been merged, the component can be published as normal using `npm publish`
+
+
+## Pull Requests
+
+When raising a PR in the mono-repo, please follow these guidelines.
+
+### PR Title
+
+- PR title's should start with the package version in the format {package-name}@v(x.x.x) (such as f-header@v1.4.0)' (unless using the `#trivial` flag described below).
+- If your change is a global configuration change, then the title should be `fozzie-components@v(x.x.x)`, where the version number relates to the version at the root of the mono-repo.
+
+### PR Descriptions
+
+- Please read and fill in the PR description template when opening a PR.
+- If you're updating package code, you'll need to update the packages `CHANGELOG` file and bump the package version in its `package.json`.
+- Where the PR template asks for a description of your changes, feel free to copy/paste the description that you added in the packages `CHANGELOG` file. That should describe what was added/changed/deleted.
+- If you've modified the styling of a component, please add a screenshot of the before/after state of the component. It helps give more context for those reviewing the change.
+
+### PR Checks/Reviews
+
+- All PRs get checked by a tool called [Danger.js](https://danger.systems/js/), which runs the following [checks against your PR](https://github.com/justeat/fozzie-components/blob/master/dangerfile.js). If you miss a version number or `CHANGELOG` entry, it will leave a comment on your PR to add them to your changes.
+- Use draft PRs when it's appropriate (for example, to share code with a colleague or get early feedback on some changes).
+- Test your changes using Storybook (and ensure any modified/added props are added to the components story).
+- Always consider if your change warrants adding/amending the components README. If you're changing or adding props, it will do.
+- You need two reviews on your PR and all of the Danger.js and CircleCI build checks should pass.
+- Please don't add any links to internal facing tools or wikis anywhere in this repo – so that's in the PR title and description, code, comments, commit titles and branch names.
+
+### Useful PR tags
+
+By default, all PRs are checked by our automated Danger.js checks, which check that any packages that have been changed also have version bumps and `CHANGELOG` entries.
+
+The following tags are read by Danger.js and will allow you to bypass certain checks if you are making only documentation or configuration changes. These tags should be added as part of the PRs title.
+
+#### `#globalconfig`
+
+If you are making configuration changes to a number of packages (such as updating linting or test config), then you can simply bump the package version at the root of the mono-repo (as well as adding a CHANGELOG entry at the root describing the changes) and add the `#globalconfig` tag to your PR. This will then only run the Danger.js checks on the root of the mono-repo, and not for packages located in the `/packages` folder.
+
+It's generally good practice to also add a `CHANGELOG` entry to the individual packages that have been modified using the title `Latest (changes to be rolled into next release)`.
+
+#### `#trivial`
+
+If you are making changes that do not need a version bump in any part of the repo (usually, only documentation related changes), then you can use this tag to skip the Danger.js checks on your PR.
+
+
+### CHANGELOG
+
+All components have an associated `CHANGELOG` that should be updated when creating new PRs. Keeping these up-to-date helps those consuming our components when upgrading to the latest version or when addressing bugs that may have occurred.
+
+Our `CHANGELOG`'s follow the principle's outlined on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+Not all PRs will require a version bump for a package (for example, an update to documentation) – in this scenario, we recommend adding the following heading to the components `CHANGELOG`, which can then be replaced when a subsequent version is released.
+
+```md
+Latest – to be added to the next release
+------------------------------
+```

--- a/stories/getting-started/getting-started.stories.mdx
+++ b/stories/getting-started/getting-started.stories.mdx
@@ -1,14 +1,20 @@
+import LinkTo from '@storybook/addon-links/react';
+
 <Meta title="Documentation/Getting Started/Intro"/>
 
 # UI Component Mono-repo
 
 ## Introduction
 
-A mono-repo is a single repository containing multiple packages – in our case UI components and services. 
+A mono-repo is a single repository containing multiple packages – in our case UI components and services.
 
 Using multi-package repository reduces the time and space requirements for numerous copies of packages in development and build environments - normally a downside of dividing a project into many separate NPM packages. Updating common configuration across components is also much simpler as these dependencies can be shared and updated from the root of the mono-repo; for example linting or test dependencies.
 
 Each individual component can be found in the [`components`](https://github.com/justeat/fozzie-components/tree/master/packages/components) directory, and are all controlled from a top level `packages.json`.
+
+## Dependencies
+
+For more information on the dependencies needed when including these shared UI components as part of your application, check out our <LinkTo kind="Documentation/Setup Guides/Dependencies" story="page">Component Dependency guide</LinkTo>.
 
 ## Folder Structure
 
@@ -65,9 +71,6 @@ The general naming convention for a Fozzie package is to use `f-{your-package-na
 * If there are JavaScript unit tests in the package you can [add a coveralls badge](https://coveralls.io/github/justeat/)
 * Check for known vulnerabilities in your package with a [Snyk.io badge](https://snyk.io/test/)
 
-## Publishing to npm
+## Contributing
 
-To publish a package to **npm**, please first ensure that you have registered an account.
-Internal contributors (Just Eat employees) can request to be added to the Just Eat npm org by asking in the #guild-ui Slack channel and providing your npm account details. External contributors should raise a pull request and the release will be handled for you once approved.
-
-Once you are happy that the package is ready to be published to the npm registry, ensure you are on the correct branch — typically the master branch with the latest changes pulled — then run `npm publish` on the command line.
+For mre information on contributing and how to publish components, <LinkTo kind="Documentation/Getting Started/Contributing" story="page">see our Contributing Guide</LinkTo>.

--- a/stories/guides/component-dependencies.stories.mdx
+++ b/stories/guides/component-dependencies.stories.mdx
@@ -1,0 +1,137 @@
+import LinkTo from '@storybook/addon-links/react';
+
+<Meta title="Documentation/Setup Guides/Dependencies"/>
+
+# Component Dependencies
+
+When using components, we expect consuming applications to include the following dependencies for them to display as intended.
+
+## Fonts
+
+Just Eat and Menulog branded websites make use of `JustEatBasis` as it's main typeface (`Regular` and `Bold` variants).
+
+To load in the required fonts, we recommend following our <LinkTo kind="Documentation/Setup Guides/Typography" story="page">typography setup guide</LinkTo> which covers how to load the font in your application.
+
+## Fozzie SCSS framework
+
+When working on a set of common components, it's useful to be able to share common SCSS utilities and base styles between them.  For this we use the [Fozzie SCSS utility framework](https://github.com/justeat/fozzie/tree/v5.0.0) (v5 or later).
+
+By default, when importing this SCSS framework, the only thing output by the framework are the shared SCSS variables, mixins and functions we use to create component styles – no SCSS classes or styles will be added to your compiled CSS unless you subsequently opt in to them in your application.
+
+The framework provides a method to include a number of styles when needed via optional mixins. As a minimum, we expect consuming applications to include the following base styles, to avoid having to set these styles within each component:
+
+### Reset Styles
+
+It's common best practice in CSS to apply a set of reset styles to an application. Rather than setting these styles inside each component, we expect the consuming application to include the reset styles that we've defined in the fozzie SCSS framework.
+
+These reset styles can be included via an optional mixin – `@include reset();` – once the SCSS framework has been imported into your applications SCSS.
+
+### Typographic defaults
+
+Including global typographic styles in every component – setting the default size for tags like headings (`h1`, `h2` etc) and paragraphs for instance – would lead to a large amount of duplication, as well as failing to utilise one of CSS's most valuable features; the cascade.
+
+Although our components will function without these defaults, they won't look as intended without these being included in a consuming application.
+
+We expect consuming applications to include the optional mixins for global typography and link styles – via `@include typography();` and `@include links();`. Similar to the reset styles, these mixins can only be included once the Fozzie SCSS framework has been imported, due to the mixins being reliant on SCSS variables, mixins and functions that are defined there.
+
+### Utility classes
+
+In specific styling situations, it's useful to have a set of "trump" utility classes; such as to hide or show information for accessibility purposes (for example `.is-visuallyHidden`).
+
+We are working on bringing these utility classes to fozzie v5 in a way that is shareable between components, but this is currently a work in progress – we're currently working on making a set of utility classes available across components, for common situations like needing to hide or show information for accessibility purposes (for example `.is-visuallyHidden`).
+
+Once these have been defined, these utility classes will be available for use in components and to consuming applications.
+
+## Importing the Fozzie SCSS framework
+
+Including the Fozzie SCSS framework in any application is straightforward, but will likely be subtly different depending on the CLI or bundling tool you are using.
+
+If you are creating a new UI component, the configuration needed to include the base utility variables, mixins and functions will be automatically setup for you when using our Yeoman component generator tool.
+
+### VueCLI (via webpack-chain)
+
+*_These setup instructions are correct with respect to `sass-loader` v10. Future releases may change the configuration slightly._*
+
+The Fozzie SCSS utility library has a couple of dependencies that need to be included by any consuming application (via NPM or Yarn). These are:
+
+- `fozzie` (>= v5.0.0-beta.2)
+- `node-sass-magic-importer` (>= v5.3.2)
+- `eyeglass` (>= v3.0.2)
+
+
+Both of these dependencies are used to handle the path links into `node_modules` that are included as part of the utility library.
+
+If you‘re using your own Webpack configuration, rather than VueCLI, you'll need to also include the latest version of `sass-loader` (at time of writing, we're using `v10.1.0`).
+
+You'll then need to create a new config file, that contains the following config for `sass-loader`:
+
+```js
+const magicImporter = require('node-sass-magic-importer');
+const eyeglass = require('eyeglass');
+
+module.exports = function init (rootDir) {
+    const sassOptions = eyeglass({
+        eyeglass: {
+            root: rootDir
+        },
+        includePaths: ['node_modules/']
+    });
+
+    sassOptions.importer = [
+        magicImporter({
+            cwd: rootDir
+        }),
+        sassOptions.importer
+    ];
+
+    return {
+        sassOptions: {
+            eyeglass: sassOptions.eyeglass,
+            functions: sassOptions.functions,
+            includePaths: sassOptions.includePaths,
+            importer: sassOptions.importer
+        },
+        sourceMap: true
+    };
+};
+```
+
+This essentially configures `node-sass-magic-importer` and `eyeglass` to work alongside `sass-loader` when Webpack runs, outputting the config as an object to be passed into `sass-loader`.
+
+When using VueCLI, we can then add the following to out `vue.config.js`:
+
+```js
+const path = require('path');
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('__PATH_TO_FILE_CREATED_ABOVE__')(rootDir);
+
+// vue.config.js
+module.exports = {
+    chainWebpack: config => {
+        config.module
+            .rule('scss-importer')
+            .test(/\.scss$/)
+            .use('importer')
+            .loader('sass-loader')
+            .options({
+                ...sassOptions,
+                // eslint-disable-next-line quotes
+                additionalData: `
+@import "@justeat/fozzie/src/scss/fozzie";
+@include reset();
+@include typography();
+@include links();`
+            });
+    }
+};
+```
+
+This passes the `sassOptions` config that has been imported from our previous configuration file, before `@import`ing the fozzie utility framework and then including the mixins needed to define the global style dependencies mentioned above.
+
+### Nuxt
+
+This section of the docs is in progress – reach out to us directly to find more information on this topic in the meantime.
+
+### Troubleshooting
+
+If you have any issues integrating the Fozzie SCSS Utility framework, reach out to the Core Web Team or through the UI Guild and we'll help get you setup.

--- a/stories/guides/typography.stories.mdx
+++ b/stories/guides/typography.stories.mdx
@@ -81,7 +81,7 @@ The base fontset comes with a huge number of glyphs and layout features that are
 
 For reference, the base Just Eat Regular font has the following properties when ijnspected using the [Wakamai Fondue tool](https://wakamaifondue.com/):
 
-![./public/justeatbasis-base.png](./public/justeatbasis-base.png)
+![Overview of the main font specification for Just Eat Basis](./justeatbasis-base.png)
 
 ### How to subset a font
 


### PR DESCRIPTION
### Added
- `Contributing Guide` to Storybook docs.
- `Dependencies Guide` to Storybook docs.

### Changed
- `Getting Started` guide updated with links to new sections.
- `CONTRIBUTING.md` updated with new info to be in-line with the Storybook docs.

### Fixed
- Image path in `Typography Setup Guide`.
- Storybook helper popup now visible (previously had black text on black bg).
- Link styling in Storybook content updated so the links are clearly visible.