### PR TITLE
f-header - component tests for different locales #trivial

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -11,6 +11,7 @@ Latest (add to next release)
 ### Added
 - Component tests for locales `au, dk, ie, es, no, it, nz`
 - Component test for offers icon in mobile spec
+- Accessibility tests for the above locales 
 
 ### Changed
 - Small refactor to `open` function in component-object

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*March 31, 2021*
+
+### Added
+- Component tests for locales au, dk, ie, es, no, it, nz
+- Component test for offers icon in mobile spec
+
+### Changed
+- Small refactor to url function in component-object
+
 
 v4.11.1
 ------------------------------

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -3,16 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
 Latest (add to next release)
 ------------------------------
 *March 31, 2021*
 
 ### Added
-- Component tests for locales au, dk, ie, es, no, it, nz
+- Component tests for locales `au, dk, ie, es, no, it, nz`
 - Component test for offers icon in mobile spec
 
 ### Changed
-- Small refactor to url function in component-object
+- Small refactor to `open` function in component-object
 
 
 v4.11.1

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -34,7 +34,7 @@
     "test": "vue-cli-service test:unit",
     "test-component:browserstack": "cross-env-shell JE_ENV=browserstack wdio ../../../../wdio-browserstack.conf.js --suite shared mobile",
     "test-component:chrome": "cross-env-shell JE_ENV=local wdio ../../../../wdio-chrome.conf.js --suite component",
-    "report:test-component:chome": "cross-env-shell JE_ENV=ci COMPONENT_TYPE=organism wdio ../../../../wdio-chrome.conf.js --suite component && yarn:allure:open",
+    "report:test-component:chrome": "cross-env-shell JE_ENV=local COMPONENT_TYPE=organism wdio ../../../../wdio-chrome.conf.js --suite component && yarn allure:open",
     "test-a11y:chrome": "cross-env-shell JE_ENV=local wdio ../../../../wdio-chrome.conf.js --suite a11y", 
     "allure:open": "yarn allure:clean && allure open",
     "allure:clean": "rimraf ../../../../test/results/allure"

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
@@ -4,38 +4,39 @@ const {
     HEADER_LOGO,
     MOBILE_NAVIGATION_BAR,
     NAVIGATION
-} = require ('./f-header.selectors');
+} = require('./f-header.selectors');
 
 module.exports = class Header extends Page {
+    get component () { return $(HEADER_COMPONENT); }
 
-    get component () { return $(HEADER_COMPONENT) }
-    get logo () { return  $(HEADER_LOGO) }
-    get mobileNavigationBar () { return $(MOBILE_NAVIGATION_BAR) }
+    get logo () { return $(HEADER_LOGO); }
+
+    get mobileNavigationBar () { return $(MOBILE_NAVIGATION_BAR); }
 
     navigation = {
         offersIcon: {
-            get link () { return $(NAVIGATION.offersIcon.link) }
+            get link () { return $(NAVIGATION.offersIcon.link); }
         },
         offersLink: {
-            get link () { return $(NAVIGATION.offersLink.link) }
+            get link () { return $(NAVIGATION.offersLink.link); }
         },
         help: {
-            get link () { return $(NAVIGATION.help.link) }
+            get link () { return $(NAVIGATION.help.link); }
         },
         delivery: {
-            get link () { return $(NAVIGATION.delivery.link) },
+            get link () { return $(NAVIGATION.delivery.link); }
         },
         userAccount: {
-            get link () { return $(NAVIGATION.userAccount.link) }
+            get link () { return $(NAVIGATION.userAccount.link); }
         },
         countrySelector: {
-            get link () { return $(NAVIGATION.countrySelector.link) },
-            get currentIcon () { return $(NAVIGATION.countrySelector.currentIcon) },
-            get countries () { return $$(NAVIGATION.countrySelector.countryList) }
+            get link () { return $(NAVIGATION.countrySelector.link); },
+            get currentIcon () { return $(NAVIGATION.countrySelector.currentIcon); },
+            get countries () { return $$(NAVIGATION.countrySelector.countryList); }
         }
     }
 
-    get countryLink () { return this.countryValue != null ?  this.countryValue : 'Please set a country value'; }
+    get countryLink () { return this.countryValue != null ? this.countryValue : 'Please set a country value'; }
 
     set expectedCountry (country) {
         this.countryValue = this.navigation.countrySelector.countries.filter(element => element.getAttribute('data-test-id').includes(country))[0];
@@ -50,7 +51,7 @@ module.exports = class Header extends Page {
     }
 
     openWithLocale (locale) {
-        let countryFormatted = locale.toUpperCase();
+        const countryFormatted = locale.toUpperCase();
         let formattedLocale = '';
         switch (countryFormatted) {
             case 'GB':
@@ -72,7 +73,7 @@ module.exports = class Header extends Page {
                 formattedLocale = `nb-${countryFormatted}`;
                 break;
             default:
-                throw new Error (`locale ${countryFormatted} is not supported`)
+                throw new Error(`locale ${countryFormatted} is not supported`);
         }
         super.openComponent('organism', `header-component&knob-Locale=${formattedLocale}`);
     }
@@ -94,7 +95,7 @@ module.exports = class Header extends Page {
     }
 
     isCurrentCountryIconDisplayed (country) {
-        let expectedIcon = this.navigation.countrySelector.currentIcon.getAttribute('class').includes(`c-ficon--flag.${country}.round`);
+        const expectedIcon = this.navigation.countrySelector.currentIcon.getAttribute('class').includes(`c-ficon--flag.${country}.round`);
         return expectedIcon ? this.navigation.countrySelector.currentIcon.isDisplayed() : false;
     }
 
@@ -106,14 +107,9 @@ module.exports = class Header extends Page {
         return this.mobileNavigationBar.isDisplayed();
     }
 
-    // saving these for another ticket
-    // isMobileOffersIconDisplayed(){
-    //     return this.mobileOffersIcon.length === 1 && element[0].isDisplayed();
-    // }
-
-    // isWebOffersIconDisplayed(){
-    //     return this.webOffersIcon.length === 1 && element[0].isDisplayed();
-    // }
+    isOffersIconLinkDisplayed () {
+        return this.navigation.offersIcon.isDisplayed();
+    }
 
     clickOffersLink () {
         return this.navigation.offersLink.link.click();

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
@@ -13,6 +13,8 @@ module.exports = class Header extends Page {
 
     get mobileNavigationBar () { return $(MOBILE_NAVIGATION_BAR); }
 
+    get locales () { return ['au', 'gb', 'ie', 'nz'] }
+
     navigation = {
         offersIcon: {
             get link () { return $(NAVIGATION.offersIcon.link); }
@@ -42,16 +44,27 @@ module.exports = class Header extends Page {
         this.countryValue = this.navigation.countrySelector.countries.filter(element => element.getAttribute('data-test-id').includes(country))[0];
     }
 
-    open () {
-        super.openComponent('organism', 'header-component');
-    }
 
-    openWithExtraFeatures () {
-        super.openComponent('organism', 'header-component&knob-Show%20offers%20link=true&knob-Show%20delivery%20enquiry=true');
-    }
+    // open () {
+    //     super.openComponent('organism', 'header-component');
+    // }
 
-    openWithLocale (locale) {
-        const countryFormatted = locale.toUpperCase();
+    // openWithExtraFeatures () {
+    //     super.openComponent('organism', 'header-component&knob-Show%20offers%20link=true&knob-Show%20delivery%20enquiry=true');
+    // }
+
+    /**
+     * @description
+     * Sets the data for the checkout component.
+     *
+     * @param {Object} header
+     * @param {String} header.locale The checkout type
+     * @param {String} header.offers The checkout authentication
+     * @param {String} header.delivery The checkout authentication
+     */
+
+    open (header) {
+        const countryFormatted = header.locale.toUpperCase();
         let formattedLocale = '';
         switch (countryFormatted) {
             case 'GB':
@@ -75,7 +88,10 @@ module.exports = class Header extends Page {
             default:
                 throw new Error(`locale ${countryFormatted} is not supported`);
         }
-        super.openComponent('organism', `header-component&knob-Locale=${formattedLocale}`);
+
+        const offersUrl = header.offers ? '&knob-Show%20offers%20link=true' : '';
+        const deliveryUrl = header.delivery ? '&knob-Show%20delivery%20enquiry=true' : '';
+        super.openComponent('organism', `header-component&knob-Locale=${formattedLocale}${offersUrl}${deliveryUrl}`);
     }
 
     waitForComponent () {

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
@@ -13,8 +13,6 @@ module.exports = class Header extends Page {
 
     get mobileNavigationBar () { return $(MOBILE_NAVIGATION_BAR); }
 
-    get locales () { return ['au', 'gb', 'ie', 'nz'] }
-
     navigation = {
         offersIcon: {
             get link () { return $(NAVIGATION.offersIcon.link); }

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
@@ -79,7 +79,6 @@ module.exports = class Header extends Page {
             default:
                 throw new Error(`locale ${countryFormatted} is not supported`);
         }
-
         const offersUrl = header.offers ? '&knob-Show%20offers%20link=true' : '';
         const deliveryUrl = header.delivery ? '&knob-Show%20delivery%20enquiry=true' : '';
         super.openComponent('organism', `header-component&knob-Locale=${formattedLocale}${offersUrl}${deliveryUrl}`);
@@ -97,8 +96,8 @@ module.exports = class Header extends Page {
         return this.logo.isDisplayed();
     }
 
-    isFieldLinkDisplayed (fieldName) {
-        return this.navigation[fieldName].link.isDisplayedInViewport();
+    isNavigationLinkDisplayed (linkName) {
+        return this.navigation[linkName].link.isDisplayedInViewport();
     }
 
     isCurrentCountryIconDisplayed (country) {

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
@@ -44,15 +44,6 @@ module.exports = class Header extends Page {
         this.countryValue = this.navigation.countrySelector.countries.filter(element => element.getAttribute('data-test-id').includes(country))[0];
     }
 
-
-    // open () {
-    //     super.openComponent('organism', 'header-component');
-    // }
-
-    // openWithExtraFeatures () {
-    //     super.openComponent('organism', 'header-component&knob-Show%20offers%20link=true&knob-Show%20delivery%20enquiry=true');
-    // }
-
     /**
      * @description
      * Sets the data for the checkout component.

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.selectors.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.selectors.js
@@ -4,23 +4,23 @@ export const MOBILE_NAVIGATION_BAR = '[data-test-id="nav-toggle"]';
 
 export const NAVIGATION = {
     offersIcon: {
-        link: '[data-test-id="offers-iconLink"]',
+        link: '[data-test-id="offers-iconLink"]'
     },
     offersLink: {
-        link: '[data-test-id="offers-link"]',
+        link: '[data-test-id="offers-link"]'
     },
     help: {
-        link: '[data-test-id="help-link"]', 
-    },  
+        link: '[data-test-id="help-link"]'
+    },
     delivery: {
-        link: '[data-test-id="delivery-link"]', 
-    }, 
+        link: '[data-test-id="delivery-link"]'
+    },
     userAccount: {
-        link: '[data-test-id="user-info-link"]', 
-    }, 
+        link: '[data-test-id="user-info-link"]'
+    },
     countrySelector: {
-        link: '[data-test-id="country-selector"] button', 
+        link: '[data-test-id="country-selector"] button',
         currentIcon: '[data-test-id="current-flag-icon"]',
         countryList: '[data-test-id="countrySelector-list"] li'
     }
-}
+};

--- a/packages/components/organisms/f-header/test/specs/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-header/test/specs/accessibility/axe-accessibility.spec.js
@@ -4,20 +4,17 @@ const Header = require('../../../test-utils/component-objects/f-header.component
 const header = new Header();
 
 describe('Accessibility tests', () => {
-    beforeEach(() => {
+    forEach(['gb', 'au', 'nz', 'ie', 'it', 'es', 'dk', 'no'])
+    .it('a11y - should test f-header component WCAG compliance', expectedLocale => {
+        // Act
         const headerData = {
-            locale: 'gb',
+            locale: expectedLocale,
             offers: true,
             delivery: true
         };
 
         header.open(headerData);
         header.waitForComponent();
-    });
-
-    forEach(['au', 'nz', 'ie', 'it', 'es', 'dk', 'no'])
-    .it('a11y - should test f-header component WCAG compliance', () => {
-        // Act
         const axeResults = getAccessibilityTestResults('f-header');
 
         // Assert

--- a/packages/components/organisms/f-header/test/specs/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-header/test/specs/accessibility/axe-accessibility.spec.js
@@ -1,14 +1,22 @@
+const forEach = require('mocha-each');
 const { getAccessibilityTestResults } = require('../../../../../../../test/utils/axe-helper');
 const Header = require('../../../test-utils/component-objects/f-header.component');
 const header = new Header();
 
 describe('Accessibility tests', () => {
     beforeEach(() => {
-        header.open();
+        const headerData = {
+            locale: 'gb',
+            offers: true,
+            delivery: true
+        };
+
+        header.open(headerData);
         header.waitForComponent();
     });
 
-    it('a11y - should test f-header component WCAG compliance', () => {
+    forEach(['au', 'nz', 'ie', 'it', 'es', 'dk', 'no'])
+    .it('a11y - should test f-header component WCAG compliance', () => {
         // Act
         const axeResults = getAccessibilityTestResults('f-header');
 

--- a/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
@@ -1,54 +1,100 @@
-// const forEach = require('mocha-each');
-// const Header = require('../../../../test-utils/component-objects/f-header.component');
-// const header = new Header();
+const forEach = require('mocha-each');
+const Header = require('../../../../test-utils/component-objects/f-header.component');
+const header = new Header();
 
-// describe('Desktop - f-header component tests', () => {
-//     beforeEach(() => {
-//         header.open();
-//         header.waitForComponent();
-//     });
+describe('Desktop - f-header component tests', () => {
+    beforeEach(() => {
+        const headerData = {
+            locale: 'gb',
+            offers: true,
+            delivery: true
+        };
 
-//     forEach(['help', 'countrySelector', 'userAccount'])
-//     .it('should only display the default navigation fields', field => {
-//         // Assert
-//         expect(header.isFieldLinkDisplayed(field)).toBe(true); 
-//         expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
-//     });
+        header.open(headerData);
+        header.waitForComponent();
+        browser.maximizeWindow();
+    });
 
-//     forEach(['offersLink', 'help', 'delivery', 'userAccount', 'countrySelector'])
-//     .it('should display extra fields as well as default when selected', field => {
-//         // Act
-//         header.openWithExtraFeatures();
+    forEach(['offersLink', 'delivery', 'help', 'countrySelector', 'userAccount'])
+    .it('should display all navigation links', field => {
+        // Assert
+        expect(header.isFieldLinkDisplayed(field)).toBe(true);
+    });
 
-//         // Assert
-//         expect(header.isFieldLinkDisplayed(field)).toBe(true);
-//     });
+    forEach(['au', 'ie', 'nz'])
+    .it('should display the below navigation links', expectedLocale => {
+        // Arrange
+        const headerData = {
+            locale: expectedLocale,
+            offers: true,
+            delivery: true
+        };
 
-//     forEach([['gb', '.co.uk'], ['au', 'au'], ['at', 'at'], ['be', 'be-en'], ['bg', 'bg'], ['ca_en', 'skipthedishes.com'], ['ca_fr', 'skipthedishes.com/fr'], ['dk', '.dk'], ['jet_fr', '.fr'], ['de', '.de'], ['ie', '.ie'], ['il', '.il'], ['it', '.it'], 
-//     ['lu', 'lu-en'], ['nl', '.nl'], ['nz', '.nz'], ['no', '.no'], ['pl', '.pl'], ['pt', '/pt'], ['ro', '/ro'], ['es', '.es'], ['ch_ch', '.ch'], ['ch_en', '/en'], ['ch_fr', '/fr'] ])
-//     .it('should display all countries and redirect to correct URL', (country, expectedUrl) => {
-//         // Act
-//         browser.maximizeWindow();
-//         header.moveToCountrySelector();
-//         header.expectedCountry = country;
+        // Act
+        ['offersLink', 'userAccount', 'help', 'countrySelector'].forEach(link => {
+            header.open(headerData);
+            header.waitForComponent();
 
-//         // Assert
-//         expect(header.isCountryLinkDisplayed()).toBe(true);
+            // Assert
+            expect(header.isFieldLinkDisplayed(link)).toBe(true);
+            expect(header.isFieldLinkDisplayed('delivery')).toBe(false);
+        });
+    });
 
-//         // Act
-//         header.clickCountryListItem();
+    forEach(['it', 'es', 'dk', 'no'])
+    .it('should display the below navigation links', expectedLocale => {
+        // Arrange
+        const headerData = {
+            locale: expectedLocale,
+            offers: true,
+            delivery: true
+        };
 
-//         // Assert
-//         expect(browser.getUrl()).toContain(expectedUrl);
-//     });
+        // Act
+        ['userAccount', 'help', 'countrySelector'].forEach(link => {
+            header.open(headerData);
+            header.waitForComponent();
 
-//     forEach(['au', 'gb', 'nz', 'ie', 'dk', 'es', 'it'])
-//     .it('should display correct country selector icon depending on which locale is chosen', country => {
-//         // Act
-//         browser.maximizeWindow();
-//         header.openWithLocale(country);
+            // Assert
+            expect(header.isFieldLinkDisplayed(link)).toBe(true);
+            expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
+            expect(header.isFieldLinkDisplayed('delivery')).toBe(false);
+        });
+    });
 
-//         // Assert
-//         expect(header.isCurrentCountryIconDisplayed(country)).toBe(true);
-//     });
-// });
+    forEach([['gb', '.co.uk'], ['au', 'au'], ['at', 'at'], ['be', 'be-en'], ['bg', 'bg'], ['ca_en', 'skipthedishes.com'], ['ca_fr', 'skipthedishes.com/fr'], ['dk', '.dk'], ['jet_fr', '.fr'], ['de', '.de'], ['ie', '.ie'], ['il', '.il'], ['it', '.it'], 
+    ['lu', 'lu-en'], ['nl', '.nl'], ['nz', '.nz'], ['no', '.no'], ['pl', '.pl'], ['pt', '/pt'], ['ro', '/ro'], ['es', '.es'], ['ch_ch', '.ch'], ['ch_en', '/en'], ['ch_fr', '/fr'] ])
+    .it('should display all countries and redirect to correct URL', (expectedLocale, expectedUrl) => {
+        // Act
+        // browser.maximizeWindow();
+        header.moveToCountrySelector();
+        header.expectedCountry = expectedLocale;
+
+        // Assert
+        expect(header.isCountryLinkDisplayed()).toBe(true);
+
+        // Act
+        header.clickCountryListItem();
+
+        // Assert
+        expect(browser.getUrl()).toContain(expectedUrl);
+    });
+
+    forEach(['au', 'gb', 'nz', 'ie', 'dk', 'es', 'it'])
+    .it('should display correct country selector icon depending on which locale is chosen', expectedLocale => {
+        // Arrange
+        const headerData = {
+            locale: expectedLocale,
+            offers: true,
+            delivery: true
+        };
+
+        // Act
+        // browser.maximizeWindow();
+        header.open(headerData);
+        header.waitForComponent();
+
+        // Assert
+        expect(header.isCurrentCountryIconDisplayed(expectedLocale)).toBe(true);
+    });
+});

--- a/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
@@ -30,8 +30,8 @@ describe('Desktop - f-header component tests', () => {
             delivery: true
         };
 
-        // Act
         ['offersLink', 'userAccount', 'help', 'countrySelector'].forEach(link => {
+            // Act
             header.open(headerData);
             header.waitForComponent();
 
@@ -50,8 +50,8 @@ describe('Desktop - f-header component tests', () => {
             delivery: true
         };
 
-        // Act
         ['userAccount', 'help', 'countrySelector'].forEach(link => {
+            // Act
             header.open(headerData);
             header.waitForComponent();
 

--- a/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
@@ -1,54 +1,54 @@
-const forEach = require('mocha-each');
-const Header = require('../../../../test-utils/component-objects/f-header.component');
-const header = new Header();
+// const forEach = require('mocha-each');
+// const Header = require('../../../../test-utils/component-objects/f-header.component');
+// const header = new Header();
 
-describe('Desktop - f-header component tests', () => {
-    beforeEach(() => {
-        header.open();
-        header.waitForComponent();
-    });
+// describe('Desktop - f-header component tests', () => {
+//     beforeEach(() => {
+//         header.open();
+//         header.waitForComponent();
+//     });
 
-    forEach(['help', 'countrySelector', 'userAccount'])
-    .it('should only display the default navigation fields', field => {
-        // Assert
-        expect(header.isFieldLinkDisplayed(field)).toBe(true); 
-        expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
-    });
+//     forEach(['help', 'countrySelector', 'userAccount'])
+//     .it('should only display the default navigation fields', field => {
+//         // Assert
+//         expect(header.isFieldLinkDisplayed(field)).toBe(true); 
+//         expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
+//     });
 
-    forEach(['offersLink', 'help', 'delivery', 'userAccount', 'countrySelector'])
-    .it('should display extra fields as well as default when selected', field => {
-        // Act
-        header.openWithExtraFeatures();
+//     forEach(['offersLink', 'help', 'delivery', 'userAccount', 'countrySelector'])
+//     .it('should display extra fields as well as default when selected', field => {
+//         // Act
+//         header.openWithExtraFeatures();
 
-        // Assert
-        expect(header.isFieldLinkDisplayed(field)).toBe(true);
-    });
+//         // Assert
+//         expect(header.isFieldLinkDisplayed(field)).toBe(true);
+//     });
 
-    forEach([['gb', '.co.uk'], ['au', 'au'], ['at', 'at'], ['be', 'be-en'], ['bg', 'bg'], ['ca_en', 'skipthedishes.com'], ['ca_fr', 'skipthedishes.com/fr'], ['dk', '.dk'], ['jet_fr', '.fr'], ['de', '.de'], ['ie', '.ie'], ['il', '.il'], ['it', '.it'], 
-    ['lu', 'lu-en'], ['nl', '.nl'], ['nz', '.nz'], ['no', '.no'], ['pl', '.pl'], ['pt', '/pt'], ['ro', '/ro'], ['es', '.es'], ['ch_ch', '.ch'], ['ch_en', '/en'], ['ch_fr', '/fr'] ])
-    .it('should display all countries and redirect to correct URL', (country, expectedUrl) => {
-        // Act
-        browser.maximizeWindow();
-        header.moveToCountrySelector();
-        header.expectedCountry = country;
+//     forEach([['gb', '.co.uk'], ['au', 'au'], ['at', 'at'], ['be', 'be-en'], ['bg', 'bg'], ['ca_en', 'skipthedishes.com'], ['ca_fr', 'skipthedishes.com/fr'], ['dk', '.dk'], ['jet_fr', '.fr'], ['de', '.de'], ['ie', '.ie'], ['il', '.il'], ['it', '.it'], 
+//     ['lu', 'lu-en'], ['nl', '.nl'], ['nz', '.nz'], ['no', '.no'], ['pl', '.pl'], ['pt', '/pt'], ['ro', '/ro'], ['es', '.es'], ['ch_ch', '.ch'], ['ch_en', '/en'], ['ch_fr', '/fr'] ])
+//     .it('should display all countries and redirect to correct URL', (country, expectedUrl) => {
+//         // Act
+//         browser.maximizeWindow();
+//         header.moveToCountrySelector();
+//         header.expectedCountry = country;
 
-        // Assert
-        expect(header.isCountryLinkDisplayed()).toBe(true);
+//         // Assert
+//         expect(header.isCountryLinkDisplayed()).toBe(true);
 
-        // Act
-        header.clickCountryListItem();
+//         // Act
+//         header.clickCountryListItem();
 
-        // Assert
-        expect(browser.getUrl()).toContain(expectedUrl);
-    });
+//         // Assert
+//         expect(browser.getUrl()).toContain(expectedUrl);
+//     });
 
-    forEach(['au', 'gb', 'nz', 'ie', 'dk', 'es', 'it'])
-    .it('should display correct country selector icon depending on which locale is chosen', country => {
-        // Act
-        browser.maximizeWindow();
-        header.openWithLocale(country);
+//     forEach(['au', 'gb', 'nz', 'ie', 'dk', 'es', 'it'])
+//     .it('should display correct country selector icon depending on which locale is chosen', country => {
+//         // Act
+//         browser.maximizeWindow();
+//         header.openWithLocale(country);
 
-        // Assert
-        expect(header.isCurrentCountryIconDisplayed(country)).toBe(true);
-    });
-});
+//         // Assert
+//         expect(header.isCurrentCountryIconDisplayed(country)).toBe(true);
+//     });
+// });

--- a/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
@@ -74,6 +74,7 @@ describe('Desktop - f-header component tests', () => {
 
         // Act
         header.clickCountryListItem();
+        header.waitForComponent();
 
         // Assert
         expect(browser.getUrl()).toContain(expectedUrl);

--- a/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
@@ -16,9 +16,9 @@ describe('Desktop - f-header component tests', () => {
     });
 
     forEach(['offersLink', 'delivery', 'help', 'countrySelector', 'userAccount'])
-    .it('should display all navigation links', field => {
+    .it('should display all navigation links', link => {
         // Assert
-        expect(header.isFieldLinkDisplayed(field)).toBe(true);
+        expect(header.isNavigationLinkDisplayed(link)).toBe(true);
     });
 
     forEach(['au', 'ie', 'nz'])
@@ -36,13 +36,13 @@ describe('Desktop - f-header component tests', () => {
             header.waitForComponent();
 
             // Assert
-            expect(header.isFieldLinkDisplayed(link)).toBe(true);
-            expect(header.isFieldLinkDisplayed('delivery')).toBe(false);
+            expect(header.isNavigationLinkDisplayed(link)).toBe(true);
+            expect(header.isNavigationLinkDisplayed('delivery')).toBe(false);
         });
     });
 
     forEach(['it', 'es', 'dk', 'no'])
-    .it('should display the below navigation links', expectedLocale => {
+    .it('should display the below navigation fields', expectedLocale => {
         // Arrange
         const headerData = {
             locale: expectedLocale,
@@ -56,9 +56,9 @@ describe('Desktop - f-header component tests', () => {
             header.waitForComponent();
 
             // Assert
-            expect(header.isFieldLinkDisplayed(link)).toBe(true);
-            expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
-            expect(header.isFieldLinkDisplayed('delivery')).toBe(false);
+            expect(header.isNavigationLinkDisplayed(link)).toBe(true);
+            expect(header.isNavigationLinkDisplayed('offersLink')).toBe(false);
+            expect(header.isNavigationLinkDisplayed('delivery')).toBe(false);
         });
     });
 
@@ -66,7 +66,6 @@ describe('Desktop - f-header component tests', () => {
     ['lu', 'lu-en'], ['nl', '.nl'], ['nz', '.nz'], ['no', '.no'], ['pl', '.pl'], ['pt', '/pt'], ['ro', '/ro'], ['es', '.es'], ['ch_ch', '.ch'], ['ch_en', '/en'], ['ch_fr', '/fr'] ])
     .it('should display all countries and redirect to correct URL', (expectedLocale, expectedUrl) => {
         // Act
-        // browser.maximizeWindow();
         header.moveToCountrySelector();
         header.expectedCountry = expectedLocale;
 
@@ -90,7 +89,6 @@ describe('Desktop - f-header component tests', () => {
         };
 
         // Act
-        // browser.maximizeWindow();
         header.open(headerData);
         header.waitForComponent();
 

--- a/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
@@ -74,7 +74,7 @@ describe('Desktop - f-header component tests', () => {
 
         // Act
         header.clickCountryListItem();
-        header.waitForComponent();
+        browser.pause(300);
 
         // Assert
         expect(browser.getUrl()).toContain(expectedUrl);

--- a/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/desktop/f-header.component.spec.js
@@ -42,7 +42,7 @@ describe('Desktop - f-header component tests', () => {
     });
 
     forEach(['it', 'es', 'dk', 'no'])
-    .it('should display the below navigation fields', expectedLocale => {
+    .it('should display the below navigation links', expectedLocale => {
         // Arrange
         const headerData = {
             locale: expectedLocale,

--- a/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
@@ -1,6 +1,5 @@
 const forEach = require('mocha-each');
 const Header = require('../../../../test-utils/component-objects/f-header.component');
-
 const header = new Header();
 
 describe('Mobile - f-header component tests', () => {

--- a/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
@@ -19,52 +19,25 @@ describe('Mobile - f-header component tests', () => {
         }
     });
 
-    // forEach(['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'])
-    // .it('should hide all navigation links, except offersIcon link, when in mobile mode', field => {
-    //     // Arrange
-    //     const locales = ['gb', 'au', 'ie', 'nz'];
+    forEach(['gb', 'au', 'ie', 'nz'])
+    .it('should hide all navigation links, except offersIcon link, when in mobile mode', expectedLocale => {
+        // Arrange
+        const headerData = {
+            locale: expectedLocale,
+            offers: true,
+            delivery: true
+        };
 
-    //     for (let i = 0; i < locales.length; i++) {
-    //         // Arrange
-    //         const headerData = {
-    //             locale: locales[i],
-    //             offers: true,
-    //             delivery: true
-    //         };
+        // Act
+        ['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'].forEach(link => {
+            header.open(headerData);
 
-    //         // Act
-    //         header.open(headerData);
-    //         console.log(headerData);
-    //     }
-
-    //     // Assert
-    //     expect(header.isMobileNavigationBarDisplayed()).toBe(true);
-    //     expect(header.isFieldLinkDisplayed(field)).toBe(false);
-    //     expect(header.isFieldLinkDisplayed('offersIcon')).toBe(true);
-    // });
-
-    // forEach(['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'])
-    // .it('should display navigation fields when burger menu has been opened', field => {
-    //     // Arrange
-    //     const locales = ['gb', 'au', 'ie', 'nz'];
-
-    //     for (let i = 0; i < locales.length; i++) {
-    //         // Arrange
-    //         const headerData = {
-    //             locale: locales[i],
-    //             offers: true,
-    //             delivery: true
-    //         };
-
-    //         // Act
-    //         header.open(headerData);
-    //         console.log('heyyy', headerData);
-    //         header.openMobileNavigation();
-    //     }
-
-    //     // Assert
-    //     expect(header.isFieldLinkDisplayed(field)).toBe(true);
-    // });
+            // Assert
+            expect(header.isMobileNavigationBarDisplayed()).toBe(true);
+            expect(header.isFieldLinkDisplayed(link)).toBe(false);
+            expect(header.isFieldLinkDisplayed('offersIcon')).toBe(true);
+        });
+    });
 
     forEach(['gb', 'au', 'ie', 'nz'])
     .it('should display navigation links when burger menu is opened', expectedLocale => {
@@ -74,75 +47,45 @@ describe('Mobile - f-header component tests', () => {
             offers: true,
             delivery: true
         };
-        let navigationLink = '';
+
         ['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'].forEach(link => {
-            navigationLink = link;
-        });
-
-        // Act
-        header.open(headerData);
-        header.openMobileNavigation();
-
-        // Assert
-        expect(header.isFieldLinkDisplayed(navigationLink)).toBe(true);
-    });
-
-    forEach(['userAccount', 'help', 'countrySelector'])
-    .it('should display all navigation links, except for offers and delivery', field => {
-        // Arrange
-        const locales = ['it', 'es', 'dk', 'no'];
-
-        for (let i = 0; i < locales.length; i++) {
-            // Arrange
-            const headerData = {
-                locale: locales[i],
-                offers: true,
-                delivery: true
-            };
-
-            // Act
             header.open(headerData);
             header.openMobileNavigation();
-        }
 
-        // Assert
-        expect(header.isFieldLinkDisplayed(field)).toBe(true);
-        expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
-        expect(header.isFieldLinkDisplayed('delivery')).toBe(false);
+            // Assert
+            expect(header.isFieldLinkDisplayed(link)).toBe(true);
+        });
     });
 
     forEach(['it', 'es', 'dk', 'no'])
-    .it('should display all navigation links, except for offers and delivery', expectedLocale => {
+    .it('should display all navigation links, except for offers and delivery, when burger menu has been opened', expectedLocale => {
         // Arrange
         const headerData = {
             locale: expectedLocale,
             offers: true,
             delivery: true
         };
-        const navigation = ['userAccount', 'help', 'countrySelector'];
-        let navigationLink = '';
 
         // Act
-        for (let i = 0; i < navigation.length; i++) {
-            navigationLink = navigation[i];
+        ['userAccount', 'help', 'countrySelector'].forEach(link => {
             header.open(headerData);
             header.openMobileNavigation();
-        }
 
-        // Assert
-        expect(header.isFieldLinkDisplayed(navigationLink)).toBe(true);
-        expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
-        expect(header.isFieldLinkDisplayed('delivery')).toBe(false);
+            // Assert
+            expect(header.isFieldLinkDisplayed(link)).toBe(true);
+            expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
+            expect(header.isFieldLinkDisplayed('delivery')).toBe(false);
+        });
     });
 
-    // forEach(['au', 'gb', 'nz', 'ie', 'dk', 'es', 'it'])
-    // .it('should display all countries when in mobile mode', country => {
-    //     // Act
-    //     header.openMobileNavigation();
-    //     header.openCountrySelector();
-    //     header.expectedCountry = country;
+    forEach(['au', 'gb', 'nz', 'ie', 'dk', 'es', 'it'])
+    .it('should display all countries when in mobile mode', country => {
+        // Act
+        header.openMobileNavigation();
+        header.openCountrySelector();
+        header.expectedCountry = country;
 
-    //     // Assert
-    //     expect(header.isCountryLinkDisplayed()).toBe(true);
-    // });
+        // Assert
+        expect(header.isCountryLinkDisplayed()).toBe(true);
+    });
 });

--- a/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
@@ -21,7 +21,7 @@ describe('Mobile - f-header component tests', () => {
 
     it('should display delivery link for GB locale', () => {
         // Assert
-        expect(header.isFieldLinkDisplayed('delivery')).toBe(true);
+        expect(header.isNavigationLinkDisplayed('delivery')).toBe(true);
     });
 
     forEach(['gb', 'au', 'ie', 'nz'])
@@ -40,8 +40,8 @@ describe('Mobile - f-header component tests', () => {
 
             // Assert
             expect(header.isMobileNavigationBarDisplayed()).toBe(true);
-            expect(header.isFieldLinkDisplayed(link)).toBe(false);
-            expect(header.isFieldLinkDisplayed('offersIcon')).toBe(true);
+            expect(header.isNavigationLinkDisplayed(link)).toBe(false);
+            expect(header.isNavigationLinkDisplayed('offersIcon')).toBe(true);
         });
     });
 
@@ -61,7 +61,7 @@ describe('Mobile - f-header component tests', () => {
             browser.pause(400);
 
             // Assert
-            expect(header.isFieldLinkDisplayed(link)).toBe(true);
+            expect(header.isNavigationLinkDisplayed(link)).toBe(true);
         });
     });
 
@@ -81,9 +81,9 @@ describe('Mobile - f-header component tests', () => {
             browser.pause(400);
 
             // Assert
-            expect(header.isFieldLinkDisplayed(link)).toBe(true);
-            expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
-            expect(header.isFieldLinkDisplayed('delivery')).toBe(false);
+            expect(header.isNavigationLinkDisplayed(link)).toBe(true);
+            expect(header.isNavigationLinkDisplayed('offersLink')).toBe(false);
+            expect(header.isNavigationLinkDisplayed('delivery')).toBe(false);
         });
     });
 

--- a/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
@@ -82,7 +82,7 @@ describe('Mobile - f-header component tests', () => {
         ['offersLink', 'userAccount', 'help', 'countrySelector'].forEach(link => {
             header.open(headerData);
             header.openMobileNavigation();
-            browser.pause(400);
+            header.waitForComponent();
 
             // Assert
             expect(header.isNavigationLinkDisplayed(link)).toBe(true);
@@ -102,7 +102,7 @@ describe('Mobile - f-header component tests', () => {
         ['userAccount', 'help', 'countrySelector'].forEach(link => {
             header.open(headerData);
             header.openMobileNavigation();
-            browser.pause(400);
+            header.waitForComponent();
 
             // Assert
             expect(header.isNavigationLinkDisplayed(link)).toBe(true);

--- a/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
@@ -12,7 +12,7 @@ describe('Mobile - f-header component tests', () => {
         }
     });
 
-    forEach(['help', 'delivery', 'userAccount', 'countrySelector'])
+    forEach(['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'])
     .it('should hide all navigation links, except offersIcon link, when in mobile mode', field => {
         // Act
         header.openWithExtraFeatures();
@@ -23,10 +23,12 @@ describe('Mobile - f-header component tests', () => {
         expect(header.isFieldLinkDisplayed('offersIcon')).toBe(true);
     });
 
-    forEach(['help', 'countrySelector', 'userAccount'])
+    forEach(['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'])
     .it('should display navigation fields when burger menu has been opened', field => {
         // Act
+        header.openWithExtraFeatures();
         header.openMobileNavigation();
+        console.log(field);
 
         // Assert
         expect(header.isFieldLinkDisplayed(field)).toBe(true);

--- a/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
@@ -1,10 +1,17 @@
 const forEach = require('mocha-each');
 const Header = require('../../../../test-utils/component-objects/f-header.component');
+
 const header = new Header();
 
 describe('Mobile - f-header component tests', () => {
     beforeEach(() => {
-        header.open();
+        const headerData = {
+            locale: 'gb',
+            offers: true,
+            delivery: true
+        };
+
+        header.open(headerData);
         header.waitForComponent();
 
         if (process.env.JE_ENV !== 'browserstack') {
@@ -14,24 +21,71 @@ describe('Mobile - f-header component tests', () => {
 
     forEach(['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'])
     .it('should hide all navigation links, except offersIcon link, when in mobile mode', field => {
-        // Act
-        header.openWithExtraFeatures();
+        // Arrange
+        const locales = ['gb', 'au', 'ie', 'nz'];
 
-        // Assert
-        expect(header.isMobileNavigationBarDisplayed()).toBe(true);
-        expect(header.isFieldLinkDisplayed(field)).toBe(false);
-        expect(header.isFieldLinkDisplayed('offersIcon')).toBe(true);
+        for (let i = 0; i < locales.length; i++) {
+            // Arrange
+            const headerData = {
+                locale: locales[i],
+                offers: true,
+                delivery: true
+            };
+
+            // Act
+            header.open(headerData);
+
+            // Assert
+            expect(header.isMobileNavigationBarDisplayed()).toBe(true);
+            expect(header.isFieldLinkDisplayed(field)).toBe(false);
+            expect(header.isFieldLinkDisplayed('offersIcon')).toBe(true);
+        }
     });
 
     forEach(['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'])
-    .it('should display navigation fields when burger menu has been opened', field => {
-        // Act
-        header.openWithExtraFeatures();
-        header.openMobileNavigation();
-        console.log(field);
+    .it.only('should display navigation fields when burger menu has been opened', field => {
+        // Arrange
+        const locales = ['gb', 'au', 'ie', 'nz'];
+        const headerData = {
+            locale: '',
+            offers: true,
+            delivery: true
+        };
+
+        for (let i = 0; i < locales.length; i++) {
+            headerData.locale = locales[i];
+
+            // Act
+            header.open(headerData);
+            header.openMobileNavigation();
+        }
 
         // Assert
         expect(header.isFieldLinkDisplayed(field)).toBe(true);
+    });
+
+    forEach(['userAccount', 'help', 'countrySelector'])
+    .it('should not display offers link and delivery fields for the below locales', field => {
+        // Arrange
+        const locales = ['it', 'es', 'dk', 'no'];
+
+        for (let i = 0; i < locales.length; i++) {
+            // Arrange
+            const headerData = {
+                locale: locales[i],
+                offers: true,
+                delivery: true
+            };
+
+            // Act
+            header.open(headerData);
+            header.openMobileNavigation();
+
+            // Assert
+            expect(header.isFieldLinkDisplayed(field)).toBe(true);
+            expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
+            expect(header.isFieldLinkDisplayed('delivery')).toBe(false);
+        }
     });
 
     forEach(['au', 'gb', 'nz', 'ie', 'dk', 'es', 'it'])

--- a/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
@@ -48,9 +48,11 @@ describe('Mobile - f-header component tests', () => {
             delivery: true
         };
 
-        ['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'].forEach(link => {
+        // Act
+        ['offersLink', 'userAccount', 'help', 'countrySelector'].forEach(link => {
             header.open(headerData);
             header.openMobileNavigation();
+            browser.pause(500);
 
             // Assert
             expect(header.isFieldLinkDisplayed(link)).toBe(true);
@@ -58,7 +60,7 @@ describe('Mobile - f-header component tests', () => {
     });
 
     forEach(['it', 'es', 'dk', 'no'])
-    .it('should display all navigation links, except for offers and delivery, when burger menu has been opened', expectedLocale => {
+    .it('should display navigation links, except offers and delivery, when menu has been opened', expectedLocale => {
         // Arrange
         const headerData = {
             locale: expectedLocale,
@@ -70,6 +72,7 @@ describe('Mobile - f-header component tests', () => {
         ['userAccount', 'help', 'countrySelector'].forEach(link => {
             header.open(headerData);
             header.openMobileNavigation();
+            browser.pause(500);
 
             // Assert
             expect(header.isFieldLinkDisplayed(link)).toBe(true);

--- a/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
@@ -19,53 +19,76 @@ describe('Mobile - f-header component tests', () => {
         }
     });
 
-    forEach(['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'])
-    .it('should hide all navigation links, except offersIcon link, when in mobile mode', field => {
+    // forEach(['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'])
+    // .it('should hide all navigation links, except offersIcon link, when in mobile mode', field => {
+    //     // Arrange
+    //     const locales = ['gb', 'au', 'ie', 'nz'];
+
+    //     for (let i = 0; i < locales.length; i++) {
+    //         // Arrange
+    //         const headerData = {
+    //             locale: locales[i],
+    //             offers: true,
+    //             delivery: true
+    //         };
+
+    //         // Act
+    //         header.open(headerData);
+    //         console.log(headerData);
+    //     }
+
+    //     // Assert
+    //     expect(header.isMobileNavigationBarDisplayed()).toBe(true);
+    //     expect(header.isFieldLinkDisplayed(field)).toBe(false);
+    //     expect(header.isFieldLinkDisplayed('offersIcon')).toBe(true);
+    // });
+
+    // forEach(['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'])
+    // .it('should display navigation fields when burger menu has been opened', field => {
+    //     // Arrange
+    //     const locales = ['gb', 'au', 'ie', 'nz'];
+
+    //     for (let i = 0; i < locales.length; i++) {
+    //         // Arrange
+    //         const headerData = {
+    //             locale: locales[i],
+    //             offers: true,
+    //             delivery: true
+    //         };
+
+    //         // Act
+    //         header.open(headerData);
+    //         console.log('heyyy', headerData);
+    //         header.openMobileNavigation();
+    //     }
+
+    //     // Assert
+    //     expect(header.isFieldLinkDisplayed(field)).toBe(true);
+    // });
+
+    forEach(['gb', 'au', 'ie', 'nz'])
+    .it('should display navigation links when burger menu is opened', expectedLocale => {
         // Arrange
-        const locales = ['gb', 'au', 'ie', 'nz'];
-
-        for (let i = 0; i < locales.length; i++) {
-            // Arrange
-            const headerData = {
-                locale: locales[i],
-                offers: true,
-                delivery: true
-            };
-
-            // Act
-            header.open(headerData);
-
-            // Assert
-            expect(header.isMobileNavigationBarDisplayed()).toBe(true);
-            expect(header.isFieldLinkDisplayed(field)).toBe(false);
-            expect(header.isFieldLinkDisplayed('offersIcon')).toBe(true);
-        }
-    });
-
-    forEach(['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'])
-    .it.only('should display navigation fields when burger menu has been opened', field => {
-        // Arrange
-        const locales = ['gb', 'au', 'ie', 'nz'];
         const headerData = {
-            locale: '',
+            locale: expectedLocale,
             offers: true,
             delivery: true
         };
+        let navigationLink = '';
+        ['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'].forEach(link => {
+            navigationLink = link;
+        });
 
-        for (let i = 0; i < locales.length; i++) {
-            headerData.locale = locales[i];
-
-            // Act
-            header.open(headerData);
-            header.openMobileNavigation();
-        }
+        // Act
+        header.open(headerData);
+        header.openMobileNavigation();
 
         // Assert
-        expect(header.isFieldLinkDisplayed(field)).toBe(true);
+        expect(header.isFieldLinkDisplayed(navigationLink)).toBe(true);
     });
 
     forEach(['userAccount', 'help', 'countrySelector'])
-    .it('should not display offers link and delivery fields for the below locales', field => {
+    .it('should display all navigation links, except for offers and delivery', field => {
         // Arrange
         const locales = ['it', 'es', 'dk', 'no'];
 
@@ -80,22 +103,46 @@ describe('Mobile - f-header component tests', () => {
             // Act
             header.open(headerData);
             header.openMobileNavigation();
-
-            // Assert
-            expect(header.isFieldLinkDisplayed(field)).toBe(true);
-            expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
-            expect(header.isFieldLinkDisplayed('delivery')).toBe(false);
         }
-    });
-
-    forEach(['au', 'gb', 'nz', 'ie', 'dk', 'es', 'it'])
-    .it('should display all countries when in mobile mode', country => {
-        // Act
-        header.openMobileNavigation();
-        header.openCountrySelector();
-        header.expectedCountry = country;
 
         // Assert
-        expect(header.isCountryLinkDisplayed()).toBe(true);
+        expect(header.isFieldLinkDisplayed(field)).toBe(true);
+        expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
+        expect(header.isFieldLinkDisplayed('delivery')).toBe(false);
     });
+
+    forEach(['it', 'es', 'dk', 'no'])
+    .it('should display all navigation links, except for offers and delivery', expectedLocale => {
+        // Arrange
+        const headerData = {
+            locale: expectedLocale,
+            offers: true,
+            delivery: true
+        };
+        const navigation = ['userAccount', 'help', 'countrySelector'];
+        let navigationLink = '';
+
+        // Act
+        for (let i = 0; i < navigation.length; i++) {
+            navigationLink = navigation[i];
+            header.open(headerData);
+            header.openMobileNavigation();
+        }
+
+        // Assert
+        expect(header.isFieldLinkDisplayed(navigationLink)).toBe(true);
+        expect(header.isFieldLinkDisplayed('offersLink')).toBe(false);
+        expect(header.isFieldLinkDisplayed('delivery')).toBe(false);
+    });
+
+    // forEach(['au', 'gb', 'nz', 'ie', 'dk', 'es', 'it'])
+    // .it('should display all countries when in mobile mode', country => {
+    //     // Act
+    //     header.openMobileNavigation();
+    //     header.openCountrySelector();
+    //     header.expectedCountry = country;
+
+    //     // Assert
+    //     expect(header.isCountryLinkDisplayed()).toBe(true);
+    // });
 });

--- a/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
@@ -19,13 +19,17 @@ describe('Mobile - f-header component tests', () => {
         }
     });
 
-    it('should display delivery link for GB locale', () => {
+    forEach(['offersLink', 'delivery', 'help', 'countrySelector', 'userAccount'])
+    .it('should display all navigation links', link => {
+        // Act
+        header.openMobileNavigation();
+
         // Assert
-        expect(header.isNavigationLinkDisplayed('delivery')).toBe(true);
+        expect(header.isNavigationLinkDisplayed(link)).toBe(true);
     });
 
-    forEach(['gb', 'au', 'ie', 'nz'])
-    .it('should hide all navigation links, except offersIcon link, when in mobile mode', expectedLocale => {
+    forEach(['au', 'ie', 'nz'])
+    .it('should hide all navigation links but display offersIcon link, when in mobile mode', expectedLocale => {
         // Arrange
         const headerData = {
             locale: expectedLocale,
@@ -45,8 +49,28 @@ describe('Mobile - f-header component tests', () => {
         });
     });
 
-    forEach(['gb', 'au', 'ie', 'nz'])
-    .it.only('should display navigation links when burger menu is opened', expectedLocale => {
+    forEach(['it', 'es', 'dk', 'no'])
+    .it('should hide all navigation links, as well as offersIcon, when in mobile mode', expectedLocale => {
+        // Arrange
+        const headerData = {
+            locale: expectedLocale,
+            offers: true,
+            delivery: true
+        };
+
+        // Act
+        ['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'].forEach(link => {
+            header.open(headerData);
+            header.waitForComponent();
+
+            // Assert
+            expect(header.isMobileNavigationBarDisplayed()).toBe(true);
+            expect(header.isNavigationLinkDisplayed(link)).toBe(false);
+        });
+    });
+
+    forEach(['au', 'ie', 'nz'])
+    .it('should display navigation links when burger menu is opened', expectedLocale => {
         // Arrange
         const headerData = {
             locale: expectedLocale,
@@ -66,7 +90,7 @@ describe('Mobile - f-header component tests', () => {
     });
 
     forEach(['it', 'es', 'dk', 'no'])
-    .it.only('should display the below navigation links when menu has been opened', expectedLocale => {
+    .it('should display the below navigation links when menu has been opened', expectedLocale => {
         // Arrange
         const headerData = {
             locale: expectedLocale,

--- a/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
@@ -19,6 +19,11 @@ describe('Mobile - f-header component tests', () => {
         }
     });
 
+    it('should display delivery link for GB locale', () => {
+        // Assert
+        expect(header.isFieldLinkDisplayed('delivery')).toBe(true);
+    });
+
     forEach(['gb', 'au', 'ie', 'nz'])
     .it('should hide all navigation links, except offersIcon link, when in mobile mode', expectedLocale => {
         // Arrange
@@ -31,6 +36,7 @@ describe('Mobile - f-header component tests', () => {
         // Act
         ['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'].forEach(link => {
             header.open(headerData);
+            header.waitForComponent();
 
             // Assert
             expect(header.isMobileNavigationBarDisplayed()).toBe(true);
@@ -40,7 +46,7 @@ describe('Mobile - f-header component tests', () => {
     });
 
     forEach(['gb', 'au', 'ie', 'nz'])
-    .it('should display navigation links when burger menu is opened', expectedLocale => {
+    .it.only('should display navigation links when burger menu is opened', expectedLocale => {
         // Arrange
         const headerData = {
             locale: expectedLocale,
@@ -52,7 +58,7 @@ describe('Mobile - f-header component tests', () => {
         ['offersLink', 'userAccount', 'help', 'countrySelector'].forEach(link => {
             header.open(headerData);
             header.openMobileNavigation();
-            browser.pause(500);
+            browser.pause(400);
 
             // Assert
             expect(header.isFieldLinkDisplayed(link)).toBe(true);
@@ -60,7 +66,7 @@ describe('Mobile - f-header component tests', () => {
     });
 
     forEach(['it', 'es', 'dk', 'no'])
-    .it('should display navigation links, except offers and delivery, when menu has been opened', expectedLocale => {
+    .it.only('should display the below navigation links when menu has been opened', expectedLocale => {
         // Arrange
         const headerData = {
             locale: expectedLocale,
@@ -72,7 +78,7 @@ describe('Mobile - f-header component tests', () => {
         ['userAccount', 'help', 'countrySelector'].forEach(link => {
             header.open(headerData);
             header.openMobileNavigation();
-            browser.pause(500);
+            browser.pause(400);
 
             // Assert
             expect(header.isFieldLinkDisplayed(link)).toBe(true);

--- a/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/mobile/f-header.component.spec.js
@@ -37,8 +37,8 @@ describe('Mobile - f-header component tests', () => {
             delivery: true
         };
 
-        // Act
         ['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'].forEach(link => {
+            // Act
             header.open(headerData);
             header.waitForComponent();
 
@@ -58,8 +58,8 @@ describe('Mobile - f-header component tests', () => {
             delivery: true
         };
 
-        // Act
         ['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'].forEach(link => {
+            // Act
             header.open(headerData);
             header.waitForComponent();
 
@@ -78,8 +78,8 @@ describe('Mobile - f-header component tests', () => {
             delivery: true
         };
 
-        // Act
         ['offersLink', 'userAccount', 'help', 'countrySelector'].forEach(link => {
+            // Act
             header.open(headerData);
             header.openMobileNavigation();
             header.waitForComponent();
@@ -98,8 +98,8 @@ describe('Mobile - f-header component tests', () => {
             delivery: true
         };
 
-        // Act
         ['userAccount', 'help', 'countrySelector'].forEach(link => {
+            // Act
             header.open(headerData);
             header.openMobileNavigation();
             header.waitForComponent();

--- a/packages/components/organisms/f-header/test/specs/component/shared/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/shared/f-header.component.spec.js
@@ -1,19 +1,25 @@
-// const Header = require('../../../../test-utils/component-objects/f-header.component');
-// const header = new Header();
+const Header = require('../../../../test-utils/component-objects/f-header.component');
+const header = new Header();
 
-// describe('Shared - f-header component tests', () => {
-//     beforeEach(() => {
-//         header.open();
-//         header.waitForComponent();
-//     });
+describe('Shared - f-header component tests', () => {
+    beforeEach(() => {
+        const headerData = {
+            locale: 'gb',
+            offers: true,
+            delivery: true
+        };
 
-//     it('should display component', () => {
-//         // Assert
-//         expect(header.isComponentDisplayed()).toBe(true);
-//     });
+        header.open(headerData);
+        header.waitForComponent();
+    });
 
-//     it('should display logo', () => {
-//         // Assert
-//         expect(header.isLogoDisplayed()).toBe(true);
-//     });
-// });
+    it('should display component', () => {
+        // Assert
+        expect(header.isComponentDisplayed()).toBe(true);
+    });
+
+    it('should display logo', () => {
+        // Assert
+        expect(header.isLogoDisplayed()).toBe(true);
+    });
+});

--- a/packages/components/organisms/f-header/test/specs/component/shared/f-header.component.spec.js
+++ b/packages/components/organisms/f-header/test/specs/component/shared/f-header.component.spec.js
@@ -1,19 +1,19 @@
-const Header = require('../../../../test-utils/component-objects/f-header.component');
-const header = new Header();
+// const Header = require('../../../../test-utils/component-objects/f-header.component');
+// const header = new Header();
 
-describe('Shared - f-header component tests', () => {
-    beforeEach(() => {
-        header.open();
-        header.waitForComponent();
-    });
+// describe('Shared - f-header component tests', () => {
+//     beforeEach(() => {
+//         header.open();
+//         header.waitForComponent();
+//     });
 
-    it('should display component', () => {
-        // Assert
-        expect(header.isComponentDisplayed()).toBe(true);
-    });
+//     it('should display component', () => {
+//         // Assert
+//         expect(header.isComponentDisplayed()).toBe(true);
+//     });
 
-    it('should display logo', () => {
-        // Assert
-        expect(header.isLogoDisplayed()).toBe(true);
-    });
-});
+//     it('should display logo', () => {
+//         // Assert
+//         expect(header.isLogoDisplayed()).toBe(true);
+//     });
+// });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2300,6 +2300,13 @@
   dependencies:
     "@justeat/f-services" "1.7.0"
 
+"@justeat/f-wdio-utils@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.1.1.tgz#5cb05f96f718566fdb844ff33c000696a12b2877"
+  integrity sha512-G80OwVKXxpwGS64+TTGIeeB3ctberVoFPotsX2QiFpBsAisR2p2j/uVzPTtyg2peP+5rvTwdTPBy9o9Z7uxyDw==
+  dependencies:
+    "@justeat/f-services" "1.7.0"
+
 "@justeat/fozzie-colour-palette@3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.1.0.tgz#3bbe51404025c5ef8c5e8bf8280a266e51d2a640"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,6 +2274,13 @@
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
 
+"@justeat/f-vue-icons@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-2.4.0.tgz#aad0aa3563ff726043da9d29e8456435176ae913"
+  integrity sha512-jeWACUUp0LfQbKO+BS8KiMIQ/RlaLNuinIHwrmDAxHfxCj2RoElS/Z426cVzGWkIuvs20RiaNFMF31pasHq4QQ==
+  dependencies:
+    babel-helper-vue-jsx-merge-props "2.0.3"
+
 "@justeat/f-wdio-utils@0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.1.0.tgz#e8a62dd2d03c2cf14ce1fa7d50540c2171b8fc38"


### PR DESCRIPTION
Latest (add to next release)
------------------------------
*March 31, 2021*

### Added
- Component tests for locales `au, dk, ie, es, no, it, nz`
- Component test for offers icon in mobile spec

### Changed
- Small refactor to `open` function in component-object