### PR TITLE
f-checkout@0.78.2 Configurable spinner timeout

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.79.0
+------------------------------
+*March 31, 2021*
+
+### Added
+- spinnerTimeout prop that defaults to 300ms
+
+### Changed
+- Spinner shows after spinnerTimeout instead of hardcoded 1s
+
+
 v0.78.0
 ------------------------------
 *March 30, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.78.0",
+  "version": "0.79.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -203,6 +203,12 @@ export default {
             default: 1000
         },
 
+        spinnerTimeout: {
+            type: Number,
+            required: false,
+            default: 300
+        },
+
         authToken: {
             type: String,
             default: ''
@@ -795,7 +801,7 @@ export default {
                 if (this.isLoading) {
                     this.shouldShowSpinner = true;
                 }
-            }, 1000);
+            }, this.spinnerTimeout);
         },
 
         handleErrorDialogClose () {

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -71,6 +71,7 @@ describe('Checkout', () => {
     const placeOrderUrl = 'http://localhost/placeorder';
     const paymentPageUrlPrefix = 'http://localhost/paymentpage';
     const getGeoLocationUrl = 'http://localhost/geolocation';
+    const spinnerTimeout = 100;
 
     const applicationName = 'Jest';
 
@@ -85,7 +86,8 @@ describe('Checkout', () => {
         placeOrderUrl,
         paymentPageUrlPrefix,
         getGeoLocationUrl,
-        applicationName
+        applicationName,
+        spinnerTimeout
     };
 
     let windowLocationSpy;
@@ -859,7 +861,7 @@ describe('Checkout', () => {
             });
 
             describe('when `isLoading` is `true`', () => {
-                it('should not set `shouldShowSpinner` to `true` before one second', () => {
+                it('should not set `shouldShowSpinner` to `true` before `spinnerTimeout`', () => {
                     // Arrange & Act
                     const wrapper = shallowMount(VueCheckout, {
                         store: createStore(),
@@ -874,13 +876,13 @@ describe('Checkout', () => {
                     });
 
                     wrapper.vm.startSpinnerCountdown();
-                    jest.advanceTimersByTime(999);
+                    jest.advanceTimersByTime(spinnerTimeout - 1);
 
                     // Assert
                     expect(wrapper.vm.shouldShowSpinner).toBe(false);
                 });
 
-                it('should set `shouldShowSpinner` to `true` after one second', () => {
+                it('should set `shouldShowSpinner` to `true` after s`pinnerTimeout`', () => {
                     // Arrange & Act
                     const wrapper = shallowMount(VueCheckout, {
                         store: createStore(),
@@ -895,7 +897,7 @@ describe('Checkout', () => {
                     });
 
                     wrapper.vm.startSpinnerCountdown();
-                    jest.advanceTimersByTime(1000);
+                    jest.advanceTimersByTime(spinnerTimeout + 1);
 
                     // Assert
                     expect(wrapper.vm.shouldShowSpinner).toBe(true);


### PR DESCRIPTION
Previous waiting spinner timeout of 1s caused it to never be shown as default API timeouts are also 1s.
This PR makes the spinner timeout configurable and changed the default to 300ms

---

## UI Review Checks

No UI changes

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
