### PR TITLE
Updated error-message, mega-modal and tabs with component tests. #trivial

### DIFF
--- a/packages/components/atoms/f-error-message/CHANGELOG.md
+++ b/packages/components/atoms/f-error-message/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v0.3.2
+v0.4.0
 ------------------------------
 *March 3, 2021*
 

--- a/packages/components/atoms/f-error-message/CHANGELOG.md
+++ b/packages/components/atoms/f-error-message/CHANGELOG.md
@@ -3,8 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-Latest (add to next release)
+v0.3.2
 ------------------------------
+*March 3, 2021*
+
+### Added
+- Added component test file and tests
+
 *February 25, 2021*
 
 ### Changed

--- a/packages/components/atoms/f-error-message/jest.config.js
+++ b/packages/components/atoms/f-error-message/jest.config.js
@@ -22,7 +22,8 @@ module.exports = {
     },
 
     modulePathIgnorePatterns: [
-        './test/specs/accessibility'
+        './test/specs/accessibility',
+        './test/specs/component'
     ],
 
     snapshotSerializers: [

--- a/packages/components/atoms/f-error-message/package.json
+++ b/packages/components/atoms/f-error-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-error-message",
   "description": "Fozzie Error Message – Generic inline error message",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "dist/f-error-message.umd.min.js",
   "files": [
     "dist"
@@ -31,6 +31,7 @@
     "lint:fix": "yarn lint --fix",
     "lint:style": "vue-cli-service lint:style",
     "test": "vue-cli-service test:unit",
+    "test-component:chrome": "wdio ../../../../wdio.conf.js --suite component",
     "test-a11y:chrome": "wdio ../../../../wdio.conf.js --suite a11y"
   },
   "browserslist": [

--- a/packages/components/atoms/f-error-message/package.json
+++ b/packages/components/atoms/f-error-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-error-message",
   "description": "Fozzie Error Message – Generic inline error message",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "main": "dist/f-error-message.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-error-message/test/specs/component/f-error-message.component.spec.js
+++ b/packages/components/atoms/f-error-message/test/specs/component/f-error-message.component.spec.js
@@ -1,0 +1,14 @@
+const ErrorMessage = require('../../../test-utils/component-objects/f-error-message.component');
+const errorMessage = new ErrorMessage();
+
+describe('f-error-message component tests', () => {
+    beforeEach(() => {
+        errorMessage.open();
+        errorMessage.waitForComponent();
+    });
+
+    it('should display the f-error-message component', () => {
+        // Assert
+        expect(errorMessage.isComponentDisplayed()).toBe(true);
+    });
+});

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -3,9 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-
-Latest (add to next release)
+v0.4.1
 ------------------------------
+*March 3, 2021*
+
+### Added
+- Added component test file, component object file and tests
+- Added `Data-test-id` to elements within the `MegaModal.stories.js`
+
 *February 25, 2021*
 
 ### Changed

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v0.4.1
+v0.5.0
 ------------------------------
 *March 3, 2021*
 

--- a/packages/components/molecules/f-mega-modal/jest.config.js
+++ b/packages/components/molecules/f-mega-modal/jest.config.js
@@ -33,7 +33,8 @@ module.exports = {
     },
 
     modulePathIgnorePatterns: [
-        './test/specs/accessibility'
+        './test/specs/accessibility',
+        './test/specs/component'
     ],
 
     testURL: 'http://localhost/',

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "main": "dist/f-mega-modal.common.js",
   "files": [
     "dist"

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/f-mega-modal.common.js",
   "files": [
     "dist"
@@ -31,6 +31,7 @@
     "lint:fix": "yarn lint --fix",
     "lint:style": "vue-cli-service lint:style",
     "test": "vue-cli-service test:unit",
+    "test-component:chrome": "wdio ../../../../wdio.conf.js --suite component",
     "test-a11y:chrome": "wdio ../../../../wdio.conf.js --suite a11y"
   },
   "browserslist": [

--- a/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
+++ b/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
@@ -78,11 +78,13 @@ export const MegaModalComponent = () => ({
             :has-close-button="hasCloseButton"
             :close-on-blur="closeOnBlur"
             :close-button-copy="closeButtonCopy">
-            <h3 class="u-noSpacing">
+            <h3 data-test-id="mega-modal-title" class="u-noSpacing">
                 This place isn't taking orders
             </h3>
 
-            <p>Let's find another restaurant to order from.</p>
+            <p data-test-id="mega-modal-content">
+                Let's find another restaurant to order from.
+            </p>
 
         </mega-modal>
     `

--- a/packages/components/molecules/f-mega-modal/test-utils/component-objects/f-mega-modal.component.js
+++ b/packages/components/molecules/f-mega-modal/test-utils/component-objects/f-mega-modal.component.js
@@ -2,6 +2,8 @@ const Page = require('@justeat/f-wdio-utils/src/page.object');
 
 module.exports = class MegaModal extends Page {
     get component () { return $('[data-test-id="mega-modal-component"]'); }
+    get megaModalTitle () { return $('[data-test-id="mega-modal-title"]'); }
+    get megaModalContent () { return $('[data-test-id="mega-modal-content"]'); }
 
     open () {
         super.openComponent('molecule', 'mega-modal-component');
@@ -10,4 +12,17 @@ module.exports = class MegaModal extends Page {
     waitForComponent () {
         super.waitForComponent(this.component);
     }
+
+    isComponentDisplayed () {
+        return this.component.isDisplayed();
+    }
+
+    isTitleDisplayed () {
+        return this.megaModalTitle.isDisplayed();
+    }
+
+    isContentDisplayed () {
+        return this.megaModalTitle.isDisplayed();
+    }
+
 };

--- a/packages/components/molecules/f-mega-modal/test/specs/component/f-mega-modal.component.spec.js
+++ b/packages/components/molecules/f-mega-modal/test/specs/component/f-mega-modal.component.spec.js
@@ -1,0 +1,24 @@
+const MegaModal = require('../../../test-utils/component-objects/f-mega-modal.component');
+const megaModal = new MegaModal();
+
+describe('f-mega-modal component tests', () => {
+    beforeEach(() => {
+        megaModal.open();
+        megaModal.waitForComponent();
+    });
+
+    it('should display Alert', () => {
+        // Assert
+        expect(megaModal.isComponentDisplayed()).toBe(true);
+    });
+
+    it('should display the title', () => {
+        // Assert
+        expect(megaModal.isTitleDisplayed()).toBe(true);
+    });
+
+    it('should display the content', () => {
+        // Assert
+        expect(megaModal.isContentDisplayed()).toBe(true);
+    });
+});

--- a/packages/components/molecules/f-tabs/CHANGELOG.md
+++ b/packages/components/molecules/f-tabs/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v0.2.2
+v0.3.0
 ------------------------------
 *March 3, 2021*
 

--- a/packages/components/molecules/f-tabs/CHANGELOG.md
+++ b/packages/components/molecules/f-tabs/CHANGELOG.md
@@ -3,9 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-
-Latest (add to next release)
+v0.2.2
 ------------------------------
+*March 3, 2021*
+
+### Added
+- Added component tests
+- Added supporting code to component object file
+
+### Changed
+- `Data-test-id` naming for `tab-` to `tab-button-` in `Tabs.vue`
+- `Data-test-id` naming for `transition-tab-` to `tab-content-` in `Tab.vue`
+
 *February 24, 2021*
 
 ### Changed

--- a/packages/components/molecules/f-tabs/CHANGELOG.md
+++ b/packages/components/molecules/f-tabs/CHANGELOG.md
@@ -12,8 +12,8 @@ v0.3.0
 - Added supporting code to component object file
 
 ### Changed
-- `Data-test-id` naming for `tab-` to `tab-button-` in `Tabs.vue`
-- `Data-test-id` naming for `transition-tab-` to `tab-content-` in `Tab.vue`
+- `Data-test-id` naming for `tab-` to `tab-button-` in `Tabs.vue` and `Tabs.test.js`
+- `Data-test-id` naming for `transition-tab-` to `tab-content-` in `Tab.vue` and `Tab.test.js`
 
 *February 24, 2021*
 

--- a/packages/components/molecules/f-tabs/package.json
+++ b/packages/components/molecules/f-tabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-tabs",
   "description": "Fozzie Tabs – Switchable slots for content&#34;",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "main": "dist/f-tabs.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-tabs/package.json
+++ b/packages/components/molecules/f-tabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-tabs",
   "description": "Fozzie Tabs – Switchable slots for content&#34;",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "dist/f-tabs.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-tabs/src/components/Tab.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tab.vue
@@ -4,7 +4,7 @@
         :name="transitionName">
         <div
             v-show="isActive"
-            :data-test-id="`transition-tab-${name}`"
+            :data-test-id="`tab-content-${name}`"
             :class="$style['c-tab']">
             <slot />
         </div>

--- a/packages/components/molecules/f-tabs/src/components/Tabs.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tabs.vue
@@ -11,7 +11,7 @@
                         { [$style['c-tabs-button--active']]: activeTab === name },
                         $style['c-tabs-button']
                     ]"
-                    :data-test-id="`tab-${name}`"
+                    :data-test-id="`tab-button-${name}`"
                     @click="selectTabIndex(name)"
                 >
                     {{ title }}

--- a/packages/components/molecules/f-tabs/src/components/tests/Tab.test.js
+++ b/packages/components/molecules/f-tabs/src/components/tests/Tab.test.js
@@ -77,7 +77,7 @@ describe('Tab.vue', () => {
     describe('Animation', () => {
         it('should only create transition element when animateTab is true', () => {
             // Act
-            const tabTransition = wrapper.find(`[data-test-id="transition-tab-${wrapper.vm.name}"]`);
+            const tabTransition = wrapper.find(`[data-test-id="tab-content-${wrapper.vm.name}"]`);
             const tabNormal = wrapper.find(`[data-test-id="no-transition-tab-${wrapper.vm.name}"]`);
 
             // Assert

--- a/packages/components/molecules/f-tabs/src/components/tests/Tabs.test.js
+++ b/packages/components/molecules/f-tabs/src/components/tests/Tabs.test.js
@@ -32,7 +32,7 @@ describe('Tabs', () => {
         it('should register a tab when addTab method is called', async () => {
             // Act
             await wrapper.vm.addTab(registeredTabsMock[0]);
-            const tabButton = wrapper.find(`[data-test-id="tab-${registeredTabsMock[0].name}"]`);
+            const tabButton = wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`);
 
             // Assert
             expect(tabButton.exists()).toBe(true);
@@ -43,7 +43,7 @@ describe('Tabs', () => {
             const tabs = [];
             registeredTabsMock.forEach(tab => {
                 wrapper.vm.addTab(tab);
-                tabs.push(wrapper.find(`[data-test-id="tab-${tab.name}"]`));
+                tabs.push(wrapper.find(`[data-test-id="tab-button-${tab.name}"]`));
             });
             await wrapper.vm.$nextTick();
 
@@ -54,7 +54,7 @@ describe('Tabs', () => {
         it('should display the name of the registered tab inside the button', async () => {
             // Act
             await wrapper.vm.addTab(registeredTabsMock[0]);
-            const tabButton = wrapper.find(`[data-test-id="tab-${registeredTabsMock[0].name}"]`);
+            const tabButton = wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`);
 
             // Assert
             expect(tabButton.text()).toBe(registeredTabsMock[0].title);
@@ -83,7 +83,7 @@ describe('Tabs', () => {
 
             await wrapper.vm.$nextTick();
 
-            const tabButton = wrapper.find(`[data-test-id="tab-${registeredTabsMock[0].name}"]`);
+            const tabButton = wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`);
             await tabButton.trigger('click');
 
             // Assert
@@ -98,7 +98,7 @@ describe('Tabs', () => {
 
             await wrapper.vm.$nextTick();
 
-            await wrapper.find(`[data-test-id="tab-${registeredTabsMock[1].name}"]`).trigger('click');
+            await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[1].name}"]`).trigger('click');
 
             // Assert
             expect(wrapper.vm.direction).toEqual('RIGHT');
@@ -112,8 +112,8 @@ describe('Tabs', () => {
 
             await wrapper.vm.$nextTick();
 
-            await wrapper.find(`[data-test-id="tab-${registeredTabsMock[1].name}"]`).trigger('click');
-            await wrapper.find(`[data-test-id="tab-${registeredTabsMock[0].name}"]`).trigger('click');
+            await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[1].name}"]`).trigger('click');
+            await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`).trigger('click');
 
             // Assert
             expect(wrapper.vm.direction).toEqual('LEFT');

--- a/packages/components/molecules/f-tabs/test-utils/component-objects/f-tabs.component.js
+++ b/packages/components/molecules/f-tabs/test-utils/component-objects/f-tabs.component.js
@@ -2,6 +2,7 @@ const Page = require('@justeat/f-wdio-utils/src/page.object');
 
 module.exports = class Tabs extends Page {
     get component () { return $('[data-test-id="tabs-component"]'); }
+    get tabButtons () { return $$('[data-test-id*="tab-button"]'); }
 
     open () {
         super.openComponent('molecule', 'vue-tabs-component');
@@ -14,4 +15,14 @@ module.exports = class Tabs extends Page {
     isComponentDisplayed () {
         return this.component.isDisplayed();
     }
-}
+
+    isTabButtonDisplayed () {
+        return this.tabButton.isDisplayed();
+    }
+
+    set expectedTabButton (tabTitle) {
+        this.tabButtonValue = this.tabButtons.filter(element => element.getText().includes(tabTitle))[0];
+    }
+
+    get tabButton () { return this.tabButtonValue != null ? this.tabButtonValue : 'Please set an expected tab button value'; }
+};

--- a/packages/components/molecules/f-tabs/test/specs/component/f-tabs.component.spec.js
+++ b/packages/components/molecules/f-tabs/test/specs/component/f-tabs.component.spec.js
@@ -1,3 +1,4 @@
+import forEach from 'mocha-each';
 const Tabs = require ('../../../test-utils/component-objects/f-tabs.component');
 const tabs = new Tabs();
 
@@ -10,5 +11,14 @@ describe('f-tabs component tests', () => {
     it('should display the f-tabs component', () => {
         // Assert
         expect(tabs.isComponentDisplayed()).toBe(true);
+    });
+
+    forEach(['Your Stampcards', 'How it works'])
+    .it('should display individual tabs', tab => {
+        // Arrange
+        tabs.expectedTabButton = tab;
+
+        // Assert
+        expect(tabs.isTabButtonDisplayed(tab)).toBe(true);
     });
 });

--- a/packages/components/organisms/f-checkout/src/components/_tests/__snapshots__/Checkout.test.js.snap
+++ b/packages/components/organisms/f-checkout/src/components/_tests/__snapshots__/Checkout.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Checkout methods :: submitCheckout :: if \`isLoggedIn\` set to \`false\` should show error message and emit failure event when the email field is invalid 1`] = `
-<p data-test-id="error-email-invalid" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
+<p data-test-id="error-email-invalid" data-test-title="" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-34.000000, -18.000000)">
         <g transform="translate(32.000000, 16.000000)">
@@ -16,7 +16,7 @@ exports[`Checkout methods :: submitCheckout :: if \`isLoggedIn\` set to \`false\
 `;
 
 exports[`Checkout methods :: submitCheckout :: if \`isLoggedIn\` set to \`false\` should show error message and emit failure event when the email field is not populated 1`] = `
-<p data-test-id="error-email-invalid" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
+<p data-test-id="error-email-invalid" data-test-title="" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-34.000000, -18.000000)">
         <g transform="translate(32.000000, 16.000000)">
@@ -31,7 +31,7 @@ exports[`Checkout methods :: submitCheckout :: if \`isLoggedIn\` set to \`false\
 `;
 
 exports[`Checkout methods :: submitCheckout :: if \`isLoggedIn\` set to \`false\` should show error message and emit failure event when the first name field is not populated 1`] = `
-<p data-test-id="error-first-name-empty" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
+<p data-test-id="error-first-name-empty" data-test-title="" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-34.000000, -18.000000)">
         <g transform="translate(32.000000, 16.000000)">
@@ -46,7 +46,7 @@ exports[`Checkout methods :: submitCheckout :: if \`isLoggedIn\` set to \`false\
 `;
 
 exports[`Checkout methods :: submitCheckout :: if \`isLoggedIn\` set to \`false\` should show error message and emit failure event when the last name field is not populated 1`] = `
-<p data-test-id="error-last-name-empty" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
+<p data-test-id="error-last-name-empty" data-test-title="" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-34.000000, -18.000000)">
         <g transform="translate(32.000000, 16.000000)">
@@ -61,7 +61,7 @@ exports[`Checkout methods :: submitCheckout :: if \`isLoggedIn\` set to \`false\
 `;
 
 exports[`Checkout methods :: submitCheckout :: if serviceType set to \`collection\` should show error message and emit failure event when the mobile number field is not populated 1`] = `
-<p data-test-id="error-mobile-number" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
+<p data-test-id="error-mobile-number" data-test-title="" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-34.000000, -18.000000)">
         <g transform="translate(32.000000, 16.000000)">
@@ -76,7 +76,7 @@ exports[`Checkout methods :: submitCheckout :: if serviceType set to \`collectio
 `;
 
 exports[`Checkout methods :: submitCheckout :: if serviceType set to \`collection\` should show error message and emit failure event when the mobile number field is populated with a < 10 numbers 1`] = `
-<p data-test-id="error-mobile-number" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
+<p data-test-id="error-mobile-number" data-test-title="" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-34.000000, -18.000000)">
         <g transform="translate(32.000000, 16.000000)">
@@ -91,7 +91,7 @@ exports[`Checkout methods :: submitCheckout :: if serviceType set to \`collectio
 `;
 
 exports[`Checkout methods :: submitCheckout :: if serviceType set to \`collection\` should show error message and emit failure event when the mobile number field is populated with non numeric value 1`] = `
-<p data-test-id="error-mobile-number" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
+<p data-test-id="error-mobile-number" data-test-title="" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-34.000000, -18.000000)">
         <g transform="translate(32.000000, 16.000000)">
@@ -106,7 +106,7 @@ exports[`Checkout methods :: submitCheckout :: if serviceType set to \`collectio
 `;
 
 exports[`Checkout methods :: submitCheckout :: if serviceType set to \`delivery\` should emit failure event and display error message when address line1 input field is empty 1`] = `
-<p data-test-id="error-address-line1-empty" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
+<p data-test-id="error-address-line1-empty" data-test-title="" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-34.000000, -18.000000)">
         <g transform="translate(32.000000, 16.000000)">
@@ -121,7 +121,7 @@ exports[`Checkout methods :: submitCheckout :: if serviceType set to \`delivery\
 `;
 
 exports[`Checkout methods :: submitCheckout :: if serviceType set to \`delivery\` should emit failure event and display error message when city input field is empty 1`] = `
-<p data-test-id="error-address-city-empty" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
+<p data-test-id="error-address-city-empty" data-test-title="" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-34.000000, -18.000000)">
         <g transform="translate(32.000000, 16.000000)">
@@ -136,7 +136,7 @@ exports[`Checkout methods :: submitCheckout :: if serviceType set to \`delivery\
 `;
 
 exports[`Checkout methods :: submitCheckout :: if serviceType set to \`delivery\` should emit failure event and display error message when postcode contains incorrect characters 1`] = `
-<p data-test-id="error-address-postcode-type-error" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
+<p data-test-id="error-address-postcode-type-error" data-test-title="" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-34.000000, -18.000000)">
         <g transform="translate(32.000000, 16.000000)">
@@ -151,7 +151,7 @@ exports[`Checkout methods :: submitCheckout :: if serviceType set to \`delivery\
 `;
 
 exports[`Checkout methods :: submitCheckout :: if serviceType set to \`delivery\` should emit failure event and display error message when postcode contains incorrect characters 2`] = `
-<p data-test-id="error-address-postcode-type-error" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
+<p data-test-id="error-address-postcode-type-error" data-test-title="" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-34.000000, -18.000000)">
         <g transform="translate(32.000000, 16.000000)">
@@ -166,7 +166,7 @@ exports[`Checkout methods :: submitCheckout :: if serviceType set to \`delivery\
 `;
 
 exports[`Checkout methods :: submitCheckout :: if serviceType set to \`delivery\` should emit failure event and display error message when postcode input field is empty 1`] = `
-<p data-test-id="error-address-postcode-empty" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
+<p data-test-id="error-address-postcode-empty" data-test-title="" class="ErrorMessage_c-errorMessage__5fre"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="c-ficon c-ficon--danger ErrorMessage_c-errorMessage-icon_3E2NJ">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-34.000000, -18.000000)">
         <g transform="translate(32.000000, 16.000000)">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,6 +1950,13 @@
   dependencies:
     qwery "4.0.0"
 
+"@justeat/f-error-message@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@justeat/f-error-message/-/f-error-message-0.3.1.tgz#07195e2621efbe43f4628d0932c2ecc43b51c71c"
+  integrity sha512-KANckjkK0ay/r9FqK2yEQOCzCASNrnJjHRdLIKvMgl4mVo8WxSSVyjIhfJtnVKQwfWv6bg0kkm1xpxxuQffokg==
+  dependencies:
+    "@justeat/f-vue-icons" "1.10.0"
+
 "@justeat/f-form-field@1.6.1":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-1.6.1.tgz#47b014847a42467737b65997cfcab212d0385ba7"
@@ -4808,7 +4815,7 @@
     deepmerge "^4.0.0"
     glob "^7.1.2"
 
-"@wdio/junit-reporter@^7.0.7":
+"@wdio/junit-reporter@7.0.7":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@wdio/junit-reporter/-/junit-reporter-7.0.7.tgz#552851641c49a093ebf0b0ac454285d048979e4a"
   integrity sha512-oSgDjfcL6ErNJYMAxbCoNsZag+lDAJJ/48F4HZI4hYaX17nTlM0+MSn0WCR5UIwniCorlgk8lIiJPGMInyQl7w==


### PR DESCRIPTION
f-error-message - v0.4.0
------------------------------
*March 3, 2021*

### Added
- Added component test file and tests

f-mega-modal - v0.5.0
------------------------------
*March 3, 2021*

### Added
- Added component test file, component object file and tests
- Added `Data-test-id` to elements within the `MegaModal.stories.js`

f-tabs - v0.3.0
------------------------------
*March 3, 2021*

### Added
- Added component tests
- Added supporting code to component object file

### Changed
- `Data-test-id` naming for `tab-` to `tab-button-` in `Tabs.vue`
- `Data-test-id` naming for `transition-tab-` to `tab-content-` in `Tab.vue`