### PR TITLE
f-checkout@0.87.1 - Update checkout timeout to 10 seconds

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.87.1
+------------------------------
+*April 12, 2021*
+
+### Changed
+- `checkoutTimeout` prop now defaults to ten seconds
+
 v0.87.0
 ------------------------------
 *April 12, 2021*

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -11,6 +11,7 @@ v0.87.1
 ### Changed
 - `checkoutTimeout` prop now defaults to ten seconds
 
+
 v0.87.0
 ------------------------------
 *April 12, 2021*

--- a/packages/components/organisms/f-checkout/README.md
+++ b/packages/components/organisms/f-checkout/README.md
@@ -79,7 +79,7 @@ The props that can be defined are as follows:
 | `getBasketUrl` | `String` | - | URL for the API called to get Basket Details.<br><br>The data returned from this API contains the serviceType, which determines if the Checkout component is created for Collection or Delivery when the user is not authenticated. |
 | `placeOrderUrl` | `String` | - | URL for the API called to place the order.<br><br>The data returned from this API contains the orderId, which is needed to redirect the user to the payment page. |
 | `getGeoLocationUrl` | `String` | - | URL for the API that can return geo location information (Latitude and Longitude) for a given address.<br>The `tenant` must be provided as the last segment of the URL and all calls must be authenticated. |
-| `checkoutTimeout` | `Number` | 1000 | Timeout for the different API calls in the component. |
+| `checkoutTimeout` | `Number` | 10000 | Timeout for the different API calls in the component. |
 | `authToken` | `String` | `''` | Authorisation token used when submitting the checkout form. |
 | `otacToAuthExchanger` | `Function` | `throw new Error('otacToAuthExchanger is not implemented');` | Function to exchange OTAC to JWT auth token |
 | `loginUrl` | `String` | `-` | URL to navigate to if the user wishes to change account. |

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.87.0",
+  "version": "0.87.1",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -201,7 +201,7 @@ export default {
         checkoutTimeout: {
             type: Number,
             required: false,
-            default: 1000
+            default: 10000
         },
 
         spinnerTimeout: {

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -1450,7 +1450,7 @@ describe('Checkout', () => {
                         registrationSource: 'Guest'
                     },
                     otacToAuthExchanger,
-                    timeout: 1000
+                    timeout: 10000
                 };
                 const createGuestUserSpy = jest.spyOn(VueCheckout.methods, 'createGuestUser');
                 const wrapper = shallowMount(VueCheckout, {
@@ -1686,7 +1686,7 @@ describe('Checkout', () => {
                             'BS1 1AA'
                         ]
                     },
-                    timeout: 1000
+                    timeout: 10000
                 };
 
                 beforeEach(async () => {
@@ -2648,7 +2648,7 @@ describe('Checkout', () => {
                         },
                         referralState: 'ReferredByWeb'
                     },
-                    timeout: 1000
+                    timeout: 10000
                 };
 
                 // Act

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -305,7 +305,7 @@ describe('CheckoutModule', () => {
                 url: 'http://localhost/account/checkout',
                 tenant: 'uk',
                 language: 'en-GB',
-                timeout: 1000,
+                timeout: 10000,
                 postData: null
             };
         });


### PR DESCRIPTION
### Changed
- `checkoutTimeout` prop now defaults to ten seconds

When you throttle your internet speed when redirecting to checkout, the initial requests time out as they are only one second. 

- [x] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
