### PR TITLE
f-form-field@1.9.0 - Pass `value` down to FormDropdown component

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -3,9 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-Latest (add to next release)
+v1.9.0
 ------------------------------
-*February 25, 2021*
+*March 30, 2021*
+
+### Added
+- New `value` prop to `FormDropdown` component to make the selected value assignable programmatically.
+  - This is done by passing down the existing `value` prop from the parent `FormField` component.
 
 ### Changed
 - Restructured component object into page object model

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
@@ -10,6 +10,7 @@
             :class="$style['c-formDropdown-select']"
             :data-test-id="testId.select"
             v-bind="attributes"
+            :value="value"
             @change="updateOption">
             <option
                 v-for="(option, index) in dropdownOptions"
@@ -36,6 +37,10 @@ export default {
         attributes: {
             type: Object,
             default: () => {}
+        },
+        value: {
+            type: String,
+            default: ''
         },
         dropdownOptions: {
             type: Array,

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -24,6 +24,7 @@
                 :id="`${uniqueId}`"
                 :attributes="$attrs"
                 :type="normalisedInputType"
+                :value="value"
                 :class="[
                     $style['c-formField-input'],
                     $style['c-formField-dropdownContainer'],

--- a/packages/components/atoms/f-form-field/src/components/_tests/FormDropdown.test.js
+++ b/packages/components/atoms/f-form-field/src/components/_tests/FormDropdown.test.js
@@ -39,6 +39,29 @@ describe('FormDropdown', () => {
                 expect(option.exists()).toBe(false);
             });
         });
+
+        describe('value ::', () => {
+            it('should default to first dropdown option when omitted', () => {
+                // Arrange & Act
+                const propsData = { dropdownOptions };
+                const wrapper = shallowMount(FormDropdown, { propsData });
+
+                // Assert
+                expect(wrapper.find('select').element.value).toBe('value 0');
+            });
+
+            it('should update selected value when changed', async () => {
+                // Arrange
+                const propsData = { dropdownOptions, value: 'value 1' };
+                const wrapper = shallowMount(FormDropdown, { propsData });
+
+                // Act
+                await wrapper.setProps({ value: 'value 3' });
+
+                // Assert
+                expect(wrapper.find('select').element.value).toBe('value 3');
+            });
+        });
     });
 
     describe('methods ::', () => {


### PR DESCRIPTION
This makes it possible to update the selected value in FormDropdown by changing the `value` passed into FormField.
When this prop is not passed in then the first value is selected by default, which is the existing behaviour.

There is no readme update because the props of FormField itself have not changed, only FormDropdown.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
