### PR TITLE
f-content-cards@3.2.0

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -14,6 +14,7 @@ v3.2.0
 - Home Promotion Cards 1 & 2 now render as a link for the full banner, rather than
   just a link for the CTA
 
+
 v3.1.1
 ------------------------------
 *February 10, 2020*

--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.2.0
+------------------------------
+*February 15, 2020*
+
+### Changed
+- Home Promotion Cards 1 & 2 now use the tracking as supplied to the containing
+  Content Cards component
+- Home Promotion Cards 1 & 2 now render as a link for the full banner, rather than
+  just a link for the CTA
+
 v3.1.1
 ------------------------------
 *February 10, 2020*

--- a/packages/components/organisms/f-content-cards/jest.config.js
+++ b/packages/components/organisms/f-content-cards/jest.config.js
@@ -37,6 +37,7 @@ module.exports = {
     testURL: 'http://localhost/',
 
     modulePathIgnorePatterns: [
+        './.yalc/', // Don't run tests in yalc-linked packages
         './test/specs/component/',
         './test/specs/accessibility'
     ],

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
@@ -143,6 +143,8 @@ export default {
 
 <style lang="scss" module>
     .c-contentCards-homePromotionCard1 {
+        text-decoration: initial;
+        display: block;
         padding: spacing(x3) 0 spacing(x2);
         width: 100%;
 

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
@@ -1,8 +1,12 @@
 <template>
-    <div
+    <component
+        :is="url ? 'a' : 'div'"
+        :href="url"
         :data-test-id="testId"
         :style="{ background: backgroundColor }"
-        :class="['c-contentCards-homePromotionCard1', $style['c-contentCards-homePromotionCard1']]">
+        :class="['c-contentCards-homePromotionCard1', $style['c-contentCards-homePromotionCard1']]"
+        @click="onClickContentCard"
+    >
         <div
             :data-test-id="containerTestId"
             :class="['l-container', 'c-contentCards-homePromotionCard1-container', $style['c-contentCards-homePromotionCard1-container']]"
@@ -25,10 +29,13 @@
                 </h3>
             </div>
             <div :class="['c-contentCards-homePromotionCard1-innerCard', $style['c-contentCards-homePromotionCard1-innerCard']]">
-                <home-promotion-card2 :card="card" />
+                <home-promotion-card2
+                    :card="card"
+                    :no-link="true"
+                />
             </div>
         </div>
-    </div>
+    </component>
 </template>
 
 <script>
@@ -39,20 +46,24 @@ export default {
     components: {
         HomePromotionCard2
     },
+
     props: {
         card: {
             type: Object,
             default: () => ({})
         },
+
         containerMaxWidth: {
             type: Number,
             default: 1272
         },
+
         testId: {
             type: String,
             default: 'home-promotion-1'
         }
     },
+
     data () {
         const {
             image,
@@ -82,6 +93,7 @@ export default {
             subtitle
         };
     },
+
     computed: {
         ctaTestId () {
             return this.testId ? `${this.testId}--cta` : false;
@@ -114,6 +126,16 @@ export default {
             } catch {
                 return false;
             }
+        }
+    },
+
+    inject: [
+        'emitCardClick'
+    ],
+
+    methods: {
+        onClickContentCard () {
+            this.emitCardClick(this.card);
         }
     }
 };

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
@@ -153,6 +153,7 @@ export default {
 
 <style lang="scss" module>
     .c-contentCards-homePromotionCard2 {
+        text-decoration: initial;
         position: relative;
         display: block;
         width: 100%;

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
@@ -145,7 +145,9 @@ export default {
         },
 
         onClickContentCard () {
-            this.emitCardClick(this.card);
+            if (!this.noLink) {
+                this.emitCardClick(this.card);
+            }
         }
     }
 };

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
@@ -1,10 +1,14 @@
 <template>
-    <div
+    <component
+        :is="showLink ? 'a' : 'div'"
+        :href="showLink ? url : null"
         :data-test-id="testId"
         :class="['c-contentCards-homePromotionCard2', $style['c-contentCards-homePromotionCard2'], {
             [$style['c-contentCards-homePromotionCard2--light']]: isLightText
         }]"
-        :style="{ background: contentBackgroundColor }">
+        :style="{ background: contentBackgroundColor }"
+        @click="onClickContentCard"
+    >
         <div
             :data-test-id="imageTestId"
             :class="['c-contentCards-homePromotionCard2-image', $style['c-contentCards-homePromotionCard2-image']]"
@@ -23,8 +27,7 @@
             </p>
         </template>
         <p v-if="url">
-            <a
-                :href="url"
+            <span
                 :data-test-id="ctaTestId"
                 :class="[
                     'o-link--full',
@@ -32,9 +35,9 @@
                     'u-color-link',
                     'u-text-left',
                     $style['c-contentCards-homePromotionCard2-link']
-                ]">{{ ctaText }}</a>
+                ]">{{ ctaText }}</span>
         </p>
-    </div>
+    </component>
 </template>
 
 <script>
@@ -46,11 +49,18 @@ export default {
             type: Object,
             default: () => ({})
         },
+
+        noLink: {
+            type: Boolean,
+            default: false
+        },
+
         testId: {
             type: String,
             default: 'home-promotion-2'
         }
     },
+
     data () {
         const {
             image,
@@ -72,6 +82,7 @@ export default {
             description
         };
     },
+
     computed: {
         ctaTestId () {
             return this.testId ? `${this.testId}--cta` : false;
@@ -88,6 +99,7 @@ export default {
         imageTestId () {
             return this.testId ? `${this.testId}--backgroundImage` : false;
         },
+
         /**
          * If background colour is set *and* dark, then use a light text colour for the title and text for A11y
          * @return {boolean}
@@ -107,6 +119,33 @@ export default {
             } catch {
                 return false;
             }
+        },
+
+        /**
+         * Encapsulated behaviour to ensure that the link is only shown when not contained within an HPC1 card
+         * @return {boolean}
+         */
+        showLink () {
+            return this.url && !this.noLink;
+        }
+    },
+
+    inject: [
+        'emitCardView',
+        'emitCardClick'
+    ],
+
+    mounted () {
+        this.onViewContentCard();
+    },
+
+    methods: {
+        onViewContentCard () {
+            this.emitCardView(this.card);
+        },
+
+        onClickContentCard () {
+            this.emitCardClick(this.card);
         }
     }
 };

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard1.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard1.test.js
@@ -11,6 +11,10 @@ const provide = {
 };
 
 describe('contentCards › HomePromotionCard1', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
     it('should apply the given test ID', () => {
         // Arrange & Act
         const wrapper = shallowMount(HomePromotionCard1, {

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard1.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard1.test.js
@@ -66,6 +66,7 @@ describe('contentCards › HomePromotionCard1', () => {
         const container = wrapper.find(`[data-test-id="${testId}"]`);
 
         // Assert
+        expect(container.element.tagName).toBe('A');
         expect(container.attributes('href')).toBe(url);
     });
 
@@ -88,6 +89,7 @@ describe('contentCards › HomePromotionCard1', () => {
 
         // Assert
         expect(provide.emitCardClick).toHaveBeenCalled();
+        expect(provide.emitCardClick).toHaveBeenCalledWith(card);
     });
 
     describe('when `backgroundColor` is "#000" ::', () => {

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard1.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard1.test.js
@@ -3,6 +3,12 @@ import Color from 'color';
 import HomePromotionCard1 from '../HomePromotionCard1.vue';
 
 const testId = '__TEST_ID__';
+const ctaText = '__CTA_TEXT__';
+const url = '__URL__';
+
+const provide = {
+    emitCardClick: jest.fn()
+};
 
 describe('contentCards › HomePromotionCard1', () => {
     it('should apply the given test ID', () => {
@@ -10,7 +16,8 @@ describe('contentCards › HomePromotionCard1', () => {
         const wrapper = shallowMount(HomePromotionCard1, {
             propsData: {
                 testId
-            }
+            },
+            provide
         });
 
         // Assert
@@ -26,13 +33,57 @@ describe('contentCards › HomePromotionCard1', () => {
             propsData: {
                 testId,
                 containerMaxWidth
-            }
+            },
+            provide
         });
 
         const styles = wrapper.find(`[data-test-id="${testId}--container"]`).attributes('style');
 
         // Assert
         expect(styles.indexOf(`max-width: ${containerMaxWidth}px;`)).toBe(0);
+    });
+
+    it('should render the container as a link', () => {
+        // Arrange
+        const card = {
+            ctaText,
+            url
+        };
+
+        // Act
+        const wrapper = shallowMount(HomePromotionCard1, {
+            propsData: {
+                card,
+                testId
+            },
+            provide
+        });
+
+        const container = wrapper.find(`[data-test-id="${testId}"]`);
+
+        // Assert
+        expect(container.attributes('href')).toBe(url);
+    });
+
+    it('should call the injected `emitCardClick` event when clicked', () => {
+        // Arrange
+        const card = {
+            ctaText,
+            url
+        };
+        const wrapper = shallowMount(HomePromotionCard1, {
+            propsData: {
+                card,
+                testId
+            },
+            provide
+        });
+
+        // Act
+        wrapper.find(`[data-test-id="${testId}"]`).trigger('click');
+
+        // Assert
+        expect(provide.emitCardClick).toHaveBeenCalled();
     });
 
     describe('when `backgroundColor` is "#000" ::', () => {
@@ -49,7 +100,8 @@ describe('contentCards › HomePromotionCard1', () => {
                 propsData: {
                     testId,
                     card
-                }
+                },
+                provide
             });
 
             // Assert
@@ -71,7 +123,8 @@ describe('contentCards › HomePromotionCard1', () => {
                 propsData: {
                     testId,
                     card
-                }
+                },
+                provide
             });
 
             // Assert
@@ -97,7 +150,8 @@ describe('contentCards › HomePromotionCard1', () => {
                     $style: {
                         'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -123,7 +177,8 @@ describe('contentCards › HomePromotionCard1', () => {
                     $style: {
                         'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -149,7 +204,8 @@ describe('contentCards › HomePromotionCard1', () => {
                     $style: {
                         'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -175,7 +231,8 @@ describe('contentCards › HomePromotionCard1', () => {
                     $style: {
                         'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -201,7 +258,8 @@ describe('contentCards › HomePromotionCard1', () => {
                     $style: {
                         'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -227,7 +285,8 @@ describe('contentCards › HomePromotionCard1', () => {
                     $style: {
                         'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -250,7 +309,8 @@ describe('contentCards › HomePromotionCard1', () => {
                     $style: {
                         'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -275,7 +335,8 @@ describe('contentCards › HomePromotionCard1', () => {
                     $style: {
                         'c-contentCards-homePromotionCard1-subtitle--light': 'c-contentCards-homePromotionCard1-subtitle--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard2.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard2.test.js
@@ -5,20 +5,39 @@ const testId = '__TEST_ID__';
 const ctaText = '__CTA_TEXT__';
 const url = '__URL__';
 
+const provide = {
+    emitCardView: jest.fn(),
+    emitCardClick: jest.fn()
+};
+
 describe('contentCards › HomePromotionCard2', () => {
     it('should apply the given test ID', () => {
         // Arrange & Act
         const wrapper = shallowMount(HomePromotionCard2, {
             propsData: {
                 testId
-            }
+            },
+            provide
         });
 
         // Assert
         expect(wrapper.find(`[data-test-id="${testId}"]`).exists()).toBe(true);
     });
 
-    it('should display a CTA link and label', () => {
+    it('should call the injected `emitCardView` event when mounted', () => {
+        // Arrange & Act
+        shallowMount(HomePromotionCard2, {
+            propsData: {
+                testId
+            },
+            provide
+        });
+
+        // Assert
+        expect(provide.emitCardView).toHaveBeenCalled();
+    });
+
+    it('should display a CTA label', () => {
         // Arrange
         const card = {
             ctaText,
@@ -30,14 +49,57 @@ describe('contentCards › HomePromotionCard2', () => {
             propsData: {
                 card,
                 testId
-            }
+            },
+            provide
         });
 
         const cta = wrapper.find(`[data-test-id="${testId}--cta"]`);
 
         // Assert
         expect(cta.text()).toBe(ctaText);
-        expect(cta.attributes('href')).toBe(url);
+    });
+
+    it('should render the container as a link', () => {
+        // Arrange
+        const card = {
+            ctaText,
+            url
+        };
+
+        // Act
+        const wrapper = shallowMount(HomePromotionCard2, {
+            propsData: {
+                card,
+                testId
+            },
+            provide
+        });
+
+        const container = wrapper.find(`[data-test-id="${testId}"]`);
+
+        // Assert
+        expect(container.attributes('href')).toBe(url);
+    });
+
+    it('should call the injected `emitCardClick` event when clicked', () => {
+        // Arrange
+        const card = {
+            ctaText,
+            url
+        };
+        const wrapper = shallowMount(HomePromotionCard2, {
+            propsData: {
+                card,
+                testId
+            },
+            provide
+        });
+
+        // Act
+        wrapper.find(`[data-test-id="${testId}"]`).trigger('click');
+
+        // Assert
+        expect(provide.emitCardClick).toHaveBeenCalled();
     });
 
     // Check contentBackgroundColour is the dominant factor
@@ -58,7 +120,8 @@ describe('contentCards › HomePromotionCard2', () => {
                     $style: {
                         'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -84,7 +147,8 @@ describe('contentCards › HomePromotionCard2', () => {
                     $style: {
                         'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -110,7 +174,8 @@ describe('contentCards › HomePromotionCard2', () => {
                     $style: {
                         'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -135,7 +200,8 @@ describe('contentCards › HomePromotionCard2', () => {
                     $style: {
                         'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -161,7 +227,8 @@ describe('contentCards › HomePromotionCard2', () => {
                     $style: {
                         'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -186,7 +253,8 @@ describe('contentCards › HomePromotionCard2', () => {
                     $style: {
                         'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -210,7 +278,8 @@ describe('contentCards › HomePromotionCard2', () => {
                     $style: {
                         'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert
@@ -237,7 +306,8 @@ describe('contentCards › HomePromotionCard2', () => {
                     $style: {
                         'c-contentCards-homePromotionCard2--light': 'c-contentCards-homePromotionCard2--light'
                     }
-                }
+                },
+                provide
             });
 
             // Assert

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard2.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard2.test.js
@@ -11,6 +11,10 @@ const provide = {
 };
 
 describe('contentCards › HomePromotionCard2', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
     it('should apply the given test ID', () => {
         // Arrange & Act
         const wrapper = shallowMount(HomePromotionCard2, {
@@ -81,6 +85,27 @@ describe('contentCards › HomePromotionCard2', () => {
         expect(container.attributes('href')).toBe(url);
     });
 
+    it('should call the injected `emitCardClick` event when clicked', () => {
+        // Arrange
+        const card = {
+            ctaText,
+            url
+        };
+        const wrapper = shallowMount(HomePromotionCard2, {
+            propsData: {
+                card,
+                testId
+            },
+            provide
+        });
+
+        // Act
+        wrapper.find(`[data-test-id="${testId}"]`).trigger('click');
+
+        // Assert
+        expect(provide.emitCardClick).toHaveBeenCalled();
+    });
+
     describe('when `no-link` prop is truthy', () => {
         it('should NOT render the container as a link', () => {
             // Arrange
@@ -104,27 +129,28 @@ describe('contentCards › HomePromotionCard2', () => {
             // Assert
             expect(container.attributes('href')).toBeUndefined();
         });
-    });
 
-    it('should call the injected `emitCardClick` event when clicked', () => {
-        // Arrange
-        const card = {
-            ctaText,
-            url
-        };
-        const wrapper = shallowMount(HomePromotionCard2, {
-            propsData: {
-                card,
-                testId
-            },
-            provide
+        it('should NOT call the injected `emitCardClick` event when clicked', () => {
+            // Arrange
+            const card = {
+                ctaText,
+                url
+            };
+            const wrapper = shallowMount(HomePromotionCard2, {
+                propsData: {
+                    card,
+                    testId,
+                    noLink: true
+                },
+                provide
+            });
+
+            // Act
+            wrapper.find(`[data-test-id="${testId}"]`).trigger('click');
+
+            // Assert
+            expect(provide.emitCardClick).not.toHaveBeenCalled();
         });
-
-        // Act
-        wrapper.find(`[data-test-id="${testId}"]`).trigger('click');
-
-        // Assert
-        expect(provide.emitCardClick).toHaveBeenCalled();
     });
 
     // Check contentBackgroundColour is the dominant factor

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard2.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard2.test.js
@@ -81,6 +81,31 @@ describe('contentCards › HomePromotionCard2', () => {
         expect(container.attributes('href')).toBe(url);
     });
 
+    describe('when `no-link` prop is truthy', () => {
+        it('should NOT render the container as a link', () => {
+            // Arrange
+            const card = {
+                ctaText,
+                url
+            };
+
+            // Act
+            const wrapper = shallowMount(HomePromotionCard2, {
+                propsData: {
+                    card,
+                    testId,
+                    noLink: true
+                },
+                provide
+            });
+
+            const container = wrapper.find(`[data-test-id="${testId}"]`);
+
+            // Assert
+            expect(container.attributes('href')).toBeUndefined();
+        });
+    });
+
     it('should call the injected `emitCardClick` event when clicked', () => {
         // Arrange
         const card = {

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard2.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/_tests/HomePromotionCard2.test.js
@@ -29,9 +29,15 @@ describe('contentCards › HomePromotionCard2', () => {
     });
 
     it('should call the injected `emitCardView` event when mounted', () => {
-        // Arrange & Act
+        // Arrange
+        const card = {
+            foo: 'bar'
+        };
+
+        // Act
         shallowMount(HomePromotionCard2, {
             propsData: {
+                card,
                 testId
             },
             provide
@@ -39,6 +45,7 @@ describe('contentCards › HomePromotionCard2', () => {
 
         // Assert
         expect(provide.emitCardView).toHaveBeenCalled();
+        expect(provide.emitCardView).toHaveBeenCalledWith(card);
     });
 
     it('should display a CTA label', () => {
@@ -82,6 +89,7 @@ describe('contentCards › HomePromotionCard2', () => {
         const container = wrapper.find(`[data-test-id="${testId}"]`);
 
         // Assert
+        expect(container.element.tagName).toBe('A');
         expect(container.attributes('href')).toBe(url);
     });
 
@@ -104,6 +112,7 @@ describe('contentCards › HomePromotionCard2', () => {
 
         // Assert
         expect(provide.emitCardClick).toHaveBeenCalled();
+        expect(provide.emitCardClick).toHaveBeenCalledWith(card);
     });
 
     describe('when `no-link` prop is truthy', () => {


### PR DESCRIPTION

### Changed
- Home Promotion Cards 1 & 2 now use the tracking as supplied to the containing
  Content Cards component
- Home Promotion Cards 1 & 2 now render as a link for the full banner, rather than
  just a link for the CTA

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Firefox
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
