### PR TITLE
f-form-field@v1.11.0 - Extended the valid Types allowed

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.11.0
+------------------------------
+*April 28, 2021*
+
+### Added
+- Extended the `Type` values to include `tel` for telephone fields.
+
 
 v1.10.1
 ------------------------------

--- a/packages/components/atoms/f-form-field/README.md
+++ b/packages/components/atoms/f-form-field/README.md
@@ -71,7 +71,7 @@ The props that can be defined are as follows (if any):
 | ----- | ----- | ------- | ----------- |
 | `locale` | `String` | `''` | Sets locale for I18n. |
 | `labelText` | `String` | `''` | The text that will be displayed in the form field label. |
-| `inputType` | `String` | `text` | The type of input needed. <br>Options: `text`, `email`, `password`, `radio`, `checkbox`, `dropdown`, `number` |
+| `inputType` | `String` | `text` | The type of input needed. <br>Options: `text`, `email`, `password`, `radio`, `checkbox`, `dropdown`, `number`, `tel`  |
 | `labelStyle` | `String` | `'default'` | Defines where the label will be rendered in relation to the form field. <br>Options: <br>`default` - Displays the label above the form field, <br>`inline` Displays the label inside the form field,<br>`inlineNarrow` Displays the label above the form field when in web/tablet. Displays the label inside the form field when in mobile.<br>|
 | `value` | `String` or `Number` | `''` | The value of the form field. |
 | `hasError` | `Boolean` | `false` | When `true` border colour changes to red. |

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-form-field/src/constants.js
+++ b/packages/components/atoms/f-form-field/src/constants.js
@@ -1,4 +1,4 @@
-export const VALID_INPUT_TYPES = ['text', 'email', 'password', 'radio', 'checkbox', 'number'];
+export const VALID_INPUT_TYPES = ['text', 'email', 'password', 'radio', 'checkbox', 'number', 'tel'];
 export const CUSTOM_INPUT_TYPES = ['dropdown'];
 export const DEFAULT_INPUT_TYPE = 'text';
 


### PR DESCRIPTION
v1.11.0
------------------------------
*April 28, 2021*

### Added
- Extended the `Type` values to include `tel` for telephone fields.