### PR TITLE
f-header@v4.12.0 - Use CSS modules (part 1)

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,8 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (add to next release)
+v4.12.0
 ------------------------------
+*April 9, 2021*
+
+### Changed
+- Add shared `nav.scss` file.
+- Convert `CountrySelectorPanel`, `Logo`, `SkipToMain` and `UserNavigationPanel` components to use css modules.
+- Unit and Component tests to support changes.
+
 *April 9, 2021*
 
 ### Changed
@@ -17,7 +24,7 @@ Latest (add to next release)
 ### Added
 - Component tests for locales `au, dk, ie, es, no, it, nz`
 - Component test for offers icon in mobile spec
-- Accessibility tests for the above locales 
+- Accessibility tests for the above locales
 
 ### Changed
 - Small refactor to `open` function in component-object

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v4.12.0
 ------------------------------
-*April 9, 2021*
+*April 14, 2021*
 
 ### Changed
 - Add shared `nav.scss` file.

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "4.11.1",
+  "version": "4.12.0",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist",
@@ -35,7 +35,7 @@
     "test-component:browserstack": "cross-env-shell JE_ENV=browserstack wdio ../../../../wdio-browserstack.conf.js --suite shared mobile",
     "test-component:chrome": "cross-env-shell JE_ENV=local wdio ../../../../wdio-chrome.conf.js --suite component",
     "report:test-component:chrome": "cross-env-shell JE_ENV=local COMPONENT_TYPE=organism wdio ../../../../wdio-chrome.conf.js --suite component && yarn allure:open",
-    "test-a11y:chrome": "cross-env-shell JE_ENV=local wdio ../../../../wdio-chrome.conf.js --suite a11y", 
+    "test-a11y:chrome": "cross-env-shell JE_ENV=local wdio ../../../../wdio-chrome.conf.js --suite a11y",
     "allure:open": "yarn allure:clean && allure open",
     "allure:clean": "rimraf ../../../../test/results/allure"
   },

--- a/packages/components/organisms/f-header/src/assets/scss/navigation.scss
+++ b/packages/components/organisms/f-header/src/assets/scss/navigation.scss
@@ -17,7 +17,6 @@ $countrySelector-flag-width : 16px;
 $countrySelector-flag-height : 16px;
 
 @mixin nav-container-visible () {
-    background: yellow;
     overflow-y: auto;
     left: 0;
     opacity: 1;
@@ -71,7 +70,7 @@ $countrySelector-flag-height : 16px;
     list-style-image: none;
     padding: 0;
 
-    & > li {
+    &>li {
         margin-bottom: 0;
 
         &:before {
@@ -86,6 +85,7 @@ $countrySelector-flag-height : 16px;
 }
 
 .c-nav-list-link {
+
     &:hover,
     &:focus,
     &:active {

--- a/packages/components/organisms/f-header/src/assets/scss/navigation.scss
+++ b/packages/components/organisms/f-header/src/assets/scss/navigation.scss
@@ -70,7 +70,7 @@ $countrySelector-flag-height : 16px;
     list-style-image: none;
     padding: 0;
 
-    &>li {
+    & > li {
         margin-bottom: 0;
 
         &:before {
@@ -85,7 +85,6 @@ $countrySelector-flag-height : 16px;
 }
 
 .c-nav-list-link {
-
     &:hover,
     &:focus,
     &:active {
@@ -127,13 +126,13 @@ $countrySelector-flag-height : 16px;
         display: none;
     }
 
-    &:checked~.c-nav-container {
+    &:checked ~ .c-nav-container {
         @include media('<=mid') {
             @include nav-container-visible();
         }
     }
 
-    &:focus~.c-nav-toggle {
+    &:focus ~ .c-nav-toggle {
         background-color: $nav-trigger-focus-bg;
         box-shadow: 0 0 6px 0 $nav-trigger-focus-color;
 

--- a/packages/components/organisms/f-header/src/assets/scss/navigation.scss
+++ b/packages/components/organisms/f-header/src/assets/scss/navigation.scss
@@ -1,0 +1,144 @@
+@import './common.scss';
+
+$nav-text-color--hover : $color-link-hover;
+$nav-text-color--transparent : $white;
+
+$nav-transition-duration : 250ms;
+
+$nav-trigger-width : 56px;
+$nav-trigger-height : 48px;
+$nav-trigger-focus-color : $blue;
+$nav-trigger-focus-bg : $blue--offWhite;
+
+$nav-popover-transition-delay : 200ms;
+$nav-popover-transition-duration : 200ms;
+
+$countrySelector-flag-width : 16px;
+$countrySelector-flag-height : 16px;
+
+@mixin nav-container-visible () {
+    background: yellow;
+    overflow-y: auto;
+    left: 0;
+    opacity: 1;
+    z-index: zIndex(high);
+    transition: opacity $nav-transition-duration ease-in-out,
+        z-index 0s linear;
+}
+
+// Global site-wide navigation
+.c-nav--global {
+    @include media('>mid') {
+        display: flex;
+        justify-content: flex-end;
+        flex-grow: 1;
+    }
+}
+
+// we have a nav container so that we don’t have to make the inner list 100% height
+// this is so we can position the logout button last on mobile
+.c-nav-container {
+    @include media('<=mid') {
+        position: fixed;
+        top: $header-height--narrow;
+        left: -99999px;
+        width: 100%;
+        padding: 0;
+        height: calc(100% - (#{$header-height--narrow}));
+        border-top: $header-separator solid $header-border-color;
+        background: $white;
+        z-index: -1;
+        opacity: 0;
+        transition: opacity $nav-transition-duration ease-in-out,
+            z-index 0s linear $nav-transition-duration,
+            left 0s linear ($nav-popover-transition-delay + $nav-popover-transition-duration);
+
+        &.is-visible {
+            @include nav-container-visible();
+        }
+    }
+}
+
+.c-nav-list {
+    position: relative;
+}
+
+.c-nav-list,
+.c-nav-popoverList {
+    margin-top: 0;
+    margin-left: 0;
+    list-style: none;
+    list-style-image: none;
+    padding: 0;
+
+    & > li {
+        margin-bottom: 0;
+
+        &:before {
+            content: none;
+        }
+    }
+
+    @include media('<=mid') {
+        display: flex;
+        flex-direction: column;
+    }
+}
+
+.c-nav-list-link {
+    &:hover,
+    &:focus,
+    &:active {
+        text-decoration: none;
+
+        @include media('>mid') {
+            color: $nav-text-color--hover;
+            text-decoration: underline;
+
+            .c-header--transparent .c-nav-popoverList & {
+                color: inherit;
+            }
+        }
+    }
+}
+
+.c-nav-list-icon--flag {
+    height: $countrySelector-flag-height;
+    width: $countrySelector-flag-width;
+    margin-right: spacing();
+}
+
+.c-nav-popoverList--twoColumns {
+    @include media('>mid') {
+        column-count: 2;
+    }
+}
+
+// Navigation Trigger
+// This is the checkbox that controls the menu active state without JS via :checked
+.c-nav-trigger {
+    position: absolute;
+    width: $nav-trigger-width;
+    height: $nav-trigger-height;
+    top: -100px;
+    left: -100px;
+
+    @include media('>mid') {
+        display: none;
+    }
+
+    &:checked~.c-nav-container {
+        @include media('<=mid') {
+            @include nav-container-visible();
+        }
+    }
+
+    &:focus~.c-nav-toggle {
+        background-color: $nav-trigger-focus-bg;
+        box-shadow: 0 0 6px 0 $nav-trigger-focus-color;
+
+        .c-header--transparent & {
+            background-color: transparent;
+        }
+    }
+}

--- a/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
+++ b/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
@@ -1,5 +1,9 @@
 <template>
-    <div :class="['c-nav-container', { 'is-visible': isOpen }]">
+    <div
+        :class="[
+            $style['c-nav-container'],
+            { [$style['is-visible']]: isOpen }
+        ]">
         <div :class="$style['c-countrySelector']">
             <header :class="$style['c-countrySelector-header']">
                 <f-button
@@ -15,7 +19,10 @@
             </header>
 
             <ul
-                class="c-nav-popoverList c-nav-popoverList--twoColumns"
+                :class="[
+                    $style['c-nav-popoverList'],
+                    $style['c-nav-popoverList--twoColumns']
+                ]"
                 data-test-id="countrySelector-list">
                 <li
                     v-for="(country) in countries"
@@ -36,7 +43,7 @@
                         @focus="$emit('focusOnLink')">
                         <flag-icon
                             :country-code="country.flagKey"
-                            class="c-nav-list-icon--flag" />
+                            :class="$style['c-nav-list-icon--flag']" />
                         <span>
                             {{ country.localisedName }}
                         </span>
@@ -79,6 +86,7 @@ export default {
 </script>
 
 <style lang="scss" module>
+@import '../assets/scss/navigation.scss';
 
 $countrySelector-text-color : $grey--darkest;
 $countrySelector-text-hover : $color-bg--darker;
@@ -115,6 +123,7 @@ $countrySelector-text-hover : $color-bg--darker;
         @include media('>mid') {
             display: none;
         }
+
         svg.c-countrySelector-goBackIcon {
             transform: rotate(180deg);
             width: 28px;

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -15,7 +15,8 @@
                 :theme="theme"
                 :company-name="copy.companyName"
                 :logo-gtm-label="copy.logo.gtm"
-                :header-background-theme="headerBackgroundTheme" />
+                :header-background-theme="headerBackgroundTheme"
+                :is-open="mobileNavIsOpen" />
 
             <navigation
                 :copy="copy"

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -2,7 +2,7 @@
     <a
         :aria-label="linkAltText"
         href="/"
-        class="c-logo"
+        :class="$style['c-logo']"
         :data-trak='`{
             "trakEvent": "click",
             "category": "engagement",
@@ -11,9 +11,11 @@
         }`'>
         <component
             :is="iconComponent"
-            :class="['c-logo-img',
-                     iconClassName,
-                     logoColourModifier]"
+            :class="[
+                $style['c-logo-img'],
+                iconClassName,
+                { [$style['c-logo-img--alt']]: isAltLogo }
+            ]"
             :data-theme-logo="iconClassName"
             data-test-id="header-logo" />
     </a>
@@ -46,6 +48,10 @@ export default {
         headerBackgroundTheme: {
             type: String,
             default: 'white'
+        },
+        isOpen: {
+            type: Boolean,
+            default: false
         }
     },
     computed: {
@@ -53,26 +59,22 @@ export default {
             return `${this.theme}-logo`;
         },
         iconClassName () {
-            return `c-icon--${this.theme}`;
+            return this.$style[`c-icon--${this.theme}`];
         },
         linkAltText () {
             return `Go to ${this.companyName} homepage`;
         },
-        logoColourModifier () {
-            switch (this.headerBackgroundTheme) {
-                case 'transparent':
-                    return 'c-icon--onTransparentBg';
-                case 'highlight':
-                    return 'c-icon--onHighlightBg';
-                default:
-                    return '';
-            }
+        isAltLogo () {
+            const isHighlight = this.headerBackgroundTheme === 'highlight';
+            const isTransparent = this.headerBackgroundTheme === 'transparent' && !this.isOpen;
+            return isHighlight || isTransparent;
         }
     }
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" module>
+
     // link with the logo
     .c-logo {
         display: block;
@@ -132,28 +134,12 @@ export default {
             fill: $header-logo-color;
         }
     }
+
     // White logo on highlights background
-    .c-icon--onHighlightBg {
-        &.c-logo-img {
+    .c-logo-img--alt {
             & g,
             & path {
                 fill: $header-logo-color--alt;
             }
-        }
     }
-
-    // Transparent goes from white to red
-    .c-icon--onTransparentBg {
-        &.c-logo-img {
-            & g,
-            & path {
-                fill: $header-logo-color--alt;
-
-                .is-navInView & {
-                    fill: $header-logo-color;
-                }
-            }
-        }
-    }
-
 </style>

--- a/packages/components/organisms/f-header/src/components/SkipToMain.vue
+++ b/packages/components/organisms/f-header/src/components/SkipToMain.vue
@@ -1,7 +1,13 @@
 <template>
-    <div :class="['c-skipTo', { 'c-skipTo--whiteLink': transparentBg }]">
+    <div
+        :class="[
+            $style['c-skipTo'],
+            { [$style['c-skipTo--whiteLink']]: transparentBg }]">
         <a
-            class="is-visuallyHidden is-focusable"
+            :class="[
+                $style['is-visuallyHidden'],
+                $style['is-focusable']
+            ]"
             href="#skipToMain">{{ text }}</a>
     </div>
 </template>
@@ -18,11 +24,10 @@ export default {
             default: false
         }
     }
-
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" module>
 
 .c-skipTo {
     position: absolute;
@@ -56,8 +61,6 @@ export default {
     }
 }
 
-
-
 .c-skipTo--whiteLink {
     .is-visuallyHidden {
         &.is-focusable:active,
@@ -66,5 +69,4 @@ export default {
         }
     }
 }
-
 </style>

--- a/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
+++ b/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
@@ -1,7 +1,7 @@
 <template>
     <ul
         :aria-label="copy.navTitle"
-        class="c-nav-popoverList">
+        :class="$style['c-nav-popoverList']">
         <li
             v-for="(link, index) in copy.navLinks"
             :key="index"
@@ -67,6 +67,7 @@ export default {
 </script>
 
 <style lang="scss" module>
+@import '../assets/scss/navigation.scss';
 
 .list-link {
     display: block;

--- a/packages/components/organisms/f-header/src/components/_tests/Logo.test.js
+++ b/packages/components/organisms/f-header/src/components/_tests/Logo.test.js
@@ -44,54 +44,57 @@ describe('Logo', () => {
         expect(logo).toBeDefined();
     });
 
-    it('should have "c-icon--onTransparentBg" class if "headerBackgroundTheme" property is "transparent"', () => {
-        // Arrange
-        const propsData = {
-            theme: 'je',
-            headerBackgroundTheme: 'transparent',
-            companyName: 'Just Eat'
+    describe('header logo :: ', () => {
+        const $style = {
+            'c-logo-img--alt': 'c-logo-img--alt'
         };
 
-        // Act
-        const wrapper = mount(Logo, { propsData });
-        const logo = wrapper.find('[data-theme-logo="c-icon--je"]');
+        it.each([
+            ['transparent'],
+            ['highlight']
+        ])('should have "c-logo-img--alt" class if "headerBackgroundTheme" property is %s', theme => {
+            // Arrange
+            const propsData = {
+                theme: 'je',
+                headerBackgroundTheme: theme,
+                companyName: 'Just Eat'
+            };
 
-        // Assert
-        expect(logo.classes('c-icon--onTransparentBg')).toBe(true);
-    });
+            // Act
+            const wrapper = mount(Logo, {
+                propsData,
+                mocks: {
+                    $style
+                }
+            });
+            const logo = wrapper.find('[data-test-id="header-logo"]');
 
-    it('should have "c-icon--onHighlightBg" class if "headerBackgroundTheme" property is "highlight"', () => {
-        // Arrange
-        const propsData = {
-            theme: 'je',
-            headerBackgroundTheme: 'highlight',
-            companyName: 'Just Eat'
-        };
+            // Assert
+            expect(logo.classes()).toContain('c-logo-img--alt');
+        });
 
-        // Act
-        const wrapper = mount(Logo, { propsData });
-        const logo = wrapper.find('[data-theme-logo="c-icon--je"]');
+        it.each([
+            ['white'],
+            ['blue']
+        ])('should not have "c-logo-img--alt" class if "headerBackgroundTheme" property is %s', theme => {
+            // Arrange
+            const propsData = {
+                theme: 'je',
+                headerBackgroundTheme: theme,
+                companyName: 'Just Eat'
+            };
 
-        // Assert
-        expect(logo.classes('c-icon--onHighlightBg')).toBe(true);
-    });
+            // Act
+            const wrapper = mount(Logo, {
+                propsData,
+                mocks: {
+                    $style
+                }
+            });
+            const logo = wrapper.find('[data-test-id="header-logo"]');
 
-    it('shouldn\'t have "c-icon--onHighlightBg" class if "headerBackgroundTheme" property is not "highlight", "transparent"', () => {
-        // Arrange
-        const propsData = {
-            theme: 'je',
-            headerBackgroundTheme: 'green',
-            companyName: 'Just Eat'
-        };
-
-        // Act
-        const wrapper = shallowMount(Logo, { propsData });
-        const logo = wrapper.find('[data-theme-logo="c-icon--je"]');
-
-        // Assert
-        // with dynamically rendered components
-        // dynamic classes returned as one string in the array
-        // so have to check for 'c-logo-img,c-icon--je,c-icon--onHighlightBg' not just 'c-icon--onHighlightBg'
-        expect(logo.classes()).not.toContain('c-logo-img,c-icon--je,c-icon--onHighlightBg');
+            // Assert
+            expect(logo.classes()).not.toContain('c-logo-img--alt');
+        });
     });
 });


### PR DESCRIPTION
### Changed
- Add shared `nav.scss` file.
- Convert `CountrySelectorPanel`, `Logo`, `SkipToMain` and `UserNavigationPanel` components to use css modules.
- Unit and Component tests to support changes.

**part 1 of 2**
[https://github.com/justeat/fozzie-components/pull/882](part2)
## UI Review Checks

**Desktop**
![image](https://user-images.githubusercontent.com/24740015/114561201-4351db00-9c65-11eb-8fe0-cc872f651354.png)
![image](https://user-images.githubusercontent.com/24740015/114561212-464ccb80-9c65-11eb-9ac7-17a8c306a682.png)
![image](https://user-images.githubusercontent.com/24740015/114561221-4947bc00-9c65-11eb-9752-a81917eccc2e.png)

**Mobile**
![image](https://user-images.githubusercontent.com/24740015/114561290-582e6e80-9c65-11eb-93b7-aba724f63064.png)
![image](https://user-images.githubusercontent.com/24740015/114561271-549ae780-9c65-11eb-9d0c-0269ca1ab528.png)
![image](https://user-images.githubusercontent.com/24740015/114561256-506eca00-9c65-11eb-83e5-b310dc56d335.png)

**Mobile - menu open**
![image](https://user-images.githubusercontent.com/24740015/114561344-65e3f400-9c65-11eb-8d4c-916efbe301c6.png)


