### PR TITLE
f-form-field@1.10.0 - Add support for number input type

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -3,6 +3,19 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v1.10.0
+------------------------------
+*April 13, 2021*
+
+### Added
+- Support for `number` input type.
+  - Includes two new optional props, `minNumber` and `maxNumber`.
+
+### Fixed
+- vuejs-accessibility violation [`form-control-has-label`](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/blob/1cb838c853af763ac4d77467cdcd790f6896a810/docs/form-control-has-label.md)
+
+
 v1.9.0
 ------------------------------
 *March 30, 2021*

--- a/packages/components/atoms/f-form-field/README.md
+++ b/packages/components/atoms/f-form-field/README.md
@@ -71,12 +71,14 @@ The props that can be defined are as follows (if any):
 | ----- | ----- | ------- | ----------- |
 | `locale` | `String` | `''` | Sets locale for I18n. |
 | `labelText` | `String` | `''` | The text that will be displayed in the form field label. |
-| `inputType` | `String` | `text` | The type of input needed. <br>Options: `text`, `email`, `password`, `radio`, `checkbox`, `dropdown` |
+| `inputType` | `String` | `text` | The type of input needed. <br>Options: `text`, `email`, `password`, `radio`, `checkbox`, `dropdown`, `number` |
 | `labelStyle` | `String` | `'default'` | Defines where the label will be rendered in relation to the form field. <br>Options: <br>`default` - Displays the label above the form field, <br>`inline` Displays the label inside the form field,<br>`inlineNarrow` Displays the label above the form field when in web/tablet. Displays the label inside the form field when in mobile.<br>|
 | `value` | `String` or `Number` | `''` | The value of the form field. |
 | `hasError` | `Boolean` | `false` | When `true` border colour changes to red. |
 | `dropdownOptions` | `Array` | `null` | The options to be displayed in the dropdown. |
 | `isGrouped` | `Boolean` | `false` | When `true` will remove margin between all grouped form fields. |
+| `minNumber` | `Number` | 0 | Sets the value of the `min` property when `inputType` is `number` |
+| `maxNumber` | `Number` | 0 | Sets the value of the `max` property when `inputType` is `number` |
 
 ### Events
 

--- a/packages/components/atoms/f-form-field/README.md
+++ b/packages/components/atoms/f-form-field/README.md
@@ -71,7 +71,7 @@ The props that can be defined are as follows (if any):
 | ----- | ----- | ------- | ----------- |
 | `locale` | `String` | `''` | Sets locale for I18n. |
 | `labelText` | `String` | `''` | The text that will be displayed in the form field label. |
-| `inputType` | `Sting` | `text` | The type of input needed. <br>Options: `text`, `email`, `password`, `radio`, `checkbox` |
+| `inputType` | `String` | `text` | The type of input needed. <br>Options: `text`, `email`, `password`, `radio`, `checkbox`, `dropdown` |
 | `labelStyle` | `String` | `'default'` | Defines where the label will be rendered in relation to the form field. <br>Options: <br>`default` - Displays the label above the form field, <br>`inline` Displays the label inside the form field,<br>`inlineNarrow` Displays the label above the form field when in web/tablet. Displays the label inside the form field when in mobile.<br>|
 | `value` | `String` or `Number` | `''` | The value of the form field. |
 | `hasError` | `Boolean` | `false` | When `true` border colour changes to red. |
@@ -84,7 +84,7 @@ The events that can be subscribed to are as follows (if any):
 
 | Event | Description |
 | ----- | ----------- |
-| `input` | Fired when a user changes the value of the form field, args contain details of the change and it's context. |
+| `input` | Fired when a user changes the value of the form field, args contain details of the change and its context. |
 
 ## Development
 

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -13,7 +13,7 @@
             <form-label
                 v-if="!isInline"
                 :label-style="normalisedLabelStyle"
-                :for="uniqueId"
+                :label-for="uniqueId"
                 :is-inline="isInline"
                 :data-test-id="testId.label">
                 {{ labelText }}
@@ -21,7 +21,7 @@
 
             <form-dropdown
                 v-if="isDropdown"
-                :id="`${uniqueId}`"
+                :id="uniqueId"
                 :attributes="$attrs"
                 :type="normalisedInputType"
                 :value="value"
@@ -37,9 +37,12 @@
             <input
                 v-else
                 :id="`${uniqueId}`"
+                :aria-labelledby="`label-${uniqueId}`"
                 :value="value"
                 v-bind="$attrs"
                 :type="normalisedInputType"
+                :min="normalisedInputType === 'number' ? minNumber : false"
+                :max="normalisedInputType === 'number' ? maxNumber : false"
                 placeholder=" "
                 :data-test-id="testId.input"
                 :class="[
@@ -51,8 +54,9 @@
             >
             <form-label
                 v-if="isInline"
+                :id="`label-${uniqueId}`"
+                :label-for="uniqueId"
                 :label-style="normalisedLabelStyle"
-                :for="uniqueId"
                 :is-inline="isInline"
                 :data-test-id="`${testId.label}--inline`">
                 {{ labelText }}
@@ -127,6 +131,16 @@ export default {
         isGrouped: {
             type: Boolean,
             default: false
+        },
+
+        minNumber: {
+            type: Number,
+            default: 0
+        },
+
+        maxNumber: {
+            type: Number,
+            default: 100
         }
     },
 

--- a/packages/components/atoms/f-form-field/src/components/FormLabel.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormLabel.vue
@@ -1,6 +1,8 @@
 <template>
     <label
         v-if="hasLabelText"
+        :id="`label-${labelFor}`"
+        :for="labelFor"
         :class="[
             $style['o-form-label'],
             $style['c-formField-label'],
@@ -25,6 +27,10 @@ export default {
         isInline: {
             type: Boolean,
             default: false
+        },
+        labelFor: {
+            type: String,
+            required: true
         }
     },
     computed: {

--- a/packages/components/atoms/f-form-field/src/components/_tests/FormField.test.js
+++ b/packages/components/atoms/f-form-field/src/components/_tests/FormField.test.js
@@ -70,6 +70,31 @@ describe('FormField', () => {
                 expect(formInput.attributes('type')).toBe(definedType);
             });
 
+            it('should include the `min` and `max` attributes if inputType=`number`', () => {
+                // Arrange
+                const propsData = {
+                    inputType: 'number'
+                };
+
+                // Act
+                const wrapper = shallowMount(FormField, { propsData });
+                const formInput = wrapper.find('input');
+
+                // Assert
+                expect(formInput.attributes('min')).toBeDefined();
+                expect(formInput.attributes('max')).toBeDefined();
+            });
+
+            it('should not include the `min` and `max` attributes for default inputType', () => {
+                // Arrange & Act
+                const wrapper = shallowMount(FormField);
+                const formInput = wrapper.find('input');
+
+                // Assert
+                expect(formInput.attributes('min')).toBeUndefined();
+                expect(formInput.attributes('max')).toBeUndefined();
+            });
+
             it('should display the dropdown component if inputType=`dropdown`', () => {
                 // Arrange
                 const propsData = {

--- a/packages/components/atoms/f-form-field/src/constants.js
+++ b/packages/components/atoms/f-form-field/src/constants.js
@@ -1,4 +1,4 @@
-export const VALID_INPUT_TYPES = ['text', 'email', 'password', 'radio', 'checkbox'];
+export const VALID_INPUT_TYPES = ['text', 'email', 'password', 'radio', 'checkbox', 'number'];
 export const CUSTOM_INPUT_TYPES = ['dropdown'];
 export const DEFAULT_INPUT_TYPE = 'text';
 

--- a/packages/components/atoms/f-form-field/test/specs/component/f-form-field.component.spec.js
+++ b/packages/components/atoms/f-form-field/test/specs/component/f-form-field.component.spec.js
@@ -1,4 +1,5 @@
 const FormField = require('../../../test-utils/component-objects/f-form-field.component');
+
 const formfield = new FormField();
 
 describe('f-form-field component tests', () => {


### PR DESCRIPTION
### Added
- Support for `number` input type.
  - Includes two new optional props, `minNumber` and `maxNumber`.

### Fixed
- vuejs-accessibility violation [`form-control-has-label`](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/blob/1cb838c853af763ac4d77467cdcd790f6896a810/docs/form-control-has-label.md)

---

## UI Review Checks

![20210413T150936](https://user-images.githubusercontent.com/26894168/114566545-4dc2a380-9c6a-11eb-8b95-12485d050266.png)

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
