### PR TITLE
f-services@1.9.0 - Update axios client config.

### DIFF
--- a/packages/services/f-services/CHANGELOG.md
+++ b/packages/services/f-services/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.9.0
+------------------------------
+*March 24, 2021*
+
+### Changed
+- `createCamelCaseClient` function passes `transformResponse` directly instead of via a `config` object.
+- `createClient` & `createCamelCaseClient` both scoop up all remaining arguments via a rest parameter allowing us to pass any additional config as you would normally to `axios.create`.
+
+
 v1.8.0
 ------------------------------
 *March 23, 2021*

--- a/packages/services/f-services/package.json
+++ b/packages/services/f-services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-services",
   "description": "Fozzie Services - Shared Services for Components and projects",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "main": "dist/f-services.umd.js",
   "module": "dist/f-services.es.js",
   "source": "src/index.js",

--- a/packages/services/f-services/src/axios.js
+++ b/packages/services/f-services/src/axios.js
@@ -132,8 +132,8 @@ const createClient = ({
     baseURL = '',
     headers,
     headerTransform,
-    config,
-    responseCallback = false
+    responseCallback = false,
+    ...args
 } = {}) => {
     const instance = axios.create({
         baseURL,
@@ -141,7 +141,7 @@ const createClient = ({
             ? headerTransform(headers)
             : objectToAlternateCasing(headers, upperKebabCase),
         timeout: getTimeout(),
-        ...config
+        ...args
     });
 
     setupResponseTimeRecording(instance, responseCallback);
@@ -157,19 +157,19 @@ const createClient = ({
 const createCamelCaseClient = ({
     baseURL,
     headers,
-    headerTransform
+    headerTransform,
+    ...args
 } = {
     baseURL: ''
 }) => createClient({
     baseURL,
     headers,
     headerTransform,
-    config: {
-        transformResponse: [
-            ...axios.defaults.transformResponse,
-            data => objectToCamelCase(data)
-        ]
-    }
+    transformResponse: [
+        ...axios.defaults.transformResponse,
+        data => objectToCamelCase(data)
+    ],
+    ...args
 });
 
 export default {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,6 +2085,18 @@
     eslint-config-airbnb-base "14.1.0"
     eslint-plugin-vue "6.2.2"
 
+"@justeat/f-braze-adapter@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-braze-adapter/-/f-braze-adapter-3.1.0.tgz#2c88bf2d450120ded677edf390cdc6a1a54c6895"
+  integrity sha512-yTSEcIfBwlVPw/eHlOEEOxkFv4puM1KCtiz2igvjt3AAV6Ppcr4aRgNpYoGo8/aekVwRbyvN+k5/S3sQr5tJaw==
+  dependencies:
+    appboy-web-sdk "2.5.2"
+    date-fns "2.16.1"
+    lodash.findindex "4.6.0"
+    lodash.orderby "4.6.0"
+    lodash.startswith "4.2.1"
+    lodash.uniq "4.5.0"
+
 "@justeat/f-button@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-0.4.1.tgz#6b735093286422f579bd41cee93400a4d32d1b2d"


### PR DESCRIPTION
### Changed
- `createCamelCaseClient` function passes `transformResponse` directly instead of via a `config` object.
- `createClient` & `createCamelCaseClient` both scoop up all remaining arguments via a rest parameter allowing us to pass any additional config as you would normally to `axios.create`.