### PR TITLE
f-braze-adapter@v3.3.0 👩‍🔧 Fixes TypeError occurrences

### DIFF
--- a/packages/services/f-braze-adapter/CHANGELOG.md
+++ b/packages/services/f-braze-adapter/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.3.0
+------------------------------
+*March 29, 2021*
+
+### Fixed
+- Handled a condition where, if appboy was not initialised when `BrazeDispatcher.configure()` was called,
+  and an in-app message was received, an error would be thrown.
+
+
 v3.2.0
 ------------------------------
 *March 17, 2021*

--- a/packages/services/f-braze-adapter/package.json
+++ b/packages/services/f-braze-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-braze-adapter",
   "description": "Fozzie Metadata Service",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "main": "src/index.js",
   "files": [
     "src"

--- a/packages/services/f-braze-adapter/src/BrazeDispatcher.js
+++ b/packages/services/f-braze-adapter/src/BrazeDispatcher.js
@@ -20,22 +20,29 @@ function interceptInAppMessageClickEventsHandler (message) {
  * click events of the CTA button
  * @param message
  * @this BrazeDispatcher
+ * @return Promise
  */
 function interceptInAppMessagesHandler (message) {
-    if (message instanceof this.appboy.ab.InAppMessage) {
-        /**
-         * Always subscribe click action to second button
-         * as this is always "success" as opposed to "dismiss"
-         * as confirmed with CRM (AS)
-         */
-        this.inAppMessagesCallbacks.forEach(callback => callback(message));
-        if (message.buttons && message.buttons.length >= 2) {
-            const [, button] = message.buttons;
-            // Note that the below subscription returns an ID that could later be used to unsubscribe
-            button.subscribeToClickedEvent(() => interceptInAppMessageClickEventsHandler.bind(this)(message));
-        }
-    }
-    this.appboy.display.showInAppMessage(message);
+    return this.appboyPromise
+        .then(appboy => {
+            if (message instanceof appboy.ab.InAppMessage) {
+                /**
+                 * Always subscribe click action to second button
+                 * as this is always "success" as opposed to "dismiss"
+                 * as confirmed with CRM (AS)
+                 */
+                this.inAppMessagesCallbacks.forEach(callback => callback(message));
+                if (message.buttons && message.buttons.length >= 2) {
+                    const [, button] = message.buttons;
+                    // Note that the below subscription returns an ID that could later be used to unsubscribe
+                    button.subscribeToClickedEvent(() => interceptInAppMessageClickEventsHandler.bind(this)(message));
+                }
+            }
+            appboy.display.showInAppMessage(message);
+        })
+        .catch(error => {
+            this.logger('error', `Error handling message - ${error}`, { message, error });
+        });
 }
 
 /**
@@ -127,7 +134,6 @@ class BrazeDispatcher {
      * @return {Promise<null|*>}
      */
     async configure (options = {}) {
-        this.appboy = window.appboy;
         const {
             apiKey,
             userId,


### PR DESCRIPTION
### Fixed
- Handled a condition where, if appboy was not initialised when `BrazeDispatcher.configure()` was called,
  and an in-app message was received, an error would be thrown.

---

- [x] Unit tests have been [created|updated]
