### PR TITLE
f-header@4.11.0 - mobile styles to include 768px wide screens + mobile nav styles amends

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -3,6 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v4.11.0
+------------------------------
+*March 15, 2021*
+
+### Changed
+- Media queries to pick up 768px width to render mobile view for tablet devices
+- `f-popover` package version bump
+- Fixed the tests for offers link
+- Mobile nav view to show offers and delivery links to have the same experience as on SiteCore header nav
+
+### Added
+- Unique keys for each link in `countryList.js`
+
+
 v4.10.0
 ------------------------------
 *March 12, 2021*
@@ -12,17 +27,6 @@ v4.10.0
 
 ### Changed
 - Restructured component tests to support Browserstack
-
-
-v4.10.0
-------------------------------
-*March 5, 2021*
-
-### Changed
-- Media queries to pick up 768px width to render mobile view for tablet devices
-
-### Added
-- Unique keys for each link in `countryList.js`
 
 
 v4.9.0

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -14,6 +14,17 @@ v4.10.0
 - Restructured component tests to support Browserstack
 
 
+v4.10.0
+------------------------------
+*March 5, 2021*
+
+### Changed
+- Media queries to pick up 768px width to render mobile view for tablet devices
+
+### Added
+- Unique keys for each link in `countryList.js`
+
+
 v4.9.0
 ------------------------------
 *March 4, 2021*

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.12.13",
     "@justeat/f-button": "1.1.0",
-    "@justeat/f-popover": "0.2.0",
+    "@justeat/f-popover": "0.2.1",
     "@justeat/f-vue-icons": "2.4.0",
     "@justeat/f-wdio-utils": "0.1.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",

--- a/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
+++ b/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
@@ -16,10 +16,10 @@
 
             <ul
                 class="c-nav-popoverList c-nav-popoverList--twoColumns"
-                data-test-id="c-countrySelector-list">
+                data-test-id="countrySelector-list">
                 <li
-                    v-for="(country, i) in countries"
-                    :key="i + '_Country'"
+                    v-for="(country) in countries"
+                    :key="country.key"
                     :class="$style['c-countrySelector-country']"
                     :data-test-id="['countrySelector-countryList-' + country.dataTestKey]">
                     <a
@@ -35,7 +35,7 @@
                         @blur="$emit('blurOnLink')"
                         @focus="$emit('focusOnLink')">
                         <flag-icon
-                            :country-code="country.key"
+                            :country-code="country.flagKey"
                             class="c-nav-list-icon--flag" />
                         <span>
                             {{ country.localisedName }}
@@ -84,7 +84,7 @@ $countrySelector-text-color : $grey--darkest;
 $countrySelector-text-hover : $color-bg--darker;
 
 .c-countrySelector {
-    @include media('>=mid') {
+    @include media('>mid') {
         padding: spacing(x3) 0;
     }
 }
@@ -93,7 +93,7 @@ $countrySelector-text-hover : $color-bg--darker;
     display: flex;
     align-items: center;
 
-    @include media('>=mid') {
+    @include media('>mid') {
         padding-bottom: spacing(x2);
         padding-left: spacing(x2);
     }
@@ -104,7 +104,7 @@ $countrySelector-text-hover : $color-bg--darker;
         margin: 0;
         margin-left: spacing();
 
-        @include media('>=mid') {
+        @include media('>mid') {
             @include font-size(heading-s);
             margin-left: 0;
         }
@@ -113,7 +113,7 @@ $countrySelector-text-hover : $color-bg--darker;
 
 .c-countrySelector-header-button {
     margin: spacing(x2);
-    @include media('>=mid') {
+    @include media('>mid') {
         display: none;
     }
     svg.c-countrySelector-goBackIcon {

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -169,7 +169,7 @@ export default {
     // when the off-screen navigation is active (on mobile), it fixes to the top of the screen.
     // this stops the content being forced upwards when this happens (preventing slight visual glitch)
     .is-navInView & {
-        @include media('<mid') {
+        @include media('<=mid') {
             position: fixed;
             top: 0;
             left: 0;
@@ -179,7 +179,7 @@ export default {
     }
 
     // Styles for a sticky header on mobile
-    @include media('<mid') {
+    @include media('<=mid') {
         &.is-sticky {
             left: 0;
             top: -60px;
@@ -191,7 +191,7 @@ export default {
         }
     }
 
-    @include media('>=mid') {
+    @include media('>mid') {
         border-bottom: $header-separator solid $header-border-color;
     }
 }
@@ -242,7 +242,7 @@ export default {
             padding-right: #{$layout-margin--mid}px;
         }
 
-        @include media('>=mid') {
+        @include media('>mid') {
             display: flex;
             min-height: $header-height;
         }

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -85,7 +85,7 @@ export default {
             padding-top: 8px;
         }
 
-        @include media('>=mid') {
+        @include media('>mid') {
             justify-content: left;
             height: $header-height;
             padding-top: 20px;
@@ -102,7 +102,7 @@ export default {
         height: 24px;
         margin-left: -10.5px; //half of hamburger menu width
 
-        @include media('>=mid') {
+        @include media('>mid') {
             width: 163px;
             height: 40px;
             margin-left: 0;
@@ -113,7 +113,7 @@ export default {
             width: 120px;
             height: 32px;
 
-            @include media('>=mid') {
+            @include media('>mid') {
                 width: 149px;
                 height: 41px;
             }

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -573,6 +573,7 @@ $nav-icon-color                    : $color-secondary;
 $nav-icon-color--transparent       : $white;
 $nav-icon-color--mobileWhiteBg     : $grey--darkest;
 $nav-transition-duration           : 250ms;
+$nav-icon-size                     : 24px;
 
 $nav-featureLinkIcon-width         : 28px;
 $nav-featureLinkIcon-height        : 28px;
@@ -834,8 +835,8 @@ $countrySelector-flag-height : 16px;
     .c-nav-icon {
         float: left;
         margin-right: spacing();
-        width: 24px;
-        height: 24px;
+        width: $nav-icon-size;
+        height: $nav-icon-size;
 
         @include media('>mid') {
             & path {

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -32,7 +32,7 @@
 
         <a
             v-if="showOffersLink && !navIsOpen"
-            data-test-id="offers-link"
+            data-test-id="offers-iconLink"
             data-trak='{
                 "trakEvent": "click",
                 "category": "header",

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -31,7 +31,7 @@
         </label>
 
         <a
-            v-if="showOffersLink"
+            v-if="showOffersLink && !navIsOpen"
             data-test-id="offers-link-without-text"
             data-trak='{
                 "trakEvent": "click",
@@ -40,7 +40,7 @@
                 "label": "offers_icon"
             }'
             :href="copy.offers.url"
-            class="c-nav-featureLink">
+            class="c-nav-featureLink c-nav-featureLink--hideAboveMid">
             <gift-icon class="c-nav-icon c-nav-icon--offers" />
             <span class="is-visuallyHidden">
                 {{ copy.offers.text }}
@@ -51,7 +51,7 @@
             :class="['c-nav-container', { 'is-visible': navIsOpen }]">
             <ul class="c-nav-list">
                 <li
-                    v-if="showOffersLink  && !isBelowMid"
+                    v-if="showOffersLink"
                     class="c-nav-list-item--horizontallyAlignedAboveMid">
                     <a
                         data-test-id="offers-link-with-text"
@@ -68,8 +68,8 @@
                     </a>
                 </li>
                 <li
-                    v-if="showDeliveryEnquiry && !isBelowMid"
-                    class="c-nav-list-item--horizontallyAlignedAboveMid "
+                    v-if="showDeliveryEnquiry"
+                    class="c-nav-list-item--horizontallyAlignedAboveMid"
                     data-test-id="delivery-enquiry">
                     <a
                         data-test-id="delivery-link"
@@ -87,7 +87,7 @@
                     </a>
                 </li>
                 <li
-                    :class="['c-nav-list-item--horizontallyAlignedAboveMid  has-sublist', {
+                    :class="['c-nav-list-item--horizontallyAlignedAboveMid has-sublist', {
                         'is-hidden': !userInfo || !showLoginInfo,
                         'is-open': navIsOpen
                     }]"
@@ -124,7 +124,7 @@
 
                 <li
                     v-if="!userInfo && showLoginInfo"
-                    class="c-nav-list-item--horizontallyAlignedAboveMid "
+                    class="c-nav-list-item--horizontallyAlignedAboveMid"
                     data-test-id="login">
                     <a
                         :href="returnLoginUrl"
@@ -143,7 +143,7 @@
 
                 <li
                     v-if="showHelpLink"
-                    class="c-nav-list-item--horizontallyAlignedAboveMid  c-nav-list-item--support">
+                    class="c-nav-list-item--horizontallyAlignedAboveMid">
                     <a
                         :href="copy.help.url"
                         :data-trak='`{
@@ -152,7 +152,7 @@
                                 "action": "header",
                                 "label": "${copy.help.gtm}"
                             }`'
-                        class="c-nav-list-link"
+                        class="c-nav-list-link c-nav-list-link--leftPaddingBelowMid"
                         data-test-id="help-link"
                         v-on="isBelowMid ? { blur: closeNav, focus: openNav } : null">
                         {{ copy.help.text }}
@@ -161,7 +161,7 @@
 
                 <li
                     v-if="userInfo && isBelowMid && showLoginInfo"
-                    class="c-nav-list-item--horizontallyAlignedAboveMid "
+                    class="c-nav-list-item--horizontallyAlignedAboveMid"
                     data-test-id="logout">
                     <a
                         :tabindex="navIsOpen ? 0 : -1"
@@ -172,7 +172,7 @@
                                 "action": "header",
                                 "label": "${copy.accountLogout.gtm}"
                             }`'
-                        class="c-nav-list-link"
+                        class="c-nav-list-link c-nav-list-link--leftPaddingBelowMid"
                         v-on="isBelowMid ? { blur: closeNav, focus: openNav } : null">
                         {{ copy.accountLogout.text }}
                     </a>
@@ -181,7 +181,7 @@
                 <li
                     v-if="showCountrySelector"
                     data-test-id="country-selector"
-                    :class="['c-nav-list-item--horizontallyAlignedAboveMid  has-sublist', {
+                    :class="['c-nav-list-item--horizontallyAlignedAboveMid has-sublist', {
                         'is-open': countrySelectorIsOpen
                     }]"
                     v-on="isBelowMid ? null : { mouseover: openCountrySelector, mouseleave: closeCountrySelector }"
@@ -571,7 +571,7 @@ $nav-text-weight                   : $font-weight-bold;
 $nav-text-subFont                  : $font-family-base;
 $nav-icon-color                    : $color-secondary;
 $nav-icon-color--transparent       : $white;
-$nav-icon-color--mobileWhiteBg     : $grey--mid;
+$nav-icon-color--mobileWhiteBg     : $grey--darkest;
 $nav-transition-duration           : 250ms;
 
 $nav-featureLinkIcon-width         : 28px;
@@ -710,9 +710,11 @@ $countrySelector-flag-height : 16px;
             width: 100%;
         }
     }
+
         .c-nav-list-link,
         .c-nav-list-text {
-            display: block;
+            display: flex;
+            align-items: center;
             padding: spacing(x1.5) spacing(x2);
             margin: 0;
             font-family: $nav-text-subFont;
@@ -727,11 +729,6 @@ $countrySelector-flag-height : 16px;
                 font-weight: $nav-text-weight;
                 color: $nav-text-color;
                 border-bottom: none;
-
-                // the following styles align the elements vertically to the height of the header bar
-                // don’t need a fallback, as it degrades gracefully
-                display: flex;
-                align-items: center;
                 height: $header-height;
 
                 .c-header--highlightBg &,
@@ -740,6 +737,13 @@ $countrySelector-flag-height : 16px;
                 }
             }
         }
+
+        .c-nav-list-text {
+            @include media('<=mid') {
+                display: block;
+            }
+        }
+
         .c-nav-list-text-sub {
             display: block;
             overflow: hidden;
@@ -776,6 +780,12 @@ $countrySelector-flag-height : 16px;
             }
         }
 
+        .c-nav-list-link--leftPaddingBelowMid {
+            @include media('<=mid') {
+                padding-left: spacing(x6);
+            }
+        }
+
         .c-nav-list-btn {
             display: flex;
             align-items: center;
@@ -805,6 +815,16 @@ $countrySelector-flag-height : 16px;
             height: spacing(x2) + $nav-featureLinkIcon-height + spacing(x2);
             padding: spacing(x2);
         }
+
+        path {
+            .c-header--highlightBg &,
+            .c-header--transparent & {
+                fill: $nav-icon-color--transparent;
+            }
+        }
+    }
+
+    .c-nav-featureLink--hideAboveMid {
         @include media('>mid') {
             display: none;
         }
@@ -814,6 +834,8 @@ $countrySelector-flag-height : 16px;
     .c-nav-icon {
         float: left;
         margin-right: spacing();
+        width: 24px;
+        height: 24px;
 
         @include media('>mid') {
             & path {
@@ -827,34 +849,12 @@ $countrySelector-flag-height : 16px;
         }
     }
 
+    .c-nav-icon--delivery,
+    .c-nav-icon--offers,
     .c-nav-icon--profile {
-        width: 20px;
-        height: 22px;
-
         @include media('<=mid') {
-            width: 33px;
-            height: 33px;
-            * {
+            & path {
                 fill: $nav-icon-color--mobileWhiteBg;
-            }
-        }
-    }
-
-    .c-nav-icon--delivery {
-        width: 20px;
-        height: 20px;
-    }
-
-    .c-nav-icon--offers {
-        width: $nav-featureLinkIcon-width;
-        height: $nav-featureLinkIcon-height;
-
-        & path {
-            fill: $nav-icon-color;
-
-            .c-header--highlightBg &,
-            .c-header--transparent & {
-                fill: $nav-icon-color--transparent;
             }
         }
     }

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -52,7 +52,7 @@
             <ul class="c-nav-list">
                 <li
                     v-if="showOffersLink"
-                    class="c-nav-list-item--horisontallyAlignedOnWiderView">
+                    class="c-nav-list-item--horizontallyAlignedAboveMid ">
                     <a
                         data-test-id="offers-link"
                         data-trak='{
@@ -69,7 +69,7 @@
                 </li>
                 <li
                     v-if="showDeliveryEnquiry && !isBelowMid"
-                    class="c-nav-list-item--horisontallyAlignedOnWiderView"
+                    class="c-nav-list-item--horizontallyAlignedAboveMid "
                     data-test-id="delivery-enquiry">
                     <a
                         data-test-id="delivery-link"
@@ -87,7 +87,7 @@
                     </a>
                 </li>
                 <li
-                    :class="['c-nav-list-item--horisontallyAlignedOnWiderView has-sublist', {
+                    :class="['c-nav-list-item--horizontallyAlignedAboveMid  has-sublist', {
                         'is-hidden': !userInfo || !showLoginInfo,
                         'is-open': navIsOpen
                     }]"
@@ -124,7 +124,7 @@
 
                 <li
                     v-if="!userInfo && showLoginInfo"
-                    class="c-nav-list-item--horisontallyAlignedOnWiderView"
+                    class="c-nav-list-item--horizontallyAlignedAboveMid "
                     data-test-id="login">
                     <a
                         :href="returnLoginUrl"
@@ -143,7 +143,7 @@
 
                 <li
                     v-if="showHelpLink"
-                    class="c-nav-list-item--horisontallyAlignedOnWiderView c-nav-list-item--support">
+                    class="c-nav-list-item--horizontallyAlignedAboveMid  c-nav-list-item--support">
                     <a
                         :href="copy.help.url"
                         :data-trak='`{
@@ -161,7 +161,7 @@
 
                 <li
                     v-if="userInfo && isBelowMid && showLoginInfo"
-                    class="c-nav-list-item--horisontallyAlignedOnWiderView"
+                    class="c-nav-list-item--horizontallyAlignedAboveMid "
                     data-test-id="logout">
                     <a
                         :tabindex="navIsOpen ? 0 : -1"
@@ -181,7 +181,7 @@
                 <li
                     v-if="showCountrySelector"
                     data-test-id="country-selector"
-                    :class="['c-nav-list-item--horisontallyAlignedOnWiderView has-sublist', {
+                    :class="['c-nav-list-item--horizontallyAlignedAboveMid  has-sublist', {
                         'is-open': countrySelectorIsOpen
                     }]"
                     v-on="isBelowMid ? null : { mouseover: openCountrySelector, mouseleave: closeCountrySelector }"
@@ -318,13 +318,14 @@ export default {
             userInfo: this.userInfoProp,
             localOrderCountExpires: false,
             countrySelectorIsOpen: false,
-            countries
+            countries,
+            midBreakpoint: 768
         };
     },
 
     computed: {
         isBelowMid () {
-            return this.currentScreenWidth < 768;
+            return this.currentScreenWidth <= this.midBreakpoint;
         },
 
         returnUrl () {
@@ -607,7 +608,7 @@ $countrySelector-flag-height : 16px;
 
 // removes scroll
 .is-navInView {
-    @include media('<mid') {
+    @include media('<=mid') {
         overflow: hidden;
 
         body {
@@ -629,7 +630,7 @@ $countrySelector-flag-height : 16px;
 
 // Global site-wide navigation
 .c-nav--global {
-    @include media('>=mid') {
+    @include media('>mid') {
         display: flex;
         justify-content: flex-end;
         flex-grow: 1;
@@ -638,7 +639,7 @@ $countrySelector-flag-height : 16px;
     // we have a nav container so that we don’t have to make the inner list 100% height
     // this is so we can position the logout button last on mobile
     & .c-nav-container {
-        @include media('<mid') {
+        @include media('<=mid') {
             position: fixed;
             top: $header-height--narrow;
             left: -99999px;
@@ -679,22 +680,22 @@ $countrySelector-flag-height : 16px;
         }
     }
 
-    @include media('<mid') {
+    @include media('<=mid') {
         display: flex;
         flex-direction: column;
     }
 }
 
     .c-nav-popoverList--twoColumns {
-        @include media('>=mid') {
+        @include media('>mid') {
             column-count: 2;
         }
     }
 
     // TODO: MAKE THIS NOT USE FLOATS
     // global modifier for list items horizontally aligned
-    .c-nav-list-item--horisontallyAlignedOnWiderView {
-        @include media('>=mid') {
+    .c-nav-list-item--horizontallyAlignedAboveMid {
+        @include media('>mid') {
             float: left;
         }
     }
@@ -703,7 +704,7 @@ $countrySelector-flag-height : 16px;
     // As an example, this is used on the logout link on the global site
     // Logout is in the popover list, but at the bottom of the
     .c-nav-list-item--forceLast {
-        @include media('<mid') {
+        @include media('<=mid') {
             position: absolute;
             top: 100%;
             width: 100%;
@@ -721,7 +722,7 @@ $countrySelector-flag-height : 16px;
             text-decoration: none;
             border-bottom: 1px solid $grey--light;
 
-            @include media('>=mid') {
+            @include media('>mid') {
                 @include font-size($nav-text-size);
                 font-weight: $nav-text-weight;
                 color: $nav-text-color;
@@ -747,7 +748,7 @@ $countrySelector-flag-height : 16px;
             max-width: 300px;
 
             &.u-showBelowMid {
-                @include media('>=mid') {
+                @include media('>mid') {
                     display: none !important;
                 }
             }
@@ -759,7 +760,7 @@ $countrySelector-flag-height : 16px;
             &:active {
                 text-decoration: none;
 
-                @include media('>=mid') {
+                @include media('>mid') {
                     color: $nav-text-color--hover;
                     text-decoration: underline;
 
@@ -785,7 +786,7 @@ $countrySelector-flag-height : 16px;
 
     .has-sublist {
         // ensures the dropdown/popover is relative to the hover element, on wider views
-        @include media('>=mid') {
+        @include media('>mid') {
             position: relative;
             cursor: pointer;
         }
@@ -796,7 +797,7 @@ $countrySelector-flag-height : 16px;
         width: $nav-featureLinkIcon-width;
         height: $nav-featureLinkIcon-height;
 
-        @include media('<mid') {
+        @include media('<=mid') {
             position: absolute;
             top: 0;
             right: 0;
@@ -812,7 +813,7 @@ $countrySelector-flag-height : 16px;
         float: left;
         margin-right: spacing();
 
-        @include media('>=mid') {
+        @include media('>mid') {
             & path {
                 fill: $nav-icon-color;
 
@@ -828,7 +829,7 @@ $countrySelector-flag-height : 16px;
         width: 20px;
         height: 22px;
 
-        @include media('<mid') {
+        @include media('<=mid') {
             width: 33px;
             height: 33px;
             * {
@@ -865,12 +866,12 @@ $countrySelector-flag-height : 16px;
     top: -100px;
     left: -100px;
 
-    @include media('>=mid') {
+    @include media('>mid') {
         display: none;
     }
 
     &:checked ~ .c-nav-container {
-        @include media('<mid') {
+        @include media('<=mid') {
             @include nav-container-visible();
         }
     }
@@ -898,7 +899,7 @@ $countrySelector-flag-height : 16px;
     border: none;
 
     // hide on wider views
-    @include media('>=mid') {
+    @include media('>mid') {
         display: none;
 
         &.is-shown--noJS {
@@ -971,7 +972,7 @@ $countrySelector-flag-height : 16px;
     }
 
 .c-nav-popover {
-    @include media('>=mid') {
+    @include media('>mid') {
         min-width: 300px;
         position: absolute;
         top: 100%;
@@ -1000,7 +1001,7 @@ $countrySelector-flag-height : 16px;
 }
 
 .c-nav-popover.c-nav-popover--countrySelector {
-    @include media('>=mid') {
+    @include media('>mid') {
         // tooltip arrow
         &:before {
             right: 4%;
@@ -1012,13 +1013,13 @@ $countrySelector-flag-height : 16px;
     height: $countrySelector-flag-height;
     width: $countrySelector-flag-width;
 
-    @include media('<mid') {
+    @include media('<=mid') {
         margin-right: spacing();
     }
 
     .c-header--highlightBg &,
     .c-header--transparent & {
-        @include media('>=mid') {
+        @include media('>mid') {
             background-color: $white;
             width: 32px;
             height: 32px;
@@ -1045,7 +1046,7 @@ $countrySelector-flag-height : 16px;
     overflow: hidden;
     @include font-size(heading-s, true, narrow);
 
-    @include media('<mid') {
+    @include media('<=mid') {
         width: auto;
     }
 }

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -51,8 +51,8 @@
             :class="['c-nav-container', { 'is-visible': navIsOpen }]">
             <ul class="c-nav-list">
                 <li
-                    v-if="showOffersLink"
-                    class="c-nav-list-item--horizontallyAlignedAboveMid ">
+                    v-if="showOffersLink  && !isBelowMid"
+                    class="c-nav-list-item--horizontallyAlignedAboveMid">
                     <a
                         data-test-id="offers-link-with-text"
                         data-trak='{
@@ -62,7 +62,7 @@
                             "label": "offers"
                         }'
                         :href="copy.offers.url"
-                        class="c-nav-list-link c-nav-list-link--showAboveMid">
+                        class="c-nav-list-link">
                         <gift-icon class="c-nav-icon c-nav-icon--offers" />
                         {{ copy.offers.text }}
                     </a>
@@ -774,12 +774,6 @@ $countrySelector-flag-height : 16px;
                     }
                 }
             }
-        }
-
-        .c-nav-list-link--showAboveMid {
-                @include media('<=mid') {
-                    display: none;
-                }
         }
 
         .c-nav-list-btn {

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -32,7 +32,7 @@
 
         <a
             v-if="showOffersLink && !navIsOpen"
-            data-test-id="offers-link-without-text"
+            data-test-id="offers-link"
             data-trak='{
                 "trakEvent": "click",
                 "category": "header",
@@ -54,7 +54,7 @@
                     v-if="showOffersLink"
                     class="c-nav-list-item--horizontallyAlignedAboveMid">
                     <a
-                        data-test-id="offers-link-with-text"
+                        data-test-id="offers-link"
                         data-trak='{
                             "trakEvent": "click",
                             "category": "header",

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -32,7 +32,7 @@
 
         <a
             v-if="showOffersLink"
-            data-test-id="offers-link"
+            data-test-id="offers-link-without-text"
             data-trak='{
                 "trakEvent": "click",
                 "category": "header",
@@ -40,7 +40,7 @@
                 "label": "offers_icon"
             }'
             :href="copy.offers.url"
-            class="c-nav-featureLink u-showBelowMid">
+            class="c-nav-featureLink">
             <gift-icon class="c-nav-icon c-nav-icon--offers" />
             <span class="is-visuallyHidden">
                 {{ copy.offers.text }}
@@ -54,7 +54,7 @@
                     v-if="showOffersLink"
                     class="c-nav-list-item--horizontallyAlignedAboveMid ">
                     <a
-                        data-test-id="offers-link"
+                        data-test-id="offers-link-with-text"
                         data-trak='{
                             "trakEvent": "click",
                             "category": "header",
@@ -62,7 +62,7 @@
                             "label": "offers"
                         }'
                         :href="copy.offers.url"
-                        class="c-nav-list-link u-showAboveMid">
+                        class="c-nav-list-link c-nav-list-link--showAboveMid">
                         <gift-icon class="c-nav-icon c-nav-icon--offers" />
                         {{ copy.offers.text }}
                     </a>
@@ -776,6 +776,12 @@ $countrySelector-flag-height : 16px;
             }
         }
 
+        .c-nav-list-link--showAboveMid {
+                @include media('<=mid') {
+                    display: none;
+                }
+        }
+
         .c-nav-list-btn {
             display: flex;
             align-items: center;
@@ -805,7 +811,9 @@ $countrySelector-flag-height : 16px;
             height: spacing(x2) + $nav-featureLinkIcon-height + spacing(x2);
             padding: spacing(x2);
         }
-
+        @include media('>mid') {
+            display: none;
+        }
     }
 
     // Icons, such as the profile icon

--- a/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
+++ b/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
@@ -87,7 +87,7 @@ export default {
         color: $grey--dark;
     }
 
-    @include media('>=mid') {
+    @include media('>mid') {
         @include font-size('body-l');
     }
 }

--- a/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
+++ b/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
@@ -90,5 +90,10 @@ export default {
     @include media('>mid') {
         @include font-size('body-l');
     }
+
+    @include media('<=mid') {
+        padding-left: spacing(x6);
+    }
+
 }
 </style>

--- a/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
+++ b/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
@@ -274,7 +274,7 @@ describe('Navigation', () => {
             await wrapper.setData(defaultData); // need to await this for the state to fully update the DOM
 
             // Assert
-            expect(wrapper.find('[data-test-id="offers-link-with-text"]').exists()).toBe(true);
+            expect(wrapper.find('[data-test-id="offers-link"].c-nav-list-link').exists()).toBe(true);
         });
 
         it('should not be shown on desktop when "showOffersLink" is false', async () => {
@@ -290,8 +290,7 @@ describe('Navigation', () => {
             await wrapper.setData(defaultData);
 
             // Assert
-            expect(wrapper.find('[data-test-id="offers-link-with-text"]').exists()).toBe(false);
-            expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(false);
+            expect(wrapper.find('[data-test-id="offers-link"].c-nav-list-link').exists()).toBe(false);
         });
 
         describe('on mobile', () => {
@@ -310,7 +309,7 @@ describe('Navigation', () => {
                 await wrapper.setData(defaultData);
 
                 // Assert
-                expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(true);
+                expect(wrapper.find('[data-test-id="offers-link"].c-nav-featureLink').exists()).toBe(true);
             });
 
             it('should not be shown when "showOffersLink" is false', async () => {
@@ -326,8 +325,8 @@ describe('Navigation', () => {
                 await wrapper.setData(defaultData);
 
                 // Assert
-                expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(false);
-                expect(wrapper.find('[data-test-id="offers-link-with-text"]').exists()).toBe(false);
+                expect(wrapper.find('[data-test-id="offers-link"].c-nav-list-link').exists()).toBe(false);
+                expect(wrapper.find('[data-test-id="offers-link"].c-nav-featureLink').exists()).toBe(false);
             });
 
             it('should be shown with open nav when "showOffersLink" is true', async () => {
@@ -346,7 +345,8 @@ describe('Navigation', () => {
                 });
 
                 // Assert
-                expect(wrapper.find('[data-test-id="offers-link-with-text"]').exists()).toBe(true);
+                expect(wrapper.find('[data-test-id="offers-link"].c-nav-list-link').exists()).toBe(true);
+                expect(wrapper.find('[data-test-id="offers-link"].c-nav-featureLink').exists()).toBe(false);
             });
 
             it('should not be shown with open nav when "showOffersLink" is false', async () => {
@@ -365,8 +365,8 @@ describe('Navigation', () => {
                 });
 
                 // Assert
-                expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(false);
-                expect(wrapper.find('[data-test-id="offers-link-with-text"]').exists()).toBe(false);
+                expect(wrapper.find('[data-test-id="offers-link"].c-nav-featureLink').exists()).toBe(false);
+                expect(wrapper.find('[data-test-id="offers-link"].c-nav-list-link').exists()).toBe(false);
             });
         });
     });

--- a/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
+++ b/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
@@ -262,8 +262,8 @@ describe('Navigation', () => {
 
 
     describe('offers link', () => {
-        it('should be shown on desktop when "showOffersLink" is true', () => {
-            // Arrange & Act
+        it('should be shown on desktop when "showOffersLink" is true', async () => {
+            // Arrange
             wrapper = shallowMount(Navigation, {
                 propsData: {
                     ...defaultPropsData,
@@ -271,18 +271,24 @@ describe('Navigation', () => {
                 }
             });
 
+            // Act
+            await wrapper.setData(defaultData); // need to await this for the state to fully update the DOM
+
             // Assert
             expect(wrapper.find('[data-test-id="offers-link-with-text"]').exists()).toBe(true);
         });
 
-        it('should not be shown on desktop when "showOffersLink" is false', () => {
-            // Arrange & Act
+        it('should not be shown on desktop when "showOffersLink" is false', async () => {
+            // Arrange
             wrapper = shallowMount(Navigation, {
                 propsData: {
                     ...defaultPropsData,
                     showOffersLink: false
                 }
             });
+
+            // Act
+            await wrapper.setData(defaultData);
 
             // Assert
             expect(wrapper.find('[data-test-id="offers-link-with-text"]').exists()).toBe(false);
@@ -291,8 +297,8 @@ describe('Navigation', () => {
         describe('on mobile', () => {
             beforeEach(setMobileViewport);
 
-            it('should be shown when "showOffersLink" is true', () => {
-                // Arrange & Act
+            it('should be shown when "showOffersLink" is true', async () => {
+                // Arrange
                 wrapper = shallowMount(Navigation, {
                     propsData: {
                         ...defaultPropsData,
@@ -300,18 +306,24 @@ describe('Navigation', () => {
                     }
                 });
 
+                // Act
+                await wrapper.setData(defaultData);
+
                 // Assert
                 expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(true);
             });
 
-            it('should not be shown when "showOffersLink" is false', () => {
-                // Arrange & Act
+            it('should not be shown when "showOffersLink" is false', async () => {
+                // Arrange
                 wrapper = shallowMount(Navigation, {
                     propsData: {
                         ...defaultPropsData,
                         showOffersLink: false
                     }
                 });
+
+                // Act
+                await wrapper.setData(defaultData);
 
                 // Assert
                 expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(false);

--- a/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
+++ b/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
@@ -272,7 +272,7 @@ describe('Navigation', () => {
             });
 
             // Assert
-            expect(wrapper.find('[data-test-id="offers-link"].u-showAboveMid').exists()).toBe(true);
+            expect(wrapper.find('[data-test-id="offers-link-with-text"]').exists()).toBe(true);
         });
 
         it('should not be shown on desktop when "showOffersLink" is false', () => {
@@ -285,7 +285,7 @@ describe('Navigation', () => {
             });
 
             // Assert
-            expect(wrapper.find('[data-test-id="offers-link"].u-showAboveMid').exists()).toBe(false);
+            expect(wrapper.find('[data-test-id="offers-link-with-text"]').exists()).toBe(false);
         });
 
         describe('on mobile', () => {
@@ -301,7 +301,7 @@ describe('Navigation', () => {
                 });
 
                 // Assert
-                expect(wrapper.find('[data-test-id="offers-link"].u-showBelowMid').exists()).toBe(true);
+                expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(true);
             });
 
             it('should not be shown when "showOffersLink" is false', () => {
@@ -314,7 +314,7 @@ describe('Navigation', () => {
                 });
 
                 // Assert
-                expect(wrapper.find('[data-test-id="offers-link"].u-showBelowMid').exists()).toBe(false);
+                expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(false);
             });
 
             it('should be shown with open nav when "showOffersLink" is true', async () => {
@@ -333,7 +333,7 @@ describe('Navigation', () => {
                 });
 
                 // Assert
-                expect(wrapper.find('[data-test-id="offers-link"].u-showBelowMid').exists()).toBe(true);
+                expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(true);
             });
 
             it('should not be shown with open nav when "showOffersLink" is false', async () => {
@@ -352,7 +352,7 @@ describe('Navigation', () => {
                 });
 
                 // Assert
-                expect(wrapper.find('[data-test-id="offers-link"].u-showBelowMid').exists()).toBe(false);
+                expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(false);
             });
         });
     });

--- a/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
+++ b/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
@@ -260,7 +260,6 @@ describe('Navigation', () => {
         });
     });
 
-
     describe('offers link', () => {
         it('should be shown on desktop when "showOffersLink" is true', async () => {
             // Arrange
@@ -292,6 +291,7 @@ describe('Navigation', () => {
 
             // Assert
             expect(wrapper.find('[data-test-id="offers-link-with-text"]').exists()).toBe(false);
+            expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(false);
         });
 
         describe('on mobile', () => {
@@ -327,6 +327,7 @@ describe('Navigation', () => {
 
                 // Assert
                 expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(false);
+                expect(wrapper.find('[data-test-id="offers-link-with-text"]').exists()).toBe(false);
             });
 
             it('should be shown with open nav when "showOffersLink" is true', async () => {
@@ -345,7 +346,7 @@ describe('Navigation', () => {
                 });
 
                 // Assert
-                expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(true);
+                expect(wrapper.find('[data-test-id="offers-link-with-text"]').exists()).toBe(true);
             });
 
             it('should not be shown with open nav when "showOffersLink" is false', async () => {
@@ -365,6 +366,7 @@ describe('Navigation', () => {
 
                 // Assert
                 expect(wrapper.find('[data-test-id="offers-link-without-text"]').exists()).toBe(false);
+                expect(wrapper.find('[data-test-id="offers-link-with-text"]').exists()).toBe(false);
             });
         });
     });

--- a/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
+++ b/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
@@ -274,7 +274,7 @@ describe('Navigation', () => {
             await wrapper.setData(defaultData); // need to await this for the state to fully update the DOM
 
             // Assert
-            expect(wrapper.find('[data-test-id="offers-link"].c-nav-list-link').exists()).toBe(true);
+            expect(wrapper.find('[data-test-id="offers-link"]').exists()).toBe(true);
         });
 
         it('should not be shown on desktop when "showOffersLink" is false', async () => {
@@ -290,7 +290,7 @@ describe('Navigation', () => {
             await wrapper.setData(defaultData);
 
             // Assert
-            expect(wrapper.find('[data-test-id="offers-link"].c-nav-list-link').exists()).toBe(false);
+            expect(wrapper.find('[data-test-id="offers-link"]').exists()).toBe(false);
         });
 
         describe('on mobile', () => {
@@ -309,7 +309,7 @@ describe('Navigation', () => {
                 await wrapper.setData(defaultData);
 
                 // Assert
-                expect(wrapper.find('[data-test-id="offers-link"].c-nav-featureLink').exists()).toBe(true);
+                expect(wrapper.find('[data-test-id="offers-iconLink"]').exists()).toBe(true);
             });
 
             it('should not be shown when "showOffersLink" is false', async () => {
@@ -325,8 +325,8 @@ describe('Navigation', () => {
                 await wrapper.setData(defaultData);
 
                 // Assert
-                expect(wrapper.find('[data-test-id="offers-link"].c-nav-list-link').exists()).toBe(false);
-                expect(wrapper.find('[data-test-id="offers-link"].c-nav-featureLink').exists()).toBe(false);
+                expect(wrapper.find('[data-test-id="offers-link"]').exists()).toBe(false);
+                expect(wrapper.find('[data-test-id="offers-iconLink"]').exists()).toBe(false);
             });
 
             it('should be shown with open nav when "showOffersLink" is true', async () => {
@@ -345,8 +345,8 @@ describe('Navigation', () => {
                 });
 
                 // Assert
-                expect(wrapper.find('[data-test-id="offers-link"].c-nav-list-link').exists()).toBe(true);
-                expect(wrapper.find('[data-test-id="offers-link"].c-nav-featureLink').exists()).toBe(false);
+                expect(wrapper.find('[data-test-id="offers-link"]').exists()).toBe(true);
+                expect(wrapper.find('[data-test-id="offers-iconLink"]').exists()).toBe(false);
             });
 
             it('should not be shown with open nav when "showOffersLink" is false', async () => {
@@ -365,8 +365,8 @@ describe('Navigation', () => {
                 });
 
                 // Assert
-                expect(wrapper.find('[data-test-id="offers-link"].c-nav-featureLink').exists()).toBe(false);
-                expect(wrapper.find('[data-test-id="offers-link"].c-nav-list-link').exists()).toBe(false);
+                expect(wrapper.find('[data-test-id="offers-link"]').exists()).toBe(false);
+                expect(wrapper.find('[data-test-id="offers-iconLink"]').exists()).toBe(false);
             });
         });
     });

--- a/packages/components/organisms/f-header/src/tenants/countryList.js
+++ b/packages/components/organisms/f-header/src/tenants/countryList.js
@@ -1,6 +1,7 @@
 export default [
     {
         key: 'gb',
+        flagKey: 'gb',
         dataTestKey: 'gb',
         localisedName: 'United Kingdom',
         siteUrl: 'https://www.just-eat.co.uk',
@@ -8,6 +9,7 @@ export default [
     },
     {
         key: 'au',
+        flagKey: 'au',
         dataTestKey: 'au',
         localisedName: 'Australia',
         siteUrl: 'https://www.menulog.com.au',
@@ -15,6 +17,7 @@ export default [
     },
     {
         key: 'at',
+        flagKey: 'at',
         dataTestKey: 'at',
         localisedName: 'Österreich',
         siteUrl: 'https://www.lieferando.at',
@@ -22,6 +25,7 @@ export default [
     },
     {
         key: 'be',
+        flagKey: 'be',
         dataTestKey: 'be',
         localisedName: 'België',
         siteUrl: 'https://www.takeaway.com/be',
@@ -29,20 +33,23 @@ export default [
     },
     {
         key: 'bg',
+        flagKey: 'bg',
         dataTestKey: 'bg',
         localisedName: 'Bulgaria',
         siteUrl: 'https://www.takeaway.com/bg',
         gtm: 'click_country_bg'
     },
     {
-        key: 'ca',
+        key: 'ca_en',
+        flagKey: 'ca',
         dataTestKey: 'ca_en',
         localisedName: 'Canada',
         siteUrl: 'https://www.skipthedishes.com',
         gtm: 'click_country_ca_en'
     },
     {
-        key: 'ca',
+        key: 'ca_fr',
+        flagKey: 'ca',
         dataTestKey: 'ca_fr',
         localisedName: 'Canada (FR)',
         siteUrl: 'https://www.skipthedishes.com/fr',
@@ -50,6 +57,7 @@ export default [
     },
     {
         key: 'dk',
+        flagKey: 'dk',
         dataTestKey: 'dk',
         localisedName: 'Danmark',
         siteUrl: 'https://www.just-eat.dk',
@@ -57,6 +65,7 @@ export default [
     },
     {
         key: 'fr',
+        flagKey: 'fr',
         dataTestKey: 'jet_fr',
         localisedName: 'France',
         siteUrl: 'https://www.just-eat.fr',
@@ -64,6 +73,7 @@ export default [
     },
     {
         key: 'de',
+        flagKey: 'de',
         dataTestKey: 'de',
         localisedName: 'Deutschland',
         siteUrl: 'https://www.lieferando.de',
@@ -71,6 +81,7 @@ export default [
     },
     {
         key: 'ie',
+        flagKey: 'ie',
         dataTestKey: 'ie',
         localisedName: 'Ireland',
         siteUrl: 'https://www.just-eat.ie',
@@ -78,6 +89,7 @@ export default [
     },
     {
         key: 'il',
+        flagKey: 'il',
         dataTestKey: 'il',
         localisedName: 'Israel',
         siteUrl: 'https://www.10bis.co.il/next',
@@ -85,6 +97,7 @@ export default [
     },
     {
         key: 'it',
+        flagKey: 'it',
         dataTestKey: 'it',
         localisedName: 'Italia',
         siteUrl: 'https://www.justeat.it',
@@ -92,6 +105,7 @@ export default [
     },
     {
         key: 'lu',
+        flagKey: 'lu',
         dataTestKey: 'lu',
         localisedName: 'Luxembourg',
         siteUrl: 'https://www.takeaway.com/lu',
@@ -99,6 +113,7 @@ export default [
     },
     {
         key: 'nl',
+        flagKey: 'nl',
         dataTestKey: 'nl',
         localisedName: 'Nederland',
         siteUrl: 'https://www.thuisbezorgd.nl',
@@ -106,6 +121,7 @@ export default [
     },
     {
         key: 'nz',
+        flagKey: 'nz',
         dataTestKey: 'nz',
         localisedName: 'New Zealand',
         siteUrl: 'https://www.menulog.co.nz',
@@ -113,6 +129,7 @@ export default [
     },
     {
         key: 'no',
+        flagKey: 'no',
         dataTestKey: 'no',
         localisedName: 'Norge',
         siteUrl: 'https://www.just-eat.no',
@@ -120,6 +137,7 @@ export default [
     },
     {
         key: 'pl',
+        flagKey: 'pl',
         dataTestKey: 'pl',
         localisedName: 'Polska',
         siteUrl: 'https://www.pyszne.pl',
@@ -127,6 +145,7 @@ export default [
     },
     {
         key: 'pt',
+        flagKey: 'pt',
         dataTestKey: 'pt',
         localisedName: 'Portugal',
         siteUrl: 'https://www.takeaway.com/pt',
@@ -134,6 +153,7 @@ export default [
     },
     {
         key: 'ro',
+        flagKey: 'ro',
         dataTestKey: 'ro',
         localisedName: 'Romania',
         siteUrl: 'https://www.takeaway.com/ro',
@@ -141,27 +161,31 @@ export default [
     },
     {
         key: 'es',
+        flagKey: 'es',
         dataTestKey: 'es',
         localisedName: 'España',
         siteUrl: 'https://www.just-eat.es',
         gtm: 'click_country_es'
     },
     {
-        key: 'ch',
+        key: 'ch_ch',
+        flagKey: 'ch',
         dataTestKey: 'ch_ch',
         localisedName: 'Schweiz',
         siteUrl: 'https://www.eat.ch',
         gtm: 'click_country_ch'
     },
     {
-        key: 'ch',
+        key: 'ch_en',
+        flagKey: 'ch',
         dataTestKey: 'ch_en',
         localisedName: 'Switzerland',
         siteUrl: 'https://www.eat.ch/en',
         gtm: 'click_country_ch_en'
     },
     {
-        key: 'ch',
+        key: 'ch_fr',
+        flagKey: 'ch',
         dataTestKey: 'ch_fr',
         localisedName: 'Suisse',
         siteUrl: 'https://www.eat.ch/fr',

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
@@ -13,8 +13,11 @@ module.exports = class Header extends Page {
     get mobileNavigationBar () { return $(MOBILE_NAVIGATION_BAR) }
 
     navigation = {
-        offers: {
-            get link () { return $(NAVIGATION.offers.link) }
+        offersIcon: {
+            get link () { return $(NAVIGATION.offersIcon.link) }
+        },
+        offersLink: {
+            get link () { return $(NAVIGATION.offersLink.link) }
         },
         help: {
             get link () { return $(NAVIGATION.help.link) }
@@ -113,7 +116,7 @@ module.exports = class Header extends Page {
     // }
 
     clickOffersLink () {
-        return this.navigation.offers.link.click();
+        return this.navigation.offersLink.link.click();
     }
 
     clickHelpLink () {

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.selectors.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.selectors.js
@@ -18,6 +18,6 @@ export const NAVIGATION = {
     countrySelector: {
         link: '[data-test-id="country-selector"] button', 
         currentIcon: '[data-test-id="current-flag-icon"]',
-        countryList: '[data-test-id="c-countrySelector-list"] li'
+        countryList: '[data-test-id="countrySelector-list"] li'
     }
 }

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.selectors.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.selectors.js
@@ -3,8 +3,11 @@ export const HEADER_LOGO = '[data-test-id="header-logo"]';
 export const MOBILE_NAVIGATION_BAR = '[data-test-id="nav-toggle"]';
 
 export const NAVIGATION = {
-    offers: {
-        link: '[data-test-id="offers-link"]', 
+    offersIcon: {
+        link: '[data-test-id="offers-iconLink"]',
+    },
+    offersLink: {
+        link: '[data-test-id="offers-link"]',
     },
     help: {
         link: '[data-test-id="help-link"]', 

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.selectors.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.selectors.js
@@ -4,7 +4,7 @@ export const MOBILE_NAVIGATION_BAR = '[data-test-id="nav-toggle"]';
 
 export const NAVIGATION = {
     offers: {
-        link: '[data-test-id="offers-link-without-text"]', 
+        link: '[data-test-id="offers-link"]', 
     },
     help: {
         link: '[data-test-id="help-link"]', 

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.selectors.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.selectors.js
@@ -4,7 +4,7 @@ export const MOBILE_NAVIGATION_BAR = '[data-test-id="nav-toggle"]';
 
 export const NAVIGATION = {
     offers: {
-        link: '[data-test-id="offers-link"]', 
+        link: '[data-test-id="offers-link-without-text"]', 
     },
     help: {
         link: '[data-test-id="help-link"]', 

--- a/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
@@ -12,10 +12,10 @@ describe('Desktop - f-header component tests', () => {
     .it('should only display the default navigation fields', field => {
         // Assert
         expect(header.isFieldLinkDisplayed(field)).toBe(true); 
-        expect(header.isFieldLinkDisplayed('offers')).toBe(false);
+        expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
     });
 
-    forEach(['offers', 'help', 'delivery', 'userAccount', 'countrySelector'])
+    forEach(['offersLink', 'help', 'delivery', 'userAccount', 'countrySelector'])
     .it('should display extra fields as well as default when selected', field => {
         // Act
         header.openWithExtraFeatures();

--- a/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
@@ -13,14 +13,14 @@ describe('Mobile - f-header component tests', () => {
     });
 
     forEach(['help', 'delivery', 'userAccount', 'countrySelector'])
-    .it('should hide all navigation links, except offers link, when in mobile mode', field => {
+    .it.only('should hide all navigation links, except offersIcon link, when in mobile mode', field => {
         // Act
         header.openWithExtraFeatures();
 
         // Assert
         expect(header.isMobileNavigationBarDisplayed()).toBe(true);
         expect(header.isFieldLinkDisplayed(field)).toBe(false);
-        expect(header.isFieldLinkDisplayed('offers')).toBe(true);
+        expect(header.isFieldLinkDisplayed('offersIcon')).toBe(true);
     });
 
     forEach(['help', 'countrySelector', 'userAccount'])

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,13 +2031,6 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.3.0.tgz#58a88476ee204264988640b3cd47ac5d295bde4a"
   integrity sha512-Cr6CDlrZAHoM3ZUJ2sOMLYAVYz+cka5R6THi24va3mhI8kgOSA4ZVzvx607QskTyasIX4xNfrju0HKity1Lq9w==
 
-"@justeat/f-popover@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@justeat/f-popover/-/f-popover-0.2.1.tgz#0c6780bcf8c452f4b0319c14b86a3cc05904dcb0"
-  integrity sha512-myeYCy8uG5k1isc4D3sPRDFeZJnX54jvFm9zbr7b45gdx/FOVLNAiB3tEQobtakTjmfW8Jl1IxiXtuUiqBD7yg==
-  dependencies:
-    "@justeat/f-services" "1.7.0"
-
 "@justeat/f-searchbox@3.10.0":
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-searchbox/-/f-searchbox-3.10.0.tgz#1a6b235494f1e22de14bd1d6eea146fd575f419b"
@@ -5043,15 +5036,6 @@
   dependencies:
     "@wdio/logger" "6.0.16"
 
-"@webassemblyjs/ast@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.7.11.tgz#b988582cafbb2b095e8b556526f30c90d057cace"
-  integrity sha512-ZEzy4vjvTzScC+SH8RBssQUawpaInUdMTYwYYLh54/s8TuT0gBLuyUnppKsVyZEi876VmmStKsUs28UxPgdvrA==
-  dependencies:
-    "@webassemblyjs/helper-module-context" "1.7.11"
-    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
-    "@webassemblyjs/wast-parser" "1.7.11"
-
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
@@ -5061,66 +5045,20 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
     "@webassemblyjs/wast-parser" "1.8.5"
 
-"@webassemblyjs/ast@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
-  integrity sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==
-  dependencies:
-    "@webassemblyjs/helper-module-context" "1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
-    "@webassemblyjs/wast-parser" "1.9.0"
-
-"@webassemblyjs/floating-point-hex-parser@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz#a69f0af6502eb9a3c045555b1a6129d3d3f2e313"
-  integrity sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg==
-
 "@webassemblyjs/floating-point-hex-parser@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz#1ba926a2923613edce496fd5b02e8ce8a5f49721"
   integrity sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==
-
-"@webassemblyjs/floating-point-hex-parser@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz#3c3d3b271bddfc84deb00f71344438311d52ffb4"
-  integrity sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==
-
-"@webassemblyjs/helper-api-error@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz#c7b6bb8105f84039511a2b39ce494f193818a32a"
-  integrity sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg==
 
 "@webassemblyjs/helper-api-error@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz#c49dad22f645227c5edb610bdb9697f1aab721f7"
   integrity sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==
 
-"@webassemblyjs/helper-api-error@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz#203f676e333b96c9da2eeab3ccef33c45928b6a2"
-  integrity sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==
-
-"@webassemblyjs/helper-buffer@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz#3122d48dcc6c9456ed982debe16c8f37101df39b"
-  integrity sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w==
-
 "@webassemblyjs/helper-buffer@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz#fea93e429863dd5e4338555f42292385a653f204"
   integrity sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==
-
-"@webassemblyjs/helper-buffer@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz#a1442d269c5feb23fcbc9ef759dac3547f29de00"
-  integrity sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==
-
-"@webassemblyjs/helper-code-frame@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz#cf8f106e746662a0da29bdef635fcd3d1248364b"
-  integrity sha512-T8ESC9KMXFTXA5urJcyor5cn6qWeZ4/zLPyWeEXZ03hj/x9weSokGNkVCdnhSabKGYWxElSdgJ+sFa9G/RdHNw==
-  dependencies:
-    "@webassemblyjs/wast-printer" "1.7.11"
 
 "@webassemblyjs/helper-code-frame@1.8.5":
   version "1.8.5"
@@ -5129,32 +5067,10 @@
   dependencies:
     "@webassemblyjs/wast-printer" "1.8.5"
 
-"@webassemblyjs/helper-code-frame@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz#647f8892cd2043a82ac0c8c5e75c36f1d9159f27"
-  integrity sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==
-  dependencies:
-    "@webassemblyjs/wast-printer" "1.9.0"
-
-"@webassemblyjs/helper-fsm@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz#df38882a624080d03f7503f93e3f17ac5ac01181"
-  integrity sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A==
-
 "@webassemblyjs/helper-fsm@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz#ba0b7d3b3f7e4733da6059c9332275d860702452"
   integrity sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==
-
-"@webassemblyjs/helper-fsm@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz#c05256b71244214671f4b08ec108ad63b70eddb8"
-  integrity sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==
-
-"@webassemblyjs/helper-module-context@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz#d874d722e51e62ac202476935d649c802fa0e209"
-  integrity sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg==
 
 "@webassemblyjs/helper-module-context@1.8.5":
   version "1.8.5"
@@ -5164,37 +5080,10 @@
     "@webassemblyjs/ast" "1.8.5"
     mamacro "^0.0.3"
 
-"@webassemblyjs/helper-module-context@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz#25d8884b76839871a08a6c6f806c3979ef712f07"
-  integrity sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-
-"@webassemblyjs/helper-wasm-bytecode@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz#dd9a1e817f1c2eb105b4cf1013093cb9f3c9cb06"
-  integrity sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ==
-
 "@webassemblyjs/helper-wasm-bytecode@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz#537a750eddf5c1e932f3744206551c91c1b93e61"
   integrity sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==
-
-"@webassemblyjs/helper-wasm-bytecode@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz#4fed8beac9b8c14f8c58b70d124d549dd1fe5790"
-  integrity sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==
-
-"@webassemblyjs/helper-wasm-section@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz#9c9ac41ecf9fbcfffc96f6d2675e2de33811e68a"
-  integrity sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==
-  dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/helper-buffer" "1.7.11"
-    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
-    "@webassemblyjs/wasm-gen" "1.7.11"
 
 "@webassemblyjs/helper-wasm-section@1.8.5":
   version "1.8.5"
@@ -5206,43 +5095,12 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
     "@webassemblyjs/wasm-gen" "1.8.5"
 
-"@webassemblyjs/helper-wasm-section@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz#5a4138d5a6292ba18b04c5ae49717e4167965346"
-  integrity sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-buffer" "1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
-    "@webassemblyjs/wasm-gen" "1.9.0"
-
-"@webassemblyjs/ieee754@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz#c95839eb63757a31880aaec7b6512d4191ac640b"
-  integrity sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==
-  dependencies:
-    "@xtuc/ieee754" "^1.2.0"
-
 "@webassemblyjs/ieee754@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz#712329dbef240f36bf57bd2f7b8fb9bf4154421e"
   integrity sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
-
-"@webassemblyjs/ieee754@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz#15c7a0fbaae83fb26143bbacf6d6df1702ad39e4"
-  integrity sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==
-  dependencies:
-    "@xtuc/ieee754" "^1.2.0"
-
-"@webassemblyjs/leb128@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.7.11.tgz#d7267a1ee9c4594fd3f7e37298818ec65687db63"
-  integrity sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==
-  dependencies:
-    "@xtuc/long" "4.2.1"
 
 "@webassemblyjs/leb128@1.8.5":
   version "1.8.5"
@@ -5251,41 +5109,10 @@
   dependencies:
     "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/leb128@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.9.0.tgz#f19ca0b76a6dc55623a09cffa769e838fa1e1c95"
-  integrity sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==
-  dependencies:
-    "@xtuc/long" "4.2.2"
-
-"@webassemblyjs/utf8@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.7.11.tgz#06d7218ea9fdc94a6793aa92208160db3d26ee82"
-  integrity sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA==
-
 "@webassemblyjs/utf8@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.8.5.tgz#a8bf3b5d8ffe986c7c1e373ccbdc2a0915f0cedc"
   integrity sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==
-
-"@webassemblyjs/utf8@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.9.0.tgz#04d33b636f78e6a6813227e82402f7637b6229ab"
-  integrity sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==
-
-"@webassemblyjs/wasm-edit@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz#8c74ca474d4f951d01dbae9bd70814ee22a82005"
-  integrity sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==
-  dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/helper-buffer" "1.7.11"
-    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
-    "@webassemblyjs/helper-wasm-section" "1.7.11"
-    "@webassemblyjs/wasm-gen" "1.7.11"
-    "@webassemblyjs/wasm-opt" "1.7.11"
-    "@webassemblyjs/wasm-parser" "1.7.11"
-    "@webassemblyjs/wast-printer" "1.7.11"
 
 "@webassemblyjs/wasm-edit@1.8.5":
   version "1.8.5"
@@ -5301,31 +5128,6 @@
     "@webassemblyjs/wasm-parser" "1.8.5"
     "@webassemblyjs/wast-printer" "1.8.5"
 
-"@webassemblyjs/wasm-edit@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz#3fe6d79d3f0f922183aa86002c42dd256cfee9cf"
-  integrity sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-buffer" "1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
-    "@webassemblyjs/helper-wasm-section" "1.9.0"
-    "@webassemblyjs/wasm-gen" "1.9.0"
-    "@webassemblyjs/wasm-opt" "1.9.0"
-    "@webassemblyjs/wasm-parser" "1.9.0"
-    "@webassemblyjs/wast-printer" "1.9.0"
-
-"@webassemblyjs/wasm-gen@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz#9bbba942f22375686a6fb759afcd7ac9c45da1a8"
-  integrity sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==
-  dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
-    "@webassemblyjs/ieee754" "1.7.11"
-    "@webassemblyjs/leb128" "1.7.11"
-    "@webassemblyjs/utf8" "1.7.11"
-
 "@webassemblyjs/wasm-gen@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz#54840766c2c1002eb64ed1abe720aded714f98bc"
@@ -5337,27 +5139,6 @@
     "@webassemblyjs/leb128" "1.8.5"
     "@webassemblyjs/utf8" "1.8.5"
 
-"@webassemblyjs/wasm-gen@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz#50bc70ec68ded8e2763b01a1418bf43491a7a49c"
-  integrity sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
-    "@webassemblyjs/ieee754" "1.9.0"
-    "@webassemblyjs/leb128" "1.9.0"
-    "@webassemblyjs/utf8" "1.9.0"
-
-"@webassemblyjs/wasm-opt@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz#b331e8e7cef8f8e2f007d42c3a36a0580a7d6ca7"
-  integrity sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==
-  dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/helper-buffer" "1.7.11"
-    "@webassemblyjs/wasm-gen" "1.7.11"
-    "@webassemblyjs/wasm-parser" "1.7.11"
-
 "@webassemblyjs/wasm-opt@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz#b24d9f6ba50394af1349f510afa8ffcb8a63d264"
@@ -5367,28 +5148,6 @@
     "@webassemblyjs/helper-buffer" "1.8.5"
     "@webassemblyjs/wasm-gen" "1.8.5"
     "@webassemblyjs/wasm-parser" "1.8.5"
-
-"@webassemblyjs/wasm-opt@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz#2211181e5b31326443cc8112eb9f0b9028721a61"
-  integrity sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-buffer" "1.9.0"
-    "@webassemblyjs/wasm-gen" "1.9.0"
-    "@webassemblyjs/wasm-parser" "1.9.0"
-
-"@webassemblyjs/wasm-parser@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz#6e3d20fa6a3519f6b084ef9391ad58211efb0a1a"
-  integrity sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==
-  dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/helper-api-error" "1.7.11"
-    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
-    "@webassemblyjs/ieee754" "1.7.11"
-    "@webassemblyjs/leb128" "1.7.11"
-    "@webassemblyjs/utf8" "1.7.11"
 
 "@webassemblyjs/wasm-parser@1.8.5":
   version "1.8.5"
@@ -5402,30 +5161,6 @@
     "@webassemblyjs/leb128" "1.8.5"
     "@webassemblyjs/utf8" "1.8.5"
 
-"@webassemblyjs/wasm-parser@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz#9d48e44826df4a6598294aa6c87469d642fff65e"
-  integrity sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-api-error" "1.9.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
-    "@webassemblyjs/ieee754" "1.9.0"
-    "@webassemblyjs/leb128" "1.9.0"
-    "@webassemblyjs/utf8" "1.9.0"
-
-"@webassemblyjs/wast-parser@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz#25bd117562ca8c002720ff8116ef9072d9ca869c"
-  integrity sha512-lEyVCg2np15tS+dm7+JJTNhNWq9yTZvi3qEhAIIOaofcYlUp0UR5/tVqOwa/gXYr3gjwSZqw+/lS9dscyLelbQ==
-  dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/floating-point-hex-parser" "1.7.11"
-    "@webassemblyjs/helper-api-error" "1.7.11"
-    "@webassemblyjs/helper-code-frame" "1.7.11"
-    "@webassemblyjs/helper-fsm" "1.7.11"
-    "@xtuc/long" "4.2.1"
-
 "@webassemblyjs/wast-parser@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz#e10eecd542d0e7bd394f6827c49f3df6d4eefb8c"
@@ -5438,27 +5173,6 @@
     "@webassemblyjs/helper-fsm" "1.8.5"
     "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/wast-parser@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz#3031115d79ac5bd261556cecc3fa90a3ef451914"
-  integrity sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/floating-point-hex-parser" "1.9.0"
-    "@webassemblyjs/helper-api-error" "1.9.0"
-    "@webassemblyjs/helper-code-frame" "1.9.0"
-    "@webassemblyjs/helper-fsm" "1.9.0"
-    "@xtuc/long" "4.2.2"
-
-"@webassemblyjs/wast-printer@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz#c4245b6de242cb50a2cc950174fdbf65c78d7813"
-  integrity sha512-m5vkAsuJ32QpkdkDOUPGSltrg8Cuk3KBx4YrmAGQwCZPRdUHXxG4phIOuuycLemHFr74sWL9Wthqss4fzdzSwg==
-  dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/wast-parser" "1.7.11"
-    "@xtuc/long" "4.2.1"
-
 "@webassemblyjs/wast-printer@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz#114bbc481fd10ca0e23b3560fa812748b0bae5bc"
@@ -5468,24 +5182,10 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/wast-printer@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz#4935d54c85fef637b00ce9f52377451d00d47899"
-  integrity sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/wast-parser" "1.9.0"
-    "@xtuc/long" "4.2.2"
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
   integrity sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==
-
-"@xtuc/long@4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
-  integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
 "@xtuc/long@4.2.2":
   version "4.2.2"
@@ -5534,13 +5234,6 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
-acorn-dynamic-import@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
-  integrity sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==
-  dependencies:
-    acorn "^5.0.0"
-
 acorn-dynamic-import@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz#482210140582a36b83c3e342e1cfebcaa9240948"
@@ -5581,7 +5274,7 @@ acorn-walk@^7.0.0, acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-"acorn@>= 2.5.2 <= 5.7.5", acorn@^5.0.0, acorn@^5.5.0, acorn@^5.5.3, acorn@^5.6.2:
+"acorn@>= 2.5.2 <= 5.7.5", acorn@^5.5.0, acorn@^5.5.3:
   version "5.7.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
   integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
@@ -5591,7 +5284,7 @@ acorn@^3.0.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
   integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
 
-acorn@^6.0.1, acorn@^6.1.1, acorn@^6.2.0, acorn@^6.2.1, acorn@^6.4.1:
+acorn@^6.0.1, acorn@^6.1.1, acorn@^6.2.0:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
@@ -5680,7 +5373,7 @@ ajv-keywords@^2.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
   integrity sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=
 
-ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
+ajv-keywords@^3.1.0, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
@@ -7898,7 +7591,7 @@ chrome-launcher@^0.13.1:
     mkdirp "^0.5.3"
     rimraf "^3.0.2"
 
-chrome-trace-event@^1.0.0, chrome-trace-event@^1.0.2:
+chrome-trace-event@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"
   integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
@@ -10145,7 +9838,7 @@ enhanced-resolve@^0.9.1:
     memory-fs "^0.2.0"
     tapable "^0.1.8"
 
-enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0, enhanced-resolve@^4.5.0:
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz#2f3cfd84dbe3b487f18f2db2ef1e064a571ca5ec"
   integrity sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==
@@ -10470,7 +10163,7 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^4.0.0, eslint-scope@^4.0.3:
+eslint-scope@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
   integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
@@ -15261,7 +14954,7 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
-jwt-decode@^3.1.2:
+jwt-decode@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
   integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
@@ -15520,7 +15213,7 @@ loader-fs-cache@^1.0.0:
     find-cache-dir "^0.1.1"
     mkdirp "^0.5.1"
 
-loader-runner@^2.3.0, loader-runner@^2.3.1, loader-runner@^2.4.0:
+loader-runner@^2.3.0, loader-runner@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
@@ -16955,7 +16648,7 @@ node-ipc@^9.1.1:
     js-message "1.0.7"
     js-queue "2.0.2"
 
-"node-libs-browser@^1.0.0 || ^2.0.0", node-libs-browser@^2.0.0, node-libs-browser@^2.2.1:
+"node-libs-browser@^1.0.0 || ^2.0.0", node-libs-browser@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
   integrity sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
@@ -20943,14 +20636,6 @@ scheduler@^0.19.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-schema-utils@^0.4.4:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
-  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
-  dependencies:
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
-
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
@@ -22400,7 +22085,7 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser-webpack-plugin@^1.1.0, terser-webpack-plugin@^1.4.3:
+terser-webpack-plugin@^1.1.0:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz#a217aefaea330e734ffacb6120ec1fa312d6040b"
   integrity sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==
@@ -23776,7 +23461,7 @@ watchpack-chokidar2@^2.0.1:
   dependencies:
     chokidar "^2.1.8"
 
-watchpack@^1.5.0, watchpack@^1.6.0, watchpack@^1.7.4:
+watchpack@^1.5.0:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
@@ -24068,7 +23753,7 @@ webpack-merge@^4.1.4, webpack-merge@^4.2.2:
   dependencies:
     lodash "^4.17.15"
 
-webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
+webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
@@ -24083,66 +23768,7 @@ webpack-virtual-modules@^0.2.2:
   dependencies:
     debug "^3.0.0"
 
-webpack@4.42.1:
-  version "4.42.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.42.1.tgz#ae707baf091f5ca3ef9c38b884287cfe8f1983ef"
-  integrity sha512-SGfYMigqEfdGchGhFFJ9KyRpQKnipvEvjc1TwrXEPCM6H5Wywu10ka8o3KGrMzSMxMQKt8aCHUFh5DaQ9UmyRg==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-module-context" "1.9.0"
-    "@webassemblyjs/wasm-edit" "1.9.0"
-    "@webassemblyjs/wasm-parser" "1.9.0"
-    acorn "^6.2.1"
-    ajv "^6.10.2"
-    ajv-keywords "^3.4.1"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "^4.1.0"
-    eslint-scope "^4.0.3"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^2.4.0"
-    loader-utils "^1.2.3"
-    memory-fs "^0.4.1"
-    micromatch "^3.1.10"
-    mkdirp "^0.5.3"
-    neo-async "^2.6.1"
-    node-libs-browser "^2.2.1"
-    schema-utils "^1.0.0"
-    tapable "^1.1.3"
-    terser-webpack-plugin "^1.4.3"
-    watchpack "^1.6.0"
-    webpack-sources "^1.4.1"
-
-"webpack@>=4 < 4.29":
-  version "4.28.4"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.28.4.tgz#1ddae6c89887d7efb752adf0c3cd32b9b07eacd0"
-  integrity sha512-NxjD61WsK/a3JIdwWjtIpimmvE6UrRi3yG54/74Hk9rwNj5FPkA4DJCf1z4ByDWLkvZhTZE+P3C/eh6UD5lDcw==
-  dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/helper-module-context" "1.7.11"
-    "@webassemblyjs/wasm-edit" "1.7.11"
-    "@webassemblyjs/wasm-parser" "1.7.11"
-    acorn "^5.6.2"
-    acorn-dynamic-import "^3.0.0"
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
-    chrome-trace-event "^1.0.0"
-    enhanced-resolve "^4.1.0"
-    eslint-scope "^4.0.0"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^2.3.0"
-    loader-utils "^1.1.0"
-    memory-fs "~0.4.1"
-    micromatch "^3.1.8"
-    mkdirp "~0.5.0"
-    neo-async "^2.5.0"
-    node-libs-browser "^2.0.0"
-    schema-utils "^0.4.4"
-    tapable "^1.1.0"
-    terser-webpack-plugin "^1.1.0"
-    watchpack "^1.5.0"
-    webpack-sources "^1.3.0"
-
-webpack@^4.0.0, webpack@^4.26.0:
+webpack@4.36.0, webpack@4.42.1, "webpack@>=4 < 4.29", webpack@^4.0.0, webpack@^4.26.0, webpack@^4.43.0:
   version "4.36.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.36.0.tgz#d49474e54acd6eed51c3aff70333cbd172f21101"
   integrity sha512-UGcu9VQMjs9CxYfDEMe7UYkMgSVx9eSgcmj8ksveJk0b7/CxPW4B0HOk+yF0CLQg8p0sxynUS4PHQtjEDSZSmg==
@@ -24170,35 +23796,6 @@ webpack@^4.0.0, webpack@^4.26.0:
     terser-webpack-plugin "^1.1.0"
     watchpack "^1.5.0"
     webpack-sources "^1.3.0"
-
-webpack@^4.43.0:
-  version "4.46.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
-  integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-module-context" "1.9.0"
-    "@webassemblyjs/wasm-edit" "1.9.0"
-    "@webassemblyjs/wasm-parser" "1.9.0"
-    acorn "^6.4.1"
-    ajv "^6.10.2"
-    ajv-keywords "^3.4.1"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "^4.5.0"
-    eslint-scope "^4.0.3"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^2.4.0"
-    loader-utils "^1.2.3"
-    memory-fs "^0.4.1"
-    micromatch "^3.1.10"
-    mkdirp "^0.5.3"
-    neo-async "^2.6.1"
-    node-libs-browser "^2.2.1"
-    schema-utils "^1.0.0"
-    tapable "^1.1.3"
-    terser-webpack-plugin "^1.4.3"
-    watchpack "^1.7.4"
-    webpack-sources "^1.4.1"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,6 +2031,13 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.3.0.tgz#58a88476ee204264988640b3cd47ac5d295bde4a"
   integrity sha512-Cr6CDlrZAHoM3ZUJ2sOMLYAVYz+cka5R6THi24va3mhI8kgOSA4ZVzvx607QskTyasIX4xNfrju0HKity1Lq9w==
 
+"@justeat/f-popover@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@justeat/f-popover/-/f-popover-0.2.1.tgz#0c6780bcf8c452f4b0319c14b86a3cc05904dcb0"
+  integrity sha512-myeYCy8uG5k1isc4D3sPRDFeZJnX54jvFm9zbr7b45gdx/FOVLNAiB3tEQobtakTjmfW8Jl1IxiXtuUiqBD7yg==
+  dependencies:
+    "@justeat/f-services" "1.7.0"
+
 "@justeat/f-searchbox@3.10.0":
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-searchbox/-/f-searchbox-3.10.0.tgz#1a6b235494f1e22de14bd1d6eea146fd575f419b"


### PR DESCRIPTION
### Changed
- Media queries to pick up 768px width to render mobile view for tablet devices
- `f-popover` package version bump
- Fixed the tests for offers link
- Mobile nav view to show offers and delivery links to have the same experience as on SiteCore header nav

### Added
- Unique keys for each link in `countryList.js`

[![Image from Gyazo](https://i.gyazo.com/7f77dc9fc14709c606b7bdd758029554.gif)](https://gyazo.com/7f77dc9fc14709c606b7bdd758029554)