### PR TITLE
f-cookie-banner@v0.3.2

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -8,7 +8,7 @@ v0.3.2
 *March 2, 2021*
 
 ### Fixed
-- Protocol missing from image request.
+- Protocol missing from image request (Required for Lighthouse checks).
 
 v0.3.1
 ------------------------------

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.3.2
+------------------------------
+*March 2, 2021*
+
+### Fixed
+- Protocol missing from image request.
+
 v0.3.1
 ------------------------------
 *March 2, 2021*

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
@@ -106,7 +106,7 @@ export default {
                 right: 8px;
                 width: 10px;
                 height: 10px;
-                background: url('//dy3erx8o0a6nh.cloudfront.net/images/icon-close-banner.png') no-repeat 50%;
+                background: url('https://dy3erx8o0a6nh.cloudfront.net/images/icon-close-banner.png') no-repeat 50%;
                 background-size: 10px 10px;
                 border: none;
                 cursor: pointer;


### PR DESCRIPTION
Lighthouse is failing on this image request because coreweb in the background spins up a non http site and then requests this image via a non https protocol. To actually fix this issue we need coreweb to work locally on a https setup so lighthouse will serve up the correct protocol automatically.

### Fixed
- Protocol missing from image request (Required for Lighthouse checks).

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
