### PR TITLE
f-cookie-banner@v0.4.0 - Remove default country value from locale prop.

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -8,7 +8,7 @@ v0.4.0
 *March 2, 2021*
 
 ### Changed
-- Default locale prop value`en-GB` to be `''`.
+- Default locale prop value `en-GB` to be `''`.
 
 
 v0.3.2

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.4.0
+------------------------------
+*March 2, 2021*
+
+### Changed
+- Default locale prop value`en-GB` to be `''`.
+
+
 v0.3.2
 ------------------------------
 *March 2, 2021*

--- a/packages/components/organisms/f-cookie-banner/README.md
+++ b/packages/components/organisms/f-cookie-banner/README.md
@@ -72,7 +72,7 @@ The props that can be defined are as follows:
 
 | Prop  | Type  | Default | Description |
 | ----- | ----- | ------- | ----------- |
-| `locale` | `String` | `'en-GB'` | Set the tenant for localisation ['da-DK', 'en-AU', 'en-GB', 'en-IE', 'en-NZ', 'es-ES', 'it-IT', 'nb-NO']. |
+| `locale` | `String` | `''` | Set the tenant for localisation ['da-DK', 'en-AU', 'en-GB', 'en-IE', 'en-NZ', 'es-ES', 'it-IT', 'nb-NO']. |
 | `isHidden` | `Boolean` | `false` | show/hide the cookie consent banner. |
 | `showLegacyBanner` | `Boolean` | `false` | Use the legacy "passive" banner markup (UK only). |
 | `cookieExpiry` | `Number` | `7776000` | Expiry time of cookies written to the browser. |

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -98,7 +98,7 @@ export default {
     props: {
         locale: {
             type: String,
-            default: 'en-GB'
+            default: ''
         },
 
         isHidden: {


### PR DESCRIPTION
### Changed
- Default locale prop value`en-GB` to be `''`.
