### PR TITLE
f-cookie-banner@v0.5.0 - Fix button style issue

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.5.0
 ------------------------------
-*March 2, 2021*
+*March 9, 2021*
 
 ### Changed
 - Legacy banner button to use native button.

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.5.0
+------------------------------
+*March 2, 2021*
+
+### Changed
+- Legacy banner button to use native button.
+- Switch to legacy banner for AU/NZ
+
+
 v0.4.0
 ------------------------------
 *March 2, 2021*

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
@@ -13,35 +13,22 @@
                         {{ legacyBannerLinkText }}
                     </a>
                 </p>
-                <button-component
-                    type="button"
+                <button
                     :class="[$style['c-cookieWarning-btn']]"
-                    button-type="icon"
-                    button-size="xsmall"
                     data-test-id="cookieBanner-close-button"
                     aria-label="Close"
                     @click.native="$emit('hide-legacy-banner')">
-                    <cross-icon />
                     <span class="is-visuallyHidden">
                         {{ legacyBannerCloseBannerText }}
                     </span>
-                </button-component>
+                </button>
             </div>
         </div>
     </div>
 </template>
 
 <script>
-import ButtonComponent from '@justeat/f-button';
-import '@justeat/f-button/dist/f-button.css';
-
-import { CrossIcon } from '@justeat/f-vue-icons';
-
 export default {
-    components: {
-        ButtonComponent,
-        CrossIcon
-    },
     props: {
         shouldHideLegacyBanner: {
             type: Boolean,

--- a/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
@@ -17,7 +17,7 @@
                     :class="[$style['c-cookieWarning-btn']]"
                     data-test-id="cookieBanner-close-button"
                     aria-label="Close"
-                    @click.native="$emit('hide-legacy-banner')">
+                    @click="$emit('hide-legacy-banner')">
                     <span class="is-visuallyHidden">
                         {{ legacyBannerCloseBannerText }}
                     </span>

--- a/packages/components/organisms/f-cookie-banner/src/tenants/en-AU.js
+++ b/packages/components/organisms/f-cookie-banner/src/tenants/en-AU.js
@@ -8,10 +8,13 @@ const messages = {
     textLine3: 'For details about the cookies and technologies we use, see our ',
     textLine4: '.  Using this banner will set a cookie on your device to remember your preferences.',
     cookiePolicyLinkText: 'cookies notice',
-    cookiePolicyLinkUrl: 'https://www.menulog.com.au/info/cookies-policy'
+    cookiePolicyLinkUrl: 'https://www.menulog.com.au/info/cookies-policy',
+    legacyBannerText: 'We use cookies to improve your browsing experience. By continuing, you agree to receive cookies on our website.',
+    legacyBannerLinkText: 'Learn more about our cookies policy.',
+    legacyBannerCloseBannerText: 'Close cookie banner'
 };
 
-const displayLegacy = false;
+const displayLegacy = true;
 
 const cookieExclusionList = [
     '_dc_gtm_',

--- a/packages/components/organisms/f-cookie-banner/src/tenants/en-NZ.js
+++ b/packages/components/organisms/f-cookie-banner/src/tenants/en-NZ.js
@@ -8,10 +8,13 @@ const messages = {
     textLine3: 'For details about the cookies and technologies we use, see our ',
     textLine4: '.  Using this banner will set a cookie on your device to remember your preferences.',
     cookiePolicyLinkText: 'cookies notice',
-    cookiePolicyLinkUrl: 'https://www.menulog.co.nz/info/cookies-policy'
+    cookiePolicyLinkUrl: 'https://www.menulog.co.nz/info/cookies-policy',
+    legacyBannerText: 'We use cookies to improve your browsing experience. By continuing, you agree to receive cookies on our website.',
+    legacyBannerLinkText: 'Learn more about our cookies policy.',
+    legacyBannerCloseBannerText: 'Close cookie banner'
 };
 
-const displayLegacy = false;
+const displayLegacy = true;
 
 const cookieExclusionList = [
     '_dc_gtm_',


### PR DESCRIPTION
---

Removed the f-button component in the legacy banner due to styling issue with mobile. Also set AU/NZ to use the legacy banner.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]

## Browsers Tested

- [x] Chrome (latest)
