### PR TITLE
f-content-cards@v4.4.0 🗯 Adds StampCard promotion card

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -4,6 +4,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.4.0
+------------------------------
+*March 23, 2021*
+
+### Updated
+- Adds `StampCardPromotionCard` component, test, stories and docs
+- Factors out some common card styling into a shared scss file
+- Factors out some common non-visual behaviour into a shared component
+
+### Fixed
+- ContentCards stories when rendered as static site
+
+
 v4.3.0
 ------------------------------
 *March 19, 2021*

--- a/packages/components/organisms/f-content-cards/docs/StampCardPromotionCard.md
+++ b/packages/components/organisms/f-content-cards/docs/StampCardPromotionCard.md
@@ -1,0 +1,30 @@
+# StampCardPromotionCard
+
+The `StampCardPromotionCard` component supports the following keys of the `card` prop, with these meanings:
+
+* `title` - `String`
+
+  This is rendered as the title of the card, and is normally the name of the restaurant
+  that the stamp card relates to.
+
+* `subtitle` - `String`
+
+  A human-readable description of the card, usually something about the type of cuisine offered.
+
+* `image` - `String`
+
+  A URL giving a banner image of the related restaurant - should be 21:9
+
+* `icon` - `String`
+
+  A URL giving a logo of the related restaurant - 1:1 at 48px × 48px
+
+* `ctaText` - `String`
+
+  Text rendered in link styling for the below URL
+
+* `url` - `String`
+
+  A URL to the menu of the related restaurant for the customers' ongoing journey
+
+

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist",
@@ -35,7 +35,7 @@
     "test:coverage": "yarn test --coverage",
     "test-component:chrome": "cross-env-shell JE_ENV=local wdio ../../../../wdio-chrome.conf.js --suite component",
     "report:test-component:chrome": "cross-env-shell JE_ENV=local COMPONENT_TYPE=organism wdio ../../../../wdio-chrome.conf.js --suite component && yarn allure:open",
-    "test-a11y:chrome": "cross-env-shell JE_ENV=local wdio ../../../../wdio-chrome.conf.js --suite a11y", 
+    "test-a11y:chrome": "cross-env-shell JE_ENV=local wdio ../../../../wdio-chrome.conf.js --suite a11y",
     "allure:open": "yarn allure:clean && allure open",
     "allure:clean": "rimraf ../../../../test/results/allure"
   },
@@ -52,7 +52,7 @@
     "vue": "2.x"
   },
   "devDependencies": {
-    "@justeat/f-braze-adapter": "3.1.0",
+    "@justeat/f-braze-adapter": "3.2.0",
     "@justeat/f-vue-icons": "1.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-content-cards/src/assets/scss/_card-styles.scss
+++ b/packages/components/organisms/f-content-cards/src/assets/scss/_card-styles.scss
@@ -1,0 +1,35 @@
+@mixin card-container {
+    width: 100%;
+    text-decoration: initial;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+
+    &,
+    &:hover,
+    &:focus {
+      color: currentColor;
+    }
+}
+
+@mixin card-container-wrapped {
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 40%;
+  margin: 0 spacing() spacing(x3) 0;
+  width: 100%;
+
+  @include media('>=narrowMid') {
+    margin: 0 spacing() spacing(x3);
+  }
+}
+
+@mixin card-bg-image {
+  width: 100%;
+  background-repeat: repeat;
+  background-size: cover;
+  background-color: $grey--lighter;
+  background-position: center;
+  border-radius: $border-radius $border-radius 0 0;
+}

--- a/packages/components/organisms/f-content-cards/src/components/ContentCards.js
+++ b/packages/components/organisms/f-content-cards/src/components/ContentCards.js
@@ -225,7 +225,8 @@ export default {
                     'Post_Order_Card_1',
                     'Home_Promotion_Card_1',
                     'Home_Promotion_Card_2',
-                    'Stamp_Card_1'
+                    'Stamp_Card_1',
+                    'StampCard_Promotion_Card_1'
                 ],
                 brands: this.brands,
                 callbacks: {

--- a/packages/components/organisms/f-content-cards/src/components/MakeTextAccessible.js
+++ b/packages/components/organisms/f-content-cards/src/components/MakeTextAccessible.js
@@ -5,6 +5,10 @@
  * remove anything but the <b></b> tags braze may sometimes provide.
  */
 export default el => {
+    if (!el.innerText) {
+        return;
+    }
+
     const text = el.innerText.trim().replace(/(<(?!(?:b|\/b)\b)[^>]*>)/gi, '');
     const containsPeriod = ['.', '!', '?', ';', ':'].includes(text.slice(-1));
     el.innerHTML = containsPeriod ? text : `${text}<span class="is-visuallyHidden">.</span>`;

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardCase.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardCase.vue
@@ -1,0 +1,56 @@
+<!--
+  LightWeight version of "CardContainer" to just control the analytics/link part,
+  and leave the styling to the card implementation
+ -->
+<template>
+    <component
+        :is="card.url ? 'a' : 'div'"
+        :href="card.url"
+        :target="target.attribute"
+        :rel="target.rel"
+        @click="onClickContentCard">
+        <slot />
+    </component>
+</template>
+
+<script>
+export default {
+    name: 'CardCase',
+
+    props: {
+        card: {
+            type: Object,
+            default: () => ({})
+        }
+    },
+
+    computed: {
+        target () {
+            return this.card.target || {};
+        }
+    },
+
+    inject: [
+        'emitCardView',
+        'emitCardClick'
+    ],
+
+    mounted () {
+        this.onViewContentCard();
+    },
+
+    methods: {
+        onViewContentCard () {
+            this.emitCardView(this.card);
+        },
+
+        onClickContentCard () {
+            this.emitCardClick(this.card);
+        },
+
+        testIdForItemWithIndex (index) {
+            return this.testId && `ContentCard-TextItem-${index}`;
+        }
+    }
+};
+</script>

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -154,18 +154,15 @@ export default {
 </script>
 
 <style lang="scss" module>
+    @import '../../../src/assets/scss/card-styles';
 
     .c-content-card-body {
         flex-grow: 1;
     }
 
     .c-contentCard {
-        width: 100%;
-        text-decoration: initial;
-        text-align: center;
-        display: flex;
-        flex-direction: column;
-        flex-grow: 1;
+        @include card-container;
+
         margin-right: spacing(x2);
         margin-bottom: spacing(x2);
 
@@ -177,22 +174,8 @@ export default {
             margin-right: 0;
         }
 
-        &,
-        &:hover,
-        &:focus {
-            color: currentColor;
-        }
-
         .c-contentCards--wrap & {
-            display: flex;
-            flex-direction: column;
-            flex: 0 0 40%;
-            margin: 0 spacing() spacing(x3) 0;
-            width: 100%;
-
-            @include media('>=narrowMid') {
-                margin: 0 spacing() spacing(x3);
-            }
+            @include card-container-wrapped;
         }
 
         /**
@@ -225,13 +208,9 @@ export default {
     }
 
     .c-contentCard-bgImg {
-        width: 100%;
+        @include card-bg-image;
+
         min-height: 170px;
-        background-repeat: repeat;
-        background-size: cover;
-        background-color: $grey--lighter;
-        background-position: center;
-        border-radius: $border-radius $border-radius 0 0;
     }
 
     .c-contentCard-title {
@@ -281,10 +260,10 @@ export default {
     }
 
     .c-contentCard-thumbnail {
-        border: 1px solid $grey--lighter;
-        margin-top: - (32px + spacing(x2)); // This offsets the thumbnail above the top of the info card
-        width: 48px;
-        min-height: 48px;
+            border: 1px solid $grey--lighter;
+            margin-top: - (32px + spacing(x2)); // This offsets the thumbnail above the top of the info card
+            width: 48px;
+            min-height: 48px;
     }
 
     .c-postOrderCardContainer {

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -244,10 +244,10 @@ export default {
     }
 
     .c-contentCard-thumbnail {
-            border: 1px solid $grey--lighter;
-            margin-top: - (32px + spacing(x2)); // This offsets the thumbnail above the top of the info card
-            width: 48px;
-            min-height: 48px;
+        border: 1px solid $grey--lighter;
+        margin-top: - (32px + spacing(x2)); // This offsets the thumbnail above the top of the info card
+        width: 48px;
+        min-height: 48px;
     }
 
     .c-postOrderCardContainer {

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -1,13 +1,8 @@
 <template>
-    <component
-        :is="url && hasCta ? 'a' : 'div'"
-        :href="hasCta && url"
-        :target="target.attribute"
-        :rel="target.rel"
+    <card-case
+        :card="card"
         :class="[$style['c-contentCard'], { [$style['c-contentCard--isolateHeroImage']]: shouldIsolateHeroImage }]"
-        :data-test-id="testId"
-        @click="onClickContentCard"
-    >
+        :data-test-id="testId">
         <div
             :style="{ 'background-image': shouldApplyImageAsBackground ? `url(${image})` : '' }"
             :class="[{ [$style['c-contentCard-bgImg']]: !!image }]">
@@ -50,11 +45,17 @@
                 <slot />
             </div>
         </div>
-    </component>
+    </card-case>
 </template>
 
 <script>
+import CardCase from './CardCase.vue';
+
 export default {
+    components: {
+        CardCase
+    },
+
     props: {
         card: {
             type: Object,
@@ -128,24 +129,7 @@ export default {
         }
     },
 
-    inject: [
-        'emitCardView',
-        'emitCardClick'
-    ],
-
-    mounted () {
-        this.onViewContentCard();
-    },
-
     methods: {
-        onViewContentCard () {
-            this.emitCardView(this.card);
-        },
-
-        onClickContentCard () {
-            this.emitCardClick(this.card);
-        },
-
         testIdForItemWithIndex (index) {
             return this.testId && `ContentCard-TextItem-${index}`;
         }

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
@@ -1,11 +1,8 @@
 <template>
-    <component
-        :is="card.url ? 'a' : 'div'"
-        :href="card.url"
+    <card-case
+        :card="card"
         :data-test-id="testId"
-        :class="[$style['c-stampCard1']]"
-        @click="onClickContentCard"
-    >
+        :class="[$style['c-stampCard1']]">
         <div :class="[$style['c-stampCard1-headerDetails']]">
             <img
                 :class="[$style['c-stampCard1-icon']]"
@@ -74,14 +71,16 @@
                 </div>
             </div>
         </div>
-    </component>
+    </card-case>
 </template>
 
 <script>
+
 import parseISO from 'date-fns/parseISO';
 import format from 'date-fns/format';
 import lightFormat from 'date-fns/lightFormat';
 
+import CardCase from './CardCase.vue';
 import EmptyStamp from './images/stamp-empty-15.svg';
 import FullStamp from './images/stamp-full-15.svg';
 
@@ -92,7 +91,8 @@ export default {
 
     components: {
         EmptyStamp,
-        FullStamp
+        FullStamp,
+        CardCase
     },
 
     directives: {
@@ -203,28 +203,16 @@ export default {
     },
 
     mounted () {
-        this.onViewContentCard();
-
         this.getDateFnsLocale(this.copy.locale).then(locale => {
             this.dateFnsLocale = locale;
         });
     },
 
     inject: [
-        'copy',
-        'emitCardView',
-        'emitCardClick'
+        'copy'
     ],
 
     methods: {
-        onViewContentCard () {
-            this.emitCardView(this.card);
-        },
-
-        onClickContentCard () {
-            this.emitCardClick(this.card);
-        },
-
         /**
          * Takes the locale and lazyloads the correct date locale from the date-fns library
          * @param locale

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCardPromotionCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCardPromotionCard.vue
@@ -1,0 +1,192 @@
+<template>
+    <card-case
+        :card="card"
+        :class="[$style['c-stampCardPromotion1']]"
+        :data-test-id="testId">
+        <div
+            :class="[{ [$style['c-stampCardPromotion1-bgImg']]: !!card.image }]">
+            <img
+                :class="$style['c-stampCardPromotion1-img']"
+                :src="card.image"
+                alt=""> <!-- Alt-text not relevant for image - would repeat title text for screenreaders -->
+        </div>
+        <div :class="[$style['c-stampCardPromotion1-info']]">
+            <img
+                v-if="card.icon"
+                :class="[$style['c-stampCardPromotion1-icon']]"
+                :src="card.icon"
+                :data-test-id="testIdForSection('icon')"
+                alt=""> <!-- Alt-text not relevant for icon - would repeat title text for screenreaders -->
+            <div :class="$style['c-stampCardPromotion1-body']">
+                <h3
+                    v-make-text-accessible
+                    :class="[$style['c-stampCardPromotion1-title']]">
+                    {{ card.title }}
+                </h3>
+                <p
+                    v-make-text-accessible
+                    :class="[$style['c-stampCardPromotion1-statusText']]"
+                >
+                    {{ card.subtitle }}
+                </p>
+                <p
+                    v-if="card.url"
+                    :class="[
+                        'o-link--full',
+                        'o-link--bold',
+                        'u-color-link',
+                        'u-text-left',
+                        $style['c-stampCardPromotion1-link']
+                    ]"
+                    :data-test-id="testIdForSection('link')">
+                    {{ card.ctaText }}
+                </p>
+            </div>
+        </div>
+    </card-case>
+</template>
+
+<script>
+import CardCase from './CardCase.vue';
+import makeTextAccessible from '../MakeTextAccessible';
+
+export default {
+    name: 'StampCardPromotionCard',
+
+    components: {
+        CardCase
+    },
+
+    directives: {
+        makeTextAccessible
+    },
+
+    props: {
+        card: {
+            type: Object,
+            required: true
+        },
+
+        testId: {
+            type: String,
+            default: null
+        }
+    },
+
+    computed: {
+        testIdForSection () {
+            return section => this.testId && `${this.testId}-${section}`;
+        }
+    }
+};
+</script>
+
+<style lang="scss" module>
+@import '../../../src/assets/scss/card-styles';
+
+.c-stampCardPromotion1 {
+    @include card-container;
+
+    position: relative;
+    border: none;
+
+    @include media('>narrowMid') {
+        max-width: 344px;
+        border-radius: 2px;
+        box-shadow: 0px 2px 2px 0px rgba(0, 0, 0, 0.03),
+            0px 3px 1px -2px rgba(0, 0, 0, 0.07),
+            0px 1px 5px 0px rgba(0, 0, 0, 0.06);
+    }
+
+    @include media('>mid') {
+        max-width: 392px;
+    }
+}
+
+.c-stampCardPromotion1-body {
+    flex-grow: 1;
+}
+
+.c-stampCardPromotion1-bgImg {
+    @include card-bg-image;
+}
+
+.c-stampCardPromotion1-img {
+    display: block;
+    width: 100%;
+    border-radius: $border-radius $border-radius 0 0;
+}
+
+.c-stampCardPromotion1-icon {
+    position: absolute;
+    top: spacing(x2);
+    left: spacing(x2);
+    margin: 0;
+    border-radius: $border-radius;
+    border: 0.5px solid $grey--light;
+
+    @include media('>narrowMid') {
+        top: spacing(x1.5) - 2px;
+    }
+}
+
+.c-stampCardPromotion1-info {
+    padding: spacing(x2);
+    background-color: $white;
+    position: static;
+    display: block;
+    text-align: left;
+    min-height: 0;
+
+    margin-top: - spacing(x3);
+    margin-left: spacing(x2);
+    margin-right: spacing(x2) - 1px;
+    border-radius: $border-radius;
+    box-shadow: 0px 2px 2px 0px rgba(0, 0, 0, 0.03),
+    0px 3px 1px -2px rgba(0, 0, 0, 0.07),
+    0px 1px 5px 0px rgba(0, 0, 0, 0.06);
+
+    @include media ('>narrowMid') {
+        margin: 0 0 0 0;
+        box-shadow: none;
+    }
+}
+
+.c-stampCardPromotion1-title {
+     @include font-size(subheading-s, false, narrow);
+
+     @include media ('>narrowMid') {
+         @include font-size(subheading-s, false);
+     }
+}
+
+.c-stampCardPromotion1-statusText {
+    @include font-size(body-s);
+
+    margin-top: spacing(x0.5);
+
+    @include media ('>narrowMid') {
+        @include font-size('body-l', false);
+    }
+}
+
+.c-stampCardPromotion1-link {
+    @include font-size('body-l', false);
+    text-decoration: none;
+    font-weight: $font-weight-bold;
+    margin-top: spacing();
+
+    & {
+        color: $color-link-default;
+    }
+
+    &:hover, &:focus {
+        color: $color-link-hover;
+    }
+
+    &:active {
+        color: $color-link-active;
+    }
+}
+
+</style>

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCardPromotionCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCardPromotionCard.vue
@@ -84,6 +84,10 @@ export default {
 <style lang="scss" module>
 @import '../../../src/assets/scss/card-styles';
 
+$stampCard-promo-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.03),
+    0 3px 1px -2px rgba(0, 0, 0, 0.07),
+    0 1px 5px 0 rgba(0, 0, 0, 0.06);
+
 .c-stampCardPromotion1 {
     @include card-container;
 
@@ -93,9 +97,7 @@ export default {
     @include media('>narrowMid') {
         max-width: 344px;
         border-radius: 2px;
-        box-shadow: 0px 2px 2px 0px rgba(0, 0, 0, 0.03),
-            0px 3px 1px -2px rgba(0, 0, 0, 0.07),
-            0px 1px 5px 0px rgba(0, 0, 0, 0.06);
+        box-shadow: $stampCard-promo-shadow;
     }
 
     @include media('>mid') {
@@ -142,12 +144,10 @@ export default {
     margin-left: spacing(x2);
     margin-right: spacing(x2) - 1px;
     border-radius: $border-radius;
-    box-shadow: 0px 2px 2px 0px rgba(0, 0, 0, 0.03),
-    0px 3px 1px -2px rgba(0, 0, 0, 0.07),
-    0px 1px 5px 0px rgba(0, 0, 0, 0.06);
+    box-shadow: $stampCard-promo-shadow;
 
     @include media ('>narrowMid') {
-        margin: 0 0 0 0;
+        margin: 0;
         box-shadow: none;
     }
 }

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/_tests/CardCase.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/_tests/CardCase.test.js
@@ -1,0 +1,95 @@
+import { createLocalVue, mount } from '@vue/test-utils';
+import CardCase from '../CardCase.vue';
+
+const localVue = createLocalVue();
+
+const url = '__URL__';
+const ctaLabel = '__CTA_LABEL__';
+const line1 = '__LINE_1__';
+const description = [line1];
+const id = btoa('ABC123');
+const type = 'Promotion_Card_1';
+
+const card = {
+    id,
+    url,
+    description,
+    ctaLabel,
+    type
+};
+
+const testId = 'CardCase';
+
+const provide = {
+    emitCardView: jest.fn(),
+    emitCardClick: jest.fn()
+};
+
+describe('CardCase', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('should render a link if url is provided', () => {
+        // Act
+        const wrapper = mount(CardCase, {
+            localVue,
+            propsData: {
+                card,
+                testId
+            },
+            provide
+        });
+
+        // Assert
+        expect(wrapper.find('a').exists()).toBe(true);
+    });
+
+    it('should apply the correct URL', () => {
+        // Arrange & Act
+        const wrapper = mount(CardCase, {
+            localVue,
+            propsData: {
+                card,
+                testId
+            },
+            provide
+        });
+
+        // Assert
+        expect(wrapper.find(`[href="${url}"]`).exists()).toBe(true);
+    });
+
+    it('should call the injected `emitCardView` event when mounted', () => {
+        // Arrange & Act
+        mount(CardCase, {
+            localVue,
+            propsData: {
+                card,
+                testId
+            },
+            provide
+        });
+
+        // Assert
+        expect(provide.emitCardView).toHaveBeenCalled();
+    });
+
+    it('should call the injected `emitCardClick` event when clicked', () => {
+        // Arrange
+        const wrapper = mount(CardCase, {
+            localVue,
+            propsData: {
+                card,
+                testId
+            },
+            provide
+        });
+
+        // Act
+        wrapper.findComponent(CardCase).trigger('click');
+
+        // Assert
+        expect(provide.emitCardClick).toHaveBeenCalled();
+    });
+});

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/_tests/CardContainer.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/_tests/CardContainer.test.js
@@ -1,4 +1,4 @@
-import { createLocalVue, shallowMount } from '@vue/test-utils';
+import { createLocalVue, mount } from '@vue/test-utils';
 import CardContainer from '../CardContainer.vue';
 
 const localVue = createLocalVue();
@@ -30,24 +30,9 @@ describe('ContentCard', () => {
         jest.resetAllMocks();
     });
 
-    it('should render a link if url is provided', () => {
-        // Act
-        const wrapper = shallowMount(CardContainer, {
-            localVue,
-            propsData: {
-                card,
-                testId
-            },
-            provide
-        });
-
-        // Assert
-        expect(wrapper.find('a').exists()).toBe(true);
-    });
-
     it('should display description lines', () => {
         // Arrange & Act
-        const wrapper = shallowMount(CardContainer, {
+        const wrapper = mount(CardContainer, {
             localVue,
             propsData: {
                 card,
@@ -58,53 +43,5 @@ describe('ContentCard', () => {
 
         // Assert
         expect(wrapper.find('[data-test-id="ContentCard-TextItem-0"]').text()).toBe(line1);
-    });
-
-    it('should apply the correct URL', () => {
-        // Arrange & Act
-        const wrapper = shallowMount(CardContainer, {
-            localVue,
-            propsData: {
-                card,
-                testId
-            },
-            provide
-        });
-
-        // Assert
-        expect(wrapper.find(`[href="${url}"]`).exists()).toBe(true);
-    });
-
-    it('should call the injected `emitCardView` event when mounted', () => {
-        // Arrange & Act
-        shallowMount(CardContainer, {
-            localVue,
-            propsData: {
-                card,
-                testId
-            },
-            provide
-        });
-
-        // Assert
-        expect(provide.emitCardView).toHaveBeenCalled();
-    });
-
-    it('should call the injected `emitCardClick` event when clicked', () => {
-        // Arrange
-        const wrapper = shallowMount(CardContainer, {
-            localVue,
-            propsData: {
-                card,
-                testId
-            },
-            provide
-        });
-
-        // Act
-        wrapper.find(`[data-test-id="${testId}"]`).trigger('click');
-
-        // Assert
-        expect(provide.emitCardClick).toHaveBeenCalled();
     });
 });

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/_tests/StampCard1.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/_tests/StampCard1.test.js
@@ -24,9 +24,7 @@ const card = {
 const localeConfig = tenantConfigs['en-GB'];
 
 const provide = {
-    copy: localeConfig,
-    emitCardView: jest.fn(),
-    emitCardClick: jest.fn()
+    copy: localeConfig
 };
 
 function getWrapper (cardDetails = {}, testId = 'stampCard1') {

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/_tests/StampCardPromotionCard.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/_tests/StampCardPromotionCard.test.js
@@ -1,0 +1,102 @@
+import { shallowMount } from '@vue/test-utils';
+import StampCardPromotionCard from '../StampCardPromotionCard.vue';
+
+const testId = '__TEST_ID__';
+const ctaText = '__CTA_TEXT__';
+const icon = '__ICON__';
+const url = '__URL__';
+
+describe('contentCards › StampCardPromotionCard1', () => {
+    it('should NOT render any test id attributes if `testId` prop not provided', () => {
+        // Arrange & Act
+        const wrapper = shallowMount(StampCardPromotionCard, {
+            propsData: {
+                card: {
+                    ctaText,
+                    icon
+                }
+            }
+        });
+
+        // Assert
+        expect(wrapper.find('[data-test-id]').exists()).toBeFalsy();
+    });
+
+    it('should render the test id attribute on the root element if `testId` prop provided', () => {
+        // Arrange & Act
+        const wrapper = shallowMount(StampCardPromotionCard, {
+            propsData: {
+                card: {
+                    ctaText,
+                    icon
+                },
+                testId
+            }
+        });
+
+        // Assert
+        expect(wrapper.find(`[data-test-id="${testId}"]`).exists()).toBeTruthy();
+    });
+
+    it('should render the icon element if `card.icon` provided', () => {
+        // Arrange & Act
+        const wrapper = shallowMount(StampCardPromotionCard, {
+            propsData: {
+                card: {
+                    ctaText,
+                    icon
+                },
+                testId
+            }
+        });
+
+        // Assert
+        expect(wrapper.find(`[data-test-id="${testId}-icon"]`).exists()).toBeTruthy();
+    });
+
+    it('should NOT render the icon element if `card.icon` not provided', () => {
+        // Arrange & Act
+        const wrapper = shallowMount(StampCardPromotionCard, {
+            propsData: {
+                card: {
+                    ctaText
+                },
+                testId
+            }
+        });
+
+        // Assert
+        expect(wrapper.find(`[data-test-id="${testId}-icon"]`).exists()).toBeFalsy();
+    });
+
+    it('should render the link element if `card.url` provided', () => {
+        // Arrange & Act
+        const wrapper = shallowMount(StampCardPromotionCard, {
+            propsData: {
+                card: {
+                    ctaText,
+                    url
+                },
+                testId
+            }
+        });
+
+        // Assert
+        expect(wrapper.find(`[data-test-id="${testId}-link"]`).exists()).toBeTruthy();
+    });
+
+    it('should NOT render the link element if `card.url` not provided', () => {
+        // Arrange & Act
+        const wrapper = shallowMount(StampCardPromotionCard, {
+            propsData: {
+                card: {
+                    ctaText
+                },
+                testId
+            }
+        });
+
+        // Assert
+        expect(wrapper.find(`[data-test-id="${testId}-link"]`).exists()).toBeFalsy();
+    });
+});

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/index.js
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/index.js
@@ -3,6 +3,7 @@ import PromotionCard from './PromotionCard.vue';
 import PostOrderCard from './PostOrderCard.vue';
 import SkeletonLoader from './SkeletonLoader.vue';
 import StampCard1 from './StampCard1.vue';
+import StampCardPromotionCard from './StampCardPromotionCard.vue';
 import TermsAndConditionsCard from './TermsAndConditionsCard.vue';
 import VoucherCard from './voucherCard/VoucherCard.vue';
 import GroupHeaderCard from './GroupHeaderCard.vue';
@@ -14,6 +15,7 @@ export {
     PostOrderCard,
     SkeletonLoader,
     StampCard1,
+    StampCardPromotionCard,
     TermsAndConditionsCard,
     VoucherCard,
     HomePromotionCard1,

--- a/packages/components/organisms/f-content-cards/src/index.js
+++ b/packages/components/organisms/f-content-cards/src/index.js
@@ -15,7 +15,8 @@ import {
     HomePromotionCard1,
     HomePromotionCard2,
     GroupHeaderCard,
-    StampCard1
+    StampCard1,
+    StampCardPromotionCard
 } from './components/cardTemplates';
 
 export {
@@ -31,5 +32,6 @@ export {
     HomePromotionCard1,
     HomePromotionCard2,
     GroupHeaderCard,
-    StampCard1
+    StampCard1,
+    StampCardPromotionCard
 };

--- a/packages/components/organisms/f-content-cards/stories/StampCardPromotionCard.stories.js
+++ b/packages/components/organisms/f-content-cards/stories/StampCardPromotionCard.stories.js
@@ -1,0 +1,83 @@
+import { StampCardPromotionCard } from '../src/components/cardTemplates';
+
+export default {
+    title: 'Components/Molecules/f-content-cards/stamp-card-promotion-card',
+    argTypes: {
+        title: {
+            control: { type: 'text' },
+            description: 'Title text for the inner card'
+        },
+        image: {
+            control: { type: 'text' },
+            description: 'If given, a URL of the image used for the inner card'
+        },
+        icon: {
+            control: { type: 'text' },
+            description: 'If given, a URL for an icon that appears in the left/top portion of the card'
+        },
+        ctaText: {
+            control: { type: 'text' },
+            description: 'Display text used for the CTA link'
+        },
+        subtitle: {
+            control: { type: 'text' },
+            description: 'The subtitle that appears below the icon on mid-breakpoint and above only'
+        },
+        url: {
+            control: { type: 'text' },
+            description: 'The url that the CTA directs to'
+        }
+    }
+};
+
+/**
+ * Definition for story for First Time Customer Card component
+ *
+ * @param {Object} args
+ * @param {{argTypes: {Array}}}
+ * @return {{
+ *  template: string,
+ *  components: {
+ *      StampCardPromotionCardComponent: {Object}
+ *  },
+ *  provide: {Function},
+ *  props: string[]
+ * }}
+ */
+export const StampCardPromotionCardComponent = (args, { argTypes }) => ({
+    components: {
+        StampCardPromotionCard
+    },
+
+    props: Object.keys(argTypes),
+
+    /**
+     * Stubbed copy for injecting when supplied card information is not complete
+     * @return {{emitCardView: {Function}, emitCardClick: {Function}}}
+     */
+    provide () {
+        return {
+            emitCardView () { },
+            emitCardClick () { }
+        };
+    },
+
+    template: '<stamp-card-promotion-card'
+        // Setting key as per below forces re-render of the component when the supplied controls change
+        // eslint-disable-next-line no-template-curly-in-string
+        + ' :key="`${title},${ctaText},${image},${icon},${url},${subtitle}`"'
+        + ' :card="{title, ctaText, image, icon, url, subtitle}"'
+        + '/>'
+});
+
+StampCardPromotionCardComponent.storyName = 'stamp-card-promotion-card';
+
+
+StampCardPromotionCardComponent.args = {
+    title: 'An Viet',
+    image: 'https://picsum.photos/seed/StampCardPromotionCard_image/384/165?blur=3',
+    icon: 'https://picsum.photos/seed/StampCardPromotionCard_icon/48/48',
+    ctaText: 'Order now',
+    subtitle: 'Vietnamese and Asian',
+    url: '#'
+};

--- a/packages/components/organisms/f-content-cards/stories/content-cards/all-cards.js
+++ b/packages/components/organisms/f-content-cards/stories/content-cards/all-cards.js
@@ -44,7 +44,6 @@ export default function ContentCardsBraze (args, { argTypes }) {
                 :user-id="userId"
                 :api-key="apiKey"
                 :locale="locale"
-                :custom-cards="customCards"
                 :key="locale"
             >
                 <template #${STATE_DEFAULT}="{ cards }">
@@ -56,7 +55,6 @@ export default function ContentCardsBraze (args, { argTypes }) {
                         :is="handleCustomCardType(card.type)"
                         :key="i"
                         :card="card"
-                        :tenant="tenant"
                     />
                 </template>
             </content-cards>`

--- a/packages/components/organisms/f-content-cards/stories/content-cards/all-cards.js
+++ b/packages/components/organisms/f-content-cards/stories/content-cards/all-cards.js
@@ -2,7 +2,9 @@ import {
     ContentCards,
     FirstTimeCustomerCard,
     PostOrderCard,
-    PromotionCard, StampCard1,
+    PromotionCard,
+    StampCard1,
+    StampCardPromotionCard,
     TermsAndConditionsCard,
     VoucherCard
 } from '../../src';
@@ -17,7 +19,8 @@ const components = {
     PromotionCard,
     TermsAndConditionsCard,
     PostOrderCard,
-    StampCard1
+    StampCard1,
+    StampCardPromotionCard
 };
 
 export default function ContentCardsBraze (args, { argTypes }) {

--- a/packages/components/organisms/f-content-cards/stories/content-cards/custom-cards.js
+++ b/packages/components/organisms/f-content-cards/stories/content-cards/custom-cards.js
@@ -68,7 +68,6 @@ export default function ContentCardsCustom (args, { argTypes }) {
                         :is="handleCustomCardType(card.type)"
                         :key="i"
                         :card="card"
-                        :tenant="tenant"
                     />
                 </template>
             </content-cards>`

--- a/packages/components/organisms/f-content-cards/stories/content-cards/error.js
+++ b/packages/components/organisms/f-content-cards/stories/content-cards/error.js
@@ -27,7 +27,6 @@ export default function ContentCardsError (args, { argTypes }) {
                 :user-id="userId"
                 :api-key="apiKey"
                 :locale="locale"
-                :custom-cards="customCards"
                 :key="locale"
             >
                 <template #${STATE_ERROR}="{ status }">

--- a/packages/components/organisms/f-content-cards/stories/content-cards/loading.js
+++ b/packages/components/organisms/f-content-cards/stories/content-cards/loading.js
@@ -22,9 +22,11 @@ export default function ContentCardsLoading (args, { argTypes }) {
          * Reject the promise set up by the above mock
          */
         beforeDestroy () {
-            this.rejectMockPromise({
-                status: 500
-            });
+            if (this.rejectMockPromise) {
+                this.rejectMockPromise({
+                    status: 500
+                });
+            }
         },
 
         template: `
@@ -36,7 +38,6 @@ export default function ContentCardsLoading (args, { argTypes }) {
                 :user-id="userId"
                 :api-key="apiKey"
                 :locale="locale"
-                :custom-cards="customCards"
                 :key="locale"
             >
                 <template #${STATE_LOADING}="{ status }">

--- a/packages/components/organisms/f-content-cards/stories/content-cards/no-cards.js
+++ b/packages/components/organisms/f-content-cards/stories/content-cards/no-cards.js
@@ -27,7 +27,6 @@ export default function ContentCardsNoCards (args, { argTypes }) {
                 :user-id="userId"
                 :api-key="apiKey"
                 :locale="locale"
-                :custom-cards="customCards"
                 :key="locale"
             >
                 <template #${STATE_NO_CARDS}="{ status }">

--- a/packages/components/organisms/f-content-cards/stories/content-cards/story-utils/methods.js
+++ b/packages/components/organisms/f-content-cards/stories/content-cards/story-utils/methods.js
@@ -20,6 +20,8 @@ export default {
                 return 'TermsAndConditionsCard';
             case 'Stamp_Card_1':
                 return 'StampCard1';
+            case 'StampCard_Promotion_Card_1':
+                return 'StampCardPromotionCard';
             case 'Post_Order_Card_1':
                 return 'PostOrderCard';
             default:

--- a/packages/components/organisms/f-content-cards/stories/mockData/cards.js
+++ b/packages/components/organisms/f-content-cards/stories/mockData/cards.js
@@ -54,6 +54,10 @@ const cardTypes = {
     Stamp_Card_1: {
         label: 'Stamp Card',
         fields: ['line_3', 'discount_percentage', 'earned_stamps', 'expiry_date', 'expiry_line', 'is_ready_to_claim', 'total_required_stamps']
+    },
+    StampCard_Promotion_Card_1: {
+        label: 'StampCard Promotion Card',
+        fields: ['icon_1', 'button_1']
     }
 };
 /* eslint-enable camelcase */
@@ -62,13 +66,25 @@ const randomSentence = faker.lorem.sentence.bind(faker.lorem, undefined, undefin
 const randomColour = faker.internet.color.bind(faker.internet, undefined, undefined, undefined);
 
 /* eslint-disable camelcase */
+
+const getImageConfigByType = type => {
+    switch (type) {
+        case 'Anniversary_Card_1':
+            return '109/96'; // Custom
+        case 'StampCard_Promotion_Card_1':
+            return '384/165?blur=3'; // 21:9
+        default:
+            return '384/216?blur=3'; // 16:9
+    }
+};
+
 /**
  * A POJO map of fieldname to generator function that will predictably generate the correct type
  * @type {Object}
  */
 const fieldTypeToFaker = {
     background_color: randomColour,
-    background_image_1: type => `https://picsum.photos/seed/${type}_background_image_1/384/216?blur=3`,
+    background_image_1: type => `https://picsum.photos/seed/${type}_background_image_1/${getImageConfigByType(type)}`,
     banner: randomSentence,
     brand_name: faker.commerce.product.bind(faker.commerce),
     button_1: faker.lorem.words.bind(faker.lorem, undefined),
@@ -86,7 +102,7 @@ const fieldTypeToFaker = {
     headline: randomSentence,
     icon_1: type => `https://picsum.photos/seed/${type}_icon_1/48/48`,
     is_ready_to_claim: () => false,
-    image_1: type => `https://picsum.photos/seed/${type}_image_1/384/216?blur=3`,
+    image_1: type => `https://picsum.photos/seed/${type}_image_1/${getImageConfigByType(type)}`,
     line3: randomSentence,
     line4: randomSentence,
     line_3: randomSentence,
@@ -95,7 +111,7 @@ const fieldTypeToFaker = {
     line_6: randomSentence,
     offer_auth_required: faker.random.boolean.bind(faker.random),
     restaurant_id: faker.random.number.bind(faker.random, { min: 100, max: 999999 }),
-    restaurant_image_url: type => `https://picsum.photos/seed/${type}_restaurant_image_url/384/216?blur=3`,
+    restaurant_image_url: type => `https://picsum.photos/seed/${type}_restaurant_image_url/${getImageConfigByType(type)}`,
     restaurant_logo_url: type => `https://picsum.photos/seed/${type}_restaurant_logo_url/48/48`,
     subtitle: randomSentence,
     total_required_stamps: () => 5,
@@ -166,11 +182,9 @@ function seededRandomCardOfType (type) {
         e,
         tp: 'short_news',
         ar: 1,
-        i: (type === 'Anniversary_Card_1'
-            ? `https://picsum.photos/seed/${type}_i/109/96`
-            : `https://picsum.photos/seed/${type}_i/384/216?blur=3`),
-        u: null,
-        uw: null,
+        i: `https://picsum.photos/seed/${type}_i/${getImageConfigByType(type)}`,
+        u: '#',
+        uw: '#',
         tt,
         ds,
         dm
@@ -199,7 +213,8 @@ export default () => {
             seededRandomCardOfType('Post_Order_Card_1'),
             seededRandomCardOfType('Anniversary_Card_1'),
             seededRandomCardOfType('Restaurant_FTC_Offer_Card'),
-            seededRandomCardOfType('Stamp_Card_1')
+            seededRandomCardOfType('Stamp_Card_1'),
+            seededRandomCardOfType('StampCard_Promotion_Card_1')
         ],
         /* eslint-disable camelcase */
         last_full_sync_at: nowMinus5Hours,


### PR DESCRIPTION
### Updated
- Adds `StampCardPromotionCard` component, test, stories and docs
- Factors out some common card styling into a shared scss file
- Factors out some common non-visual behaviour into a shared component

### Fixed
- ContentCards stories when rendered as static site

### Screenshots

#### Desktop

![image](https://user-images.githubusercontent.com/6674452/112180275-51c34e80-8bf3-11eb-8c75-27e67cf087a2.png)

#### Tablet

![image](https://user-images.githubusercontent.com/6674452/112180367-699ad280-8bf3-11eb-9699-9687a029620d.png)

#### Mobile

![image](https://user-images.githubusercontent.com/6674452/112180417-73bcd100-8bf3-11eb-853f-5695b688c574.png)

---

## UI Review Checks


- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
