### PR TITLE
f-registration@0.48.0 Remove default value for 'locale' prop

### DIFF
--- a/packages/components/organisms/f-registration/CHANGELOG.md
+++ b/packages/components/organisms/f-registration/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.48.0
+------------------------------
+*March 18, 2021*
+
+## Removed
+- Remove 'en-GB' as the default value for `props.locale.default`
 
 v0.47.0
 ------------------------------

--- a/packages/components/organisms/f-registration/package.json
+++ b/packages/components/organisms/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-registration/src/components/Registration.vue
+++ b/packages/components/organisms/f-registration/src/components/Registration.vue
@@ -227,7 +227,7 @@ export default {
     props: {
         locale: {
             type: String,
-            default: 'en-GB'
+            default: ''
         },
         createAccountUrl: {
             type: String,

--- a/packages/components/organisms/f-registration/src/components/_tests/Registration.test.js
+++ b/packages/components/organisms/f-registration/src/components/_tests/Registration.test.js
@@ -10,6 +10,7 @@ let wrapper;
 
 describe('Registration', () => {
     const propsData = {
+        locale: "en-GB",
         createAccountUrl: 'http://localhost/account/register',
         showLoginLink: true,
         loginUrl: '/account/register'
@@ -112,20 +113,6 @@ describe('Registration', () => {
 
             // Assert
             expect(wrapper.emitted(EventNames.VisitLoginPage).length).toBe(1);
-        });
-
-        it('should fallback to use the en-GB locale if no locale passed', () => {
-            // Arrange & Act
-            wrapper = shallowMount(Registration, {
-                propsData: {
-                    createAccountUrl: 'http://localhost/account/register',
-                    showLoginLink: true,
-                    loginUrl: '/account/register'
-                }
-            });
-
-            // Assert
-            expect(wrapper.vm.tenant).toBe('uk');
         });
     });
 


### PR DESCRIPTION
## Removed
* Default value for `locale`

## UI Review Checks

- [ ] Unit tests have been [created|updated]

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
