### PR TITLE
f-registration@v0.51.0 Add support for i18n to f-registration error messages.

### DIFF
--- a/packages/components/organisms/f-registration/CHANGELOG.md
+++ b/packages/components/organisms/f-registration/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.51.0
+------------------------------
+*April 15, 2021*
+
+### Changes
+- Error messages retrieved from i18n files.
 
 v0.50.0
 ------------------------------

--- a/packages/components/organisms/f-registration/package.json
+++ b/packages/components/organisms/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-registration/src/components/Registration.vue
+++ b/packages/components/organisms/f-registration/src/components/Registration.vue
@@ -275,53 +275,61 @@ export default {
 
         describeFirstnameErrorMessage () {
             if (this.$v.firstName.$dirty) {
+                const messages = this.copy.validationMessages.firstName;
+
                 if (!this.$v.firstName.required) {
-                    return 'Please include your first name';
+                    return messages.requiredError;
                 }
                 if (!this.$v.firstName.maxLength) {
-                    return 'First name exceeds 50 characters';
+                    return messages.maxLengthError;
                 }
                 if (!this.$v.firstName.meetsCharacterValidationRules) {
-                    return 'Your name can only contain letters, hyphens or apostrophes';
+                    return messages.invalidCharError;
                 }
             }
             return '';
         },
         describeLastnameErrorMessage () {
             if (this.$v.lastName.$dirty) {
+                const messages = this.copy.validationMessages.lastName;
+
                 if (!this.$v.lastName.required) {
-                    return 'Please include your last name';
+                    return messages.requiredError;
                 }
                 if (!this.$v.lastName.maxLength) {
-                    return 'Last name exceeds 50 characters';
+                    return messages.maxLengthError;
                 }
                 if (!this.$v.lastName.meetsCharacterValidationRules) {
-                    return 'Your last name can only contain letters, hyphens or apostrophes';
+                    return messages.invalidCharError;
                 }
             }
             return '';
         },
         describeEmailErrorMessage () {
             if (this.$v.email.$dirty) {
+                const messages = this.copy.validationMessages.email;
+
                 if (!this.$v.email.required) {
-                    return 'Please enter your email address';
+                    return messages.requiredError;
                 }
                 if (!this.$v.email.maxLength) {
-                    return 'Email address exceeds 50 characters';
+                    return messages.maxLengthError;
                 }
                 if (!this.$v.email.email) {
-                    return 'Please enter your email address correctly';
+                    return messages.invalidEmailError;
                 }
             }
             return '';
         },
         describePasswordErrorMessage () {
             if (this.$v.password.$dirty) {
+                const messages = this.copy.validationMessages.password;
+
                 if (!this.$v.password.required) {
-                    return 'Please enter a password';
+                    return messages.requiredError;
                 }
                 if (!this.$v.password.minLength) {
-                    return 'Password is less than four characters';
+                    return messages.minLengthError;
                 }
             }
             return '';


### PR DESCRIPTION
Retrieve the inline error messages from the i18n files.
---

## UI Review Checks

- [X] README and/or UI Documentation has been [created|updated]
- [X] Unit tests have been [created|updated]
- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [X] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)