### PR TITLE
f-braze-adapter@v3.1.0 🍽 Stampcard refinements for rest. card

### DIFF
--- a/packages/services/f-braze-adapter/CHANGELOG.md
+++ b/packages/services/f-braze-adapter/CHANGELOG.md
@@ -3,14 +3,27 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v3.1.0
+------------------------------
+*March 17, 2021*
+
+### Changed
+- If present, `isReadyToClaim` now transformed to a `Boolean`
+- If present, `displayTimesJson` now takes effect independent of `brand` being present.
+
+
 v3.0.0
 ------------------------------
+*February 22, 2021*
 
 ### Added
 - Properties for stamp-cards card
 
 ### Changed
 - Renamed package f-braze-adapter from f-metadata
+
+*December 4, 2020*
 
 ### Fixed
 - Removed optional chaining to fix storybook

--- a/packages/services/f-braze-adapter/package.json
+++ b/packages/services/f-braze-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-braze-adapter",
   "description": "Fozzie Metadata Service",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "src/index.js",
   "files": [
     "src"

--- a/packages/services/f-braze-adapter/src/BrazeDispatcher.js
+++ b/packages/services/f-braze-adapter/src/BrazeDispatcher.js
@@ -188,7 +188,7 @@ class BrazeDispatcher {
         }
 
         if (disableComponent || !apiKey || !userId) {
-            this.appboyPromise = Promise.resolve();
+            this.appboyPromise = Promise.reject(new Error('Not initialising braze due to config'));
             return this.appboyPromise;
         }
 

--- a/packages/services/f-braze-adapter/src/services/utils/_tests/isCardCurrentlyActive.test.js
+++ b/packages/services/f-braze-adapter/src/services/utils/_tests/isCardCurrentlyActive.test.js
@@ -6,22 +6,21 @@ const brand = '__BRAND__';
 const brands = [brand];
 
 const card = {
-    brand,
     displayTimes: {}
 };
 
 describe('services › utils › transformCardData', () => {
-    it('should return true if card does not contain brand', () => {
+    it('should return true if card contains neither brand nor display times', () => {
         // Arrange & Act
-        const result = isCardCurrentlyActive({ displayTimes: {} });
+        const result = isCardCurrentlyActive({});
 
         // Assert
         expect(result).toBe(true);
     });
 
-    it('should return true if card does not contain display times', () => {
+    it('should return true if card does not contain brand', () => {
         // Arrange & Act
-        const result = isCardCurrentlyActive({ brand });
+        const result = isCardCurrentlyActive(card);
 
         // Assert
         expect(result).toBe(true);
@@ -29,7 +28,7 @@ describe('services › utils › transformCardData', () => {
 
     it('should return false if card brand is not in users brand list', () => {
         // Arrange & Act
-        const result = isCardCurrentlyActive(card);
+        const result = isCardCurrentlyActive({ ...card, brand }, []);
 
         // Assert
         expect(result).toBe(false);
@@ -37,15 +36,15 @@ describe('services › utils › transformCardData', () => {
 
     it('should return true if card brand is in users brand list', () => {
         // Arrange & Act
-        const result = isCardCurrentlyActive(card, brands);
+        const result = isCardCurrentlyActive({ ...card, brand }, brands);
 
         // Assert
         expect(result).toBe(true);
     });
 
-    it('should return true if no display times are provided', () => {
+    it('should return true if card does not contain display times', () => {
         // Arrange & Act
-        const result = isCardCurrentlyActive(card, brands);
+        const result = isCardCurrentlyActive({ brand }, brands);
 
         // Assert
         expect(result).toBe(true);
@@ -65,7 +64,7 @@ describe('services › utils › transformCardData', () => {
         };
 
         // Act
-        const result = isCardCurrentlyActive({ ...card, displayTimes }, brands);
+        const result = isCardCurrentlyActive({ displayTimes });
 
         // Assert
         expect(result).toBe(true);
@@ -85,7 +84,7 @@ describe('services › utils › transformCardData', () => {
         };
 
         // Act
-        const result = isCardCurrentlyActive({ ...card, displayTimes }, brands);
+        const result = isCardCurrentlyActive({ displayTimes });
 
         // Assert
         expect(result).toBe(true);
@@ -111,7 +110,7 @@ describe('services › utils › transformCardData', () => {
         };
 
         // Act
-        const result = isCardCurrentlyActive({ ...card, displayTimes }, brands);
+        const result = isCardCurrentlyActive({ displayTimes });
 
         // Assert
         expect(result).toBe(false);

--- a/packages/services/f-braze-adapter/src/services/utils/_tests/transformCardData.test.js
+++ b/packages/services/f-braze-adapter/src/services/utils/_tests/transformCardData.test.js
@@ -75,7 +75,7 @@ const reformattedCard = {
     icon,
     ctaText: button,
     image,
-    isReadyToClaim,
+    isReadyToClaim: false, // because `'__IS_READY_TO_CLAIM__'` is not `true` or `'true'`
     title,
     totalRequiredStamps,
     subtitle: description,

--- a/packages/services/f-braze-adapter/src/services/utils/isCardCurrentlyActive.js
+++ b/packages/services/f-braze-adapter/src/services/utils/isCardCurrentlyActive.js
@@ -3,19 +3,11 @@ import {
 } from 'date-fns';
 
 /**
- * Determines whether a card is currently active using display times JSON
- * Can be used in isolation or as part of Array.filter
- * @param card {object}
- * @param card.displayTimes {object} - Display times
- * @param brands {string[]} - String of current brands
- * @returns {boolean} - is card active
+ * Determines whether the current time is within the display times JSON
+ * @param displayTimes
+ * @return {boolean|boolean}
  */
-const isCardCurrentlyActive = (card = {}, brands = []) => {
-    const { displayTimes, brand } = card;
-
-    if (!displayTimes || !brand) return true;
-    if (!brands.includes(brand)) return false;
-
+function isCardActiveBasedOnTime (displayTimes) {
     const now = new Date();
     const currentDay = format(now, 'E');
     const times = displayTimes[currentDay] || displayTimes.Any || [];
@@ -30,6 +22,21 @@ const isCardCurrentlyActive = (card = {}, brands = []) => {
 
             return isAfter(now, startTime) && isBefore(now, endTime);
         });
+}
+
+/**
+ * Can be used in isolation or as part of Array.filter
+ * @param card {object}
+ * @param card.displayTimes {object} - Display times
+ * @param card.brand {string} - Identifier string for relevant brand
+ * @param brands {string[]} - String of current brands
+ * @returns {boolean} - is card active
+ */
+const isCardCurrentlyActive = (card = {}, brands = []) => {
+    const { displayTimes, brand } = card;
+
+    return (!brand || brands.includes(brand))
+        && (!displayTimes || isCardActiveBasedOnTime(displayTimes));
 };
 
 export default isCardCurrentlyActive;

--- a/packages/services/f-braze-adapter/src/services/utils/transformCardData.js
+++ b/packages/services/f-braze-adapter/src/services/utils/transformCardData.js
@@ -44,7 +44,6 @@ const transformCardData = card => {
         expiry_date: expiryDate,
         expiry_line: expiryLine,
         footer,
-        is_ready_to_claim: isReadyToClaim,
         restaurant_logo_url: restaurantLogoUrl,
         icon_1: icon = restaurantLogoUrl,
         restaurant_image_url: restaurantImageUrl,
@@ -61,7 +60,9 @@ const transformCardData = card => {
         display_times_json: displayTimesJson
     } = (extras || {});
 
-    const description = Object.keys(extras)
+    const extrasMembers = Object.keys(extras);
+
+    const description = extrasMembers
         .filter(key => key.indexOf('line_') !== -1)
         .map(key => extras[key]);
 
@@ -75,6 +76,10 @@ const transformCardData = card => {
 
     const extractedCardId = extractCardId(id);
     const target = getCardUrlTarget(url);
+
+    const isReadyToClaim = extrasMembers.includes('is_ready_to_claim')
+        ? ['true', true].includes(extras.is_ready_to_claim)
+        : undefined;
 
     return {
         backgroundColor,

--- a/packages/services/f-braze-adapter/src/tests/BrazeDispatcher.test.js
+++ b/packages/services/f-braze-adapter/src/tests/BrazeDispatcher.test.js
@@ -127,7 +127,7 @@ describe('instantiation', () => {
                 };
 
                 // Act
-                await brazeDispatcher.configure(options);
+                expect(brazeDispatcher.configure(options)).rejects.toEqual(new Error('Not initialising braze due to config'));
 
                 // Assert
                 expect(appboy.subscribeToInAppMessage).not.toHaveBeenCalled();


### PR DESCRIPTION
Non-presentational change only to fix content-card handling.

### Changed
- If present, `isReadyToClaim` now transformed to a `Boolean`
- If present, `displayTimesJson` now takes effect independent of `brand` being present.
- When initialising braze via `configure()` - if no apiKey or userId is present, the resulting promise is rejected
