### PR TITLE
f-footer@4.18.0 - Expander buttons are present only for below "wide" screen

### DIFF
--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.18.0
+------------------------------
+*April 9, 2021*
+
+### Changed
+- Expander buttons are present only for below `wide` screen 
+
 
 Latest (add to next release)
 ------------------------------

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "4.17.0",
+  "version": "4.18.0",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-footer/src/components/LinkList.vue
+++ b/packages/components/organisms/f-footer/src/components/LinkList.vue
@@ -8,6 +8,7 @@
         :data-test-id="testId">
         <h2>
             <button
+                v-if="isBelowWide"
                 :id="listHeadingId"
                 :tabindex="isBelowWide ? 0 : -1"
                 :disabled="!isBelowWide"
@@ -26,6 +27,14 @@
                         [$style['c-icon--chevron--up']]: !panelCollapsed
                     }]" />
             </button>
+
+            <span
+                v-else
+                :id="listHeadingId"
+                :class="[
+                    $style['c-footer-heading'],
+                    $style['c-footer-heading--button']
+                ]">{{ linkList.title }}</span>
         </h2>
 
         <ul


### PR DESCRIPTION
**Issue description:** 
When in mobile view the footer uses expandable drop down sections. These correctly use a button and aria-expanded attributes to show the status of the dropdowns, however, these buttons are still present in the desktop version of the page. The buttons should be replaced with static header text for the lists.

**Acceptance criteria:**
Expander buttons are not present in desktop viewport

---

### Changed
- Expander buttons are present only for below `wide` screen 

---

<img width="1190" alt="Screenshot 2021-04-07 at 11 10 10" src="https://user-images.githubusercontent.com/3179649/113850145-12b80000-9792-11eb-8d84-0a653e038769.png">

<img width="746" alt="Screenshot 2021-04-07 at 11 10 19" src="https://user-images.githubusercontent.com/3179649/113850152-13e92d00-9792-11eb-8a7a-d890de469957.png">
