### PR TITLE
f-cookie-banner@v0.6.1 fix datalayer push

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.6.1
+------------------------------
+*April 6, 2021*
+
+### Fixed
+- DataLayer push on showing banner
+- Call resendEvents on "Accept all" button click
+- Update tests
+
+
 v0.6.0
 ------------------------------
 *March 18, 2021*

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -170,6 +170,7 @@ export default {
             this.setCookieBannerCookie('full');
             this.setLegacyCookieBannerCookie();
             this.dataLayerPush('full');
+            this.resendEvents();
             this.shouldHideBanner = true;
         },
 
@@ -210,7 +211,13 @@ export default {
                 this.setLegacyCookieBannerCookie();
             } else {
                 const cookieConsent = CookieHelper.get(this.consentCookieName);
-                this.shouldHideBanner = cookieConsent === 'full' || cookieConsent === 'necessary';
+                const isConsentCookiePresent = cookieConsent === 'full' || cookieConsent === 'necessary';
+                if (isConsentCookiePresent) {
+                    this.shouldHideBanner = true;
+                } else {
+                    this.shouldHideBanner = false;
+                    this.dataLayerPush('shown');
+                }
             }
         },
 

--- a/packages/components/organisms/f-cookie-banner/src/components/_tests/CookieBanner.test.js
+++ b/packages/components/organisms/f-cookie-banner/src/components/_tests/CookieBanner.test.js
@@ -6,7 +6,7 @@ import CookieBanner from '../CookieBanner.vue';
 const localVue = createLocalVue();
 localVue.use(VueI18n);
 const i18n = {
-    locale: 'en-GB'
+    locale: 'en-IE'
 };
 
 describe('CookieBanner', () => {
@@ -63,6 +63,7 @@ describe('CookieBanner', () => {
                         dataLayer: []
                     }
                 });
+                window.dataLayer = [];
 
                 // Act
                 const wrapper = shallowMount(CookieBanner, {
@@ -83,7 +84,7 @@ describe('CookieBanner', () => {
                 [false, 'random value'],
                 [true, 'full'],
                 [true, 'necessary']
-            ])('shouldHideBanner should "%s" when `je-cookieConsent` value is "%s"', (
+            ])('shouldHideBanner should be "%s" when `je-cookieConsent` value is "%s"', (
                 expected,
                 cookieValue
             ) => {
@@ -104,6 +105,54 @@ describe('CookieBanner', () => {
 
                 // Assert
                 expect(wrapper.vm.shouldHideBanner).toBe(expected);
+            });
+
+            it('if no consent cookie is present, should push the value `shown` to the dataLayer ', () => {
+                // Arrange
+                const propsData = {};
+                const expected = { event: 'trackConsent', userData: { consent: 'shown' } };
+                Object.defineProperty(global, 'window', {
+                    value: {
+                        dataLayer: []
+                    }
+                });
+                window.dataLayer = [];
+                CookieHelper.remove('je-cookieConsent');
+
+                // Act
+                const wrapper = shallowMount(CookieBanner, {
+                    localVue,
+                    i18n,
+                    propsData
+                });
+                wrapper.vm.checkCookieBannerCookie();
+
+                // Assert
+                expect(window.dataLayer).toContainEqual(expected);
+            });
+
+            it('if consent cookie is present and set to `full`, should not push the value `shown` to the dataLayer ', () => {
+                // Arrange
+                const propsData = {};
+                const expected = { event: 'trackConsent', userData: { consent: 'shown' } };
+                Object.defineProperty(global, 'window', {
+                    value: {
+                        dataLayer: []
+                    }
+                });
+                window.dataLayer = [];
+                CookieHelper.set('je-cookieConsent', 'full');
+
+                // Act
+                const wrapper = shallowMount(CookieBanner, {
+                    localVue,
+                    i18n,
+                    propsData
+                });
+                wrapper.vm.checkCookieBannerCookie();
+
+                // Assert
+                expect(window.dataLayer).not.toContainEqual(expected);
             });
         });
 

--- a/packages/components/organisms/f-cookie-banner/src/tenants/da-DK.js
+++ b/packages/components/organisms/f-cookie-banner/src/tenants/da-DK.js
@@ -8,7 +8,7 @@ const messages = {
     textLine3: 'For nærmere oplysninger om de anvendte cookies og teknologier henviser vi til vores ',
     textLine4: '. Ved brug af denne banner placeres en cookie på din enhed, som husker dine præferencer.',
     cookiePolicyLinkText: 'cookie-meddelelse',
-    cookiePolicyLinkUrl: 'https://www.just-eat.dk/info/cookiepolitik'
+    cookiePolicyLinkUrl: 'https://www.just-eat.dk/cookie-erklaering'
 };
 
 const displayLegacy = false;

--- a/packages/components/organisms/f-cookie-banner/src/tenants/nb-NO.js
+++ b/packages/components/organisms/f-cookie-banner/src/tenants/nb-NO.js
@@ -8,7 +8,7 @@ const messages = {
     textLine3: 'For detaljer om hvilke informasjonskapsler og teknologier vi bruker, se vår ',
     textLine4: '. Ved å bruke dette banneret, plasseres en informasjonskapsel på enheten din for å huske dine preferanser.',
     cookiePolicyLinkText: 'melding om informasjonskapsler',
-    cookiePolicyLinkUrl: 'https://www.just-eat.no/info/cookie-politikk'
+    cookiePolicyLinkUrl: 'https://www.just-eat.no/informasjonskapselerklaering'
 };
 
 const displayLegacy = false;

--- a/packages/components/organisms/f-cookie-banner/test/specs/component/desktop/f-cookieConsentBanner.component.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/specs/component/desktop/f-cookieConsentBanner.component.spec.js
@@ -28,10 +28,10 @@ describe('New - f-cookieBanner component tests', () => {
 describe('New - Multi-tenant - f-cookieBanner component tests', () => {
     forEach([
         ['es', 'es/info/politica-de-cookies'],
-        ['dk', 'dk/info/cookiepolitik'],
+        ['dk', 'dk/cookie-erklaering'],
         ['ie', 'ie/info/cookies-policy'],
         ['it', 'it/informazioni/politica-dei-cookie'],
-        ['no', 'no/info/cookie-politikk']
+        ['no', 'no/informasjonskapselerklaering']
     ])
     .it('should go to the correct cookie policy page', (tenant, expectedCookiePolicyUrl) => {
 


### PR DESCRIPTION
---

Needs to push { 'event': 'trackConsent', 'userData': { 'consent': 'shown' } } to the dataLayer when the banner is shown. Tests need to be updated to reflect the change.

---
