### PR TITLE
f-card@1.1.0 - Adding the cardHeadingTag prop.

### DIFF
--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -4,14 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (add to next release)
+v1.1.0
 ------------------------------
-*February 25, 2021*
+*March 17, 2021*
+
+### Added
+- Added a `prop` to allow the customisation of the heading level.
 
 ### Changed
 - Restructured component object into page object model
 - Refactored accessibility tests
-
 
 v1.0.0
 ------------------------------

--- a/packages/components/atoms/f-card/README.md
+++ b/packages/components/atoms/f-card/README.md
@@ -68,6 +68,7 @@ The props that can be defined are as follows:
 | :---                      | :---:      | :---:      | :---:   | :---        |
 | `cardHeadingPosition`     | `String`   |  No        | `left`  | Sets the text alignment of the card component's heading.<br><br>When set to `left` the heading will aligned to the left.<br>When set to `center` the heading will be centrally aligned.<br>When set to `right` the heading will be aligned to the right. |
 | `cardHeading`             | `String`   |  No        | `''`    | When set, will add a heading to the top of the card component. |
+| `cardHeadingTag`          | `String`   |  No        | `'h1'`  | Sets the tag for the card component's heading.<br><br>Allowed values are `h1`, `h2`, `h3`, `h4`, `h5` and `h6` |
 | `hasOutline`              | `Boolean`  |  No        | `false` | When set to `true`, an outline is applied to the card component.  |
 | `isPageContentWrapper`    | `Boolean`  |  No        | `false` | When set to `true`, applies styles to make the card act like a page content wrapper.<br><br>The card will be full width on narrow devices, and then a fixed width above a certain breakpoint width (about 480px), when the card will be centred on the page. |
 | `isRounded`               | `Boolean`  |  No        | `false` | When set to `true`, rounded corners are applied to the card component. |

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card",
   "description": "Fozzie Card Component – Used for providing wrapper card styling to an element (or group of elements)",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/f-card.umd.min.js",
   "files": [
     "dist"
@@ -31,7 +31,7 @@
     "lint:fix": "yarn lint --fix",
     "lint:style": "vue-cli-service lint:style",
     "test": "vue-cli-service test:unit",
-    "test-a11y:chrome": "cross-env-shell JE_ENV=local wdio ../../../../wdio-chrome.conf.js --suite a11y", 
+    "test-a11y:chrome": "cross-env-shell JE_ENV=local wdio ../../../../wdio-chrome.conf.js --suite a11y",
     "test-component:chrome": "wdio ../../../../wdio-chrome.conf.js --suite component"
   },
   "browserslist": [

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -6,8 +6,10 @@
             (isRounded ? $style['c-card--rounded'] : ''),
             (hasOutline ? $style['c-card--outline'] : ''),
             (isPageContentWrapper ? $style['c-card--pageContentWrapper'] : '')
-        ]">
-        <h1
+        ]"
+    >
+        <component
+            :is="cardHeadingTag"
             v-if="cardHeading"
             :class="[
                 $style['c-card-heading'],
@@ -16,7 +18,7 @@
             data-test-id="card-heading"
         >
             {{ cardHeading }}
-        </h1>
+        </component>
         <slot />
     </div>
 </template>
@@ -34,6 +36,11 @@ export default {
             type: String,
             default: 'left',
             validator: value => ['left', 'right', 'center'].indexOf(value) !== -1
+        },
+        cardHeadingTag: {
+            type: String,
+            default: 'h1',
+            validator: value => ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].indexOf(value) !== -1
         },
         hasOutline: {
             type: Boolean,

--- a/packages/components/atoms/f-card/src/components/_tests/Card.test.js
+++ b/packages/components/atoms/f-card/src/components/_tests/Card.test.js
@@ -41,9 +41,7 @@ describe('Card', () => {
             expect(cardTitleElement.text()).toBe(propsData.cardHeading);
         });
 
-        it.each(
-            ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
-        )('should set the tag to be %s, as passed in the `cardHeading` prop', (headingTag) => {
+        it.each(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])('should set the tag to be %s, as passed in the `cardHeading` prop', headingTag => {
             // Arrange
             const propsData = {
                 cardHeading: 'Test card title',

--- a/packages/components/atoms/f-card/src/components/_tests/Card.test.js
+++ b/packages/components/atoms/f-card/src/components/_tests/Card.test.js
@@ -40,6 +40,23 @@ describe('Card', () => {
             // Assert
             expect(cardTitleElement.text()).toBe(propsData.cardHeading);
         });
+
+        it.each(
+            ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+        )('should set the tag to be %s, as passed in the `cardHeading` prop', (headingTag) => {
+            // Arrange
+            const propsData = {
+                cardHeading: 'Test card title',
+                cardHeadingTag: headingTag
+            };
+
+            // Act
+            const wrapper = shallowMount(Card, { propsData });
+            const cardTitle = wrapper.find('[data-test-id="card-heading"]');
+
+            // Assert
+            expect(cardTitle.element.tagName.toLowerCase()).toBe(headingTag);
+        });
     });
 
     describe('props', () => {
@@ -160,6 +177,39 @@ describe('Card', () => {
                 expect(position.validator('left')).toBeTruthy();
                 expect(position.validator('right')).toBeTruthy();
                 expect(position.validator('center')).toBeTruthy();
+            });
+        });
+
+
+        describe('cardHeadingTag', () => {
+            it('should default to `h1` if it is not set', () => {
+                // Arrange
+                const propsData = {};
+
+                // Act
+                const wrapper = shallowMount(Card, { propsData });
+
+                // Assert
+                expect(wrapper.vm.cardHeadingTag).toBe('h1');
+            });
+
+            it('should only allow `h1`, `h2`, `h3`, `h4`, `h5` or `h6` to be passed in', () => {
+                // Arrange
+                const propsData = {};
+
+                // Act
+                const wrapper = shallowMount(Card, { propsData });
+
+                const heading = wrapper.vm.$options.props.cardHeadingTag;
+
+                // Assert
+                expect(heading.validator('h100')).toBeFalsy();
+                expect(heading.validator('h1')).toBeTruthy();
+                expect(heading.validator('h2')).toBeTruthy();
+                expect(heading.validator('h3')).toBeTruthy();
+                expect(heading.validator('h4')).toBeTruthy();
+                expect(heading.validator('h5')).toBeTruthy();
+                expect(heading.validator('h6')).toBeTruthy();
             });
         });
     });

--- a/packages/components/atoms/f-card/stories/card.stories.js
+++ b/packages/components/atoms/f-card/stories/card.stories.js
@@ -19,12 +19,13 @@ export const CardComponent = (args, { argTypes }) => ({
     components: { Card },
     props: Object.keys(argTypes),
     template:
-        '<card :cardHeading="cardHeading" :cardHeadingPosition="cardHeadingPosition" :isRounded="isRounded" :hasOutline="hasOutline" :isPageContentWrapper="isPageContentWrapper"><p>Some Card Content</p></card>'
+        '<card :cardHeading="cardHeading" :cardHeadingPosition="cardHeadingPosition" :cardHeadingTag="cardHeadingTag" :isRounded="isRounded" :hasOutline="hasOutline" :isPageContentWrapper="isPageContentWrapper"><p>Some Card Content</p></card>'
 });
 
 CardComponent.args = {
     cardHeading: 'My Card Heading',
     cardHeadingPosition: 'left',
+    cardHeadingTag: 'h1',
     isRounded: false,
     hasOutline: false,
     isPageContentWrapper: false
@@ -33,6 +34,9 @@ CardComponent.args = {
 CardComponent.argTypes = {
     cardHeadingPosition: {
         control: { type: 'select', options: ['left', 'center', 'right'] }
+    },
+    cardHeadingTag: {
+        control: { type: 'select', options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] }
     }
 };
 


### PR DESCRIPTION
v1.1.0
------------------------------
*March 17, 2021*

### Added
- Added a `prop` to allow the customisation of the heading level.

### Changed
- Restructured component object into page object model
- Refactored accessibility tests