### PR TITLE
f-skeleton-loader@0.3.0 Restaurant carousel card

### DIFF
--- a/packages/components/molecules/f-skeleton-loader/CHANGELOG.md
+++ b/packages/components/molecules/f-skeleton-loader/CHANGELOG.md
@@ -11,6 +11,12 @@ v0.3.0
 ### Added
 - Skeleton components to make restaurant carousel card
 
+### Changed
+- Styles to use modules rather than scoped
+
+### Removed
+- Removed isAnimated prop
+
 
 v0.2.0
 ------------------------------

--- a/packages/components/molecules/f-skeleton-loader/CHANGELOG.md
+++ b/packages/components/molecules/f-skeleton-loader/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.3.0
+------------------------------
+*March 19, 2021*
+
+### Added
+- Skeleton components to make restaurant carousel card
+
+
 v0.2.0
 ------------------------------
 *March 19, 2021*

--- a/packages/components/molecules/f-skeleton-loader/package.json
+++ b/packages/components/molecules/f-skeleton-loader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-skeleton-loader",
   "description": "Fozzie Skeleton Loader - Provides a visual indication that another component is loading. ",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/f-skeleton-loader.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-skeleton-loader/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-skeleton-loader/src/assets/scss/common.scss
@@ -9,3 +9,32 @@ $skeleton-loader-heading-height: spacing(x4);
 $skeleton-loader-text-height: spacing(x2);
 $skeleton-loader-bone-background-color: $grey--mid;
 $skeleton-loader-image-height: spacing(x8);
+
+@keyframes loading {
+    100% {
+        transform: translateX(100%);
+    }
+}
+
+.c-text,
+.c-image,
+.c-heading {
+    background-color: $skeleton-loader-bone-background-color;
+    overflow: hidden;
+    position: relative;
+    vertical-align: top;
+
+    &:after {
+        background: linear-gradient(90deg, hsla(0, 0%, 100%, 0), hsla(0, 0%, 100%, 0.3), hsla(0, 0%, 100%, 0));
+        animation: loading 1.5s infinite;
+        content: '';
+        height: 100%;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+        transform: translateX(-100%);
+        z-index: 1;
+    }
+}
+

--- a/packages/components/molecules/f-skeleton-loader/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-skeleton-loader/src/assets/scss/common.scss
@@ -8,3 +8,4 @@ $theme: 'jet' !default;
 $skeleton-loader-heading-height: spacing(x4);
 $skeleton-loader-text-height: spacing(x2);
 $skeleton-loader-bone-background-color: $grey--mid;
+$skeleton-loader-image-height: spacing(x8);

--- a/packages/components/molecules/f-skeleton-loader/src/components/SkeletonLoader.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/SkeletonLoader.vue
@@ -2,13 +2,9 @@
 <template>
     <div
         data-test-id="skeletonLoader"
-        :class="[
-            'c-skeleton-loader',
-            {
-                ['c-skeleton-loader--animated']: isAnimated
-            }
-        ]">
-        <component :is="skeletonType" />
+        :class="$style['c-skeleton-loader']">
+        <component
+            :is="skeletonType" />
     </div>
 </template>
 
@@ -25,46 +21,16 @@ export default {
             validator (value) {
                 return Object.keys(skeletons).includes(value);
             }
-        },
-        isAnimated: {
-            type: Boolean,
-            default: true
         }
     }
 };
 </script>
 
-<style lang="scss" scoped>
-@keyframes loading {
-    100% {
-        transform: translateX(100%);
-    }
-}
+<style lang="scss" module>
+
 .c-skeleton-loader {
     position: relative;
     vertical-align: top;
 }
-.c-skeleton-loader-bone {
-    border-radius: inherit;
-    overflow: hidden;
-    position: relative;
-}
-.c-skeleton-loader--animated .c-skeleton-loader-bone:after {
-    background: linear-gradient(90deg, hsla(0, 0%, 100%, 0), hsla(0, 0%, 100%, 0.3), hsla(0, 0%, 100%, 0));
-    animation: loading 1.5s infinite;
-    content: '';
-    height: 100%;
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    transform: translateX(-100%);
-    z-index: 1;
-  }
-// Use /deep/ to ensure scoped class cascades to children within children
-/deep/ .c-skeleton-loader-heading,
-/deep/ .c-skeleton-loader-text,
-/deep/ .c-skeleton-loader-image {
-    background-color: $skeleton-loader-bone-background-color;
-}
+
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/SkeletonLoader.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/SkeletonLoader.vue
@@ -63,7 +63,8 @@ export default {
   }
 // Use /deep/ to ensure scoped class cascades to children within children
 /deep/ .c-skeleton-loader-heading,
-/deep/ .c-skeleton-loader-text {
+/deep/ .c-skeleton-loader-text,
+/deep/ .c-skeleton-loader-image {
     background-color: $skeleton-loader-bone-background-color;
 }
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardBackground.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardBackground.vue
@@ -8,7 +8,6 @@
 import ImageBlock from './Image.vue';
 
 export default {
-    name: 'CarouselCardBackground',
     components: { ImageBlock }
 };
 </script>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardBackground.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardBackground.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="c-skeleton-loader-carouselCardBackground c-skeleton-loader-bone">
-        <image-block />
+    <div>
+        <image-block :class="$style['c-carouselCardBackground-image']" />
     </div>
 </template>
 
@@ -12,8 +12,10 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
-.c-skeleton-loader-bone {
+<style lang="scss" module>
+
+.c-carouselCardBackground-image {
     height: 200px;
 }
+
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardBackground.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardBackground.vue
@@ -1,0 +1,20 @@
+<template>
+    <div class="c-skeleton-loader-carouselCardBackground c-skeleton-loader-bone">
+        <image-block />
+    </div>
+</template>
+
+<script>
+import ImageBlock from './Image.vue';
+
+export default {
+    name: 'CarouselCardBackground',
+    components: { ImageBlock }
+};
+</script>
+
+<style lang="scss" scoped>
+.c-skeleton-loader-bone {
+    height: 200px;
+}
+</style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantData.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantData.vue
@@ -1,0 +1,39 @@
+<template>
+    <div class="c-skeleton-loader-restaurantData c-skeleton-loader-bone">
+        <sentence />
+        <rating />
+    </div>
+</template>
+
+<script>
+import Sentence from './Sentence.vue';
+import Rating from './Rating.vue';
+
+export default {
+    name: 'CarouselCardRestaurantData',
+    components: { Sentence, Rating }
+};
+</script>
+
+<style lang="scss" scoped>
+.c-skeleton-loader-restaurantData {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    width: 96%;
+    margin: auto;
+    padding: spacing();
+
+    .c-skeleton-loader-sentence {
+        width: 25%;
+    }
+    /deep/ .c-skeleton-loader-sentence .c-skeleton-loader-text {
+        width: 70%;
+        height: spacing(x1.8);
+    }
+    /deep/ .c-skeleton-loader-sentence .c-skeleton-loader-text:nth-child(2) {
+        margin-bottom: 0;
+    }
+}
+</style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantData.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantData.vue
@@ -1,21 +1,25 @@
 <template>
-    <div class="c-skeleton-loader-restaurantData c-skeleton-loader-bone">
-        <sentence />
+    <div :class="$style['c-restaurantData']">
+        <div :class="$style['c-restaurantData-textWrapper']">
+            <text-block :class="[$style['c-restaurantData-text']]" />
+            <text-block :class="[$style['c-restaurantData-text']]" />
+        </div>
         <rating />
     </div>
 </template>
 
 <script>
-import Sentence from './Sentence.vue';
+import TextBlock from './Text.vue';
 import Rating from './Rating.vue';
 
 export default {
-    components: { Sentence, Rating }
+    components: { TextBlock, Rating }
 };
 </script>
 
-<style lang="scss" scoped>
-.c-skeleton-loader-restaurantData {
+<style lang="scss" module>
+
+.c-restaurantData {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
@@ -23,16 +27,15 @@ export default {
     width: 96%;
     margin: auto;
     padding: spacing();
-
-    .c-skeleton-loader-sentence {
-        width: 25%;
-    }
-    /deep/ .c-skeleton-loader-text {
-        width: 70%;
-        height: spacing(x1.8);
-    }
-    /deep/ .c-skeleton-loader-text:nth-child(2) {
-        margin-bottom: 0;
-    }
 }
+
+.c-restaurantData-textWrapper {
+    flex: 1;
+}
+
+.c-restaurantData-text {
+    width: 25%;
+    height: spacing(x1.5);
+}
+
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantData.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantData.vue
@@ -10,7 +10,6 @@ import Sentence from './Sentence.vue';
 import Rating from './Rating.vue';
 
 export default {
-    name: 'CarouselCardRestaurantData',
     components: { Sentence, Rating }
 };
 </script>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantData.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantData.vue
@@ -27,11 +27,11 @@ export default {
     .c-skeleton-loader-sentence {
         width: 25%;
     }
-    /deep/ .c-skeleton-loader-sentence .c-skeleton-loader-text {
+    /deep/ .c-skeleton-loader-text {
         width: 70%;
         height: spacing(x1.8);
     }
-    /deep/ .c-skeleton-loader-sentence .c-skeleton-loader-text:nth-child(2) {
+    /deep/ .c-skeleton-loader-text:nth-child(2) {
         margin-bottom: 0;
     }
 }

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantHeader.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantHeader.vue
@@ -1,9 +1,9 @@
 <template>
-    <div class="c-skeleton-loader-carouselCardRestaurantHeader c-skeleton-loader-bone">
-        <image-block />
-        <heading />
-        <text-block />
-        <text-block />
+    <div :class="$style['c-carouselCardRestaurantHeader']">
+        <image-block :class="$style['c-carouselCardRestaurantHeader-logo']" />
+        <heading :class="$style['c-carouselCardRestaurantHeader-heading']" />
+        <text-block :class="[$style['c-text']]" />
+        <text-block :class="[$style['c-text']]" />
     </div>
 </template>
 
@@ -17,19 +17,20 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss" module>
 
 $restaurant-logo-width: 48px;
 
-.c-skeleton-loader-carouselCardRestaurantHeader {
+.c-carouselCardRestaurantHeader {
     text-align: center;
     background-color: #fff;
     margin: auto;
     width: 96%;
     padding-bottom: spacing(x2);
+    position: relative;
 }
 
-.c-skeleton-loader-image {
+.c-carouselCardRestaurantHeader-logo {
     margin: auto;
     width: $restaurant-logo-width;
     height: $restaurant-logo-width;
@@ -37,21 +38,21 @@ $restaurant-logo-width: 48px;
     transform: translateY(-50%);
 }
 
-.c-skeleton-loader-heading {
+.c-carouselCardRestaurantHeader-heading {
     height: spacing(x3);
     margin: 0 auto spacing();
 }
 
-.c-skeleton-loader-text {
+.c-text {
     max-width: 40%;
     margin: auto;
 }
 
-.c-skeleton-loader-text:nth-child(3) {
+.c-text:nth-child(3) {
     max-width: 35%;
 }
 
-.c-skeleton-loader-text:not(:last-child) {
+.c-text:not(:last-child) {
     margin-bottom: spacing();
 }
 

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantHeader.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantHeader.vue
@@ -13,12 +13,12 @@ import TextBlock from './Text.vue';
 import Heading from './Heading.vue';
 
 export default {
-    name: 'CarouselCardRestaurantHeader',
     components: { ImageBlock, Heading, TextBlock }
 };
 </script>
 
 <style lang="scss" scoped>
+
 $restaurant-logo-width: 48px;
 
 .c-skeleton-loader-carouselCardRestaurantHeader {
@@ -28,6 +28,7 @@ $restaurant-logo-width: 48px;
     width: 96%;
     padding-bottom: spacing(x2);
 }
+
 .c-skeleton-loader-image {
     margin: auto;
     width: $restaurant-logo-width;
@@ -35,19 +36,24 @@ $restaurant-logo-width: 48px;
     border: 1px solid white;
     transform: translateY(-50%);
 }
+
 .c-skeleton-loader-heading {
     margin: auto;
     height: spacing(x3);
     margin-bottom: spacing();
 }
+
 .c-skeleton-loader-text {
     max-width: 40%;
     margin: auto;
 }
+
 .c-skeleton-loader-text:nth-child(3) {
     max-width: 35%;
 }
+
 .c-skeleton-loader-text:not(:last-child) {
     margin-bottom: spacing();
 }
+
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantHeader.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantHeader.vue
@@ -38,9 +38,8 @@ $restaurant-logo-width: 48px;
 }
 
 .c-skeleton-loader-heading {
-    margin: auto;
     height: spacing(x3);
-    margin-bottom: spacing();
+    margin: 0 auto spacing();
 }
 
 .c-skeleton-loader-text {

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantHeader.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/CarouselCardRestaurantHeader.vue
@@ -1,0 +1,53 @@
+<template>
+    <div class="c-skeleton-loader-carouselCardRestaurantHeader c-skeleton-loader-bone">
+        <image-block />
+        <heading />
+        <text-block />
+        <text-block />
+    </div>
+</template>
+
+<script>
+import ImageBlock from './Image.vue';
+import TextBlock from './Text.vue';
+import Heading from './Heading.vue';
+
+export default {
+    name: 'CarouselCardRestaurantHeader',
+    components: { ImageBlock, Heading, TextBlock }
+};
+</script>
+
+<style lang="scss" scoped>
+$restaurant-logo-width: 48px;
+
+.c-skeleton-loader-carouselCardRestaurantHeader {
+    text-align: center;
+    background-color: #fff;
+    margin: auto;
+    width: 96%;
+    padding-bottom: spacing(x2);
+}
+.c-skeleton-loader-image {
+    margin: auto;
+    width: $restaurant-logo-width;
+    height: $restaurant-logo-width;
+    border: 1px solid white;
+    transform: translateY(-50%);
+}
+.c-skeleton-loader-heading {
+    margin: auto;
+    height: spacing(x3);
+    margin-bottom: spacing();
+}
+.c-skeleton-loader-text {
+    max-width: 40%;
+    margin: auto;
+}
+.c-skeleton-loader-text:nth-child(3) {
+    max-width: 35%;
+}
+.c-skeleton-loader-text:not(:last-child) {
+    margin-bottom: spacing();
+}
+</style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Heading.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Heading.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="c-skeleton-loader-heading c-skeleton-loader-bone" />
+        :class="$style['c-heading']" />
 </template>
 
 <script>
@@ -9,9 +9,11 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
-.c-skeleton-loader-heading {
+<style lang="scss" module>
+
+.c-heading {
     height: $skeleton-loader-heading-height;
     width: 65%;
 }
+
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Image.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Image.vue
@@ -1,0 +1,15 @@
+<template>
+    <div class="c-skeleton-loader-image c-skeleton-loader-bone" />
+</template>
+
+<script>
+export default {
+    name: 'ImageBlock'
+};
+</script>
+
+<style lang="scss" scoped>
+.c-skeleton-loader-image {
+    height: $skeleton-loader-image-height;
+}
+</style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Image.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Image.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="c-skeleton-loader-image c-skeleton-loader-bone" />
+    <div :class="$style['c-image']" />
 </template>
 
 <script>
@@ -8,8 +8,10 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
-.c-skeleton-loader-image {
+<style lang="scss" module>
+
+.c-image {
     height: $skeleton-loader-image-height;
 }
+
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Rating.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Rating.vue
@@ -10,8 +10,10 @@ export default {};
 </script>
 
 <style lang="scss" scoped>
+
 .c-skeleton-loader-rating {
      color: $skeleton-loader-bone-background-color;
      font-size: spacing(x2);
 }
+
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Rating.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Rating.vue
@@ -6,9 +6,7 @@
 </template>
 
 <script>
-export default {
-    name: 'Rating'
-};
+export default {};
 </script>
 
 <style lang="scss" scoped>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Rating.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Rating.vue
@@ -12,10 +12,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-
 .c-skeleton-loader-rating {
-     color:  $skeleton-loader-bone-background-color;
+     color: $skeleton-loader-bone-background-color;
      font-size: spacing(x2);
 }
-
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Rating.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Rating.vue
@@ -1,0 +1,21 @@
+<template>
+    <div
+        class="c-skeleton-loader-rating c-skeleton-loader-bone">
+        ★★★★★★
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'Rating'
+};
+</script>
+
+<style lang="scss" scoped>
+
+.c-skeleton-loader-rating {
+     color:  $skeleton-loader-bone-background-color;
+     font-size: spacing(x2);
+}
+
+</style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Rating.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Rating.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="c-skeleton-loader-rating c-skeleton-loader-bone">
+        :class="$style['c-rating']">
         ★★★★★★
     </div>
 </template>
@@ -9,9 +9,9 @@
 export default {};
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss" module>
 
-.c-skeleton-loader-rating {
+.c-rating {
      color: $skeleton-loader-bone-background-color;
      font-size: spacing(x2);
 }

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCarouselCard.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCarouselCard.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="c-skeleton-loader-restaurantCarouselCard c-skeleton-loader-bone">
-        <carousel-card-background />
-        <carousel-card-restaurant-header />
-        <carousel-card-restaurant-data />
+    <div :class="$style['c-restaurantCarouselCard']">
+        <carousel-card-background :class="$style['c-restaurantCarouselCard-background']" />
+        <carousel-card-restaurant-header :class="$style['c-restaurantCarouselCard-header']" />
+        <carousel-card-restaurant-data :class="$style['c-restaurantCarouselCard-data']" />
     </div>
 </template>
 
@@ -18,26 +18,27 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss" module>
 
-.c-skeleton-loader-restaurantCarouselCard {
+.c-restaurantCarouselCard {
     max-width: 400px;
     text-align: center;
     margin: auto;
-
-    .c-skeleton-loader-carouselCardBackground {
-        margin-bottom: -(spacing(x8));
-    }
-
-    .c-skeleton-loader-carouselCardRestaurantHeader,
-    .c-skeleton-loader-restaurantData {
-        border: 1px solid $skeleton-loader-bone-background-color;
-        border-top: 0;
-    }
-
-    .c-skeleton-loader-carouselCardRestaurantHeader {
-        border-bottom: 0;
-    }
 }
+
+.c-restaurantCarouselCard-background {
+    margin-bottom: -(spacing(x8));
+}
+
+.c-restaurantCarouselCard-header,
+.c-restaurantCarouselCard-data {
+    border: 1px solid $skeleton-loader-bone-background-color;
+    border-top: 0;
+}
+
+.c-restaurantCarouselCard-header {
+    border-bottom: 0;
+}
+
 
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCarouselCard.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCarouselCard.vue
@@ -1,0 +1,45 @@
+<template>
+    <div class="c-skeleton-loader-favouriteCarouselCard c-skeleton-loader-bone">
+        <carousel-card-background />
+        <carousel-card-restaurant-header />
+        <carousel-card-restaurant-data />
+    </div>
+</template>
+
+<script>
+import CarouselCardBackground from './CarouselCardBackground.vue';
+import CarouselCardRestaurantData from './CarouselCardRestaurantData.vue';
+import CarouselCardRestaurantHeader from './CarouselCardRestaurantHeader.vue';
+
+export default {
+    name: 'RestaurantCarouselCard',
+    components: {
+        CarouselCardBackground, CarouselCardRestaurantData, CarouselCardRestaurantHeader
+    }
+};
+</script>
+
+<style lang="scss" scoped>
+.c-skeleton-loader-favouriteCarouselCard {
+    max-width: 400px;
+    text-align: center;
+    margin: auto;
+
+    .c-skeleton-loader-carouselCardBackground {
+        margin-bottom: -(spacing(x8));
+    }
+    .c-skeleton-loader-carouselCardRestaurantHeader,
+    .c-skeleton-loader-restaurantData  {
+        border: 1px solid $skeleton-loader-bone-background-color;
+    }
+
+    .c-skeleton-loader-carouselCardRestaurantHeader {
+        border-top: 0px;
+        border-bottom: 0px;
+    }
+
+    .c-skeleton-loader-restaurantData {
+        border-top: 0px;
+    }
+}
+</style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCarouselCard.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCarouselCard.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="c-skeleton-loader-favouriteCarouselCard c-skeleton-loader-bone">
+    <div class="c-skeleton-loader-restaurantCarouselCard c-skeleton-loader-bone">
         <carousel-card-background />
         <carousel-card-restaurant-header />
         <carousel-card-restaurant-data />
@@ -19,7 +19,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.c-skeleton-loader-favouriteCarouselCard {
+
+.c-skeleton-loader-restaurantCarouselCard {
     max-width: 400px;
     text-align: center;
     margin: auto;
@@ -38,4 +39,5 @@ export default {
         border-bottom: 0;
     }
 }
+
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCarouselCard.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCarouselCard.vue
@@ -29,17 +29,13 @@ export default {
         margin-bottom: -(spacing(x8));
     }
     .c-skeleton-loader-carouselCardRestaurantHeader,
-    .c-skeleton-loader-restaurantData  {
+    .c-skeleton-loader-restaurantData {
         border: 1px solid $skeleton-loader-bone-background-color;
+        border-top: 0;
     }
 
     .c-skeleton-loader-carouselCardRestaurantHeader {
-        border-top: 0px;
-        border-bottom: 0px;
-    }
-
-    .c-skeleton-loader-restaurantData {
-        border-top: 0px;
+        border-bottom: 0;
     }
 }
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCarouselCard.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCarouselCard.vue
@@ -12,7 +12,6 @@ import CarouselCardRestaurantData from './CarouselCardRestaurantData.vue';
 import CarouselCardRestaurantHeader from './CarouselCardRestaurantHeader.vue';
 
 export default {
-    name: 'RestaurantCarouselCard',
     components: {
         CarouselCardBackground, CarouselCardRestaurantData, CarouselCardRestaurantHeader
     }
@@ -28,6 +27,7 @@ export default {
     .c-skeleton-loader-carouselCardBackground {
         margin-bottom: -(spacing(x8));
     }
+
     .c-skeleton-loader-carouselCardRestaurantHeader,
     .c-skeleton-loader-restaurantData {
         border: 1px solid $skeleton-loader-bone-background-color;

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Sentence.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Sentence.vue
@@ -1,7 +1,7 @@
 <template>
-    <div class="c-skeleton-loader-sentence c-skeleton-loader-bone">
-        <text-block />
-        <text-block />
+    <div>
+        <text-block :class="$style['c-sentence-textBlock']" />
+        <text-block :class="$style['c-sentence-textBlock']" />
     </div>
 </template>
 
@@ -9,16 +9,18 @@
 import TextBlock from './Text.vue';
 
 export default {
-    name: 'Sentence',
     components: { TextBlock }
 };
 </script>
 
-<style lang="scss" scoped>
-.c-skeleton-loader-text:nth-child(2) {
+<style lang="scss" module>
+
+.c-sentence-textBlock:nth-child(2) {
     max-width: 70%;
 }
-.c-skeleton-loader-text:not(:last-child) {
+
+.c-sentence-textBlock:not(:last-child) {
     margin-bottom: spacing();
 }
+
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Sentence.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Sentence.vue
@@ -19,6 +19,6 @@ export default {
     max-width: 70%;
 }
 .c-skeleton-loader-text:not(:last-child) {
-    margin-bottom: 6px;
+    margin-bottom: spacing();
 }
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Text.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Text.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="c-skeleton-loader-text c-skeleton-loader-bone" />
+    <div :class="$style['c-text']" />
 </template>
 
 <script>
@@ -8,10 +8,12 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
-.c-skeleton-loader-text {
+<style lang="scss" module>
+
+.c-text {
     flex: 1 0 auto;
     height: $skeleton-loader-text-height;
     margin-bottom: spacing();
 }
+
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/index.js
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/index.js
@@ -6,4 +6,4 @@ export { default as Rating } from './Rating.vue';
 export { default as CarouselCardRestaurantHeader } from './CarouselCardRestaurantHeader.vue';
 export { default as CarouselCardBackground } from './CarouselCardBackground.vue';
 export { default as CarouselCardRestaurantData } from './CarouselCardRestaurantData.vue';
-export { default as RestaurantCarouselCard } from './FavouriteCarouselCard.vue';
+export { default as RestaurantCarouselCard } from './RestaurantCarouselCard.vue';

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/index.js
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/index.js
@@ -1,3 +1,9 @@
 export { default as TextBlock } from './Text.vue';
 export { default as Heading } from './Heading.vue';
 export { default as Sentence } from './Sentence.vue';
+export { default as ImageBlock } from './Image.vue';
+export { default as Rating } from './Rating.vue';
+export { default as CarouselCardRestaurantHeader } from './CarouselCardRestaurantHeader.vue';
+export { default as CarouselCardBackground } from './CarouselCardBackground.vue';
+export { default as CarouselCardRestaurantData } from './CarouselCardRestaurantData.vue';
+export { default as RestaurantCarouselCard } from './FavouriteCarouselCard.vue';

--- a/packages/components/molecules/f-skeleton-loader/stories/SkeletonLoader.stories.js
+++ b/packages/components/molecules/f-skeleton-loader/stories/SkeletonLoader.stories.js
@@ -10,12 +10,11 @@ export default {
 export const SkeletonLoaderComponent = (args, { argTypes }) => ({
     components: { SkeletonLoader },
     props: Object.keys(argTypes),
-    template: '<skeleton-loader :skeletonType="skeletonType" :isAnimated="isAnimated" />'
+    template: '<skeleton-loader :skeletonType="skeletonType" />'
 });
 
 SkeletonLoaderComponent.args = {
-    skeletonType: 'Sentence',
-    isAnimated: true
+    skeletonType: 'Sentence'
 };
 
 SkeletonLoaderComponent.argTypes = {


### PR DESCRIPTION
### Added
- Skeleton components to build a single restaurant carousel card

![image](https://user-images.githubusercontent.com/20644043/112027474-18290f80-8b2f-11eb-8d79-ceb40311fc74.png)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)
