### PR TITLE
f-cookie-banner@v0.7.1 - Update README and visuallyHidden CSS

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.7.1
+------------------------------
+*April 22, 2021*
+
+### Changed
+- Added is-visuallyHidden CSS to Legacy Banner
+- Add locale prop to usage documentation in README
+
+
 v0.7.0
 ------------------------------
 *April 8, 2021*

--- a/packages/components/organisms/f-cookie-banner/README.md
+++ b/packages/components/organisms/f-cookie-banner/README.md
@@ -59,7 +59,8 @@ export default {
 Call the component in your template:
 
 ```js
-<f-cookie-banner />
+<f-cookie-banner
+    :locale="$i18n.locale" />
 ```
 
 ## Configuration

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
@@ -104,4 +104,15 @@ export default {
     .c-cookieWarning--is-hidden {
         display: none;
     }
+
+    .is-visuallyHidden {
+        border: 0;
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+    }
 </style>


### PR DESCRIPTION
---

Due to PI regarding wrong version served to tenant, have updated documentation to include locale prop

Also fixes small issue with visually hidden text visible on legacy banner (although the text is dark grey on a dark grey background, so no effect on users!)

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
