### PR TITLE
f-registration@0.49.0 Add translations for en-AU and en-NZ

### DIFF
--- a/packages/components/organisms/f-registration/CHANGELOG.md
+++ b/packages/components/organisms/f-registration/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.49.0
+------------------------------
+*March 19, 2021*
+
+## Added
+- Add translations for 'en-AU' and 'en-NZ'
+
 v0.48.0
 ------------------------------
 *March 18, 2021*

--- a/packages/components/organisms/f-registration/package.json
+++ b/packages/components/organisms/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-registration/src/tenants/en-AU.js
+++ b/packages/components/organisms/f-registration/src/tenants/en-AU.js
@@ -6,7 +6,7 @@ export default {
             prefix: 'By creating an account you agree to our ',
             suffix: '.',
             text: 'Terms and Conditions',
-            url: '/info/terms-and-conditions'
+            url: '/info/privacy-policy'
         },
         privacyPolicy: {
             prefix: 'Please read our ',
@@ -15,9 +15,9 @@ export default {
         },
         cookiesPolicy: {
             prefix: ' and ',
+            suffix: '.',
             text: 'Cookie Policy',
-            url: '/info/cookies-policy',
-            suffix: '.'
+            url: '/info/privacy-policy'
         },
         login: {
             text: 'Already on Menulog?'

--- a/packages/components/organisms/f-registration/src/tenants/en-AU.js
+++ b/packages/components/organisms/f-registration/src/tenants/en-AU.js
@@ -1,3 +1,61 @@
 export default {
-    locale: 'en-AU'
+    locale: 'en-AU',
+
+    navLinks: {
+        termsAndConditions: {
+            prefix: 'By creating an account you agree to our ',
+            suffix: '.',
+            text: 'Terms and Conditions',
+            url: '/info/terms-and-conditions'
+        },
+        privacyPolicy: {
+            prefix: 'Please read our ',
+            text: 'Privacy Policy',
+            url: '/info/privacy-policy'
+        },
+        cookiesPolicy: {
+            prefix: ' and ',
+            text: 'Cookie Policy',
+            url: '/info/cookies-policy',
+            suffix: '.'
+        },
+        login: {
+            text: 'Already on Menulog?'
+        }
+    },
+
+    labels: {
+        createAccountTitle: 'Create account',
+        createAccountBtn: 'Create account',
+        firstName: 'First name',
+        lastName: 'Last name',
+        email: 'Email',
+        password: 'Password'
+    },
+
+    validationMessages: {
+        firstName: {
+            requiredError: 'Please include your first name',
+            maxLengthError: 'First name exceeds 50 characters',
+            invalidCharError: 'Your name can only contain letters, hyphens or apostrophes'
+        },
+
+        lastName: {
+            requiredError: 'Please include your last name',
+            maxLengthError: 'Last name exceeds 50 characters',
+            invalidCharError: 'Your last name can only contain letters, hyphens or apostrophes'
+        },
+
+        email: {
+            requiredError: 'Please include your email address',
+            maxLengthError: 'Email address exceeds 50 characters',
+            invalidEmailError: 'Please enter your email address correctly',
+            alreadyExistsError: 'Email address is already registered'
+        },
+
+        password: {
+            requiredError: 'Please enter a password',
+            minLengthError: 'Password is less than four characters '
+        }
+    }
 };

--- a/packages/components/organisms/f-registration/src/tenants/en-NZ.js
+++ b/packages/components/organisms/f-registration/src/tenants/en-NZ.js
@@ -6,7 +6,7 @@ export default {
             prefix: 'By creating an account you agree to our ',
             suffix: '.',
             text: 'Terms and Conditions',
-            url: '/info/terms-and-conditions'
+            url: '/info/privacy-policy'
         },
         privacyPolicy: {
             prefix: 'Please read our ',
@@ -15,9 +15,9 @@ export default {
         },
         cookiesPolicy: {
             prefix: ' and ',
+            suffix: '.',
             text: 'Cookie Policy',
-            url: '/info/cookies-policy',
-            suffix: '.'
+            url: '/info/privacy-policy'
         },
         login: {
             text: 'Already on Menulog?'

--- a/packages/components/organisms/f-registration/src/tenants/en-NZ.js
+++ b/packages/components/organisms/f-registration/src/tenants/en-NZ.js
@@ -1,3 +1,61 @@
 export default {
-    locale: 'en-NZ'
+    locale: 'en-NZ',
+
+    navLinks: {
+        termsAndConditions: {
+            prefix: 'By creating an account you agree to our ',
+            suffix: '.',
+            text: 'Terms and Conditions',
+            url: '/info/terms-and-conditions'
+        },
+        privacyPolicy: {
+            prefix: 'Please read our ',
+            text: 'Privacy Policy',
+            url: '/info/privacy-policy'
+        },
+        cookiesPolicy: {
+            prefix: ' and ',
+            text: 'Cookie Policy',
+            url: '/info/cookies-policy',
+            suffix: '.'
+        },
+        login: {
+            text: 'Already on Menulog?'
+        }
+    },
+
+    labels: {
+        createAccountTitle: 'Create account',
+        createAccountBtn: 'Create account',
+        firstName: 'First name',
+        lastName: 'Last name',
+        email: 'Email',
+        password: 'Password'
+    },
+
+    validationMessages: {
+        firstName: {
+            requiredError: 'Please include your first name',
+            maxLengthError: 'First name exceeds 50 characters',
+            invalidCharError: 'Your name can only contain letters, hyphens or apostrophes'
+        },
+
+        lastName: {
+            requiredError: 'Please include your last name',
+            maxLengthError: 'Last name exceeds 50 characters',
+            invalidCharError: 'Your last name can only contain letters, hyphens or apostrophes'
+        },
+
+        email: {
+            requiredError: 'Please include your email address',
+            maxLengthError: 'Email address exceeds 50 characters',
+            invalidEmailError: 'Please enter your email address correctly',
+            alreadyExistsError: 'Email address is already registered'
+        },
+
+        password: {
+            requiredError: 'Please enter a password',
+            minLengthError: 'Password is less than four characters '
+        }
+    }
 };


### PR DESCRIPTION
This PR adds in the f-registration translations for en-AU and en-NZ

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
