### PR TITLE
f-checkout@v0.73.0 - Add token checkout refresh specific changes.

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,23 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.72.0
+------------------------------
+*March 18, 2021*
+
+### Changed
+- `Checkout.vue` watcher `authToken` to only initialise checkout when the token updates as below:
+  - Truthy > Falsey
+  - Falsey > Truthy
+  - Truthy > Truthy (Checkout will not reload)
+
+### Added
+- Tests to cover authToken watcher changes.
+
+### Removed
+- Some tests that are not required as they're now covered in these new changes.
+
+
 v0.71.0
 ------------------------------
 *March 16, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -315,11 +315,11 @@ export default {
          *
          * */
         async authToken (newTokenVal, oldTokenVal) {
+            this.setAuthToken(this.authToken);
+
             if ((!newTokenVal && oldTokenVal) || (!oldTokenVal && newTokenVal)) {
                 await this.initialise();
             }
-
-            this.setAuthToken(this.authToken);
         }
     },
 

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -304,8 +304,19 @@ export default {
     },
 
     watch: {
-        async authToken () {
-            await this.initialise();
+        /**
+         * Only reload checkout if the token changes as below:
+         * Truthy > Falsey
+         * Falsey > Truthy
+         *
+         * Do not reload checkout if the token changes from one token to another token
+         * as it will always be valid.
+         * */
+        async authToken (newTokenVal, oldTokenVal) {
+            if (!newTokenVal || (!oldTokenVal && newTokenVal)) {
+                await this.initialise();
+                this.setAuthToken(this.authToken);
+            }
         }
     },
 
@@ -342,7 +353,6 @@ export default {
          */
         async initialise () {
             this.isLoading = true;
-            this.setAuthToken(this.authToken);
 
             this.startSpinnerCountdown();
 

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -305,18 +305,21 @@ export default {
 
     watch: {
         /**
+         *
          * Only reload checkout if the token changes as below:
          * Truthy > Falsey
          * Falsey > Truthy
          *
          * Do not reload checkout if the token changes from one token to another token
          * as it will always be valid.
+         *
          * */
         async authToken (newTokenVal, oldTokenVal) {
-            if (!newTokenVal || (!oldTokenVal && newTokenVal)) {
+            if ((!newTokenVal && oldTokenVal) || (!oldTokenVal && newTokenVal)) {
                 await this.initialise();
-                this.setAuthToken(this.authToken);
             }
+
+            this.setAuthToken(this.authToken);
         }
     },
 

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -259,26 +259,6 @@ describe('Checkout', () => {
         });
     });
 
-    describe('props ::', () => {
-        describe('authToken ::', () => {
-            it('should store auth token', async () => {
-                // Arrange
-                const setAuthToken = jest.fn();
-
-                // Act
-                shallowMount(VueCheckout, {
-                    store: createStore(defaultCheckoutState, { ...defaultCheckoutActions, setAuthToken }),
-                    i18n,
-                    localVue,
-                    propsData
-                });
-
-                // Assert
-                expect(setAuthToken).toHaveBeenCalled();
-            });
-        });
-    });
-
     describe('computed ::', () => {
         describe('isMobileNumberValid ::', () => {
             let wrapper;
@@ -571,26 +551,6 @@ describe('Checkout', () => {
         });
 
         describe('initialise ::', () => {
-            it('should call `setAuthToken`', () => {
-                // Arrange & Act
-                const setAuthTokenSpy = jest.spyOn(VueCheckout.methods, 'setAuthToken');
-
-                const propsDataWithAuthToken = {
-                    ...propsData,
-                    authToken: 'mytoken'
-                };
-
-                shallowMount(VueCheckout, {
-                    store: createStore(),
-                    i18n,
-                    localVue,
-                    propsData: propsDataWithAuthToken
-                });
-
-                // Assert
-                expect(setAuthTokenSpy).toHaveBeenCalledWith(propsDataWithAuthToken.authToken);
-            });
-
             it('should call `loadBasket`', async () => {
                 // Arrange & Act
                 const loadBasketSpy = jest.spyOn(VueCheckout.methods, 'loadBasket');
@@ -2499,28 +2459,102 @@ describe('Checkout', () => {
 
     describe('watch ::', () => {
         describe('authToken ::', () => {
-            afterEach(() => {
-                jest.clearAllMocks();
-            });
+            describe('when invoked', () => {
+                describe('AND the token changes from falsey > truthy', () => {
+                    it('should make a call to `initialise` so we can reload checkout when the authToken updates', async () => {
+                        // Arrange
+                        const wrapper = shallowMount(VueCheckout, {
+                            store: createStore(),
+                            i18n,
+                            localVue,
+                            propsData
+                        });
+                        const initialiseSpy = jest.spyOn(wrapper.vm, 'initialise');
 
-            it('should call `initialise`', async () => {
-                // Arrange
-                const initialiseSpy = jest.spyOn(VueCheckout.methods, 'initialise');
+                        // Act
+                        await wrapper.vm.$options.watch.authToken[0].call(wrapper.vm, '', 'NewToken');
 
-                const wrapper = shallowMount(VueCheckout, {
-                    store: createStore(),
-                    i18n,
-                    localVue,
-                    propsData
+                        // Assert
+                        expect(initialiseSpy).toHaveBeenCalled();
+                    });
+
+                    it('should make a call to `setAuthToken` to set the updated authToken', async () => {
+                        // Arrange
+                        const wrapper = shallowMount(VueCheckout, {
+                            store: createStore(),
+                            i18n,
+                            localVue,
+                            propsData
+                        });
+                        const setAuthTokenSpy = jest.spyOn(wrapper.vm, 'setAuthToken');
+                        wrapper.setProps({ authToken: 'NewToken' });
+
+                        // Act
+                        await wrapper.vm.$options.watch.authToken[0].call(wrapper.vm, '', 'NewToken');
+
+                        // Assert
+                        expect(setAuthTokenSpy).toHaveBeenCalledWith('NewToken');
+                    });
                 });
 
-                jest.clearAllMocks(); // Reset the mock calls given the initialise function gets called upon mount.
+                describe('AND the token changes from truthy > falsey', () => {
+                    it('should make a call to `initialise` so we can reload checkout when the authToken updates', async () => {
+                        // Arrange
+                        const wrapper = shallowMount(VueCheckout, {
+                            store: createStore(),
+                            i18n,
+                            localVue,
+                            propsData
+                        });
 
-                // Act
-                await wrapper.vm.$options.watch.authToken[0].call(wrapper.vm);
+                        const initialiseSpy = jest.spyOn(wrapper.vm, 'initialise');
 
-                // Assert
-                expect(initialiseSpy).toHaveBeenCalled();
+                        // Act
+                        await wrapper.vm.$options.watch.authToken[0].call(wrapper.vm, 'NewToken', '');
+
+                        // Assert
+                        expect(initialiseSpy).toHaveBeenCalled();
+                    });
+
+                    it('should make a call to `setAuthToken` to set the updated authToken', async () => {
+                        // Arrange
+                        const wrapper = shallowMount(VueCheckout, {
+                            store: createStore(),
+                            i18n,
+                            localVue,
+                            propsData
+                        });
+                        const setAuthTokenSpy = jest.spyOn(wrapper.vm, 'setAuthToken');
+
+                        // Act
+                        await wrapper.vm.$options.watch.authToken[0].call(wrapper.vm, 'NewToken', '');
+
+                        // Assert
+                        expect(setAuthTokenSpy).toHaveBeenCalledWith('');
+                    });
+                });
+
+                describe('AND the token changes / refreshes from truthy > truthy', () => {
+                    it('should NOT make a call to `initialise` to avoid a checkout refresh', async () => {
+                        // Arrange
+                        const wrapper = shallowMount(VueCheckout, {
+                            store: createStore(),
+                            i18n,
+                            localVue,
+                            propsData: {
+                                ...propsData,
+                                authToken: 'kevin'
+                            }
+                        });
+                        const initialiseSpy = jest.spyOn(wrapper.vm, 'initialise');
+
+                        // Act
+                        await wrapper.vm.$options.watch.authToken[0].call(wrapper.vm, 'NewToken', 'OldToken');
+
+                        // Assert
+                        expect(initialiseSpy).not.toHaveBeenCalled();
+                    });
+                });
             });
         });
     });

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -2477,24 +2477,6 @@ describe('Checkout', () => {
                         // Assert
                         expect(initialiseSpy).toHaveBeenCalled();
                     });
-
-                    it('should make a call to `setAuthToken` to set the updated authToken', async () => {
-                        // Arrange
-                        const wrapper = shallowMount(VueCheckout, {
-                            store: createStore(),
-                            i18n,
-                            localVue,
-                            propsData
-                        });
-                        const setAuthTokenSpy = jest.spyOn(wrapper.vm, 'setAuthToken');
-                        wrapper.setProps({ authToken: 'NewToken' });
-
-                        // Act
-                        await wrapper.vm.$options.watch.authToken[0].call(wrapper.vm, '', 'NewToken');
-
-                        // Assert
-                        expect(setAuthTokenSpy).toHaveBeenCalledWith('NewToken');
-                    });
                 });
 
                 describe('AND the token changes from truthy > falsey', () => {
@@ -2514,23 +2496,6 @@ describe('Checkout', () => {
 
                         // Assert
                         expect(initialiseSpy).toHaveBeenCalled();
-                    });
-
-                    it('should make a call to `setAuthToken` to set the updated authToken', async () => {
-                        // Arrange
-                        const wrapper = shallowMount(VueCheckout, {
-                            store: createStore(),
-                            i18n,
-                            localVue,
-                            propsData
-                        });
-                        const setAuthTokenSpy = jest.spyOn(wrapper.vm, 'setAuthToken');
-
-                        // Act
-                        await wrapper.vm.$options.watch.authToken[0].call(wrapper.vm, 'NewToken', '');
-
-                        // Assert
-                        expect(setAuthTokenSpy).toHaveBeenCalledWith('');
                     });
                 });
 
@@ -2554,6 +2519,23 @@ describe('Checkout', () => {
                         // Assert
                         expect(initialiseSpy).not.toHaveBeenCalled();
                     });
+                });
+
+                it('should make a call to `setAuthToken` to set the updated authToken', async () => {
+                    // Arrange
+                    const wrapper = shallowMount(VueCheckout, {
+                        store: createStore(),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+                    const setAuthTokenSpy = jest.spyOn(wrapper.vm, 'setAuthToken');
+
+                    // Act
+                    await wrapper.vm.$options.watch.authToken[0].call(wrapper.vm);
+
+                    // Assert
+                    expect(setAuthTokenSpy).toHaveBeenCalledWith(wrapper.vm.authToken);
                 });
             });
         });

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -2460,6 +2460,23 @@ describe('Checkout', () => {
     describe('watch ::', () => {
         describe('authToken ::', () => {
             describe('when invoked', () => {
+                it('should make a call to `setAuthToken` to set the updated authToken', async () => {
+                    // Arrange
+                    const wrapper = shallowMount(VueCheckout, {
+                        store: createStore(),
+                        i18n,
+                        localVue,
+                        propsData
+                    });
+                    const setAuthTokenSpy = jest.spyOn(wrapper.vm, 'setAuthToken');
+
+                    // Act
+                    await wrapper.vm.$options.watch.authToken[0].call(wrapper.vm);
+
+                    // Assert
+                    expect(setAuthTokenSpy).toHaveBeenCalledWith(wrapper.vm.authToken);
+                });
+
                 describe('AND the token changes from falsey > truthy', () => {
                     it('should make a call to `initialise` so we can reload checkout when the authToken updates', async () => {
                         // Arrange
@@ -2519,23 +2536,6 @@ describe('Checkout', () => {
                         // Assert
                         expect(initialiseSpy).not.toHaveBeenCalled();
                     });
-                });
-
-                it('should make a call to `setAuthToken` to set the updated authToken', async () => {
-                    // Arrange
-                    const wrapper = shallowMount(VueCheckout, {
-                        store: createStore(),
-                        i18n,
-                        localVue,
-                        propsData
-                    });
-                    const setAuthTokenSpy = jest.spyOn(wrapper.vm, 'setAuthToken');
-
-                    // Act
-                    await wrapper.vm.$options.watch.authToken[0].call(wrapper.vm);
-
-                    // Assert
-                    expect(setAuthTokenSpy).toHaveBeenCalledWith(wrapper.vm.authToken);
                 });
             });
         });


### PR DESCRIPTION
### Changed
- `Checkout.vue` watcher `authToken` to only initialise checkout when the token updates as below:
  - Truthy > Falsey
  - Falsey > Truthy
  - Truthy > Truthy (Checkout will not reload)

### Added
- Tests to cover authToken watcher changes.

### Removed
- Some tests that are not required as they're now covered in these new changes.

## UI Review Checks

- [x] Unit tests have been [created|updated]


## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
