### PR TITLE
fozzie-components@v3.14.0 – Storybook documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.14.0
+------------------------------
+*February 15, 2021*
+
+### Added
+- `Utility Tools` page to Storybook docs.
+
+### Changed
+- `Setup Guides` just changed to `Guides` in Storybook sidebar.
+- Content moved out of `Getting Started` and into separate sub-pages.
+
+
 v3.13.0
 ------------------------------
 *February 12, 2021*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.27.0
+------------------------------
+*February 15, 2021*
+
+### Changed
+- Ordering of sub-pages updated with new documentation added.
+
+
 v0.26.0
 ------------------------------
 *February 9, 2021*

--- a/packages/storybook/config/storybook/preview.js
+++ b/packages/storybook/config/storybook/preview.js
@@ -18,6 +18,7 @@ export const parameters = {
                     'Getting Started',
                     [
                         'Intro',
+                        'Structure',
                         'Development Principles',
                         'Contributing',
                         'Troubleshooting'
@@ -30,7 +31,13 @@ export const parameters = {
                             'Checklist'
                         ]
                     ],
-                    'Setup Guides'
+                    'Guides',
+                    [
+                        [
+                            'Component Dependencies',
+                            'Typography'
+                        ]
+                    ]
                 ],
                 'Components']
         }

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "scripts": {
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -s public -p 8080 -c config/storybook",

--- a/stories/getting-started/contributing-guide.stories.mdx
+++ b/stories/getting-started/contributing-guide.stories.mdx
@@ -8,6 +8,12 @@ New components should use [generator-component](https://github.com/justeat/fozzi
 
 All of our components and services are published to NPM, so that they can be consumed as versioned packages. More information on versioning and publishing a component can be found below.
 
+
+## Naming your packages in the mono-repo
+
+The general naming convention for a Fozzie package is to use `f-{your-package-name}` e.g. [`f-footer`](https://github.com/justeat/fozzie-components/tree/master/packages/components/organisms/f-footer), [`f-header`](https://github.com/justeat/fozzie-components/tree/master/packages/components/organisms/f-header), [`f-checkout`](https://github.com/justeat/fozzie-components/tree/master/packages/components/organisms/f-checkout).
+
+
 ## Versioning
 
 We use [Semantic Versioning](http://semver.org/spec/v2.0.0.html) to publish all of our npm packages.
@@ -17,6 +23,19 @@ The basic premise of semantic versioning is that given a version number MAJOR.MI
 - MAJOR version when you make incompatible API changes,
 - MINOR version when you add functionality in a backwards compatible manner, and
 - PATCH version when you make backwards compatible bug fixes.
+
+
+## Badges for README.md
+
+### General Badges (should be added to all packages)
+
+* npm version badge from [badge.fury.io](https://badge.fury.io/)
+
+### Optional Badges
+
+* To report the build status you can [add a CircleCI badge](https://circleci.com/gh/justeat/workflows/fozzie-components)
+* If there are JavaScript unit tests in the package you can [add a coveralls badge](https://coveralls.io/github/justeat/)
+* Check for known vulnerabilities in your package with a [Snyk.io badge](https://snyk.io/test/)
 
 
 ## Publishing via npm

--- a/stories/getting-started/getting-started.stories.mdx
+++ b/stories/getting-started/getting-started.stories.mdx
@@ -14,63 +14,18 @@ Each individual component can be found in the [`components`](https://github.com/
 
 ## Dependencies
 
-For more information on the dependencies needed when including these shared UI components as part of your application, check out our <LinkTo kind="Documentation/Setup Guides/Dependencies" story="page">Component Dependency guide</LinkTo>.
+For more information on the dependencies needed when including these shared UI components as part of your application, check out our <LinkTo kind="Documentation/Guides/Component Dependencies" story="page">Component Dependency guide</LinkTo>.
 
-## Folder Structure
+## Repo Structure
 
-The mono-repo folder structure has been organised to differentiate between several distinct types of packages. These are:
+Full details on the mono-repo structure – and an explanation of how we categorise components and packages – can be found on the <LinkTo kind="Documentation/Getting Started/Structure" story="page">Mono-repo Structure page</LinkTo>.
 
-- Components
-- Services
-- Tools
-
-### Components
-
-UI components written in Vue.js, which can be pulled into a Vue application as a shared library component.
-
-Components are organised into sub-folders loosely matching the [Atomic Design Methodology](https://bradfrost.com/blog/post/atomic-web-design/), such as **Atoms**, **Molecules** and **Organisms**.
-
-As a rough guide:
-- **Atom** = Basic building blocks of an application.
-- **Molecule** = A group of component atoms that form a small fundamental component.
-- **Organism** = A group of molecules joined together to form a relatively complex, distinct section of an interface.
-
-As a general rule, if a component depends on another UI component (for example, it contains a `button` component), it will be at the very least a molecule in size. Atoms by their definition are the simplest form of components.
-
-### Services
-
-Services are packages that are written solely in JavaScript and provide a distinct piece of client-side or middleware functionality.
-
-For instance, it would make sense to write a specific package to handle how components handle globalisation and internationalisation via the Vue i18n module – and we have a package that does just that (`f-globalisation`).
-
-We currently have a shared package called `f-services` which defines a number of client-side utility services that components can make use of.
-
-### Tools
-
-Tools are packages that are used to provide a specific piece of functionality that is used by components or more generally in the mono-repo.
-
-Currently, we have the following tools:
-
-- [`f-vue-icons`](https://github.com/justeat/fozzie-components/tree/master/packages/tools/f-vue-icons) – Provides an interface for our Vue components to use icons defined in  the [`f-icons` package](https://github.com/justeat/f-icons).
-- [`generator-component`](https://github.com/justeat/fozzie-components/tree/master/packages/tools/generator-component) – A yeoman generator that should be used when creating new packages to provide a base folder structure to start from.
-- [`storybook`](https://github.com/justeat/fozzie-components/tree/master/packages/tools/storybook) – Our component library documentation tool that allows us to preview and test components in isolation before being integrated into JE web applications.
-
-## Naming your packages in the mono-repo
-
-The general naming convention for a Fozzie package is to use `f-{your-package-name}` e.g. [`f-footer`](https://github.com/justeat/fozzie-components/tree/master/packages/components/organisms/f-footer), [`f-header`](https://github.com/justeat/fozzie-components/tree/master/packages/components/organisms/f-header), [`f-checkout`](https://github.com/justeat/fozzie-components/tree/master/packages/components/organisms/f-checkout).
-
-## Badges for README.md
-
-### General Badges (should be added to all packages)
-
-* npm version badge from [badge.fury.io](https://badge.fury.io/)
-
-### Optional Badges
-
-* To report the build status you can [add a CircleCI badge](https://circleci.com/gh/justeat/workflows/fozzie-components)
-* If there are JavaScript unit tests in the package you can [add a coveralls badge](https://coveralls.io/github/justeat/)
-* Check for known vulnerabilities in your package with a [Snyk.io badge](https://snyk.io/test/)
 
 ## Contributing
 
-For mre information on contributing and how to publish components, <LinkTo kind="Documentation/Getting Started/Contributing" story="page">see our Contributing Guide</LinkTo>.
+For more information on creating, contributing to and publishing components, <LinkTo kind="Documentation/Getting Started/Contributing" story="page">see our Contributing Guide</LinkTo>.
+
+
+## Having Issues?
+
+If you are having any issues, please check out our <LinkTo kind="Documentation/Getting Started/Troubleshooting" story="page">Troubleshooting Guide</LinkTo>, send us a message in `#guild-ui` or [open an issue](https://github.com/justeat/fozzie-components/issues) on the repo.

--- a/stories/getting-started/structure.stories.mdx
+++ b/stories/getting-started/structure.stories.mdx
@@ -1,0 +1,42 @@
+import LinkTo from '@storybook/addon-links/react';
+
+<Meta title="Documentation/Getting Started/Structure"/>
+
+# Mono-repo Structure
+
+The mono-repo structure has been organised to differentiate between several distinct types of packages. These are:
+
+- Components
+- Services
+- Tools
+
+### Components
+
+UI components written in Vue.js, which can be pulled into a Vue application as a shared library component.
+
+Components are organised into sub-folders loosely matching the [Atomic Design Methodology](https://bradfrost.com/blog/post/atomic-web-design/), such as **Atoms**, **Molecules** and **Organisms**.
+
+As a rough guide:
+- **Atom** = Basic building blocks of an application.
+- **Molecule** = A group of component atoms that form a small fundamental component.
+- **Organism** = A group of molecules joined together to form a relatively complex, distinct section of an interface.
+
+As a general rule, if a component depends on another UI component (for example, it contains a `button` component), it will be at the very least a molecule in size. Atoms by their definition are the simplest form of components.
+
+### Services
+
+Services are packages that are written solely in JavaScript and provide a distinct piece of client-side or middleware functionality.
+
+For instance, it would make sense to write a specific package to handle how components handle globalisation and internationalisation via the Vue i18n module – and we have a package that does just that (`f-globalisation`).
+
+We currently have a shared package called `f-services` which defines a number of client-side utility services that components can make use of.
+
+### Tools
+
+Tools are packages that are used to provide a specific piece of functionality that is used by components or more generally in the mono-repo.
+
+Currently, we have the following tools:
+
+- [`f-vue-icons`](https://github.com/justeat/fozzie-components/tree/master/packages/tools/f-vue-icons) – Provides an interface for our Vue components to use icons defined in  the [`f-icons` package](https://github.com/justeat/f-icons).
+- [`generator-component`](https://github.com/justeat/fozzie-components/tree/master/packages/tools/generator-component) – A yeoman generator that should be used when creating new packages to provide a base folder structure to start from.
+- [`storybook`](https://github.com/justeat/fozzie-components/tree/master/packages/tools/storybook) – Our component library documentation tool that allows us to preview and test components in isolation before being integrated into JE web applications.

--- a/stories/guides/component-dependencies.stories.mdx
+++ b/stories/guides/component-dependencies.stories.mdx
@@ -1,6 +1,6 @@
 import LinkTo from '@storybook/addon-links/react';
 
-<Meta title="Documentation/Setup Guides/Dependencies"/>
+<Meta title="Documentation/Guides/Component Dependencies"/>
 
 # Component Dependencies
 
@@ -10,7 +10,7 @@ When using components, we expect consuming applications to include the following
 
 Just Eat and Menulog branded websites make use of `JustEatBasis` as it's main typeface (`Regular` and `Bold` variants).
 
-To load in the required fonts, we recommend following our <LinkTo kind="Documentation/Setup Guides/Typography" story="page">typography setup guide</LinkTo> which covers how to load the font in your application.
+To load in the required fonts, we recommend following our <LinkTo kind="Documentation/Guides/Typography" story="page">typography setup guide</LinkTo> which covers how to load the font in your application.
 
 ## Fozzie SCSS framework
 

--- a/stories/guides/typography.stories.mdx
+++ b/stories/guides/typography.stories.mdx
@@ -1,4 +1,4 @@
-<Meta title="Documentation/Setup Guides/Typography"/>
+<Meta title="Documentation/Guides/Typography"/>
 
 # Typography
 

--- a/stories/guides/utility-tools.stories.mdx
+++ b/stories/guides/utility-tools.stories.mdx
@@ -1,0 +1,37 @@
+import LinkTo from '@storybook/addon-links/react';
+
+<Meta title="Documentation/Guides/Utility Tools"/>
+
+# Utility Tools
+
+## Danger.js
+<a name="dangerjs"></a>
+
+[Danger.js](http://danger.systems/js/) is a tool that we use to automate certain aspects of our code review process.
+
+Checks that we automate include:
+
+- Ensuring that the `package.json` has been updated so that a package can be successfully published to NPM.
+- Making sure that each code change has an entry in the packages `CHANGELOG` so that the history is kept up to date.
+
+We automate Danger.js checks through CircleCI and they appear via our `fozzie-bot` github bot.
+
+---
+
+### Configuring Danger.js
+
+All of the checks that Danger.js performs are configured inside a `dangerfile.js` file [located at the root of the mono-repo](https://github.com/justeat/fozzie-components/blob/master/dangerfile.js).
+
+If you want to add, edit or remove any of the checks that Danger.js performs, you will need to edit this file. For information on the API that Danger exposes for us to hook onto, check out their [reference guide](https://danger.systems/js/reference.html).
+
+
+### Testing Danger.js locally
+
+To test changes you've made to a dangerfile locally against an existing public PR, simply run:
+
+```sh
+danger pr {URL_TO_PR}
+```
+
+Replacing `{URL_TO_PR}` with the relevant URL. This will enable you to test changes without having to run a full CircleCI build (which can be slow when testing script changes like this).
+


### PR DESCRIPTION
### Added
- `Utility Tools` page to Storybook docs.

### Changed
- `Setup Guides` just changed to `Guides` in Storybook sidebar.
- Content moved out of `Getting Started` and into separate sub-pages.