### PR TITLE
f-checkout@0.87.0 isGuestCreated flag

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.87.0
+------------------------------
+*April 12, 2021*
+
+### Added
+- `isGuestCreated` store flag that prevents multiple guest accounts from being created when form is resubmitted after failed validation
+
+
 v0.86.0
 ------------------------------
 *April 12, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.86.0",
+  "version": "0.87.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -282,6 +282,7 @@ export default {
             'customer',
             'errors',
             'geolocation',
+            'isGuestCreated',
             'hasAsapSelected',
             'id',
             'isFulfillable',
@@ -432,7 +433,7 @@ export default {
          */
         async submitCheckout () {
             try {
-                if (!this.isLoggedIn) {
+                if (!this.isLoggedIn && !this.isGuestCreated) {
                     await this.setupGuestUser();
                 }
 

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -977,42 +977,100 @@ describe('Checkout', () => {
 
             describe('when invoked', () => {
                 describe('AND `isLoggedIn` is falsey', () => {
-                    it('should call `setupGuestUser`', async () => {
-                        // Arrange
-                        const setupGuestUserSpy = jest.spyOn(wrapper.vm, 'setupGuestUser');
+                    describe('AND `isGuestCreated` is falsey', () => {
+                        it('should call `setupGuestUser`', async () => {
+                            // Arrange
+                            const setupGuestUserSpy = jest.spyOn(wrapper.vm, 'setupGuestUser');
 
-                        // Act
-                        await wrapper.vm.submitCheckout();
+                            // Act
+                            await wrapper.vm.submitCheckout();
 
-                        // Assert
-                        expect(setupGuestUserSpy).toHaveBeenCalled();
+                            // Assert
+                            expect(setupGuestUserSpy).toHaveBeenCalled();
+                        });
+                    });
+
+                    describe('AND `isGuestCreated` is truthy', () => {
+                        it('should not call `setupGuestUser`', async () => {
+                            // Arrange
+                            wrapper = mount(VueCheckout, {
+                                store: createStore({
+                                    ...defaultCheckoutState,
+                                    isGuestCreated: true
+                                }),
+                                i18n,
+                                localVue,
+                                propsData,
+                                mocks: {
+                                    $logger
+                                }
+                            });
+                            const setupGuestUserSpy = jest.spyOn(wrapper.vm, 'setupGuestUser');
+
+                            // Act
+                            await wrapper.vm.submitCheckout();
+
+                            // Assert
+                            expect(setupGuestUserSpy).not.toHaveBeenCalled();
+                        });
                     });
                 });
 
                 describe('AND `isLoggedIn` is truthy', () => {
-                    it('should not call `setupGuestUser`', async () => {
-                        // Arrange
-                        wrapper = mount(VueCheckout, {
-                            store: createStore({
-                                ...defaultCheckoutState,
-                                serviceType: CHECKOUT_METHOD_COLLECTION,
-                                isLoggedIn: true
-                            }),
-                            i18n,
-                            localVue,
-                            propsData,
-                            mocks: {
-                                $logger
-                            }
+                    describe('AND `isGuestCreated` is falsey', () => {
+                        it('should not call `setupGuestUser`', async () => {
+                            // Arrange
+                            wrapper = mount(VueCheckout, {
+                                store: createStore({
+                                    ...defaultCheckoutState,
+                                    serviceType: CHECKOUT_METHOD_COLLECTION,
+                                    isLoggedIn: true,
+                                    isGuestCreated: false
+                                }),
+                                i18n,
+                                localVue,
+                                propsData,
+                                mocks: {
+                                    $logger
+                                }
+                            });
+
+                            const setupGuestUserSpy = jest.spyOn(wrapper.vm, 'setupGuestUser');
+
+                            // Act
+                            await wrapper.vm.submitCheckout();
+
+                            // Assert
+                            expect(setupGuestUserSpy).not.toHaveBeenCalled();
                         });
+                    });
 
-                        const setupGuestUserSpy = jest.spyOn(wrapper.vm, 'setupGuestUser');
+                    describe('AND `isGuestCreated` is truthy', () => {
+                        it('should not call `setupGuestUser`', async () => {
+                            // Arrange
+                            wrapper = mount(VueCheckout, {
+                                store: createStore({
+                                    ...defaultCheckoutState,
+                                    serviceType: CHECKOUT_METHOD_COLLECTION,
+                                    isLoggedIn: true,
+                                    isGuestCreated: true
+                                }),
+                                i18n,
+                                localVue,
+                                propsData,
+                                mocks: {
+                                    $logger
+                                }
+                            });
 
-                        // Act
-                        await wrapper.vm.submitCheckout();
+                            const setupGuestUserSpy = jest.spyOn(wrapper.vm, 'setupGuestUser');
 
-                        // Assert
-                        expect(setupGuestUserSpy).not.toHaveBeenCalled();
+                            // Act
+                            await wrapper.vm.submitCheckout();
+
+                            // Assert
+                            expect(setupGuestUserSpy).not.toHaveBeenCalled();
+                        });
                     });
                 });
 

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -64,6 +64,7 @@ export default {
         },
         authToken: '',
         isLoggedIn: false,
+        isGuestCreated: false,
         geolocation: null,
         hasAsapSelected: false
     }),
@@ -399,6 +400,7 @@ export default {
         [UPDATE_AUTH_GUEST]: (state, authToken) => {
             state.authToken = authToken;
             state.isLoggedIn = false;
+            state.isGuestCreated = true;
         },
 
         [UPDATE_AVAILABLE_FULFILMENT_TIMES]: (state, {

--- a/packages/components/organisms/f-checkout/src/store/tests/__snapshots__/checkout.module.test.js.snap
+++ b/packages/components/organisms/f-checkout/src/store/tests/__snapshots__/checkout.module.test.js.snap
@@ -28,6 +28,7 @@ Object {
   "hasAsapSelected": false,
   "id": "12345",
   "isFulfillable": true,
+  "isGuestCreated": false,
   "isLoggedIn": false,
   "messages": Array [
     Object {

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -121,6 +121,7 @@ const defaultState = {
     },
     authToken: '',
     isLoggedIn: false,
+    isGuestCreated: false,
     userNote: '',
     geolocation: null,
     hasAsapSelected: false
@@ -203,6 +204,14 @@ describe('CheckoutModule', () => {
                 // Assert
                 expect(state.authToken).toEqual(authToken);
                 expect(state.isLoggedIn).toBeFalsy();
+            });
+
+            it('should update state with `isGuestCreated` set to true', () => {
+                // Act
+                mutations[UPDATE_AUTH_GUEST](state, authToken);
+
+                // Assert
+                expect(state.isGuestCreated).toBeTruthy();
             });
         });
 


### PR DESCRIPTION
`isGuestCreated` store flag that prevents multiple guest accounts from being created when form is resubmitted

## UI Review Checks
No UI changes

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
