### PR TITLE
f-footer@4.19.0 - Expander buttons are present only for narrow screens

### DIFF
--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -3,6 +3,20 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.19.0
+------------------------------
+*April 15, 2021*
+
+### Changed
+- Expander buttons are present only for narrow screens 
+
+### Added
+- Tests to cover this change
+
+### Fixed
+- Window resize before each test. Resize events shouldn't be throttled in tests, but they were before the fix.
+
+
 v4.18.0
 ------------------------------
 *April 12, 2021*

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-footer/src/components/LinkList.vue
+++ b/packages/components/organisms/f-footer/src/components/LinkList.vue
@@ -8,17 +8,15 @@
         :data-test-id="testId">
         <h2>
             <button
+                v-if="isBelowWide"
                 :id="listHeadingId"
-                :tabindex="isBelowWide ? 0 : -1"
-                :disabled="!isBelowWide"
-                :aria-disabled="!isBelowWide"
                 :aria-expanded="!panelCollapsed ? 'true' : 'false'"
                 :aria-controls="listId"
                 :class="[
                     $style['c-footer-heading'],
                     $style['c-footer-heading--button']
                 ]"
-                data-test-id="linkList-header"
+                data-test-id="linkList-header-button"
                 @click="onPanelClick">
                 {{ linkList.title }}
                 <chevron-icon
@@ -26,6 +24,15 @@
                         [$style['c-icon--chevron--up']]: !panelCollapsed
                     }]" />
             </button>
+
+            <span
+                v-else
+                :id="listHeadingId"
+                data-test-id="linkList-header-text"
+                :class="[
+                    $style['c-footer-heading'],
+                    $style['c-footer-heading--button']
+                ]">{{ linkList.title }}</span>
         </h2>
 
         <ul

--- a/packages/components/organisms/f-footer/src/components/_tests/LinkList.test.js
+++ b/packages/components/organisms/f-footer/src/components/_tests/LinkList.test.js
@@ -1,5 +1,22 @@
 import { shallowMount } from '@vue/test-utils';
+import { windowServices } from '@justeat/f-services';
+import root from 'window-or-global';
 import LinkList from '../LinkList.vue';
+
+jest.mock('@justeat/f-services', () => ({
+    windowServices: {
+        addEvent: jest.fn(),
+        getWindowWidth: jest.fn()
+    }
+}));
+
+const addEvent = (eventName, callbackFunction) => {
+    root.addEventListener(eventName, callbackFunction);
+    return callbackFunction;
+};
+
+windowServices.addEvent.mockImplementation(addEvent);
+windowServices.getWindowWidth.mockImplementation(() => root.innerWidth);
 
 const wrapper = shallowMount(LinkList, {
     propsData: {
@@ -26,6 +43,16 @@ describe('LinkList component', () => {
             window.dispatchEvent(new Event('resize'));
         });
 
+        it('should display the headers as buttons', () => {
+            // Arrange
+            const linkListHeaderButton = wrapper.find('[data-test-id="linkList-header-button"]');
+            const linkListHeaderText = wrapper.find('[data-test-id="linkList-header-text"]');
+
+            // Assert
+            expect(linkListHeaderButton.exists()).toBe(true);
+            expect(linkListHeaderText.exists()).toBe(false);
+        });
+
         it('should be in a collapsed state', () => {
             // Arrange & Act
             const linkListCollapsedWrapper = wrapper.find('[data-test-id="linkList-wrapper-collapsed"]');
@@ -36,7 +63,7 @@ describe('LinkList component', () => {
 
         it('should be in an open state when linkList title has been clicked', async () => {
             // Arrange
-            const linkListHeader = wrapper.find('[data-test-id="linkList-header"]');
+            const linkListHeader = wrapper.find('[data-test-id="linkList-header-button"]');
 
             // Act
             await linkListHeader.trigger('click'); // wait for DOM to update as a result of click being triggered
@@ -53,6 +80,16 @@ describe('LinkList component', () => {
         beforeEach(() => {
             window.innerWidth = 1200;
             window.dispatchEvent(new Event('resize'));
+        });
+
+        it('should display the headers as text', () => {
+            // Arrange
+            const linkListHeaderButton = wrapper.find('[data-test-id="linkList-header-button"]');
+            const linkListHeaderText = wrapper.find('[data-test-id="linkList-header-text"]');
+
+            // Assert
+            expect(linkListHeaderButton.exists()).toBe(false);
+            expect(linkListHeaderText.exists()).toBe(true);
         });
 
         it('should be in an open state', () => {

--- a/packages/components/organisms/f-footer/src/components/_tests/LinkList.test.js
+++ b/packages/components/organisms/f-footer/src/components/_tests/LinkList.test.js
@@ -1,52 +1,32 @@
 import { shallowMount } from '@vue/test-utils';
 import { windowServices } from '@justeat/f-services';
-import root from 'window-or-global';
 import LinkList from '../LinkList.vue';
 
-jest.mock('@justeat/f-services', () => ({
-    windowServices: {
-        addEvent: jest.fn(),
-        getWindowWidth: jest.fn()
+const propsData = {
+    linkList: {
+        title: 'Customer service',
+        links: [
+            {
+                url: '/contact',
+                text: 'Contact us'
+            }
+        ]
     }
-}));
-
-const addEvent = (eventName, callbackFunction) => {
-    root.addEventListener(eventName, callbackFunction);
-    return callbackFunction;
 };
 
-windowServices.addEvent.mockImplementation(addEvent);
-windowServices.getWindowWidth.mockImplementation(() => root.innerWidth);
-
-const wrapper = shallowMount(LinkList, {
-    propsData: {
-        linkList: {
-            title: 'Customer service',
-            links: [
-                {
-                    url: '/contact',
-                    text: 'Contact us'
-                }
-            ]
-        }
-    }
-});
-
 describe('LinkList component', () => {
-    it('should be defined', () => {
-        expect(wrapper.exists()).toBe(true);
-    });
-
     describe('for narrow viewport widths', () => {
-        beforeEach(() => {
-            window.innerWidth = 414;
-            window.dispatchEvent(new Event('resize'));
+        jest.spyOn(windowServices, 'getWindowWidth').mockImplementation(() => 414);
+
+        const wrapper = shallowMount(LinkList, {
+            propsData
         });
 
         it('should display the headers as buttons', () => {
             // Arrange
             const linkListHeaderButton = wrapper.find('[data-test-id="linkList-header-button"]');
             const linkListHeaderText = wrapper.find('[data-test-id="linkList-header-text"]');
+
 
             // Assert
             expect(linkListHeaderButton.exists()).toBe(true);
@@ -77,15 +57,18 @@ describe('LinkList component', () => {
     });
 
     describe('for wide viewport widths', () => {
-        beforeEach(() => {
-            window.innerWidth = 1200;
-            window.dispatchEvent(new Event('resize'));
+        jest.spyOn(windowServices, 'getWindowWidth').mockImplementation(() => 1200);
+
+        const wrapper = shallowMount(LinkList, {
+            propsData
         });
 
         it('should display the headers as text', () => {
             // Arrange
             const linkListHeaderButton = wrapper.find('[data-test-id="linkList-header-button"]');
             const linkListHeaderText = wrapper.find('[data-test-id="linkList-header-text"]');
+
+            jest.spyOn(windowServices, 'getWindowWidth').mockImplementation(() => 1200);
 
             // Assert
             expect(linkListHeaderButton.exists()).toBe(false);


### PR DESCRIPTION
### Changed
- Expander buttons are present only for narrow screens 

### Added
- Tests to cover this change

### Fixed
- Window resize before each test. Resize events shouldn't be throttled in tests, but they were before the fix.