### PR TITLE
f-registration Move 'email in use' test from CoreWeb #trivial

### DIFF
--- a/packages/components/organisms/f-registration/CHANGELOG.md
+++ b/packages/components/organisms/f-registration/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Latest (add to next release)
 ------------------------------
 
+*March 8, 2021*
+
+### Added
+- Axios mocks for Storybook
+- 'email in use' component test
+
 *February 4, 2021*
 
 ### Added

--- a/packages/components/organisms/f-registration/src/mocks/email-in-use.json
+++ b/packages/components/organisms/f-registration/src/mocks/email-in-use.json
@@ -1,0 +1,8 @@
+{
+    "faultId": "5bdb442d-7e66-4ca0-aaed-41101d8e8b90",
+    "traceId": "80000144-0000-fa00-b63f-84710c7967bb",
+    "errors": [{
+        "description": "The specified email already exists",
+        "errorCode": "409"
+    }]
+}

--- a/packages/components/organisms/f-registration/src/mocks/registrationMock.js
+++ b/packages/components/organisms/f-registration/src/mocks/registrationMock.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import emailInUse from './email-in-use.json';
+
+const mock = new MockAdapter(axios);
+
+export default {
+    setupEmailInUse (createAccountUrl) {
+        mock.onPost(createAccountUrl).reply(409, emailInUse);
+    },
+
+    passThroughAny () {
+        mock.onAny().passThrough();
+    }
+};

--- a/packages/components/organisms/f-registration/stories/Registration.stories.js
+++ b/packages/components/organisms/f-registration/stories/Registration.stories.js
@@ -1,11 +1,16 @@
 import { withKnobs, select, text, boolean } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
 import Registration from '../src/components/Registration.vue';
+import RegistrationMock from '../src/mocks/registrationMock';
 
 export default {
     title: 'Components/Organisms',
     decorators: [withKnobs, withA11y]
 };
+
+const createAccountUrl = '/account/register';
+RegistrationMock.setupEmailInUse(createAccountUrl)
+RegistrationMock.passThroughAny();
 
 export const RegistrationComponent = () => ({
     components: { Registration },
@@ -17,7 +22,7 @@ export const RegistrationComponent = () => ({
             default: text('Title', 'Create Account')
         },
         createAccountUrl: {
-            default: text('Create Account URL', '/account/register')
+            default: text('Create Account URL', createAccountUrl)
         },
         buttonText: {
             default: text('Button Text', 'Create Account')
@@ -26,7 +31,7 @@ export const RegistrationComponent = () => ({
             default: boolean('Show Login Link', true)
         },
         loginUrl: {
-            default: text('Login URL', '/account/register')
+            default: text('Login URL', createAccountUrl)
         }
     },
     parameters: {

--- a/packages/components/organisms/f-registration/stories/Registration.stories.js
+++ b/packages/components/organisms/f-registration/stories/Registration.stories.js
@@ -10,6 +10,7 @@ export default {
 
 const createAccountUrl = '/account/register';
 RegistrationMock.setupEmailInUse(createAccountUrl)
+RegistrationMock.passThroughAny();
 
 
 export const RegistrationComponent = () => ({

--- a/packages/components/organisms/f-registration/stories/Registration.stories.js
+++ b/packages/components/organisms/f-registration/stories/Registration.stories.js
@@ -8,7 +8,8 @@ export default {
     decorators: [withKnobs, withA11y]
 };
 
-RegistrationMock.setupEmailInUse('')
+const createAccountUrl = '/account/register';
+RegistrationMock.setupEmailInUse(createAccountUrl)
 
 
 export const RegistrationComponent = () => ({
@@ -21,7 +22,7 @@ export const RegistrationComponent = () => ({
             default: text('Title', 'Create Account')
         },
         createAccountUrl: {
-            default: text('Create Account URL', '/account/register')
+            default: text('Create Account URL', createAccountUrl)
         },
         buttonText: {
             default: text('Button Text', 'Create Account')

--- a/packages/components/organisms/f-registration/stories/Registration.stories.js
+++ b/packages/components/organisms/f-registration/stories/Registration.stories.js
@@ -8,9 +8,8 @@ export default {
     decorators: [withKnobs, withA11y]
 };
 
-const createAccountUrl = '/account/register';
-RegistrationMock.setupEmailInUse(createAccountUrl)
-RegistrationMock.passThroughAny();
+RegistrationMock.setupEmailInUse('')
+
 
 export const RegistrationComponent = () => ({
     components: { Registration },
@@ -22,7 +21,7 @@ export const RegistrationComponent = () => ({
             default: text('Title', 'Create Account')
         },
         createAccountUrl: {
-            default: text('Create Account URL', createAccountUrl)
+            default: text('Create Account URL', '/account/register')
         },
         buttonText: {
             default: text('Button Text', 'Create Account')
@@ -31,7 +30,7 @@ export const RegistrationComponent = () => ({
             default: boolean('Show Login Link', true)
         },
         loginUrl: {
-            default: text('Login URL', createAccountUrl)
+            default: text('Login URL', '/account/login')
         }
     },
     parameters: {

--- a/packages/components/organisms/f-registration/test/specs/component/f-registration.component.spec.js
+++ b/packages/components/organisms/f-registration/test/specs/component/f-registration.component.spec.js
@@ -13,6 +13,23 @@ describe('f-registration component tests', () => {
         expect(registration.isComponentDisplayed()).toBe(true);
     });
 
+    it('should display the "Email address is already registered" error', () => {
+
+        // Arrange
+        const userInfo = {
+            firstName: 'Test',
+            lastName: 'User',
+            email: 'test@user.com',
+            password: 'testuser123'
+        };
+
+        // Act
+        registration.submitForm(userInfo);
+
+        // Assert
+        expect(registration.isEmailExistsErrorDisplayed()).toBe(true);
+    });
+
     forEach(['firstName', 'lastName', 'email', 'password'])
     .it('should display input field', field => {
         // Assert


### PR DESCRIPTION
Added
- 'email in use' mock for f-registration
- 'email in use' component test