### PR TITLE
f-registration@v0.50.0 - Add a11y markup to f-registration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -85,6 +85,7 @@ module.exports = {
         }
     },
     globals: {
+        browser: 'readonly',
         allure: 'readonly'
     }
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.26.0
+------------------------------
+*March 29, 2021*
+
+## Added
+- A11y markup added for screen-reader support to f-registration.
+
 v3.25.0
 ------------------------------
 *March 24, 2021*
@@ -18,7 +25,7 @@ v3.24.1
 *March 23, 2021*
 
 ## Added
-- `f-wdio-utils` package to all component folders 
+- `f-wdio-utils` package to all component folders
 - `f-wdio-utils` package to generator
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "3.25.0",
+  "version": "3.26.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",

--- a/packages/components/organisms/f-registration/CHANGELOG.md
+++ b/packages/components/organisms/f-registration/CHANGELOG.md
@@ -4,12 +4,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.50.0
+------------------------------
+*April 1, 2021*
+
+### Added
+- A11y markup to support screen-reader
+
+
 v0.49.2
 ------------------------------
-*March 31, 2021*
+*April 1, 2021*
 
 ### Added
 - `o-link` fozzie classes for the links.
+
+*March 31, 2021*
 
 ### Changed
 - user email and password in unit and component tests

--- a/packages/components/organisms/f-registration/package.json
+++ b/packages/components/organisms/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.49.2",
+  "version": "0.50.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",
@@ -37,7 +37,7 @@
     "test-component:browserstack": "cross-env-shell JE_ENV=browserstack wdio ../../../../wdio-browserstack.conf.js --suite shared",
     "test-component:chrome": "cross-env-shell JE_ENV=local wdio ../../../../wdio-chrome.conf.js --suite component",
     "report:test-component:chrome": "cross-env-shell JE_ENV=local COMPONENT_TYPE=organism wdio ../../../../wdio-chrome.conf.js --suite component && yarn allure:open",
-    "test-a11y:chrome": "cross-env-shell JE_ENV=local wdio ../../../../wdio-chrome.conf.js --suite a11y", 
+    "test-a11y:chrome": "cross-env-shell JE_ENV=local wdio ../../../../wdio-chrome.conf.js --suite a11y",
     "allure:open": "yarn allure:clean && allure open",
     "allure:clean": "rimraf ../../../../test/results/allure"
   },

--- a/packages/components/organisms/f-registration/src/components/Registration.vue
+++ b/packages/components/organisms/f-registration/src/components/Registration.vue
@@ -30,108 +30,108 @@
                 @click="formStart"
                 @focus="formStart"
                 @submit.prevent="onFormSubmit">
-                <error-message
-                    v-if="genericErrorMessage"
-                    :class="$style['c-registration-genericError']">
-                    {{ genericErrorMessage }}
-                </error-message>
+                <section
+                    id="error-summary-container"
+                    :class="$style['is-visuallyHidden']"
+                    role="alert"
+                    data-test-id="error-summary-container">
+                    <p
+                        v-if="genericErrorMessage"
+                        :class="$style['o-form-error']">
+                        <warning-icon :class="$style['o-form-error-icon']" />
+                        {{ genericErrorMessage }}
+                    </p>
+                </section>
+
                 <form-field
+                    ref="firstName"
                     v-model="firstName"
+                    aria-required="true"
+                    aria-describedby="error-message-firstname"
+                    :aria-invalid="!!describeFirstnameErrorMessage"
                     name="firstName"
                     :label-text="copy.labels.firstName"
                     input-type="text"
                     @blur="formFieldBlur('firstName')">
-                    <template #error>
-                        <error-message
-                            v-if="shouldShowFirstNameRequiredError"
-                            data-test-id='error-first-name-empty'>
-                            {{ copy.validationMessages.firstName.requiredError }}
-                        </error-message>
-                        <error-message
-                            v-if="shouldShowFirstNameMaxLengthError"
-                            data-test-id='error-first-name-maxlength'>
-                            {{ copy.validationMessages.firstName.maxLengthError }}
-                        </error-message>
-                        <error-message
-                            v-if="shouldShowFirstNameInvalidCharError"
-                            data-test-id='error-first-name-invalid'>
-                            {{ copy.validationMessages.firstName.invalidCharError }}
-                        </error-message>
+                    <template
+                        v-if="describeFirstnameErrorMessage"
+                        #error>
+                        <p
+                            id="error-message-firstname"
+                            :class="$style['o-form-error']"
+                            data-test-id='error-message-firstname'>
+                            <warning-icon :class="$style['o-form-error-icon']" />
+                            {{ describeFirstnameErrorMessage }}
+                        </p>
                     </template>
                 </form-field>
 
                 <form-field
+                    ref="lastName"
                     v-model="lastName"
                     name="lastName"
+                    data-test-id="input-last-name"
                     :label-text="copy.labels.lastName"
                     input-type="text"
+                    aria-describedby="error-message-lastname"
+                    :aria-invalid="!!describeLastnameErrorMessage"
                     @blur="formFieldBlur('lastName')">
-                    <template #error>
-                        <error-message
-                            v-if="shouldShowLastNameRequiredError"
-                            data-test-id='error-last-name-empty'>
-                            {{ copy.validationMessages.lastName.requiredError }}
-                        </error-message>
-                        <error-message
-                            v-if="shouldShowLastNameMaxLengthError"
-                            data-test-id='error-last-name-maxlength'>
-                            {{ copy.validationMessages.lastName.maxLengthError }}
-                        </error-message>
-                        <error-message
-                            v-if="shouldShowLastNameInvalidCharError"
-                            data-test-id='error-last-name-invalid'>
-                            {{ copy.validationMessages.lastName.invalidCharError }}
-                        </error-message>
+                    <template
+                        v-if="describeLastnameErrorMessage"
+                        #error>
+                        <p
+                            id="error-message-lastname"
+                            :class="$style['o-form-error']"
+                            data-test-id='error-message-lastname'>
+                            <warning-icon :class="$style['o-form-error-icon']" />
+                            {{ describeLastnameErrorMessage }}
+                        </p>
                     </template>
                 </form-field>
 
                 <form-field
+                    ref="email"
                     v-model="email"
+                    aria-required="true"
                     name="email"
+                    aria-describedby="error-message-email"
+                    :aria-invalid="!!describeEmailErrorMessage"
                     :label-text="copy.labels.email"
                     input-type="email"
                     @blur="formFieldBlur('email')">
-                    <template #error>
-                        <error-message
-                            v-if="shouldShowEmailRequiredError"
-                            data-test-id='error-email-empty'>
-                            {{ copy.validationMessages.email.requiredError }}
-                        </error-message>
-                        <error-message
-                            v-else-if="shouldShowEmailInvalidError"
-                            data-test-id='error-email-invalid'>
-                            {{ copy.validationMessages.email.invalidEmailError }}
-                        </error-message>
-                        <error-message
-                            v-if="shouldShowEmailMaxLengthError"
-                            data-test-id='error-email-maxlength'>
-                            {{ copy.validationMessages.email.maxLengthError }}
-                        </error-message>
-                        <error-message
-                            v-else-if="shouldShowEmailAlreadyExistsError"
-                            data-test-id='error-email-exists'>
-                            {{ copy.validationMessages.email.alreadyExistsError }}
-                        </error-message>
+                    <template
+                        v-if="describeEmailErrorMessage"
+                        #error>
+                        <p
+                            id="error-message-email"
+                            :class="$style['o-form-error']"
+                            data-test-id='error-message-email'>
+                            <warning-icon :class="$style['o-form-error-icon']" />
+                            {{ describeEmailErrorMessage }}
+                        </p>
                     </template>
                 </form-field>
 
                 <form-field
+                    ref="password"
                     v-model="password"
+                    aria-required="true"
+                    aria-describedby="error-message-password"
+                    :aria-invalid="!!describePasswordErrorMessage"
                     name="password"
                     :label-text="copy.labels.password"
                     input-type="password"
                     @blur="formFieldBlur('password')">
-                    <template #error>
-                        <error-message
-                            v-if="shouldShowPasswordRequiredError"
-                            data-test-id='error-password-empty'>
-                            {{ copy.validationMessages.password.requiredError }}
-                        </error-message>
-                        <error-message
-                            v-if="shouldShowPasswordMinLengthError"
-                            data-test-id='error-password-minlength'>
-                            {{ copy.validationMessages.password.minLengthError }}
-                        </error-message>
+                    <template
+                        v-if="describePasswordErrorMessage"
+                        #error>
+                        <p
+                            id="error-message-password"
+                            :class="$style['o-form-error']"
+                            data-test-id='error-message-password'>
+                            <warning-icon :class="$style['o-form-error-icon']" />
+                            {{ describePasswordErrorMessage }}
+                        </p>
                     </template>
                 </form-field>
 
@@ -185,7 +185,6 @@ import CardComponent from '@justeat/f-card';
 import '@justeat/f-card/dist/f-card.css';
 import FormField from '@justeat/f-form-field';
 import '@justeat/f-form-field/dist/f-form-field.css';
-import ErrorMessage from '@justeat/f-error-message';
 import '@justeat/f-error-message/dist/f-error-message.css';
 import tenantConfigs from '../tenants';
 import RegistrationServiceApi from '../services/RegistrationServiceApi';
@@ -225,8 +224,7 @@ export default {
         FButton,
         CardComponent,
         FormField,
-        BagCelebrateIcon,
-        ErrorMessage
+        BagCelebrateIcon
     },
 
     mixins: [validationMixin],
@@ -281,6 +279,60 @@ export default {
          * The $dirty boolean changes to true when the user has focused/lost
          * focus on the input field.
          */
+
+        describeFirstnameErrorMessage () {
+            if (this.$v.firstName.$dirty) {
+                if (!this.$v.firstName.required) {
+                    return 'Please include your first name';
+                }
+                if (!this.$v.firstName.maxLength) {
+                    return 'First name exceeds 50 characters';
+                }
+                if (!this.$v.firstName.meetsCharacterValidationRules) {
+                    return 'Your name can only contain letters, hyphens or apostrophes';
+                }
+            }
+            return '';
+        },
+        describeLastnameErrorMessage () {
+            if (this.$v.lastName.$dirty) {
+                if (!this.$v.lastName.required) {
+                    return 'Please include your last name';
+                }
+                if (!this.$v.lastName.maxLength) {
+                    return 'Last name exceeds 50 characters';
+                }
+                if (!this.$v.lastName.meetsCharacterValidationRules) {
+                    return 'Your last name can only contain letters, hyphens or apostrophes';
+                }
+            }
+            return '';
+        },
+        describeEmailErrorMessage () {
+            if (this.$v.email.$dirty) {
+                if (!this.$v.email.required) {
+                    return 'Please enter your email address';
+                }
+                if (!this.$v.email.maxLength) {
+                    return 'Email address exceeds 50 characters';
+                }
+                if (!this.$v.email.email) {
+                    return 'Please enter your email address correctly';
+                }
+            }
+            return '';
+        },
+        describePasswordErrorMessage () {
+            if (this.$v.password.$dirty) {
+                if (!this.$v.password.required) {
+                    return 'Please enter a password';
+                }
+                if (!this.$v.password.minLength) {
+                    return 'Password is less than four characters';
+                }
+            }
+            return '';
+        },
 
         shouldShowFirstNameRequiredError () {
             return !this.$v.firstName.required && this.$v.firstName.$dirty;
@@ -428,8 +480,26 @@ export default {
         },
 
         isFormInvalid () {
-            this.$v.$touch();
-            return this.$v.$invalid;
+            const v = this.$v;
+            function countErrors () {
+                return [
+                    v.firstName.$anyError,
+                    v.lastName.$anyError,
+                    v.email.$anyError,
+                    v.password.$anyError
+                ].filter(x => x)
+                    .length;
+            }
+            v.firstName.$touch();
+            v.lastName.$touch();
+            v.email.$touch();
+            v.password.$touch();
+            if (v.$invalid) {
+                this.genericErrorMessage = `There are ${countErrors()} errors in the form.`;
+                return true;
+            }
+            this.genericErrorMessage = '';
+            return false;
         }
     }
 };

--- a/packages/components/organisms/f-registration/src/components/Registration.vue
+++ b/packages/components/organisms/f-registration/src/components/Registration.vue
@@ -54,6 +54,7 @@
                     <template v-show="describeFirstnameErrorMessage"
                               #error>
                         <error-message
+                            test-data-id="firstnameErrorMessage"
                             :class="$style['c-registration-genericError']">
                             {{ describeFirstnameErrorMessage }}
                         </error-message>
@@ -74,6 +75,7 @@
                         v-show="describeLastnameErrorMessage"
                         #error>
                         <error-message
+                            test-data-id="lastnameErrorMessage"
                             :class="$style['c-registration-genericError']">
                             {{ describeLastnameErrorMessage }}
                         </error-message>
@@ -94,6 +96,7 @@
                         v-show="describeEmailErrorMessage"
                         #error>
                         <error-message
+                            test-data-id="emailErrorMessage"
                             :class="$style['c-registration-genericError']">
                             {{ describeEmailErrorMessage }}
                         </error-message>
@@ -114,6 +117,7 @@
                         v-show="describePasswordErrorMessage"
                         #error>
                         <error-message
+                            test-data-id="passwordErrorMessage"
                             :class="$style['c-registration-genericError']">
                             {{ describePasswordErrorMessage }}
                         </error-message>

--- a/packages/components/organisms/f-registration/src/components/Registration.vue
+++ b/packages/components/organisms/f-registration/src/components/Registration.vue
@@ -11,7 +11,7 @@
             :class="$style['c-registration-card']">
             <bag-celebrate-icon :class="$style['c-registration-icon']" />
             <p
-                v-if="showLoginLink"
+                v-show="showLoginLink"
                 :class="[
                     $style['c-registration-link'],
                     $style['c-registration-link--subtitle']
@@ -35,11 +35,10 @@
                     :class="$style['is-visuallyHidden']"
                     role="alert"
                     data-test-id="error-summary-container">
-                    <p
-                        v-if="genericErrorMessage"
-                        :class="$style['o-form-error']">
+                    <error-message v-show="genericErrorMessage"
+                                   :class="$style['c-registration-genericError']">
                         {{ genericErrorMessage }}
-                    </p>
+                    </error-message>
                 </section>
 
                 <form-field
@@ -52,15 +51,12 @@
                     :label-text="copy.labels.firstName"
                     input-type="text"
                     @blur="formFieldBlur('firstName')">
-                    <template
-                        v-if="describeFirstnameErrorMessage"
-                        #error>
-                        <p
-                            id="error-message-firstname"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-message-firstname'>
+                    <template v-show="describeFirstnameErrorMessage"
+                              #error>
+                        <error-message
+                            :class="$style['c-registration-genericError']">
                             {{ describeFirstnameErrorMessage }}
-                        </p>
+                        </error-message>
                     </template>
                 </form-field>
 
@@ -75,14 +71,12 @@
                     :aria-invalid="!!describeLastnameErrorMessage"
                     @blur="formFieldBlur('lastName')">
                     <template
-                        v-if="describeLastnameErrorMessage"
+                        v-show="describeLastnameErrorMessage"
                         #error>
-                        <p
-                            id="error-message-lastname"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-message-lastname'>
+                        <error-message
+                            :class="$style['c-registration-genericError']">
                             {{ describeLastnameErrorMessage }}
-                        </p>
+                        </error-message>
                     </template>
                 </form-field>
 
@@ -97,14 +91,12 @@
                     input-type="email"
                     @blur="formFieldBlur('email')">
                     <template
-                        v-if="describeEmailErrorMessage"
+                        v-show="describeEmailErrorMessage"
                         #error>
-                        <p
-                            id="error-message-email"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-message-email'>
+                        <error-message
+                            :class="$style['c-registration-genericError']">
                             {{ describeEmailErrorMessage }}
-                        </p>
+                        </error-message>
                     </template>
                 </form-field>
 
@@ -119,14 +111,12 @@
                     input-type="password"
                     @blur="formFieldBlur('password')">
                     <template
-                        v-if="describePasswordErrorMessage"
+                        v-show="describePasswordErrorMessage"
                         #error>
-                        <p
-                            id="error-message-password"
-                            :class="$style['o-form-error']"
-                            data-test-id='error-message-password'>
+                        <error-message
+                            :class="$style['c-registration-genericError']">
                             {{ describePasswordErrorMessage }}
-                        </p>
+                        </error-message>
                     </template>
                 </form-field>
 
@@ -180,6 +170,7 @@ import CardComponent from '@justeat/f-card';
 import '@justeat/f-card/dist/f-card.css';
 import FormField from '@justeat/f-form-field';
 import '@justeat/f-form-field/dist/f-form-field.css';
+import ErrorMessage from '@justeat/f-error-message';
 import '@justeat/f-error-message/dist/f-error-message.css';
 import tenantConfigs from '../tenants';
 import RegistrationServiceApi from '../services/RegistrationServiceApi';
@@ -219,7 +210,8 @@ export default {
         FButton,
         CardComponent,
         FormField,
-        BagCelebrateIcon
+        BagCelebrateIcon,
+        ErrorMessage
     },
 
     mixins: [validationMixin],

--- a/packages/components/organisms/f-registration/src/components/Registration.vue
+++ b/packages/components/organisms/f-registration/src/components/Registration.vue
@@ -51,7 +51,7 @@
                     :label-text="copy.labels.firstName"
                     input-type="text"
                     @blur="formFieldBlur('firstName')">
-                    <template v-show="describeFirstnameErrorMessage"
+                    <template v-if="describeFirstnameErrorMessage"
                               #error>
                         <error-message
                             test-data-id="firstnameErrorMessage"
@@ -72,7 +72,7 @@
                     :aria-invalid="!!describeLastnameErrorMessage"
                     @blur="formFieldBlur('lastName')">
                     <template
-                        v-show="describeLastnameErrorMessage"
+                        v-if="describeLastnameErrorMessage"
                         #error>
                         <error-message
                             test-data-id="lastnameErrorMessage"
@@ -93,7 +93,7 @@
                     input-type="email"
                     @blur="formFieldBlur('email')">
                     <template
-                        v-show="describeEmailErrorMessage"
+                        v-if="describeEmailErrorMessage"
                         #error>
                         <error-message
                             test-data-id="emailErrorMessage"
@@ -114,7 +114,7 @@
                     input-type="password"
                     @blur="formFieldBlur('password')">
                     <template
-                        v-show="describePasswordErrorMessage"
+                        v-if="describePasswordErrorMessage"
                         #error>
                         <error-message
                             test-data-id="passwordErrorMessage"

--- a/packages/components/organisms/f-registration/src/components/Registration.vue
+++ b/packages/components/organisms/f-registration/src/components/Registration.vue
@@ -11,7 +11,7 @@
             :class="$style['c-registration-card']">
             <bag-celebrate-icon :class="$style['c-registration-icon']" />
             <p
-                v-show="showLoginLink"
+                v-if="showLoginLink"
                 :class="[
                     $style['c-registration-link'],
                     $style['c-registration-link--subtitle']

--- a/packages/components/organisms/f-registration/src/components/Registration.vue
+++ b/packages/components/organisms/f-registration/src/components/Registration.vue
@@ -35,8 +35,9 @@
                     :class="$style['is-visuallyHidden']"
                     role="alert"
                     data-test-id="error-summary-container">
-                    <error-message v-show="genericErrorMessage"
-                                   :class="$style['c-registration-genericError']">
+                    <error-message
+                        v-show="genericErrorMessage"
+                        :class="$style['c-registration-genericError']">
                         {{ genericErrorMessage }}
                     </error-message>
                 </section>
@@ -51,8 +52,9 @@
                     :label-text="copy.labels.firstName"
                     input-type="text"
                     @blur="formFieldBlur('firstName')">
-                    <template v-if="describeFirstnameErrorMessage"
-                              #error>
+                    <template
+                        v-if="describeFirstnameErrorMessage"
+                        #error>
                         <error-message
                             test-data-id="firstnameErrorMessage"
                             :class="$style['c-registration-genericError']">

--- a/packages/components/organisms/f-registration/src/components/Registration.vue
+++ b/packages/components/organisms/f-registration/src/components/Registration.vue
@@ -38,7 +38,6 @@
                     <p
                         v-if="genericErrorMessage"
                         :class="$style['o-form-error']">
-                        <warning-icon :class="$style['o-form-error-icon']" />
                         {{ genericErrorMessage }}
                     </p>
                 </section>
@@ -60,7 +59,6 @@
                             id="error-message-firstname"
                             :class="$style['o-form-error']"
                             data-test-id='error-message-firstname'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
                             {{ describeFirstnameErrorMessage }}
                         </p>
                     </template>
@@ -83,7 +81,6 @@
                             id="error-message-lastname"
                             :class="$style['o-form-error']"
                             data-test-id='error-message-lastname'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
                             {{ describeLastnameErrorMessage }}
                         </p>
                     </template>
@@ -106,7 +103,6 @@
                             id="error-message-email"
                             :class="$style['o-form-error']"
                             data-test-id='error-message-email'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
                             {{ describeEmailErrorMessage }}
                         </p>
                     </template>
@@ -129,7 +125,6 @@
                             id="error-message-password"
                             :class="$style['o-form-error']"
                             data-test-id='error-message-password'>
-                            <warning-icon :class="$style['o-form-error-icon']" />
                             {{ describePasswordErrorMessage }}
                         </p>
                     </template>

--- a/packages/components/organisms/f-registration/src/components/_tests/Registration.test.js
+++ b/packages/components/organisms/f-registration/src/components/_tests/Registration.test.js
@@ -237,7 +237,7 @@ describe('Registration', () => {
 
                 // Assert
                 expect(RegistrationServiceApi.createAccount).toHaveBeenCalledTimes(1);
-                expect(wrapper.vm.genericErrorMessage).toBeNull();
+                expect(wrapper.vm.genericErrorMessage).toBe('');
                 expect(wrapper.emitted(EventNames.CreateAccountSuccess).length).toBe(1);
             });
 

--- a/packages/components/organisms/f-registration/stories/Registration.stories.js
+++ b/packages/components/organisms/f-registration/stories/Registration.stories.js
@@ -1,4 +1,6 @@
-import { withKnobs, select, text, boolean } from '@storybook/addon-knobs';
+import {
+    withKnobs, select, text, boolean
+} from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
 import Registration from '../src/components/Registration.vue';
 import RegistrationMock from '../src/mocks/registrationMock';
@@ -9,7 +11,7 @@ export default {
 };
 
 const createAccountUrl = '/account/register';
-RegistrationMock.setupEmailInUse(createAccountUrl)
+RegistrationMock.setupEmailInUse(createAccountUrl);
 RegistrationMock.passThroughAny();
 
 

--- a/packages/components/organisms/f-registration/test-utils/component-objects/f-registration.component.js
+++ b/packages/components/organisms/f-registration/test-utils/component-objects/f-registration.component.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 const Page = require('@justeat/f-wdio-utils/src/page.object');
 const {
     REGISTRATION_COMPONENT,
@@ -6,22 +7,12 @@ const {
     PRIVACY_POLICY_LINK,
     COOKIES_POLICY_LINK,
     FIRST_NAME_INPUT,
-    // FIRST_NAME_EMPTY_ERROR,
-    // FIRST_NAME_MAX_LENGTH_ERROR,
-    // FIRST_NAME_INVALID_ERROR,
     FIRST_NAME_ERROR_MESSAGE,
     LAST_NAME_INPUT,
-    // LAST_NAME_EMPTY_ERROR,
-    // LAST_NAME_MAX_LENGTH_ERROR,
-    // LAST_NAME_INVALID_ERROR,
     LAST_NAME_ERROR_MESSAGE,
     EMAIL_INPUT,
-    // EMAIL_EMPTY_ERROR,
-    // EMAIL_EXISTS_ERROR,
-    // EMAIL_INVALID_ERROR,
     EMAIL_ERROR_MESSAGE,
     PASSWORD_INPUT,
-    // PASSWORD_EMPTY_ERROR,
     PASSWORD_ERROR_MESSAGE
 } = require('./f-registration.selectors');
 
@@ -38,27 +29,36 @@ module.exports = class Registration extends Page {
 
     fields = {
         firstName: {
+            errorMessages: {
+                maxCharacters: 'First name exceeds 50 characters',
+                missing: 'Please include your first name',
+                invalidFormat: 'Your first name can only contain letters, hyphens or apostrophes'
+            },
             get input () { return $(FIRST_NAME_INPUT); },
-            // get emptyError () { return $(FIRST_NAME_EMPTY_ERROR) },
-            // get maxLengthError () { return $(FIRST_NAME_MAX_LENGTH_ERROR) } ,
-            // get invalidError () { return $(FIRST_NAME_INVALID_ERROR) }
             get errorMessage () { return $(FIRST_NAME_ERROR_MESSAGE).innerText; }
         },
         lastName: {
+            errorMessages: {
+                maxCharacters: 'Last name exceeds 50 characters',
+                missing: 'Please include your last name',
+                invalidFormat: 'Your last name can only contain letters, hyphens or apostrophes'
+            },
             get input () { return $(LAST_NAME_INPUT); },
-            // get emptyError () { return $(LAST_NAME_EMPTY_ERROR) },
-            // get maxLengthError () { return $(LAST_NAME_MAX_LENGTH_ERROR) },
-            // get invalidError () { return  $(LAST_NAME_INVALID_ERROR) }
             get errorMessage () { return $(LAST_NAME_ERROR_MESSAGE).innerText; }
         },
         email: {
+            errorMessages: {
+                invalidFormat: 'Please enter your email address correctly',
+                missing: 'Please enter your email address'
+            },
             get input () { return $(EMAIL_INPUT); },
-            // get emptyError () { return $(EMAIL_EMPTY_ERROR) },
-            // get invalidError () { return $(EMAIL_INVALID_ERROR) },
-            // get existsError () { return $(EMAIL_EXISTS_ERROR) }
             get errorMessage () { return $(EMAIL_ERROR_MESSAGE).innerText; }
         },
         password: {
+            errorMessages: {
+                minLength: 'Password is less than four characters',
+                missing: 'Please enter a password'
+            },
             get input () { return $(PASSWORD_INPUT); },
             get errorMessage () { return $(PASSWORD_ERROR_MESSAGE).innerText; }
         }
@@ -91,27 +91,32 @@ module.exports = class Registration extends Page {
      * @param {String} userInfo.password The user's password
      */
     submitForm (userInfo) {
-        this.fields.firstName.input.setValue(userInfo.firstName);
-        this.fields.lastName.input.setValue(userInfo.lastName);
-        this.fields.email.input.setValue(userInfo.email);
-        this.fields.password.input.setValue(userInfo.password);
+        const { fields } = this;
+        fields.firstName.input.setValue(userInfo.firstName);
+        fields.lastName.input.setValue(userInfo.lastName);
+        fields.email.input.setValue(userInfo.email);
+        fields.password.input.setValue(userInfo.password);
         this.createAccountButton.click();
     }
 
     isEmptyErrorDisplayed (fieldName) {
-        return this.fields[fieldName].errorMessage !== '';
+        const field = this.fields[fieldName];
+        return field.errorMessage === field.missing;
     }
 
     isMaxLengthErrorDisplayed (fieldName) {
-        return this.fields[fieldName].errorMessage === 'First name exceeds 50 characters';
+        const field = this.fields[fieldName];
+        return field.errorMessage === field.maxCharacters;
     }
 
     isEmailExistsErrorDisplayed () {
-        return this.fields.email.errorMessage === 'email bad';
+        const field = this.fields.email;
+        return field.errorMessage === field.exists;
     }
 
     isInvalidErrorDisplayed (fieldName) {
-        return this.fields[fieldName].invalidError === 'What????';
+        const field = this.fields[fieldName];
+        return field.innerText === field.invalidFormat;
     }
 
     termsAndConditionsLinkCanBeClicked () {

--- a/packages/components/organisms/f-registration/test-utils/component-objects/f-registration.component.js
+++ b/packages/components/organisms/f-registration/test-utils/component-objects/f-registration.component.js
@@ -1,74 +1,85 @@
 const Page = require('@justeat/f-wdio-utils/src/page.object');
 const {
-    REGISTRATION_COMPONENT, 
-    CREATE_ACCOUNT_BUTTON, 
-    TERMS_AND_CONDITIONS_LINK, 
-    PRIVACY_POLICY_LINK, 
+    REGISTRATION_COMPONENT,
+    CREATE_ACCOUNT_BUTTON,
+    TERMS_AND_CONDITIONS_LINK,
+    PRIVACY_POLICY_LINK,
     COOKIES_POLICY_LINK,
     FIRST_NAME_INPUT,
-    FIRST_NAME_EMPTY_ERROR,
-    FIRST_NAME_MAX_LENGTH_ERROR,
-    FIRST_NAME_INVALID_ERROR,
+    // FIRST_NAME_EMPTY_ERROR,
+    // FIRST_NAME_MAX_LENGTH_ERROR,
+    // FIRST_NAME_INVALID_ERROR,
+    FIRST_NAME_ERROR_MESSAGE,
     LAST_NAME_INPUT,
-    LAST_NAME_EMPTY_ERROR,
-    LAST_NAME_MAX_LENGTH_ERROR,
-    LAST_NAME_INVALID_ERROR,
+    // LAST_NAME_EMPTY_ERROR,
+    // LAST_NAME_MAX_LENGTH_ERROR,
+    // LAST_NAME_INVALID_ERROR,
+    LAST_NAME_ERROR_MESSAGE,
     EMAIL_INPUT,
-    EMAIL_EMPTY_ERROR,
-    EMAIL_EXISTS_ERROR,
-    EMAIL_INVALID_ERROR,
+    // EMAIL_EMPTY_ERROR,
+    // EMAIL_EXISTS_ERROR,
+    // EMAIL_INVALID_ERROR,
+    EMAIL_ERROR_MESSAGE,
     PASSWORD_INPUT,
-    PASSWORD_EMPTY_ERROR, 
+    // PASSWORD_EMPTY_ERROR,
+    PASSWORD_ERROR_MESSAGE
 } = require('./f-registration.selectors');
 
 module.exports = class Registration extends Page {
+    get component () { return $(REGISTRATION_COMPONENT); }
 
-    get component () { return $(REGISTRATION_COMPONENT) }
-    get createAccountButton () { return $(CREATE_ACCOUNT_BUTTON) }
-    get termsAndConditionsLink () { return $(TERMS_AND_CONDITIONS_LINK) }
-    get privacyPolicyLink () { return $(PRIVACY_POLICY_LINK) }
-    get cookiesPolicyLink () { return $(COOKIES_POLICY_LINK) }
-  
+    get createAccountButton () { return $(CREATE_ACCOUNT_BUTTON); }
+
+    get termsAndConditionsLink () { return $(TERMS_AND_CONDITIONS_LINK); }
+
+    get privacyPolicyLink () { return $(PRIVACY_POLICY_LINK); }
+
+    get cookiesPolicyLink () { return $(COOKIES_POLICY_LINK); }
+
     fields = {
         firstName: {
-            get input () { return $(FIRST_NAME_INPUT) }, 
-            get emptyError () { return $(FIRST_NAME_EMPTY_ERROR) }, 
-            get maxLengthError () { return $(FIRST_NAME_MAX_LENGTH_ERROR) } , 
-            get invalidError () { return $(FIRST_NAME_INVALID_ERROR) }
-        }, 
+            get input () { return $(FIRST_NAME_INPUT); },
+            // get emptyError () { return $(FIRST_NAME_EMPTY_ERROR) },
+            // get maxLengthError () { return $(FIRST_NAME_MAX_LENGTH_ERROR) } ,
+            // get invalidError () { return $(FIRST_NAME_INVALID_ERROR) }
+            get errorMessage () { return $(FIRST_NAME_ERROR_MESSAGE).innerText; }
+        },
         lastName: {
-            get input () { return $(LAST_NAME_INPUT) }, 
-            get emptyError () { return $(LAST_NAME_EMPTY_ERROR) }, 
-            get maxLengthError () { return $(LAST_NAME_MAX_LENGTH_ERROR) }, 
-            get invalidError () { return  $(LAST_NAME_INVALID_ERROR) }
-        }, 
+            get input () { return $(LAST_NAME_INPUT); },
+            // get emptyError () { return $(LAST_NAME_EMPTY_ERROR) },
+            // get maxLengthError () { return $(LAST_NAME_MAX_LENGTH_ERROR) },
+            // get invalidError () { return  $(LAST_NAME_INVALID_ERROR) }
+            get errorMessage () { return $(LAST_NAME_ERROR_MESSAGE).innerText; }
+        },
         email: {
-            get input () { return $(EMAIL_INPUT) }, 
-            get emptyError () { return $(EMAIL_EMPTY_ERROR) }, 
-            get invalidError () { return $(EMAIL_INVALID_ERROR) }, 
-            get existsError () { return $(EMAIL_EXISTS_ERROR) }
-        }, 
+            get input () { return $(EMAIL_INPUT); },
+            // get emptyError () { return $(EMAIL_EMPTY_ERROR) },
+            // get invalidError () { return $(EMAIL_INVALID_ERROR) },
+            // get existsError () { return $(EMAIL_EXISTS_ERROR) }
+            get errorMessage () { return $(EMAIL_ERROR_MESSAGE).innerText; }
+        },
         password: {
-            get input () { return $(PASSWORD_INPUT) }, 
-            get emptyError () { return $(PASSWORD_EMPTY_ERROR) }
+            get input () { return $(PASSWORD_INPUT); },
+            get errorMessage () { return $(PASSWORD_ERROR_MESSAGE).innerText; }
         }
     };
 
-    open() {
+    open () {
         super.openComponent('organism', 'registration-component');
-    };
+    }
 
-    waitForComponent(){
+    waitForComponent () {
         super.waitForComponent(this.component);
-    };
+    }
 
     isComponentDisplayed () {
         return this.component.isDisplayed();
-    };
+    }
 
-    isInputFieldDisplayed(fieldName){
+    isInputFieldDisplayed (fieldName) {
         return this.fields[fieldName].input.isDisplayed();
-    };
+    }
+
     /**
      * @description
      * Inputs user details into the registration component and submits the form.
@@ -79,39 +90,39 @@ module.exports = class Registration extends Page {
      * @param {String} userInfo.email The user's e-mail address
      * @param {String} userInfo.password The user's password
      */
-    submitForm(userInfo){
-        this.fields.firstName.input.setValue(userInfo.firstName); 
+    submitForm (userInfo) {
+        this.fields.firstName.input.setValue(userInfo.firstName);
         this.fields.lastName.input.setValue(userInfo.lastName);
         this.fields.email.input.setValue(userInfo.email);
         this.fields.password.input.setValue(userInfo.password);
         this.createAccountButton.click();
-    };
-
-    isEmptyErrorDisplayed(fieldName){
-        return this.fields[fieldName].emptyError.isDisplayed();
-    };
-
-    isMaxLengthErrorDisplayed(fieldName) {
-        return this.fields[fieldName].maxLengthError.isDisplayed();
-    };
-
-    isEmailExistsErrorDisplayed(){
-        return this.fields.email.existsError.isDisplayed();
     }
 
-    isInvalidErrorDisplayed(fieldName) {
-        return this.fields[fieldName].invalidError.isDisplayed();
-    };
+    isEmptyErrorDisplayed (fieldName) {
+        return this.fields[fieldName].errorMessage !== '';
+    }
 
-    termsAndConditionsLinkCanBeClicked(){
+    isMaxLengthErrorDisplayed (fieldName) {
+        return this.fields[fieldName].errorMessage === 'First name exceeds 50 characters';
+    }
+
+    isEmailExistsErrorDisplayed () {
+        return this.fields.email.errorMessage === 'email bad';
+    }
+
+    isInvalidErrorDisplayed (fieldName) {
+        return this.fields[fieldName].invalidError === 'What????';
+    }
+
+    termsAndConditionsLinkCanBeClicked () {
         return this.termsAndConditionsLink.isClickable();
-    };
+    }
 
-    privacyPolicyLinkCanBeClicked(){
+    privacyPolicyLinkCanBeClicked () {
         return this.privacyPolicyLink.isClickable();
-    };
-    
-    cookiesPolicyLinkCanBeClicked(){
+    }
+
+    cookiesPolicyLinkCanBeClicked () {
         return this.cookiesPolicyLink.isClickable();
-    };
+    }
 };

--- a/packages/components/organisms/f-registration/test-utils/component-objects/f-registration.selectors.js
+++ b/packages/components/organisms/f-registration/test-utils/component-objects/f-registration.selectors.js
@@ -6,23 +6,13 @@ exports.COOKIES_POLICY_LINK = '[data-test-id="cookies-policy-link"]';
 exports.REQUEST_ERROR = '[data-test-id="error-message-component"]';
 
 exports.FIRST_NAME_INPUT = '[data-test-id="formfield-firstName-input"]';
-// exports.FIRST_NAME_EMPTY_ERROR = '[data-test-id="error-first-name-empty"]';
-// exports.FIRST_NAME_MAX_LENGTH_ERROR = '[data-test-id="error-first-name-maxlength"]';
-// exports.FIRST_NAME_INVALID_ERROR = '[data-test-id="error-first-name-invalid"]';
 exports.FIRST_NAME_ERROR_MESSAGE = '[data-test-id="firstnameErrorMessage"]';
 
 exports.LAST_NAME_INPUT = '[data-test-id="formfield-lastName-input"]';
-// exports.LAST_NAME_EMPTY_ERROR = '[data-test-id="error-last-name-empty"]';
-// exports.LAST_NAME_MAX_LENGTH_ERROR = '[data-test-id="error-last-name-maxlength"]';
-// exports.LAST_NAME_INVALID_ERROR = '[data-test-id="error-last-name-invalid"]';
 exports.LAST_NAME_ERROR_MESSAGE = '[data-test-id="lastnameErrorMessage"]';
 
 exports.EMAIL_INPUT = '[data-test-id="formfield-email-input"]';
-// exports.EMAIL_EMPTY_ERROR = '[data-test-id="error-email-empty"]';
-// exports.EMAIL_INVALID_ERROR = '[data-test-id="error-email-invalid"]';
-// exports.EMAIL_EXISTS_ERROR = '[data-test-id="error-email-exists"]';
 exports.EMAIL_ERROR_MESSAGE = '[data-test-id="emailErrorMessage"]';
 
 exports.PASSWORD_INPUT = '[data-test-id="formfield-password-input"]';
-// exports.PASSWORD_EMPTY_ERROR = '[data-test-id="error-password-empty"]';
 exports.PASSWORD_ERROR_MESSAGE = '[data-test-id="passwordErrorMessage"]';

--- a/packages/components/organisms/f-registration/test-utils/component-objects/f-registration.selectors.js
+++ b/packages/components/organisms/f-registration/test-utils/component-objects/f-registration.selectors.js
@@ -1,24 +1,28 @@
 exports.REGISTRATION_COMPONENT = '[data-test-id="registration-component"]';
-exports.CREATE_ACCOUNT_BUTTON ='[data-test-id="create-account-submit-button"]';
+exports.CREATE_ACCOUNT_BUTTON = '[data-test-id="create-account-submit-button"]';
 exports.TERMS_AND_CONDITIONS_LINK = '[data-test-id="ts-and-cs-link"]';
 exports.PRIVACY_POLICY_LINK = '[data-test-id="privacy-policy-link"]';
 exports.COOKIES_POLICY_LINK = '[data-test-id="cookies-policy-link"]';
 exports.REQUEST_ERROR = '[data-test-id="error-message-component"]';
 
 exports.FIRST_NAME_INPUT = '[data-test-id="formfield-firstName-input"]';
-exports.FIRST_NAME_EMPTY_ERROR = '[data-test-id="error-first-name-empty"]';
-exports.FIRST_NAME_MAX_LENGTH_ERROR = '[data-test-id="error-first-name-maxlength"]';
-exports.FIRST_NAME_INVALID_ERROR = '[data-test-id="error-first-name-invalid"]';
+// exports.FIRST_NAME_EMPTY_ERROR = '[data-test-id="error-first-name-empty"]';
+// exports.FIRST_NAME_MAX_LENGTH_ERROR = '[data-test-id="error-first-name-maxlength"]';
+// exports.FIRST_NAME_INVALID_ERROR = '[data-test-id="error-first-name-invalid"]';
+exports.FIRST_NAME_ERROR_MESSAGE = '[data-test-id="firstnameErrorMessage"]';
 
-exports.LAST_NAME_INPUT ='[data-test-id="formfield-lastName-input"]';
-exports.LAST_NAME_EMPTY_ERROR = '[data-test-id="error-last-name-empty"]';
-exports.LAST_NAME_MAX_LENGTH_ERROR = '[data-test-id="error-last-name-maxlength"]';
-exports.LAST_NAME_INVALID_ERROR = '[data-test-id="error-last-name-invalid"]';
+exports.LAST_NAME_INPUT = '[data-test-id="formfield-lastName-input"]';
+// exports.LAST_NAME_EMPTY_ERROR = '[data-test-id="error-last-name-empty"]';
+// exports.LAST_NAME_MAX_LENGTH_ERROR = '[data-test-id="error-last-name-maxlength"]';
+// exports.LAST_NAME_INVALID_ERROR = '[data-test-id="error-last-name-invalid"]';
+exports.LAST_NAME_ERROR_MESSAGE = '[data-test-id="lastnameErrorMessage"]';
 
-exports.EMAIL_INPUT = '[data-test-id="formfield-email-input"]'
-exports.EMAIL_EMPTY_ERROR = '[data-test-id="error-email-empty"]';
-exports.EMAIL_INVALID_ERROR = '[data-test-id="error-email-invalid"]';
-exports.EMAIL_EXISTS_ERROR = '[data-test-id="error-email-exists"]';
+exports.EMAIL_INPUT = '[data-test-id="formfield-email-input"]';
+// exports.EMAIL_EMPTY_ERROR = '[data-test-id="error-email-empty"]';
+// exports.EMAIL_INVALID_ERROR = '[data-test-id="error-email-invalid"]';
+// exports.EMAIL_EXISTS_ERROR = '[data-test-id="error-email-exists"]';
+exports.EMAIL_ERROR_MESSAGE = '[data-test-id="emailErrorMessage"]';
 
-exports.PASSWORD_INPUT = '[data-test-id="formfield-password-input"]'
-exports.PASSWORD_EMPTY_ERROR = '[data-test-id="error-password-empty"]';
+exports.PASSWORD_INPUT = '[data-test-id="formfield-password-input"]';
+// exports.PASSWORD_EMPTY_ERROR = '[data-test-id="error-password-empty"]';
+exports.PASSWORD_ERROR_MESSAGE = '[data-test-id="passwordErrorMessage"]';

--- a/packages/components/organisms/f-registration/test/specs/component/shared/f-registration.component.spec.js
+++ b/packages/components/organisms/f-registration/test/specs/component/shared/f-registration.component.spec.js
@@ -1,5 +1,6 @@
 const forEach = require('mocha-each');
-const Registration = require ('../../../../test-utils/component-objects/f-registration.component');
+const Registration = require('../../../../test-utils/component-objects/f-registration.component');
+
 const registration = new Registration();
 
 describe('Shared - f-registration component tests', () => {
@@ -14,7 +15,6 @@ describe('Shared - f-registration component tests', () => {
     });
 
     it('should display the "Email address is already registered" error', () => {
-
         // Arrange
         const userInfo = {
             firstName: 'Test',
@@ -48,7 +48,7 @@ describe('Shared - f-registration component tests', () => {
 
         // Act
         registration.submitForm(userInfo);
-        
+
         // Assert
         expect(registration.isEmptyErrorDisplayed(field)).toBe(true);
     });
@@ -65,7 +65,7 @@ describe('Shared - f-registration component tests', () => {
 
         // Act
         registration.submitForm(userInfo);
-        
+
         // Assert
         expect(registration.isInvalidErrorDisplayed(field)).toBe(true);
     });
@@ -82,7 +82,7 @@ describe('Shared - f-registration component tests', () => {
 
         // Act
         registration.submitForm(userInfo);
-        
+
         // Assert
         expect(registration.isMaxLengthErrorDisplayed(field)).toBe(true);
     });


### PR DESCRIPTION
Add screen reader accessibility markup to f-registration.

Reopened from #787 due to bad branch name

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
