### PR TITLE
f-footer@v4.9.0 - Reduce bundle size in f-footer.

### DIFF
--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.9.0
+------------------------------
+*February 16, 2021*
+
+### Changed
+- Marked `f-vue-icons` as external via config.
+- Move `f-vue-icons` to peer `peerDependencies`.
+
 
 v4.8.3
 ------------------------------

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "4.8.3",
+  "version": "4.9.0",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist",
@@ -40,11 +40,11 @@
   ],
   "dependencies": {
     "@justeat/f-services": "1.3.0",
-    "@justeat/f-vue-icons": "1.10.0",
     "v-click-outside": "3.1.2"
   },
   "peerDependencies": {
-    "@justeat/f-trak": ">=0.6.0"
+    "@justeat/f-trak": ">=0.6.0",
+    "@justeat/f-vue-icons": "1.10.0"
   },
   "devDependencies": {
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",

--- a/packages/components/organisms/f-footer/vue.config.js
+++ b/packages/components/organisms/f-footer/vue.config.js
@@ -17,6 +17,11 @@ module.exports = {
                 additionalData: `@import "../assets/scss/common.scss";`
             });
     },
+    configureWebpack: {
+        externals: [
+            '@justeat/f-vue-icons'
+        ]
+    },
     pluginOptions: {
         lintStyleOnBuild: true
     }


### PR DESCRIPTION
### Changed

- Marked `f-vue-icons` as external via config.
- Move `f-vue-icons` to peer `peerDependencies`.


### Before

<img width="663" alt="Screen Shot 2021-02-16 at 3 34 43 PM" src="https://user-images.githubusercontent.com/2299779/108085216-00acc180-706d-11eb-9253-993fddf4406e.png">


### After

<img width="659" alt="Screen Shot 2021-02-16 at 3 21 57 PM" src="https://user-images.githubusercontent.com/2299779/108085244-073b3900-706d-11eb-8e9d-7b7278eadd24.png">


## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]

## Tested in HomeWeb (offers)

![Screen Shot 2021-02-16 at 3 39 07 PM](https://user-images.githubusercontent.com/2299779/108085369-29cd5200-706d-11eb-8713-0ac8b44d68d8.png)


