### PR TITLE
f-cookie-banner@v0.2.0 - Swap to using js-cookie for cookie handling

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.1.3
+------------------------------
+*February 17, 2021*
+
+### Changed
+- Use js-cookie instead of universal-cookie.
+
+### Removed
+- Remove Storybook 'knob' for setting legacy banner.
+
 v0.1.2
 ------------------------------
 *February 12, 2021*

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v0.1.3
+v0.2.0
 ------------------------------
 *February 17, 2021*
 

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",
@@ -41,13 +41,14 @@
   ],
   "dependencies": {
     "@justeat/f-globalisation": "1.0.0",
-    "@justeat/f-services": "1.7.0"
+    "@justeat/f-services": "1.7.0",
+    "js-cookie": "2.2.1"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1"
   },
   "devDependencies": {
-    "@justeat/f-button": "0.7.0",
+    "@justeat/f-button": "1.0.0",
     "@justeat/f-vue-icons": "2.3.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",
@@ -41,11 +41,11 @@
   ],
   "dependencies": {
     "@justeat/f-globalisation": "1.0.0",
-    "@justeat/f-services": "1.7.0",
-    "js-cookie": "2.2.1"
+    "@justeat/f-services": "1.7.0"
   },
   "peerDependencies": {
-    "@justeat/browserslist-config-fozzie": ">=1.1.1"
+    "@justeat/browserslist-config-fozzie": ">=1.1.1",
+    "js-cookie": "2.2.1"
   },
   "devDependencies": {
     "@justeat/f-button": "1.0.0",

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -77,6 +77,8 @@
 </template>
 
 <script>
+import CookieHelper from 'js-cookie';
+
 import { globalisationServices } from '@justeat/f-services';
 import { VueGlobalisationMixin } from '@justeat/f-globalisation';
 
@@ -203,10 +205,10 @@ export default {
          */
         checkCookieBannerCookie () {
             if (this.legacyBanner) {
-                this.shouldHideBanner = this.$cookies.get(this.legacyConsentCookieName) === 2;
+                this.shouldHideBanner = CookieHelper.get(this.legacyConsentCookieName) === 2;
                 this.setLegacyCookieBannerCookie();
             } else {
-                const cookieConsent = this.$cookies.get(this.consentCookieName);
+                const cookieConsent = CookieHelper.get(this.consentCookieName);
                 this.shouldHideBanner = cookieConsent === 'full' || cookieConsent === 'necessary';
             }
         },
@@ -216,9 +218,9 @@ export default {
          * @param {String} cookieValue
          */
         setCookieBannerCookie (cookieValue) {
-            this.$cookies.set(this.consentCookieName, cookieValue, {
+            CookieHelper.set(this.consentCookieName, cookieValue, {
                 path: '/',
-                maxAge: this.cookieExpiry
+                expires: this.cookieExpiry
             });
         },
 
@@ -226,9 +228,9 @@ export default {
          * Set the legacy cookie banner cookie
          */
         setLegacyCookieBannerCookie () {
-            this.$cookies.set(this.legacyConsentCookieName, '2', {
+            CookieHelper.set(this.legacyConsentCookieName, '130315', {
                 path: '/',
-                maxAge: this.cookieExpiry
+                expires: this.cookieExpiry
             });
         },
 
@@ -255,9 +257,9 @@ export default {
          * Remove unnecessary cookies
          */
         removeUnnecessaryCookies () {
-            const cookies = Object.keys(this.$cookies.getAll());
+            const cookies = Object.keys(CookieHelper.get());
             for (let i = 0; i < cookies.length; i++) {
-                if (this.isNotExcluded(cookies[i])) this.$cookies.remove(cookies[i]);
+                if (this.isNotExcluded(cookies[i])) CookieHelper.remove(cookies[i]);
             }
         },
 

--- a/packages/components/organisms/f-cookie-banner/src/components/_tests/CookieBanner.test.js
+++ b/packages/components/organisms/f-cookie-banner/src/components/_tests/CookieBanner.test.js
@@ -1,10 +1,9 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Cookie from 'cookie-universal';
 import { VueI18n } from '@justeat/f-globalisation';
 import CookieBanner from '../CookieBanner.vue';
+import CookieHelper from 'js-cookie';
 
 const localVue = createLocalVue();
-localVue.prototype.$cookies = Cookie();
 localVue.use(VueI18n);
 const i18n = {
     locale: 'en-GB'
@@ -100,7 +99,7 @@ describe('CookieBanner', () => {
                         legacyBanner: () => false
                     }
                 });
-                wrapper.vm.$cookies.set('je-cookieConsent', cookieValue);
+                CookieHelper.set('je-cookieConsent', cookieValue);
                 wrapper.vm.checkCookieBannerCookie();
 
                 // Assert
@@ -119,18 +118,18 @@ describe('CookieBanner', () => {
                     i18n,
                     propsData
                 });
-                const cookieSpy = jest.spyOn(wrapper.vm.$cookies, 'set');
+                const mockCookieHelper = jest.spyOn(CookieHelper, 'set').mockImplementation(() => {});
                 const payloadName = 'je-cookieConsent';
                 const payloadValue = 'foo';
                 const payloadObj = {
                     path: '/',
-                    maxAge: 7776000
+                    expires: 7776000
                 };
 
                 wrapper.vm.setCookieBannerCookie('foo');
 
                 // Assert
-                expect(cookieSpy).toHaveBeenCalledWith(payloadName, payloadValue, payloadObj);
+                expect(mockCookieHelper).toHaveBeenCalledWith(payloadName, payloadValue, payloadObj);
             });
         });
 
@@ -145,18 +144,18 @@ describe('CookieBanner', () => {
                     i18n,
                     propsData
                 });
-                const cookieSpy = jest.spyOn(wrapper.vm.$cookies, 'set');
+                const mockCookieHelper = jest.spyOn(CookieHelper, 'set').mockImplementation(() => {});
                 const payloadName = 'je-banner_cookie';
-                const payloadValue = '2';
+                const payloadValue = '130315';
                 const payloadObj = {
                     path: '/',
-                    maxAge: 7776000
+                    expires: 7776000
                 };
 
                 wrapper.vm.setLegacyCookieBannerCookie();
 
                 // Assert
-                expect(cookieSpy).toHaveBeenCalledWith(payloadName, payloadValue, payloadObj);
+                expect(mockCookieHelper).toHaveBeenCalledWith(payloadName, payloadValue, payloadObj);
             });
         });
 

--- a/packages/components/organisms/f-cookie-banner/stories/CookieBanner.stories.js
+++ b/packages/components/organisms/f-cookie-banner/stories/CookieBanner.stories.js
@@ -16,16 +16,11 @@ export const CookieBannerComponent = () => ({
 
         isHidden: {
             default: boolean('Is hidden', false)
-        },
-        
-        showLegacyBanner: {
-            default: boolean('Show legacy banner', false)
         }
     },
     template: `<cookie-banner
         :locale="locale"
         :is-hidden="isHidden"
-        :show-legacy-banner="showLegacyBanner"
         :key="locale"/>`
 });
 

--- a/packages/components/organisms/f-cookie-banner/vue.config.js
+++ b/packages/components/organisms/f-cookie-banner/vue.config.js
@@ -16,6 +16,10 @@ module.exports = {
                 // eslint-disable-next-line quotes
                 additionalData: `@import "../assets/scss/common.scss";`
             });
+        
+        config.externals({
+            'js-cookie': 'js-cookie'
+        });
     },
     pluginOptions: {
         lintStyleOnBuild: true


### PR DESCRIPTION
---

Remove the dependence on universal-cookie being present in the consuming application by using js-cookie directly in the component.

---

## Browsers Tested

- [x] Chrome (latest)
- [x] Edge (latest)
- [x] FireFox (84.0.2)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
