### PR TITLE
#trivial - small css hover fix for storybook

### DIFF
--- a/packages/storybook/config/storybook/manager-head.html
+++ b/packages/storybook/config/storybook/manager-head.html
@@ -75,6 +75,11 @@
         padding-bottom: 8px;
     }
 
+    a.sidebar-item:hover,
+    a.sidebar-item:focus {
+        color: #fff;
+    }
+
     span.sidebar-expander {
         top: 12px;
     }


### PR DESCRIPTION
Before:
![Screen Shot 2021-02-17 at 15 37 28](https://user-images.githubusercontent.com/19548183/108227742-1d60fc00-7136-11eb-8012-f35ef46d021f.png)

After:
![Screen Shot 2021-02-17 at 15 58 53](https://user-images.githubusercontent.com/19548183/108230848-17b8e580-7139-11eb-9bdc-b9af3c9c94ce.png)

