### PR TITLE
f-searchbox@v4.0.0 beta.26 – Adding vuex namespace

### DIFF
--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -3,9 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-(To be rolled into the next release)
+v4.0.0-beta.26
 ------------------------------
-*February 19, 2021*
+*February 23, 2021*
+
+### Changed
+- `searchbox` Vuex namespace to `fSearchboxModule` to avoid clashes in consuming applications.
 
 ### Fixed
 - Store / dispatch error in storybook.

--- a/packages/components/molecules/f-searchbox/README.md
+++ b/packages/components/molecules/f-searchbox/README.md
@@ -106,8 +106,7 @@ yarn test-component:chrome
 
 ### Vuex namespacing
 
-The Vuex store in this application uses `fSearchboxModule` as its namespace. When registering modules in your own application please be mindful that naming a Vuex store
-in your application the same as the one that's registered here will cause Vuex errors.
+The Vuex store in this application uses `fSearchboxModule` as its namespace. When registering modules in your own application please be mindful that naming a Vuex store in your application the same as the one that's registered here will cause Vuex errors.
 
 ### Config example
 

--- a/packages/components/molecules/f-searchbox/README.md
+++ b/packages/components/molecules/f-searchbox/README.md
@@ -104,6 +104,11 @@ yarn test-component:chrome
 
 ## Configuration
 
+### Vuex namespacing
+
+The Vuex store in this application uses `fSearchboxModule` as its namespace. When registering modules in your own application please be mindful that naming a Vuex store
+in your application the same as the one that's registered here will cause Vuex errors.
+
 ### Config example
 
 To apply these configs, pass them through as part of an optional `config` prop.

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-searchbox",
   "description": "Fozzie Searchbox – Just Eat Takeaway Global Searchbox",
-  "version": "4.0.0-beta.25",
+  "version": "4.0.0-beta.26",
   "main": "dist/f-searchbox.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-searchbox/src/components/Form.vue
+++ b/packages/components/molecules/f-searchbox/src/components/Form.vue
@@ -65,7 +65,7 @@ import FormFullAddressSearchSuggestions from './formElements/FormFullAddressSear
 import searchboxModule from '../store/searchbox.module';
 import { getLastLocation, normalisePostcode } from '../utils/helpers';
 import { search, selectedSuggestion } from '../services/search.services';
-import { JE_FULL_ADDRESS_DETAILS } from '../services/constants';
+import { JE_FULL_ADDRESS_DETAILS, VUEX_MODULE_NAMESPACE } from '../services/constants';
 import {
     processLocationCookie,
     onCustomSubmit,
@@ -137,7 +137,7 @@ export default {
     },
 
     computed: {
-        ...mapState('searchbox', [
+        ...mapState(VUEX_MODULE_NAMESPACE, [
             'address',
             'errors',
             'fullAddressDetails',
@@ -278,17 +278,17 @@ export default {
     },
 
     beforeCreate () {
-        if (!this.$store.hasModule('searchbox')) {
-            this.$store.registerModule('searchbox', searchboxModule);
+        if (!this.$store.hasModule(VUEX_MODULE_NAMESPACE)) {
+            this.$store.registerModule(VUEX_MODULE_NAMESPACE, searchboxModule);
         }
     },
 
     beforeDestroy () {
-        this.$store.unregisterModule('searchbox');
+        this.$store.unregisterModule(VUEX_MODULE_NAMESPACE);
     },
 
     methods: {
-        ...mapActions('searchbox', [
+        ...mapActions('fSearchboxModule', [
             'setAddress',
             'setAutoNavigateToSerp',
             'setSuggestions',

--- a/packages/components/molecules/f-searchbox/src/components/Form.vue
+++ b/packages/components/molecules/f-searchbox/src/components/Form.vue
@@ -288,7 +288,7 @@ export default {
     },
 
     methods: {
-        ...mapActions('fSearchboxModule', [
+        ...mapActions(VUEX_MODULE_NAMESPACE, [
             'setAddress',
             'setAutoNavigateToSerp',
             'setSuggestions',

--- a/packages/components/molecules/f-searchbox/src/components/FormStates/FormLoadingIndicator.vue
+++ b/packages/components/molecules/f-searchbox/src/components/FormStates/FormLoadingIndicator.vue
@@ -9,10 +9,11 @@
 
 <script>
 import { mapState } from 'vuex';
+import { VUEX_MODULE_NAMESPACE } from '../../services/constants';
 
 export default {
     computed: {
-        ...mapState('searchbox', [
+        ...mapState(VUEX_MODULE_NAMESPACE, [
             'isFullAddressSearchEnabled',
             'isLoadingResults'
         ]),

--- a/packages/components/molecules/f-searchbox/src/components/FormStates/tests/FormLoadingIndicator.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/FormStates/tests/FormLoadingIndicator.test.js
@@ -1,6 +1,7 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import FormLoadingIndicator from '../FormLoadingIndicator.vue';
+import { VUEX_MODULE_NAMESPACE } from '../../../services/constants';
 
 const localVue = createLocalVue();
 
@@ -13,7 +14,7 @@ const mockState = {
 
 const createStore = (state = mockState) => new Vuex.Store({
     modules: {
-        fSearchboxModule: {
+        [VUEX_MODULE_NAMESPACE]: {
             namespaced: true,
             state
         }

--- a/packages/components/molecules/f-searchbox/src/components/FormStates/tests/FormLoadingIndicator.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/FormStates/tests/FormLoadingIndicator.test.js
@@ -13,7 +13,7 @@ const mockState = {
 
 const createStore = (state = mockState) => new Vuex.Store({
     modules: {
-        searchbox: {
+        fSearchboxModule: {
             namespaced: true,
             state
         }

--- a/packages/components/molecules/f-searchbox/src/components/_tests/Form.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/_tests/Form.test.js
@@ -4,7 +4,7 @@ import Form from '../Form.vue';
 import * as generalServices from '../../services/general.services';
 import * as searchService from '../../services/search.services';
 import * as helperService from '../../utils/helpers';
-import { JE_FULL_ADDRESS_DETAILS } from '../../services/constants';
+import { JE_FULL_ADDRESS_DETAILS, VUEX_MODULE_NAMESPACE } from '../../services/constants';
 
 const localVue = createLocalVue();
 
@@ -32,7 +32,7 @@ const mockActions = {
 
 const createStore = (state = mockState, actions = mockActions) => new Vuex.Store({
     modules: {
-        fSearchboxModule: {
+        [VUEX_MODULE_NAMESPACE]: {
             namespaced: true,
             state,
             actions

--- a/packages/components/molecules/f-searchbox/src/components/_tests/Form.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/_tests/Form.test.js
@@ -32,7 +32,7 @@ const mockActions = {
 
 const createStore = (state = mockState, actions = mockActions) => new Vuex.Store({
     modules: {
-        searchbox: {
+        fSearchboxModule: {
             namespaced: true,
             state,
             actions

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressContinueWithSuggestion.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressContinueWithSuggestion.vue
@@ -20,6 +20,7 @@
 <script>
 import { mapState, mapActions } from 'vuex';
 import fullAddressSearchMixin from '../../mixin/fullAddressSearch.mixin';
+import { VUEX_MODULE_NAMESPACE } from '../../services/constants';
 
 export default {
     mixins: [
@@ -44,7 +45,7 @@ export default {
     },
 
     computed: {
-        ...mapState('searchbox', [
+        ...mapState(VUEX_MODULE_NAMESPACE, [
             'continueWithSuggestionDetails',
             'isBelowMid',
             'shouldAutoNavigateToSerp'
@@ -70,7 +71,7 @@ export default {
     },
 
     methods: {
-        ...mapActions('searchbox', [
+        ...mapActions(VUEX_MODULE_NAMESPACE, [
             'clearSuggestions',
             'setAddress',
             'setShouldShowSuggestionModel'

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchModalOverlay.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchModalOverlay.vue
@@ -58,6 +58,7 @@ import '@justeat/f-button/dist/f-button.css';
 import FullAddressSearchSuggestions from './FormFullAddressSearchSuggestions.vue';
 import LoadingIndicator from '../FormStates/FormLoadingIndicator.vue';
 import { ON_FULL_ADDRESS_MODAL_CLOSED } from '../../event-types';
+import { VUEX_MODULE_NAMESPACE } from '../../services/constants';
 
 export default {
     components: {
@@ -92,7 +93,7 @@ export default {
     },
 
     computed: {
-        ...mapState('searchbox', [
+        ...mapState(VUEX_MODULE_NAMESPACE, [
             'isBelowMid',
             'isFullAddressSearchEnabled',
             'suggestions',
@@ -120,7 +121,7 @@ export default {
     },
 
     methods: {
-        ...mapActions('searchbox', [
+        ...mapActions(VUEX_MODULE_NAMESPACE, [
             'getMatchedAreaAddressResults',
             'setAddress'
         ]),

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
@@ -50,6 +50,7 @@ import { mapState, mapActions } from 'vuex';
 import { MapPinIcon } from '@justeat/f-vue-icons';
 import ContinueWithSuggestion from './FormFullAddressContinueWithSuggestion.vue';
 import fullAddressSearchMixin from '../../mixin/fullAddressSearch.mixin';
+import { VUEX_MODULE_NAMESPACE } from '../../services/constants';
 
 export default {
     components: {
@@ -91,7 +92,7 @@ export default {
     }),
 
     computed: {
-        ...mapState('searchbox', [
+        ...mapState(VUEX_MODULE_NAMESPACE, [
             'address',
             'isBelowMid',
             'isInputFocus',
@@ -143,7 +144,7 @@ export default {
     },
 
     methods: {
-        ...mapActions('searchbox', [
+        ...mapActions(VUEX_MODULE_NAMESPACE, [
             'getMatchedAreaAddressResults',
             'getFinalAddressSelectionDetails',
             'setAddress',

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchField.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchField.vue
@@ -68,6 +68,7 @@ import FormSearchInnerFieldWrapper from './FormSearchInnerFieldWrapper.vue';
 import FormFullAddressSearchOverlay from './FormFullAddressSearchModalOverlay.vue';
 import LoadingIndicator from '../FormStates/FormLoadingIndicator.vue';
 import { ADDRESS_SEARCH_FOCUS } from '../../event-types';
+import { VUEX_MODULE_NAMESPACE } from '../../services/constants';
 
 const ALLOWED_SELECTION_TIME = 500;
 
@@ -131,7 +132,7 @@ export default {
     },
 
     computed: {
-        ...mapState('searchbox', [
+        ...mapState(VUEX_MODULE_NAMESPACE, [
             'address',
             'isBelowMid',
             'inputTimeoutValue',
@@ -181,7 +182,7 @@ export default {
     },
 
     methods: {
-        ...mapActions('searchbox', [
+        ...mapActions(VUEX_MODULE_NAMESPACE, [
             'clearSuggestions',
             'setAddress',
             'setInputFocus',

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchGeo.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchGeo.vue
@@ -20,6 +20,7 @@
 <script>
 import { mapState, mapActions } from 'vuex';
 import { GeoOutlineIcon, GeoFillIcon } from '@justeat/f-vue-icons';
+import { VUEX_MODULE_NAMESPACE } from '../../services/constants';
 
 export default {
     components: {
@@ -40,7 +41,7 @@ export default {
     },
 
     computed: {
-        ...mapState('searchbox', [
+        ...mapState(VUEX_MODULE_NAMESPACE, [
             'suggestions'
         ]),
 
@@ -56,7 +57,7 @@ export default {
     },
 
     methods: {
-        ...mapActions('searchbox', [
+        ...mapActions(VUEX_MODULE_NAMESPACE, [
             'setSuggestions',
             'setIsDirty'
         ]),

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchInnerFieldWrapper.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchInnerFieldWrapper.vue
@@ -22,6 +22,7 @@
 <script>
 import { mapState, mapActions } from 'vuex';
 import FormSearchGeo from './FormSearchGeo.vue';
+import { VUEX_MODULE_NAMESPACE } from '../../services/constants';
 
 export default {
     components: {
@@ -47,14 +48,14 @@ export default {
     },
 
     computed: {
-        ...mapState('searchbox', [
+        ...mapState(VUEX_MODULE_NAMESPACE, [
             'isStreetNumberRequired',
             'isGeoLocationAvailable'
         ])
     },
 
     methods: {
-        ...mapActions('searchbox', [
+        ...mapActions(VUEX_MODULE_NAMESPACE, [
             'setStreetNumber'
         ]),
 

--- a/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressContinueWithSuggestion.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressContinueWithSuggestion.test.js
@@ -1,6 +1,7 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import FullAddressContinueWithSuggestion from '../FormFullAddressContinueWithSuggestion.vue';
+import { VUEX_MODULE_NAMESPACE } from '../../../services/constants';
 
 const localVue = createLocalVue();
 
@@ -12,7 +13,7 @@ const mockState = {
 
 const createStore = (state = mockState) => new Vuex.Store({
     modules: {
-        fSearchboxModule: {
+        [VUEX_MODULE_NAMESPACE]: {
             namespaced: true,
             state
         }

--- a/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressContinueWithSuggestion.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressContinueWithSuggestion.test.js
@@ -12,7 +12,7 @@ const mockState = {
 
 const createStore = (state = mockState) => new Vuex.Store({
     modules: {
-        searchbox: {
+        fSearchboxModule: {
             namespaced: true,
             state
         }

--- a/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressSearchModalOverlay.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressSearchModalOverlay.test.js
@@ -1,6 +1,7 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import FormFullAddressSearchModalOverlay from '../FormFullAddressSearchModalOverlay.vue';
+import { VUEX_MODULE_NAMESPACE } from '../../../services/constants';
 
 const localVue = createLocalVue();
 
@@ -20,7 +21,7 @@ const mockActions = {
 
 const createStore = (state = mockState, actions = mockActions) => new Vuex.Store({
     modules: {
-        fSearchboxModule: {
+        [VUEX_MODULE_NAMESPACE]: {
             namespaced: true,
             state,
             actions

--- a/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressSearchModalOverlay.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressSearchModalOverlay.test.js
@@ -20,7 +20,7 @@ const mockActions = {
 
 const createStore = (state = mockState, actions = mockActions) => new Vuex.Store({
     modules: {
-        searchbox: {
+        fSearchboxModule: {
             namespaced: true,
             state,
             actions

--- a/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressSearchSuggestions.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressSearchSuggestions.test.js
@@ -1,6 +1,7 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import FullAddressSuggestions from '../FormFullAddressSearchSuggestions.vue';
+import { VUEX_MODULE_NAMESPACE } from '../../../services/constants';
 
 const localVue = createLocalVue();
 
@@ -43,7 +44,7 @@ const mockActions = {
 
 const createStore = (state = mockState, actions = mockActions) => new Vuex.Store({
     modules: {
-        fSearchboxModule: {
+        [VUEX_MODULE_NAMESPACE]: {
             namespaced: true,
             state,
             actions

--- a/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressSearchSuggestions.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormFullAddressSearchSuggestions.test.js
@@ -43,7 +43,7 @@ const mockActions = {
 
 const createStore = (state = mockState, actions = mockActions) => new Vuex.Store({
     modules: {
-        searchbox: {
+        fSearchboxModule: {
             namespaced: true,
             state,
             actions

--- a/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormSearchField.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormSearchField.test.js
@@ -1,6 +1,7 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import FormSearchField from '../FormSearchField.vue';
+import { VUEX_MODULE_NAMESPACE } from '../../../services/constants';
 
 const localVue = createLocalVue();
 
@@ -32,7 +33,7 @@ const mockActions = {
 
 const createStore = (state = mockState, actions = mockActions) => new Vuex.Store({
     modules: {
-        fSearchboxModule: {
+        [VUEX_MODULE_NAMESPACE]: {
             namespaced: true,
             state,
             actions

--- a/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormSearchField.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormSearchField.test.js
@@ -32,7 +32,7 @@ const mockActions = {
 
 const createStore = (state = mockState, actions = mockActions) => new Vuex.Store({
     modules: {
-        searchbox: {
+        fSearchboxModule: {
             namespaced: true,
             state,
             actions

--- a/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormSearchInnerFieldWrapper.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormSearchInnerFieldWrapper.test.js
@@ -18,7 +18,7 @@ const mockActions = {
 
 const createStore = (state = mockState, actions = mockActions) => new Vuex.Store({
     modules: {
-        searchbox: {
+        fSearchboxModule: {
             namespaced: true,
             state,
             actions

--- a/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormSearchInnerFieldWrapper.test.js
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/tests/FormSearchInnerFieldWrapper.test.js
@@ -1,6 +1,7 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import FormSearchInnerFieldWrapper from '../FormSearchInnerFieldWrapper.vue';
+import { VUEX_MODULE_NAMESPACE } from '../../../services/constants';
 
 const localVue = createLocalVue();
 
@@ -18,7 +19,7 @@ const mockActions = {
 
 const createStore = (state = mockState, actions = mockActions) => new Vuex.Store({
     modules: {
-        fSearchboxModule: {
+        [VUEX_MODULE_NAMESPACE]: {
             namespaced: true,
             state,
             actions

--- a/packages/components/molecules/f-searchbox/src/mixin/fullAddressSearch.mixin.js
+++ b/packages/components/molecules/f-searchbox/src/mixin/fullAddressSearch.mixin.js
@@ -1,16 +1,16 @@
 import { mapState, mapActions } from 'vuex';
 import { extractPostcode, fullAddressLocalStorageService } from '../services/general.services';
 import { generatePostForm } from '../utils/helpers';
-import { JE_FULL_ADDRESS_DETAILS } from '../services/constants';
+import { JE_FULL_ADDRESS_DETAILS, VUEX_MODULE_NAMESPACE } from '../services/constants';
 
 export default {
-    computed: mapState('searchbox', [
+    computed: mapState(VUEX_MODULE_NAMESPACE, [
         'address',
         'savedFullAddressDetails'
     ]),
 
     methods: {
-        ...mapActions('searchbox', [
+        ...mapActions(VUEX_MODULE_NAMESPACE, [
             'setSavedFullAddressDetails'
         ]),
 

--- a/packages/components/molecules/f-searchbox/src/services/constants.js
+++ b/packages/components/molecules/f-searchbox/src/services/constants.js
@@ -9,3 +9,5 @@ export const LOCATION_COOKIE_PROPS = [
 export const JE_LOCATION = 'je-location';
 
 export const JE_FULL_ADDRESS_DETAILS = 'je-full-address-details';
+
+export const VUEX_MODULE_NAMESPACE = 'fSearchboxModule';


### PR DESCRIPTION
### Changed
- `searchbox` Vuex namespace to `fSearchboxModule` to avoid clashes in consuming applications.

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
