### PR TITLE
f-checkout@0.57.0: Logic to choose closest address for uk tenant

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -8,7 +8,7 @@ v0.57.0
 *February 15, 2021*
 
 ### Added
-- logic to choose closest address for uk tenant
+- Logic to choose closest address for uk tenant
 
 
 v0.56.2

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.57.0
+-------------------------------
+*February 15, 2021*
+
+### Added
+- logic to choose closest address for uk tenant
+
+
 v0.56.2
 -------------------------------
 *February 12, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.56.2",
+  "version": "0.57.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -472,6 +472,7 @@ export default {
             try {
                 await this.getAddress({
                     url: this.getAddressUrl,
+                    tenant: this.tenant,
                     language: this.$i18n.locale,
                     timeout: this.getAddressTimeout
                 });

--- a/packages/components/organisms/f-checkout/src/services/addressService.js
+++ b/packages/components/organisms/f-checkout/src/services/addressService.js
@@ -5,7 +5,7 @@ function isFullPostCode (postcode) {
         return false;
     }
 
-    return postcode.Length > 4;
+    return postcode.length > 4;
 }
 
 function toFormattedPostcode (postcode) {
@@ -13,12 +13,12 @@ function toFormattedPostcode (postcode) {
         return '';
     }
 
-    let formatted = postcode.replaceAll(' ', '').replaceAll('-', '');
+    let formatted = postcode.replace(/ /g, '').replace(/-/g, '');
 
     if (isFullPostCode(formatted)) {
-        const last3 = formatted.Substring(formatted.Length - 3);
-        formatted.splice(formatted.length - 3);
-        formatted += ` ${last3}`;
+        const last3 = formatted.slice(formatted.length - 3);
+        const prefix = formatted.slice(0, formatted.length - 3);
+        formatted = `${prefix} ${last3}`;
     }
 
     return formatted.toUpperCase();
@@ -29,6 +29,7 @@ function getAddress (postcode, address) {
         return {
             line1: '',
             line2: '',
+            city: '',
             postcode: toFormattedPostcode(postcode)
         };
     }
@@ -56,12 +57,12 @@ function getAddressClosestToPostcode (postcode, addresses) {
         return getDefaultAddress(addresses);
     }
 
-    let formattedPostcode = postcode.replaceAll(' ', '').replaceAll('-', '');
+    let formattedPostcode = postcode.replace(/ /g, '').replace(/-/g, '');
 
     let address = addresses.find(a => a.ZipCode === formattedPostcode);
 
     if (isFullPostCode(formattedPostcode)) {
-        formattedPostcode = formattedPostcode.splice(postcode.length - 3);
+        formattedPostcode = formattedPostcode.slice(0, formattedPostcode.length - 3);
     }
 
     address = address ?? addresses.find(a => a && a.ZipCode.startsWith(formattedPostcode));

--- a/packages/components/organisms/f-checkout/src/services/addressService.js
+++ b/packages/components/organisms/f-checkout/src/services/addressService.js
@@ -1,0 +1,70 @@
+import getCookie from '../utils/helpers';
+
+function cleanupPostcode (postcode) {
+    if (!postcode) {
+        return '';
+    }
+
+    return postcode.replaceAll(' ', '').replaceAll('-', '');
+}
+
+function isFullPostCode (postcode) {
+    if (!postcode) {
+        return false;
+    }
+
+    return postcode.Length > 4;
+}
+
+function toFormattedPostcode (postcode) {
+    if (!postcode) {
+        return '';
+    }
+
+    let formatted = cleanupPostcode(postcode);
+
+    if (isFullPostCode(formatted)) {
+        const last3 = formatted.Substring(formatted.Length - 3);
+        formatted.splice(formatted.length - 3);
+        formatted += ` ${last3}`;
+    }
+
+    return formatted.toUpperCase();
+}
+
+function mapAddress (postcode, address) {
+    return {
+        line1: (address && address.Line1) || '',
+        line2: (address && address.Line2) || '',
+        city: (address && address.City) || '',
+        postcode: (address && address.ZipCode) || toFormattedPostcode(postcode)
+    };
+}
+
+export default {
+    getClosestAddress (addresses, tenant) {
+        let selectedAddress = {};
+
+        if (tenant !== 'uk') {
+            // For tenants other than uk just select the first address
+            // TODO: Add proper implementation for tenants other than uk
+            [selectedAddress] = addresses;
+        }
+
+        const postcode = cleanupPostcode(getCookie('je-location'));
+        if (addresses) {
+            selectedAddress = addresses.find(a => a.IsDefault);
+        }
+
+        if (!selectedAddress) {
+            let shortPostcode = postcode;
+            if (isFullPostCode(postcode)) {
+                shortPostcode = postcode.splice(postcode.length - 3);
+            }
+
+            selectedAddress = addresses.find(a => !!a && a.ZipCode.startsWith(shortPostcode));
+        }
+
+        return mapAddress(postcode, selectedAddress);
+    }
+};

--- a/packages/components/organisms/f-checkout/src/services/addressService.js
+++ b/packages/components/organisms/f-checkout/src/services/addressService.js
@@ -65,7 +65,7 @@ function getAddressClosestToPostcode (postcode, addresses) {
         formattedPostcode = formattedPostcode.slice(0, formattedPostcode.length - 3);
     }
 
-    address = address ?? addresses.find(a => a && a.ZipCode.startsWith(formattedPostcode));
+    address = address || addresses.find(a => a && a.ZipCode.startsWith(formattedPostcode));
 
     return address;
 }

--- a/packages/components/organisms/f-checkout/src/services/addressService.js
+++ b/packages/components/organisms/f-checkout/src/services/addressService.js
@@ -13,7 +13,7 @@ function toFormattedPostcode (postcode) {
         return '';
     }
 
-    let formatted = cleanupPostcode(postcode);
+    let formatted = postcode.replaceAll(' ', '').replaceAll('-', '');
 
     if (isFullPostCode(formatted)) {
         const last3 = formatted.Substring(formatted.Length - 3);
@@ -51,7 +51,7 @@ function getDefaultAddress (addresses) {
     return addresses.find(a => a && a.IsDefault);
 }
 
-function getAddressClosestToPostcode(postcode, addresses) {
+function getAddressClosestToPostcode (postcode, addresses) {
     if (!postcode) {
         return getDefaultAddress(addresses);
     }

--- a/packages/components/organisms/f-checkout/src/services/tests/addressService.test.js
+++ b/packages/components/organisms/f-checkout/src/services/tests/addressService.test.js
@@ -1,7 +1,54 @@
+import addressService from '../addressService';
+import { getCookie } from '../../utils/helpers';
+
+jest.mock('../../utils/helpers');
+
+const area511Line = {
+    City: 'Area 51',
+    ZipCode: 'AR51 1AA',
+    IsDefault: false,
+    Line1: '1 Test Road',
+    Line2: null,
+    Line3: null
+};
+
+const bristol2Lines = {
+    City: 'Bristol',
+    ZipCode: 'BS1 1AA',
+    IsDefault: false,
+    Line1: '1 Bristol Road',
+    Line2: 'Flat 1',
+    Line3: null
+};
+
+const london3LinesDefault = {
+    City: 'London',
+    ZipCode: 'EC4M 7RF',
+    IsDefault: true,
+    Line1: 'Fleet Place House',
+    Line2: 'Farringdon',
+    Line3: 'City of London'
+};
+
 describe('addressService', () => {
-    describe('when addresses are empty', () => {
-        it('should return empty address when there is no postcode', () => {
-            expect(true).toBeTruthy();
+    describe('getClosestAddress ::', () => {
+        it('should return default address when there is no postcode', () => {
+            // Arrange
+            const postcode = '';
+            const tenant = 'uk';
+            const addresses = [area511Line, bristol2Lines, london3LinesDefault];
+            getCookie.mockReturnValue(postcode);
+
+            // Act
+            const actual = addressService.getClosestAddress(addresses, tenant);
+
+            // Assert
+            expect(actual).toEqual({
+                line1: london3LinesDefault.Line1,
+                line2: `${london3LinesDefault.Line2}, ${london3LinesDefault.Line3}`,
+                city: london3LinesDefault.City,
+                postcode: london3LinesDefault.ZipCode
+            });
         });
     });
 });

--- a/packages/components/organisms/f-checkout/src/services/tests/addressService.test.js
+++ b/packages/components/organisms/f-checkout/src/services/tests/addressService.test.js
@@ -1,0 +1,7 @@
+describe('addressService', () => {
+    describe('when addresses are empty', () => {
+        it('should return empty address when there is no postcode', () => {
+            expect(true).toBeTruthy();
+        });
+    });
+});

--- a/packages/components/organisms/f-checkout/src/services/tests/addressService.test.js
+++ b/packages/components/organisms/f-checkout/src/services/tests/addressService.test.js
@@ -31,16 +31,17 @@ const london3LinesDefault = {
 };
 
 describe('addressService', () => {
+    const tenant = 'uk';
+    const allAddresses = [area511Line, bristol2Lines, london3LinesDefault];
+
     describe('getClosestAddress ::', () => {
         it('should return default address when there is no postcode', () => {
             // Arrange
             const postcode = '';
-            const tenant = 'uk';
-            const addresses = [area511Line, bristol2Lines, london3LinesDefault];
             getCookie.mockReturnValue(postcode);
 
             // Act
-            const actual = addressService.getClosestAddress(addresses, tenant);
+            const actual = addressService.getClosestAddress(allAddresses, tenant);
 
             // Assert
             expect(actual).toEqual({
@@ -48,6 +49,23 @@ describe('addressService', () => {
                 line2: `${london3LinesDefault.Line2}, ${london3LinesDefault.Line3}`,
                 city: london3LinesDefault.City,
                 postcode: london3LinesDefault.ZipCode
+            });
+        });
+
+        it('should return empty address with postcode when postcode does not match', () => {
+            // Arrange
+            const postcode = 'EN1 1AA';
+            getCookie.mockReturnValue(postcode);
+
+            // Act
+            const actual = addressService.getClosestAddress(allAddresses, tenant);
+
+            // Assert
+            expect(actual).toEqual({
+                line1: '',
+                line2: '',
+                city: '',
+                postcode
             });
         });
     });

--- a/packages/components/organisms/f-checkout/src/services/tests/addressService.test.js
+++ b/packages/components/organisms/f-checkout/src/services/tests/addressService.test.js
@@ -35,37 +35,142 @@ describe('addressService', () => {
     const allAddresses = [area511Line, bristol2Lines, london3LinesDefault];
 
     describe('getClosestAddress ::', () => {
-        it('should return default address when there is no postcode', () => {
-            // Arrange
+        describe('when last searched postcode is not present', () => {
             const postcode = '';
-            getCookie.mockReturnValue(postcode);
 
-            // Act
-            const actual = addressService.getClosestAddress(allAddresses, tenant);
+            it('should return empty address if addresses is empty', () => {
+                // Arrange
+                getCookie.mockReturnValue(postcode);
 
-            // Assert
-            expect(actual).toEqual({
-                line1: london3LinesDefault.Line1,
-                line2: `${london3LinesDefault.Line2}, ${london3LinesDefault.Line3}`,
-                city: london3LinesDefault.City,
-                postcode: london3LinesDefault.ZipCode
+                // Act
+                const actual = addressService.getClosestAddress([], tenant);
+
+                // Assert
+                expect(actual).toEqual({
+                    line1: '',
+                    line2: '',
+                    city: '',
+                    postcode: ''
+                });
+            });
+
+            it('should return default address if default address is present', () => {
+                // Arrange
+                getCookie.mockReturnValue(postcode);
+
+                // Act
+                const actual = addressService.getClosestAddress(allAddresses, tenant);
+
+                // Assert
+                expect(actual).toEqual({
+                    line1: london3LinesDefault.Line1,
+                    line2: `${london3LinesDefault.Line2}, ${london3LinesDefault.Line3}`,
+                    city: london3LinesDefault.City,
+                    postcode: london3LinesDefault.ZipCode
+                });
             });
         });
+        describe('when last searched postcode is present', () => {
+            it('should return empty address with postcode set, when postcode does not match', () => {
+                // Arrange
+                const postcode = 'EN1 1AA';
+                getCookie.mockReturnValue(postcode);
 
-        it('should return empty address with postcode when postcode does not match', () => {
-            // Arrange
-            const postcode = 'EN1 1AA';
-            getCookie.mockReturnValue(postcode);
+                // Act
+                const actual = addressService.getClosestAddress(allAddresses, tenant);
 
-            // Act
-            const actual = addressService.getClosestAddress(allAddresses, tenant);
+                // Assert
+                expect(actual).toEqual({
+                    line1: '',
+                    line2: '',
+                    city: '',
+                    postcode
+                });
+            });
 
-            // Assert
-            expect(actual).toEqual({
-                line1: '',
-                line2: '',
-                city: '',
-                postcode
+            it('should return empty address with formatted postcode set, when postcode does not match and has no spaces', () => {
+                // Arrange
+                const postcode = 'EN11AA';
+                getCookie.mockReturnValue(postcode);
+
+                // Act
+                const actual = addressService.getClosestAddress(allAddresses, tenant);
+
+                // Assert
+                expect(actual).toEqual({
+                    line1: '',
+                    line2: '',
+                    city: '',
+                    postcode: 'EN1 1AA'
+                });
+            });
+
+            it('should return empty address with postcode set, when postcode does not match', () => {
+                // Arrange
+                const postcode = 'EN1 1AA';
+                getCookie.mockReturnValue(postcode);
+
+                // Act
+                const actual = addressService.getClosestAddress(allAddresses, tenant);
+
+                // Assert
+                expect(actual).toEqual({
+                    line1: '',
+                    line2: '',
+                    city: '',
+                    postcode
+                });
+            });
+
+            it('should return address with full postcode match', () => {
+                // Arrange
+                const postcode = 'BS1 1AA';
+                getCookie.mockReturnValue(postcode);
+
+                // Act
+                const actual = addressService.getClosestAddress(allAddresses, tenant);
+
+                // Assert
+                expect(actual).toEqual({
+                    line1: bristol2Lines.Line1,
+                    line2: bristol2Lines.Line2,
+                    city: bristol2Lines.City,
+                    postcode: bristol2Lines.ZipCode
+                });
+            });
+
+            it('should return address with full postcode match when address has no spaces', () => {
+                // Arrange
+                const postcode = 'EC4M7RF';
+                getCookie.mockReturnValue(postcode);
+
+                // Act
+                const actual = addressService.getClosestAddress(allAddresses, tenant);
+
+                // Assert
+                expect(actual).toEqual({
+                    line1: london3LinesDefault.Line1,
+                    line2: `${london3LinesDefault.Line2}, ${london3LinesDefault.Line3}`,
+                    city: london3LinesDefault.City,
+                    postcode: london3LinesDefault.ZipCode
+                });
+            });
+
+            it('should return address with postcode partial match', () => {
+                // Arrange
+                const postcode = 'AR51';
+                getCookie.mockReturnValue(postcode);
+
+                // Act
+                const actual = addressService.getClosestAddress(allAddresses, tenant);
+
+                // Assert
+                expect(actual).toEqual({
+                    line1: area511Line.Line1,
+                    line2: '',
+                    city: area511Line.City,
+                    postcode: area511Line.ZipCode
+                });
             });
         });
     });

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -209,15 +209,7 @@ export default {
 
             const { data } = await axios.get(url, config);
 
-            const addressTmp = addressService.getClosestAddress(data.Addresses, tenant);
-            const [selectedAddress] = data.Addresses;
-
-            const addressDetails = {
-                line1: selectedAddress.Line1,
-                line2: selectedAddress.Line2,
-                city: selectedAddress.City,
-                postcode: selectedAddress.ZipCode
-            };
+            const addressDetails = addressService.getClosestAddress(data.Addresses, tenant);
 
             commit(UPDATE_FULFILMENT_ADDRESS, addressDetails);
         },

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import addressService from '../services/addressService';
 
 import {
     UPDATE_AUTH,
@@ -190,6 +191,7 @@ export default {
          */
         getAddress: async ({ commit, state }, {
             url,
+            tenant,
             language,
             timeout
         }) => {
@@ -207,7 +209,7 @@ export default {
 
             const { data } = await axios.get(url, config);
 
-            // TODO: Implement logic to select best address. For now, select the first address
+            const addressTmp = addressService.getClosestAddress(data.Addresses, tenant);
             const [selectedAddress] = data.Addresses;
 
             const addressDetails = {

--- a/packages/components/organisms/f-checkout/src/utils/helpers.js
+++ b/packages/components/organisms/f-checkout/src/utils/helpers.js
@@ -1,0 +1,23 @@
+/**
+ * Gets a specific cookie based on the cookie name you provide it.
+ *
+ * TODO: Use universal cookie helper when consuming apps are ready.
+ *
+ * @param name
+ * @returns {*}
+ */
+const getCookie = name => {
+    const nameEQ = `${name}=`;
+    const ca = document.cookie.split(';');
+    for (let i = 0; i < ca.length; i++) {
+        let c = ca[i];
+        while (c.charAt(0) === ' ') c = c.substring(1, c.length);
+        if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
+    }
+    return null;
+};
+
+export {
+    // eslint-disable-next-line import/prefer-default-export
+    getCookie
+};


### PR DESCRIPTION

Logic translated close to 1:1 from ConsumerWeb.
This is temporary until we have an api endpoint to provide the closest address.

---

## UI Review Checks

No UI changes

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
