### PR TITLE
f-content-cards@v4.2.0 🔮 Medium-size stamp card

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -3,7 +3,19 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v4.0.1
+v4.2.0
+------------------------------
+*March 08, 2021*
+
+### Added
+- Mid-size stamp card in an intermediate breakpoint for tablet view
+
+### Fixed
+- Margin on bottom of restaurant icon in stampcard prevents text from butting up
+on the bottom of it when it flows onto the next line
+
+
+v4.1.0
 ------------------------------
 *March 03, 2021*
 

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
@@ -270,7 +270,8 @@ $stampCard-expiryInfo-colour: $grey--dark;
 $stampCard-iconSize-landscape: 56px;
 $stampCard-iconSize-portrait: 48px;
 
-$stampCard-responsive-mobileViewBreakpoint: '<narrowMid';
+$stampCard-responsive-mobileViewBreakpoint: '<=narrowMid';
+$stampCard-responsive-tabletViewBreakpoint: '<=mid';
 
 .c-stampCard1 {
     text-decoration: initial;
@@ -290,6 +291,10 @@ $stampCard-responsive-mobileViewBreakpoint: '<narrowMid';
         color: $color-text;
     }
 
+    @include media($stampCard-responsive-tabletViewBreakpoint) {
+        width: 344px;
+    }
+
     @include media($stampCard-responsive-mobileViewBreakpoint) {
         width: auto;
         box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.12);
@@ -303,6 +308,7 @@ $stampCard-responsive-mobileViewBreakpoint: '<narrowMid';
 .c-stampCard1-icon {
     float: left;
     margin-right: spacing(x2);
+    margin-bottom: spacing();
     width: $stampCard-iconSize-landscape;
     height: $stampCard-iconSize-landscape;
     border-radius: $border-radius;


### PR DESCRIPTION
### Added
- Mid-size stamp card in an intermediate breakpoint for tablet view

### Fixed
- Margin on bottom of restaurant icon in stampcard prevents text from butting up
on the bottom of it when it flows onto the next line

---

## ~UI Review Checks~ N/A - minor, visual changes included only

- [ ] ~README and/or UI Documentation has been [created|updated]~
- [ ] ~Unit tests have been [created|updated]~
- [ ] ~This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)~

## Screenshots

### Desktop:

![image](https://user-images.githubusercontent.com/6674452/110318015-e0857800-8004-11eb-9747-778ffe7a1ea4.png)

### Tablet:

![image](https://user-images.githubusercontent.com/6674452/110317977-d06d9880-8004-11eb-9fe8-76a8f2f7c31d.png)


## Browsers Tested

- [x] Chrome (latest)
- [x] Firefox (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
