### PR TITLE
f-checkout@v0.94.0 Display logged in state when guest user is created

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.94.0
+------------------------------
+*April 23, 2021*
+
+### Changed
+- `UPDATE_AUTH_GUEST` mutation now sets `isLoggedIn` to `true`
+
+
 v0.93.0
 ------------------------------
 *April 20, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.93.0",
+  "version": "0.94.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -411,7 +411,7 @@ export default {
 
         [UPDATE_AUTH_GUEST]: (state, authToken) => {
             state.authToken = authToken;
-            state.isLoggedIn = false;
+            state.isLoggedIn = true;
             state.isGuestCreated = true;
         },
 

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -196,13 +196,13 @@ describe('CheckoutModule', () => {
         });
 
         describe(`${UPDATE_AUTH_GUEST} ::`, () => {
-            it('should update state with authToken and set `isLoggedIn` to false', () => {
+            it('should update state with authToken and set `isLoggedIn` to true', () => {
                 // Act
                 mutations[UPDATE_AUTH_GUEST](state, authToken);
 
                 // Assert
                 expect(state.authToken).toEqual(authToken);
-                expect(state.isLoggedIn).toBeFalsy();
+                expect(state.isLoggedIn).toBeTruthy();
             });
 
             it('should update state with `isGuestCreated` set to true', () => {


### PR DESCRIPTION
Display logged in state when user submits guest checkout and gets a validation error e.g. "The restaurant doesn't delivery to this address". To keep experience consistent with legacy checkout.

---

## UI Review Checks
Old:
<img width="400" alt="Screenshot 2021-04-23 at 10 31 25" src="https://user-images.githubusercontent.com/6950110/115851991-7a6f7b80-a41f-11eb-9901-c026493c7127.png">
New:
<img width="400" alt="Screenshot 2021-04-23 at 10 29 53" src="https://user-images.githubusercontent.com/6950110/115852015-822f2000-a41f-11eb-9b0e-edf136c57c3c.png">

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
