### PR TITLE
f-checkout@v0.83.0 - Fix top margin for the error messages

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.83.0
+------------------------------
+*April 6, 2021*
+
+### Fixed
+- Error alert top margin.
+
+
 v0.82.0
 ------------------------------
 *April 1, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.82.0",
+  "version": "0.83.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -896,7 +896,8 @@ export default {
 
 .c-checkout-alert {
     width: $checkout-width;
-    margin: 0 auto;
+    margin-left: auto;
+    margin-right: auto;
 }
 /* If these stay the same then just rename the class to something more generic */
 .c-checkout-submitButton {


### PR DESCRIPTION
This PR fixes the top margin for the error message on the checkout.

[This style](https://github.com/justeat/fozzie-components/blob/19d13e7f8cc07911e6b364cfefd354b7d66debf5/packages/components/molecules/f-alert/src/components/Alert.vue#L118) was overwritten by `margin: 0 auto`. To fix the `margin` I removed the shorthand.

**Before:** 
![image-20210330-072604](https://user-images.githubusercontent.com/3179649/113006920-ade71f00-916d-11eb-9e31-c2b0cdfd2dd4.png)

**After:**
<img width="1195" alt="Screenshot 2021-03-31 at 11 44 39" src="https://user-images.githubusercontent.com/3179649/113132594-931cb500-9216-11eb-9af1-574b7427a784.png">

