### PR TITLE
f-button@1.1.0 - f-button--icon sizes #trivial

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -4,18 +4,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (add to next release)
+v1.1.0
 ------------------------------
 *March 3, 2021*
 
 ### Added
+- Separate story for `f-button--icon`
 - Component  and accessibility test for link button
-
-*February 25, 2021*
 
 ### Changed
 - Restructured component object into page object model
 - Refactored component and accessibility tests
+- `f-button--icon` styles to show different button sizes for `--sizeMedium`, `--sizeLarge`, `--sizeSmall` and `--sizeXSmall`
+- `f-button--icon` styles to show blue background for large f-button--icon
 
 
 v1.0.0

--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -16,7 +16,7 @@ v1.1.0
 - Restructured component object into page object model
 - Refactored component and accessibility tests
 - `f-button--icon` styles to show different button sizes for `--sizeMedium`, `--sizeLarge`, `--sizeSmall` and `--sizeXSmall`
-- `f-button--icon` styles to show blue background for large f-button--icon
+- `f-button--icon` styles to show blue background for large primary `f-button--icon` instead of orange
 
 
 v1.0.0

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/f-button.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -192,7 +192,8 @@ $btn-sizeXSmall-lineHeight      : 1;
  * Sets the btn colour to site primary colour
  */
 
-.o-btn--primary {
+.o-btn--primary,
+.o-btn--icon.o-btn--primary.o-btn--sizeLarge {
     background-color: $btn-primary-bgColor;
 
     &,
@@ -328,13 +329,13 @@ $btn-sizeXSmall-lineHeight      : 1;
  */
 
 .o-btn--icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     border-radius: 50%;
-    svg {
-        width: 90%;
-        height: 80%;
-    }
 
-    &.o-btn--primary {
+    &.o-btn--primary,
+    &.o-btn--primary.o-btn--sizeLarge {
         path {
             fill: $btn-primary-textColor;
         }
@@ -375,6 +376,47 @@ $btn-sizeXSmall-lineHeight      : 1;
                 fill: $color-link-active;
             }
         }
+    }
+}
+
+.o-btn--icon.o-btn--sizeLarge {
+    width: 56px;
+    height: 56px;
+    padding: 0;
+
+    svg {
+        width: 21px;
+        height: 21px;
+    }
+}
+.o-btn--icon.o-btn--sizeMedium {
+    width: 48px;
+    height: 48px;
+    padding: 0;
+
+    svg {
+        width: 21px;
+        height: 21px;
+    }
+}
+.o-btn--icon.o-btn--sizeSmall {
+    width: 40px;
+    height: 40px;
+    padding: 0;
+
+    svg {
+        width: 18px;
+        height: 18px;
+    }
+}
+.o-btn--icon.o-btn--sizeXSmall {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+
+    svg {
+        width: 18px;
+        height: 18px;
     }
 }
 

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -334,8 +334,7 @@ $btn-sizeXSmall-lineHeight      : 1;
     justify-content: center;
     border-radius: 50%;
 
-    &.o-btn--primary,
-    &.o-btn--primary.o-btn--sizeLarge {
+    &.o-btn--primary {
         path {
             fill: $btn-primary-textColor;
         }

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -119,6 +119,15 @@ $btn-sizeSmall-padding          : 7px 1em 9px;
 $btn-sizeXSmall-padding         : 5px 0.5em 7px;
 $btn-sizeXSmall-lineHeight      : 1;
 
+$btn-icon-sizeLarge-buttonSize  : 56px; // button--icon is a sircle so width and height can use one var
+$btn-icon-sizeLarge-iconSize    : 21px;
+$btn-icon-sizeMedium-buttonSize  : 48px;
+$btn-icon-sizeMedium-iconSize    : 21px;
+$btn-icon-sizeSmall-buttonSize  : 40px;
+$btn-icon-sizeSmall-iconSize    : 18px;
+$btn-icon-sizeXSmall-buttonSize  : 32px;
+$btn-icon-sizeXSmall-iconSize    : 18px;
+
 
 .o-btn {
     display: inline-block;
@@ -379,43 +388,43 @@ $btn-sizeXSmall-lineHeight      : 1;
 }
 
 .o-btn--icon.o-btn--sizeLarge {
-    width: 56px;
-    height: 56px;
+    width: $btn-icon-sizeLarge-buttonSize;
+    height: $btn-icon-sizeLarge-buttonSize;
     padding: 0;
 
     svg {
-        width: 21px;
-        height: 21px;
+        width: $btn-icon-sizeLarge-iconSize;
+        height: $btn-icon-sizeLarge-iconSize;
     }
 }
 .o-btn--icon.o-btn--sizeMedium {
-    width: 48px;
-    height: 48px;
+    width: $btn-icon-sizeMedium-buttonSize;
+    height: $btn-icon-sizeMedium-buttonSize;
     padding: 0;
 
     svg {
-        width: 21px;
-        height: 21px;
+        width: $btn-icon-sizeMedium-iconSize;
+        height: $btn-icon-sizeMedium-iconSize;
     }
 }
 .o-btn--icon.o-btn--sizeSmall {
-    width: 40px;
-    height: 40px;
+    width: $btn-icon-sizeSmall-buttonSize;
+    height: $btn-icon-sizeSmall-buttonSize;
     padding: 0;
 
     svg {
-        width: 18px;
-        height: 18px;
+        width: $btn-icon-sizeSmall-iconSize;
+        height: $btn-icon-sizeSmall-iconSize;
     }
 }
 .o-btn--icon.o-btn--sizeXSmall {
-    width: 32px;
-    height: 32px;
+    width: $btn-icon-sizeXSmall-buttonSize;
+    height: $btn-icon-sizeXSmall-buttonSize;
     padding: 0;
 
     svg {
-        width: 18px;
-        height: 18px;
+        width: $btn-icon-sizeXSmall-iconSize;
+        height: $btn-icon-sizeXSmall-iconSize;
     }
 }
 

--- a/packages/components/atoms/f-button/stories/Button.stories.js
+++ b/packages/components/atoms/f-button/stories/Button.stories.js
@@ -5,7 +5,7 @@ import { withA11y } from '@storybook/addon-a11y';
 import FButton from '../src/components/Button.vue';
 
 export default {
-    title: 'Components/Atoms',
+    title: 'Components/Atoms/f-button',
     decorators: [withKnobs, withA11y]
 };
 
@@ -26,12 +26,18 @@ export const ButtonComponent = () => ({
         },
         href: {
             default: text('href', '')
-        },
-        isIcon: {
-            default: boolean('isIcon', false)
         }
     },
-    template: '<f-button :buttonType="buttonType" :buttonSize="buttonSize" :isFullWidth="isFullWidth" :actionType="actionType" :href="href" :isIcon="isIcon">Default Button Text</f-button>'
+    template: `
+        <f-button 
+            :buttonType="buttonType"
+            :buttonSize="buttonSize"
+            :isFullWidth="isFullWidth"
+            :actionType="actionType"
+            :href="href"
+            :isIcon="false">
+            Default Button Text
+        </f-button>`
 });
 
 ButtonComponent.storyName = 'f-button';

--- a/packages/components/atoms/f-button/stories/IconButton.stories.js
+++ b/packages/components/atoms/f-button/stories/IconButton.stories.js
@@ -1,0 +1,65 @@
+import {
+    withKnobs, select, boolean, text
+} from '@storybook/addon-knobs';
+import { withA11y } from '@storybook/addon-a11y';
+import FButton from '../src/components/Button.vue';
+import { CrossIcon, PlusIcon,  MoreVerticalIcon} from '../../../../tools/f-vue-icons/dist/f-vue-icons.js';
+
+export default {
+    title: 'Components/Atoms/f-button',
+    decorators: [withKnobs, withA11y]
+};
+
+export const IconButtonComponent = () => ({
+    components: {
+        FButton,
+        CrossIcon,
+        PlusIcon,
+        MoreVerticalIcon
+    },
+    props: {
+        buttonType: {
+            default: select('Button Type', ['primary', 'secondary', 'outline', 'ghost', 'link'], 'primary')
+        },
+        buttonSize: {
+            default: select('Button Size', ['xsmall', 'small', 'medium', 'large'], 'medium')
+        },
+        actionType: {
+            default: select('Action Type', ['button', 'submit', 'reset'], 'button')
+        },
+        href: {
+            default: text('href', '')
+        }
+    },
+    template: `
+    <div style="display: flex; width: 300px; justify-content: space-between">
+        <f-button
+            :buttonType="buttonType"
+            :buttonSize="buttonSize"
+            :actionType="actionType"
+            :href="href"
+            :isIcon="true">
+                <CrossIcon />
+        </f-button>
+
+        <f-button
+            :buttonType="buttonType"
+            :buttonSize="buttonSize"
+            :actionType="actionType"
+            :href="href"
+            :isIcon="true">
+                <PlusIcon />
+        </f-button>
+
+        <f-button
+            :buttonType="buttonType"
+            :buttonSize="buttonSize"
+            :actionType="actionType"
+            :href="href"
+            :isIcon="true">
+                <MoreVerticalIcon />
+        </f-button>
+    </div>`
+});
+
+IconButtonComponent.storyName = 'f-button--icon';

--- a/packages/components/atoms/f-button/stories/IconButton.stories.js
+++ b/packages/components/atoms/f-button/stories/IconButton.stories.js
@@ -1,5 +1,5 @@
 import {
-    withKnobs, select, boolean, text
+    withKnobs, select, text
 } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
 import FButton from '../src/components/Button.vue';

--- a/packages/components/atoms/f-button/stories/IconButton.stories.js
+++ b/packages/components/atoms/f-button/stories/IconButton.stories.js
@@ -32,7 +32,7 @@ export const IconButtonComponent = () => ({
         }
     },
     template: `
-    <div style="display: flex; width: 300px; justify-content: space-between">
+    <div class="wrapper--horisontal">
         <f-button
             :buttonType="buttonType"
             :buttonSize="buttonSize"

--- a/packages/components/atoms/f-button/test-utils/component-objects/f-button.component.js
+++ b/packages/components/atoms/f-button/test-utils/component-objects/f-button.component.js
@@ -8,7 +8,7 @@ module.exports = class Buttons extends Page {
     open (buttonType = '') {
         const url = buttonType === 'link' ? '&knob-Button%20Type=link&knob-href=link' : '';
 
-        super.openComponent('atom', `button-component${url}`);
+        browser.url(`/iframe.html?id=components-atoms-f-button--button-component${url}`)
     }
 
     waitForActionComponent () {

--- a/packages/storybook/config/storybook/preview-head.html
+++ b/packages/storybook/config/storybook/preview-head.html
@@ -61,4 +61,10 @@
     .c-matrix-gradeA { background-color: #e5faef; }
     .c-matrix-gradeB { background-color: #fff9df; }
     .c-matrix-gradeC { background-color: #ffe9ea; }
+
+    .wrapper--horisontal {
+        display: flex;
+        width: 300px;
+        justify-content: space-between
+    }
 </style>


### PR DESCRIPTION
Related to https://github.com/justeat/fozzie-components/issues/762

### Added
- Separate story for `f-button--icon`

### Changed
- `f-button--icon` styles to show different button sizes for `--sizeMedium`, `--sizeLarge`, `--sizeSmall` and `--sizeXSmall`
- `f-button--icon` styles to show blue background for large f-button--icon instead of orange

![Screenshot 2021-03-03 at 11 47 18](https://user-images.githubusercontent.com/19548183/109801425-5a3cf080-7c16-11eb-9d1c-8298977704fd.png)

![Screenshot 2021-03-03 at 11 47 25](https://user-images.githubusercontent.com/19548183/109801389-4db89800-7c16-11eb-9766-cde2e9a710c9.png)

![Screenshot 2021-03-03 at 11 47 33](https://user-images.githubusercontent.com/19548183/109801408-5315e280-7c16-11eb-8d53-c74a05b55a1d.png)

![Screenshot 2021-03-03 at 11 47 42](https://user-images.githubusercontent.com/19548183/109801442-61fc9500-7c16-11eb-83ba-c7881e8b9ae6.png)


