### PR TITLE
f-tabs@v0.4.0 🧰 Fix setting active tab programatically

### DIFF
--- a/packages/components/molecules/f-tabs/CHANGELOG.md
+++ b/packages/components/molecules/f-tabs/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.4.0
 ------------------------------
-*March 29, 2021*
+*April 1, 2021*
 
 ### Fixed
 - When tab selection is updated in `Tab` props, ensures that the focus is reflected back

--- a/packages/components/molecules/f-tabs/CHANGELOG.md
+++ b/packages/components/molecules/f-tabs/CHANGELOG.md
@@ -3,6 +3,19 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.4.0
+------------------------------
+*March 29, 2021*
+
+### Fixed
+- When tab selection is updated in `Tab` props, ensures that the focus is reflected back
+  to surrounding `Tabs` component
+
+### Changed
+- Factored out Tabs' `provide` keys to constants
+
+
 v0.3.0
 ------------------------------
 *March 3, 2021*

--- a/packages/components/molecules/f-tabs/package.json
+++ b/packages/components/molecules/f-tabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-tabs",
   "description": "Fozzie Tabs – Switchable slots for content&#34;",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "dist/f-tabs.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-tabs/src/components/Tab.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tab.vue
@@ -20,13 +20,18 @@
 </template>
 
 <script>
-import { DIRECTION } from '../constants';
+import { DIRECTION, INJECTIONS } from '../constants';
+
+const {
+    REGISTER,
+    SELECT,
+    TABS_COMPONENT
+} = INJECTIONS;
 
 export default {
     name: 'Tab',
 
     props: {
-
         title: {
             required: true,
             type: String
@@ -43,25 +48,34 @@ export default {
         }
     },
 
-    inject: ['register', 'tabsComponent'],
+    inject: [REGISTER, SELECT, TABS_COMPONENT],
 
     computed: {
-
         isActive () {
-            return this.tabsComponent.activeTab === this.name;
+            return this[TABS_COMPONENT].activeTab === this.name;
         },
 
         transitionName () {
-            return this.tabsComponent.animationDirection === DIRECTION.LEFT ?
-                this.$style['fade-in-right'] : this.$style['fade-in-left'];
+            return this[TABS_COMPONENT].animationDirection === DIRECTION.LEFT
+                ? this.$style['fade-in-right']
+                : this.$style['fade-in-left'];
         },
 
         animateTab () {
-            return this.tabsComponent.animate;
+            return this[TABS_COMPONENT].animate;
         }
     },
+
+    watch: {
+        selected (current, previous) {
+            if (current && !previous) {
+                this[SELECT](this.name);
+            }
+        }
+    },
+
     created () {
-        this.register({
+        this[REGISTER]({
             name: this.name,
             title: this.title,
             selected: this.selected

--- a/packages/components/molecules/f-tabs/src/components/Tabs.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tabs.vue
@@ -26,7 +26,9 @@
 
 <script>
 
-import { DIRECTION } from '../constants';
+import { DIRECTION, INJECTIONS } from '../constants';
+
+const { REGISTER, TABS_COMPONENT, SELECT } = INJECTIONS;
 
 export default {
     name: 'Tabs',
@@ -64,10 +66,13 @@ export default {
         });
 
         return {
-            register (tab) {
+            [REGISTER]: tab => {
                 component.addTab(tab);
             },
-            tabsComponent
+            [SELECT]: name => {
+                component.selectTabIndex(name);
+            },
+            [TABS_COMPONENT]: tabsComponent
         };
     },
     methods: {

--- a/packages/components/molecules/f-tabs/src/components/tests/Tab.test.js
+++ b/packages/components/molecules/f-tabs/src/components/tests/Tab.test.js
@@ -1,5 +1,12 @@
 import { shallowMount } from '@vue/test-utils';
 import Tab from '../Tab.vue';
+import { INJECTIONS } from '../../constants';
+
+const {
+    REGISTER,
+    SELECT,
+    TABS_COMPONENT
+} = INJECTIONS;
 
 const REGISTER_DATA = {
     name: '__TAB_NAME__',
@@ -8,77 +15,101 @@ const REGISTER_DATA = {
 };
 
 describe('Tab.vue', () => {
-    let wrapper;
+    let activeWrapper;
 
-    beforeEach(() => {
-        // Arrange
-        wrapper = shallowMount(Tab, {
+    function defineActiveCompoment () {
+        activeWrapper = shallowMount(Tab, {
             propsData: {
                 name: REGISTER_DATA.name,
                 title: REGISTER_DATA.title,
-                selected: REGISTER_DATA.selected
+                selected: true
             },
             provide: {
-                register: jest.fn(),
-                tabsComponent: {
+                [REGISTER]: jest.fn(),
+                [SELECT]: jest.fn(),
+                [TABS_COMPONENT]: {
                     activeTab: REGISTER_DATA.name,
                     animationDirection: 'LEFT',
                     animate: true
                 }
             }
         });
-    });
+    }
 
     it('should be defined', () => {
+        // Arrange & Act
+        defineActiveCompoment();
+
         // Assert
-        expect(wrapper.exists()).toBe(true);
+        expect(activeWrapper.exists()).toBe(true);
     });
 
-    it('should call the register callback method when created', () => {
-        // Assert
-        expect(wrapper.vm.register).toHaveBeenCalled();
-    });
-
-    it('should supply the correct object to the callback method', () => {
-        // Assert
-        expect(wrapper.vm.register).toHaveBeenCalledWith(REGISTER_DATA);
-    });
-
-    it('should show only if isActive is true', () => {
-        // Arrange
-        const isActiveWrapper = shallowMount(Tab, {
-            propsData: {
-                name: REGISTER_DATA.name,
-                title: REGISTER_DATA.title,
-                selected: false
-            },
-            provide: {
-                register: jest.fn(),
-                tabsComponent: {
-                    activeTab: '',
-                    animationDirection: 'LEFT',
-                    animate: true
-                }
-            },
-            mocks: {
-                $style: {
-                    'c-tab': 'c-tab'
-                }
-            }
+    describe('when active', () => {
+        beforeEach(() => {
+            // Arrange & Act
+            defineActiveCompoment();
         });
 
-        // Act
-        const tab = isActiveWrapper.find('.c-tab');
+        it('should call the register callback method when created', () => {
+            // Assert
+            expect(activeWrapper.vm[REGISTER]).toHaveBeenCalled();
+        });
 
-        // Assert
-        expect(tab.isVisible()).toBe(false);
+        it('should supply the correct object to the callback method', () => {
+            // Assert
+            expect(activeWrapper.vm[REGISTER]).toHaveBeenCalledWith(REGISTER_DATA);
+        });
+
+        it('should show', () => {
+            // Assert
+            const tab = activeWrapper.find('.c-tab');
+            expect(tab.isVisible()).toBe(true);
+        });
+    });
+
+    describe('when inactive', () => {
+        let inactiveWrapper;
+
+        beforeEach(() => {
+            // Arrange & Act
+            inactiveWrapper = shallowMount(Tab, {
+                propsData: {
+                    name: REGISTER_DATA.name,
+                    title: REGISTER_DATA.title,
+                    selected: false
+                },
+                provide: {
+                    [REGISTER]: jest.fn(),
+                    [SELECT]: jest.fn(),
+                    [TABS_COMPONENT]: {
+                        activeTab: '',
+                        animationDirection: 'LEFT',
+                        animate: true
+                    }
+                }
+            });
+        });
+
+        it('should not show', () => {
+            // Assert
+            const tab = inactiveWrapper.find('.c-tab');
+            expect(tab.isVisible()).toBe(false);
+        });
+
+        it('should call the select callback when becoming active via selected prop', async () => {
+            // Act
+            await inactiveWrapper.setProps({ selected: true });
+
+            // Assert
+            expect(inactiveWrapper.vm[SELECT]).toHaveBeenCalled();
+        });
     });
 
     describe('Animation', () => {
         it('should only create transition element when animateTab is true', () => {
             // Act
-            const tabTransition = wrapper.find(`[data-test-id="tab-content-${wrapper.vm.name}"]`);
-            const tabNormal = wrapper.find(`[data-test-id="no-transition-tab-${wrapper.vm.name}"]`);
+            const tabTransition = activeWrapper.find(`[data-test-id="tab-content-${activeWrapper.vm.name}"]`);
+            const tabNormal = activeWrapper.find(`[data-test-id="no-transition-tab-${activeWrapper.vm.name}"]`);
 
             // Assert
             expect(tabTransition.exists()).toBe(true);
@@ -94,8 +125,9 @@ describe('Tab.vue', () => {
                     selected: REGISTER_DATA.selected
                 },
                 provide: {
-                    register: jest.fn(),
-                    tabsComponent: {
+                    [REGISTER]: jest.fn(),
+                    [SELECT]: jest.fn(),
+                    [TABS_COMPONENT]: {
                         activeTab: '',
                         animationDirection: 'LEFT',
                         animate: true
@@ -116,8 +148,9 @@ describe('Tab.vue', () => {
                     selected: REGISTER_DATA.selected
                 },
                 provide: {
-                    register: jest.fn(),
-                    tabsComponent: {
+                    [REGISTER]: jest.fn(),
+                    [SELECT]: jest.fn(),
+                    [TABS_COMPONENT]: {
                         activeTab: '',
                         animationDirection: 'RIGHT',
                         animate: true

--- a/packages/components/molecules/f-tabs/src/components/tests/Tabs.test.js
+++ b/packages/components/molecules/f-tabs/src/components/tests/Tabs.test.js
@@ -1,5 +1,13 @@
 import { shallowMount } from '@vue/test-utils';
+import Vue from 'vue';
 import Tabs from '../Tabs.vue';
+import { INJECTIONS } from '../../constants';
+
+const {
+    REGISTER,
+    SELECT,
+    TABS_COMPONENT
+} = INJECTIONS;
 
 const registeredTabsMock = [
     {
@@ -15,23 +23,92 @@ const registeredTabsMock = [
 ];
 
 describe('Tabs', () => {
-    it('should be defined', () => {
+    const Tab = Vue.extend({
+        name: 'Tab',
+        template: '<div data-tab="true"></div>',
+        inject: [REGISTER, SELECT, TABS_COMPONENT]
+    });
+
+    const arrange = ({ mocks } = {}) => {
         const propsData = {};
-        const wrapper = shallowMount(Tabs, { propsData });
-        expect(wrapper.exists()).toBe(true);
+        const tabsInstance = shallowMount(Tabs, {
+            ...{
+                propsData,
+                stubs: {
+                    Tab
+                },
+                scopedSlots: {
+                    default: '<tab/>'
+                }
+            },
+            ...{
+                mocks
+            }
+        });
+
+        const tabStub = tabsInstance.findComponent(Tab);
+
+        return { tabsInstance, tabStub };
+    };
+
+    it('should be defined', () => {
+        const { tabsInstance } = arrange();
+        expect(tabsInstance.exists()).toBe(true);
+    });
+
+    describe('when mounting descendants', () => {
+        let tabsInstance,
+            tabStub;
+
+        beforeEach(() => {
+            ({ tabsInstance, tabStub } = arrange());
+        });
+
+        it(`should provide a "${REGISTER}" callback`, () => {
+            // Assert
+            expect(tabStub.vm[REGISTER]).toBeDefined();
+        });
+
+        it(`should provide a "${SELECT}" callback`, () => {
+            // Assert
+            expect(tabStub.vm[SELECT]).toBeDefined();
+        });
+
+        describe(`should provide a "${TABS_COMPONENT}" object`, () => {
+            it('', () => {
+                // Assert
+                expect(tabStub.vm[TABS_COMPONENT]).toBeDefined();
+            });
+
+            describe('which', () => {
+                const propertyToState = {
+                    activeTab: 'activeTab',
+                    animationDirection: 'direction',
+                    animate: 'animate'
+                };
+
+                it.each(Object.entries(propertyToState))('should surface the {state} state of the Tabs object as {property}', (
+                    property,
+                    state
+                ) => {
+                    expect(tabStub.vm[TABS_COMPONENT][property]).toBe(tabsInstance.vm[state]);
+                });
+            });
+        });
     });
 
     describe('Tabs registration', () => {
-        let wrapper;
+        let wrapper,
+            tabStub;
 
         beforeEach(() => {
             // Arrange
-            wrapper = shallowMount(Tabs);
+            ({ tabsInstance: wrapper, tabStub } = arrange());
         });
 
-        it('should register a tab when addTab method is called', async () => {
+        it(`should register a tab when provided ${REGISTER} method is called`, async () => {
             // Act
-            await wrapper.vm.addTab(registeredTabsMock[0]);
+            await tabStub.vm[REGISTER](registeredTabsMock[0]);
             const tabButton = wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`);
 
             // Assert
@@ -41,10 +118,10 @@ describe('Tabs', () => {
         it('should display a button for each registered tab', async () => {
             // Act
             const tabs = [];
-            registeredTabsMock.forEach(tab => {
-                wrapper.vm.addTab(tab);
+            await Promise.all(registeredTabsMock.map(async tab => {
+                await tabStub.vm[REGISTER](tab);
                 tabs.push(wrapper.find(`[data-test-id="tab-button-${tab.name}"]`));
-            });
+            }));
             await wrapper.vm.$nextTick();
 
             // Assert
@@ -53,70 +130,88 @@ describe('Tabs', () => {
 
         it('should display the name of the registered tab inside the button', async () => {
             // Act
-            await wrapper.vm.addTab(registeredTabsMock[0]);
-            const tabButton = wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`);
+            await tabStub.vm[REGISTER](registeredTabsMock[0]);
 
             // Assert
+            const tabButton = wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`);
             expect(tabButton.text()).toBe(registeredTabsMock[0].title);
         });
     });
 
     describe('Tabs selection', () => {
-        let wrapper;
+        let wrapper,
+            tabStub;
 
-        beforeEach(() => {
+        beforeEach(async () => {
             // Arrange
-            wrapper = shallowMount(Tabs, {
+            ({ tabsInstance: wrapper, tabStub } = arrange({
                 mocks: {
                     $style: {
                         'c-tabs-button--active': 'c-tabs-button--active'
                     }
                 }
+            }));
+
+            await Promise.all(registeredTabsMock.map(async tab => {
+                await tabStub.vm[REGISTER](tab);
+            }));
+            await wrapper.vm.$nextTick();
+        });
+
+        describe('by user click', () => {
+            it('should apply a active class to the selected tab when selectTabIndex method is called', async () => {
+                // Act
+                const tabButton = wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`);
+                await tabButton.trigger('click');
+
+                // Assert
+                expect(tabButton.classes()).toContain('c-tabs-button--active');
+            });
+
+            it('should set the direction to RIGHT when new index > old index', async () => {
+                // Act
+                await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[1].name}"]`).trigger('click');
+
+                // Assert
+                expect(wrapper.vm.direction).toEqual('RIGHT');
+            });
+
+            it('should set the direction to LEFT when new index <= old index', async () => {
+                // Act
+                await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[1].name}"]`).trigger('click');
+                await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`).trigger('click');
+
+                // Assert
+                expect(wrapper.vm.direction).toEqual('LEFT');
             });
         });
 
-        it('should apply a active class to the selected tab when selectTabIndex method is called', async () => {
-            // Act
-            registeredTabsMock.forEach(tab => {
-                wrapper.vm.addTab(tab);
+        describe('programmatically', () => {
+            it('should apply a active class to the selected tab when selectTabIndex method is called', async () => {
+                // Act
+                await tabStub.vm[SELECT](registeredTabsMock[0].name);
+
+                // Assert
+                const tabButton = wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`);
+                expect(tabButton.classes()).toContain('c-tabs-button--active');
             });
 
-            await wrapper.vm.$nextTick();
+            it('should set the direction to RIGHT when new index > old index', async () => {
+                // Act
+                await tabStub.vm[SELECT](registeredTabsMock[1].name);
 
-            const tabButton = wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`);
-            await tabButton.trigger('click');
-
-            // Assert
-            expect(tabButton.classes()).toContain('c-tabs-button--active');
-        });
-
-        it('should set the direction to RIGHT when new index > old index', async () => {
-            // Act
-            registeredTabsMock.forEach(tab => {
-                wrapper.vm.addTab(tab);
+                // Assert
+                expect(wrapper.vm.direction).toEqual('RIGHT');
             });
 
-            await wrapper.vm.$nextTick();
+            it('should set the direction to LEFT when new index <= old index', async () => {
+                // Act
+                await tabStub.vm[SELECT](registeredTabsMock[1].name);
+                await tabStub.vm[SELECT](registeredTabsMock[0].name);
 
-            await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[1].name}"]`).trigger('click');
-
-            // Assert
-            expect(wrapper.vm.direction).toEqual('RIGHT');
-        });
-
-        it('should set the direction to LEFT when new index <= old index', async () => {
-            // Act
-            registeredTabsMock.forEach(tab => {
-                wrapper.vm.addTab(tab);
+                // Assert
+                expect(wrapper.vm.direction).toEqual('LEFT');
             });
-
-            await wrapper.vm.$nextTick();
-
-            await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[1].name}"]`).trigger('click');
-            await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`).trigger('click');
-
-            // Assert
-            expect(wrapper.vm.direction).toEqual('LEFT');
         });
     });
 });

--- a/packages/components/molecules/f-tabs/src/components/tests/Tabs.test.js
+++ b/packages/components/molecules/f-tabs/src/components/tests/Tabs.test.js
@@ -30,20 +30,17 @@ describe('Tabs', () => {
     });
 
     const arrange = ({ mocks } = {}) => {
-        const propsData = {};
         const tabsInstance = shallowMount(Tabs, {
-            ...{
-                propsData,
-                stubs: {
-                    Tab
-                },
-                scopedSlots: {
-                    default: '<tab/>'
-                }
+            // default mounting settings
+            propsData: {},
+            stubs: {
+                Tab
             },
-            ...{
-                mocks
-            }
+            scopedSlots: {
+                default: '<tab/>'
+            },
+            // mounting settings from parameters
+            mocks
         });
 
         const tabStub = tabsInstance.findComponent(Tab);

--- a/packages/components/molecules/f-tabs/src/constants.js
+++ b/packages/components/molecules/f-tabs/src/constants.js
@@ -3,3 +3,9 @@ export const DIRECTION = {
     LEFT: 'LEFT',
     RIGHT: 'RIGHT'
 };
+
+export const INJECTIONS = {
+    REGISTER: 'fTabs_register',
+    SELECT: 'fTabs_select',
+    TABS_COMPONENT: 'fTabs_tabsComponent'
+};

--- a/packages/components/molecules/f-tabs/stories/Tabs.stories.js
+++ b/packages/components/molecules/f-tabs/stories/Tabs.stories.js
@@ -11,17 +11,20 @@ export default {
     decorators: [withA11y]
 };
 
-export const VueTabsComponent = () => ({
+export const VueTabsComponent = (args, { argTypes }) => ({
     components: { Tabs, Tab },
+
+    props: Object.keys(argTypes),
+
     template: `
         <tabs :animate="true">
-            <tab name="a" title="Your Stampcards" :selected="true">
+            <tab name="a" title="Your Stampcards" :selected="'a' === selected">
                 Lorem ipsum dolor sit amet consectetur adipisicing elit. Corrupti
                 temporibus deleniti quas dolor eos et delectus eveniet sequi dolore,
                 minus vel ad nesciunt voluptatibus numquam nulla distinctio modi,
                 voluptas exercitationem?
             </tab>
-            <tab name="b" title="How it works">
+            <tab name="b" title="How it works" :selected="'b' === selected">
                 Lorem ipsum, dolor sit amet consectetur adipisicing elit. Commodi eaque
                 dicta quisquam voluptate inventore repellendus ut itaque, animi, magni
                 consectetur dolore, sapiente error! Eos cupiditate harum quidem sit illo
@@ -32,3 +35,9 @@ export const VueTabsComponent = () => ({
 });
 
 VueTabsComponent.storyName = 'f-tabs';
+VueTabsComponent.args = {
+    selected: 'a'
+};
+VueTabsComponent.argTypes = {
+    selected: { control: { type: 'radio', options: ['a', 'b'] } }
+};


### PR DESCRIPTION
### Fixed
- When tab selection is updated in `Tab` props, ensures that the focus is reflected back
  to surrounding `Tabs` component to action the change

### Changed
- Factored out Tabs' `provide` keys to constants

---

## UI Review Checks
- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
