### PR TITLE
f-cookie-banner@v0.3.1 - Default banner visiblity to hidden.

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v0.3.0
+v0.3.1
 ------------------------------
 *March 1, 2021*
 

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.3.0
 ------------------------------
+*March 1, 2021*
+
+### Changed
+- `shouldHideBanner` data property defaults to `true` in order to avoid flash of cookie banner after it has been dismissed.
+
+v0.3.0
+------------------------------
 *February 25, 2021*
 
 ### Changed

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -5,9 +5,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.3.1
 ------------------------------
-*March 1, 2021*
+*March 2, 2021*
 
-### Changed
+### Fixed
 - `shouldHideBanner` data property defaults to `true` in order to avoid flash of cookie banner after it has been dismissed.
 
 v0.3.0

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -129,7 +129,7 @@ export default {
             config: { ...localeConfig },
             theme,
             copy,
-            shouldHideBanner: false,
+            shouldHideBanner: true,
             consentCookieName,
             legacyConsentCookieName,
             isIosBrowser: false

--- a/yarn.lock
+++ b/yarn.lock
@@ -8893,7 +8893,7 @@ date-fns@2.16.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
-date-fns@^2.17.0:
+date-fns@2.17.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.17.0.tgz#afa55daea539239db0a64e236ce716ef3d681ba1"
   integrity sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==


### PR DESCRIPTION
### Changed
- `shouldHideBanner` data property defaults to `true` in order to avoid flash of cookie banner after it has been dismissed.