### PR TITLE
f-checkout@0.65.1 - Fix changeFields mutation

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.65.1
+------------------------------
+*March 5, 2021*
+
+### Fixed
+- `UPDATE_CHANGED_FIELD` mutation to sort `changedFields` correctly.
+
 
 v0.65.0
 -------------------------------

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.65.0",
+  "version": "0.65.1",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -1878,7 +1878,7 @@ describe('Checkout', () => {
 
             describe('when `getAddress` request fails', () => {
                 it('should emit failure event and log a warning', async () => {
-                    const store = createStore(defaultCheckoutState, { ...defaultCheckoutActions, getAddress: jest.fn(async () => Promise.reject()) })
+                    const store = createStore(defaultCheckoutState, { ...defaultCheckoutActions, getAddress: jest.fn(async () => Promise.reject()) });
                     // Arrange
                     const wrapper = mount(VueCheckout, {
                         store,

--- a/packages/components/organisms/f-checkout/src/store/checkoutAnalytics.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkoutAnalytics.module.js
@@ -89,7 +89,7 @@ export default {
                     action,
                     error: mappedError,
                     autofill: state.autofill,
-                    changes: state.changedFields.sort()
+                    changes: state.changedFields
                 }
             });
         }
@@ -100,6 +100,8 @@ export default {
             if (!state.changedFields.includes(field)) {
                 state.changedFields.push(field);
             }
+
+            state.changedFields.sort();
         },
 
         [UPDATE_AUTOFILL]: (state, autofill) => {


### PR DESCRIPTION
### Fixed
- `UPDATE_CHANGED_FIELD` mutation to sort `changedFields` correctly.
