### PR TITLE
f-braze-adapter@v3.4.0, f-content-cards@v4.5.0 🍪 Respect cookie preference

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -3,12 +3,22 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v4.5.0
+------------------------------
+*April 29, 2021*
+
+### Changed
+- Bumped version of f-braze-adapter to respect cookie preferences
+
+
 v4.4.1
 ------------------------------
 *March 25, 2021*
 
 ### Fixed
-- ContentCards Component Page Object model Fixed to use base page package. 
+- ContentCards Component Page Object model Fixed to use base page package.
+
 
 v4.4.0
 ------------------------------

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist",
@@ -53,14 +53,14 @@
     "vue": "2.x"
   },
   "devDependencies": {
-    "@justeat/f-braze-adapter": "3.2.0",
+    "@justeat/f-braze-adapter": "3.4.0",
     "@justeat/f-vue-icons": "1.2.0",
+    "@justeat/f-wdio-utils": "0.1.1",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
     "@vue/test-utils": "1.0.3",
-    "@justeat/f-wdio-utils": "0.1.1",
     "color": "3.1.3",
     "copy-to-clipboard": "3.3.1",
     "crypto-js": "4.0.0",

--- a/packages/services/f-braze-adapter/CHANGELOG.md
+++ b/packages/services/f-braze-adapter/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.4.0
+------------------------------
+*April 28, 2021*
+
+### Changed
+- If the `je-cookieConsent` cookie is unset, or set to something other than `"full"`, the `noCookies`
+  option will be set on initialisation of the braze SDK.
+
+
 v3.3.0
 ------------------------------
 *March 29, 2021*

--- a/packages/services/f-braze-adapter/README.md
+++ b/packages/services/f-braze-adapter/README.md
@@ -49,6 +49,10 @@ This method returns an instance of the BrazeDispatcher class, which can also be 
 
 All other functionality, such as handling content cards or intercepting in-app messages can be done with callbacks passed through config.
 
+Note that the [`noCookies`](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions) option is passed to
+braze SDK as `true` if the `je-cookieConsent` cookie (as set by [`@justeat/f-cookie-banner`](https://www.npmjs.com/package/@justeat/f-cookie-banner))
+is not `"full"`.
+
 #### Basic Example
 
 ```js

--- a/packages/services/f-braze-adapter/README.md
+++ b/packages/services/f-braze-adapter/README.md
@@ -134,6 +134,17 @@ A callback to be invoked when in-app messages have been retrieved.
 
 The callback to be invoked when in-app messages have been clicked.
 
+#### `config.loggerCallbacks`
+
+A dictionary of functions that should accept the parameters:
+
+* `level` String - one of (`logInfo`|`logWarn`|`logError`)
+* `message` String - A useful log message
+* `payload` Object - Any other relevant info for logging
+
+This will be used to log out any information from the service. In a later version it will also be set up as a log target
+for the braze SDK, based on the `enableLogging` configuration value.
+
 ## Migration to v2
 
 Version 2 exposes the appboy instance as opposed to content cards as part of the refresh callback, this makes it easier to access properties on the instance such as `getUnviewedCardCount` and is a step closer to an isomorphic solution.

--- a/packages/services/f-braze-adapter/package.json
+++ b/packages/services/f-braze-adapter/package.json
@@ -48,6 +48,10 @@
     "@vue/cli-plugin-unit-jest": "4.4.6",
     "core-js": "3.6.5",
     "jest-extended": "0.11.5",
-    "mockdate": "3.0.2"
+    "mockdate": "3.0.2",
+    "js-cookie": "2.2.1"
+  },
+  "peerDependencies": {
+    "js-cookie": ">=2.2.1"
   }
 }

--- a/packages/services/f-braze-adapter/package.json
+++ b/packages/services/f-braze-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-braze-adapter",
   "description": "Fozzie Metadata Service",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "main": "src/index.js",
   "files": [
     "src"

--- a/packages/services/f-braze-adapter/src/BrazeDispatcher.js
+++ b/packages/services/f-braze-adapter/src/BrazeDispatcher.js
@@ -3,6 +3,7 @@ import uniq from 'lodash.uniq';
 import ContentCards from './services/contentCard.service';
 import isAppboyInitialised from './utils/isAppboyInitialised';
 import { LogService } from './services/logging/logging.service';
+import areCookiesPermitted from './utils/areCookiesPermitted';
 
 /* braze event handler callbacks */
 
@@ -201,7 +202,11 @@ class BrazeDispatcher {
         try {
             this.appboyPromise = import(/* webpackChunkName: "appboy-web-sdk" */ 'appboy-web-sdk')
                 .then(({ default: appboy }) => {
-                    appboy.initialize(apiKey, { enableLogging, sessionTimeoutInSeconds: this.sessionTimeoutInSeconds });
+                    appboy.initialize(apiKey, {
+                        enableLogging,
+                        sessionTimeoutInSeconds: this.sessionTimeoutInSeconds,
+                        noCookies: !areCookiesPermitted()
+                    });
                     appboy.openSession();
 
                     window.appboy = appboy;

--- a/packages/services/f-braze-adapter/src/services/utils/_tests/transformCardData.test.js
+++ b/packages/services/f-braze-adapter/src/services/utils/_tests/transformCardData.test.js
@@ -188,4 +188,55 @@ describe('services › utils › transformCardData', () => {
 
         await Promise.all(tests.map(test => expect(transformCardData(test)).toEqual({})));
     });
+
+    describe('when `display_times_json is defined', () => {
+        describe('as a string', () => {
+            it('should attempt to parse `display_times_json` as JSON into `displayTimes`', () => {
+                // Arrange
+                const data = {
+                    extras: { display_times_json: '{"foo":"bar"}' } // eslint-disable-line camelcase
+                };
+
+                // Act
+                const output = transformCardData(data);
+
+                // Assert
+                expect(output.displayTimes).toEqual({ foo: 'bar' });
+            });
+
+            it('should result in `displayTimes` being an empty object if it fails to parse', () => {
+                // Arrange
+                const data = {
+                    extras: { display_times_json: '{invalid}' } // eslint-disable-line camelcase
+                };
+
+                // Act
+                const output = transformCardData(data);
+
+                // Assert
+                expect(output.displayTimes).toEqual({});
+            });
+        });
+
+        describe('as an object', () => {
+            it('should pass `display_times_json` verbatim into `displayTimes', () => {
+                // Arrange
+                const data = {
+                    extras: {
+                        display_times_json: { // eslint-disable-line camelcase
+                            foo: 'bar'
+                        }
+                    }
+                };
+
+                // Act
+                const output = transformCardData(data);
+
+                // Assert
+                expect(output.displayTimes).toEqual({
+                    foo: 'bar'
+                });
+            });
+        });
+    });
 });

--- a/packages/services/f-braze-adapter/src/tests/BrazeDispatcher.test.js
+++ b/packages/services/f-braze-adapter/src/tests/BrazeDispatcher.test.js
@@ -172,7 +172,7 @@ describe('instantiation', () => {
                     [true, true, true, false],
                     [false, false, false, true],
                     [false, false, true, false],
-                    [undefined, undefined, true, false],
+                    [undefined, undefined, true, false]
                 ])('should initialise appboy with the correct logging (`%p` ➡ `%p`) and cookie (`%p` ➡ `$p`) parameters', async (
                     enableLoggingConfig,
                     expectedEnableLoggingParameter,

--- a/packages/services/f-braze-adapter/src/tests/index.test.js
+++ b/packages/services/f-braze-adapter/src/tests/index.test.js
@@ -41,6 +41,14 @@ describe('f-braze-adapter initialise', () => {
         expect(configure).toHaveBeenCalledWith(settings);
     });
 
+    it('should call configure with a blank object if no settings given', async () => {
+        // Arrange & Act
+        await initialiseBraze();
+
+        // Assert
+        expect(configure).toHaveBeenCalledWith({});
+    });
+
     it('should wrap and rethrow an error if thrown by configure', async () => {
         const message = 'Punkd!';
 

--- a/packages/services/f-braze-adapter/src/utils/_tests/areCookiesPermitted.test.js
+++ b/packages/services/f-braze-adapter/src/utils/_tests/areCookiesPermitted.test.js
@@ -1,6 +1,11 @@
 import CookieHelper from 'js-cookie';
 
-import areCookiesPermitted from '../areCookiesPermitted';
+import areCookiesPermitted, {
+    consentCookieName,
+    consentCookieValue,
+    legacyBannerCookieName,
+    legacyBannerCookieValue
+} from '../areCookiesPermitted';
 
 jest.mock('js-cookie');
 
@@ -11,24 +16,49 @@ describe('f-braze-adapter › areCookiesPermitted', () => {
     });
 
     describe('when called', () => {
-        it('should query the value of `je-cookieConsent` cookie', () => {
+        it(`should query the value of \`${consentCookieName}\` cookie`, () => {
             // Act
             areCookiesPermitted();
 
             // Assert
-            expect(CookieHelper.get).toHaveBeenCalledWith('je-cookieConsent');
+            expect(CookieHelper.get).toHaveBeenCalledWith(consentCookieName);
         });
 
         it.each([
-            [true, 'full'],
+            [true, consentCookieValue],
             [false, 'necessary'],
             [false, null]
-        ])('should return `%p` when `je-cookieConsent` is `%p`', (expected, cookieValue) => {
+        ])(`should return \`%p\` when \`${consentCookieName}\` is \`%p\``, (expected, cookieValue) => {
             // Arrange
             CookieHelper.get.mockReturnValue(cookieValue);
 
             // Act & Assert
             expect(areCookiesPermitted()).toBe(expected);
+        });
+
+        describe(`and when the value of the \`${consentCookieName}\` cookie is not \`${consentCookieValue}\``, () => {
+            beforeEach(() => {
+                CookieHelper.get.mockReturnValueOnce(null);
+            });
+
+            it(`should query the value of \`${legacyBannerCookieName}\` cookie`, () => {
+                // Act
+                areCookiesPermitted();
+
+                // Assert
+                expect(CookieHelper.get).toHaveBeenCalledWith(legacyBannerCookieName);
+            });
+
+            it.each([
+                [true, legacyBannerCookieValue],
+                [false, null]
+            ])(`should return \`%p\` when \`${legacyBannerCookieName}\` is \`%p\``, (expected, cookieValue) => {
+                // Arrange
+                CookieHelper.get.mockReturnValue(cookieValue);
+
+                // Act & Assert
+                expect(areCookiesPermitted()).toBe(expected);
+            });
         });
     });
 });

--- a/packages/services/f-braze-adapter/src/utils/_tests/areCookiesPermitted.test.js
+++ b/packages/services/f-braze-adapter/src/utils/_tests/areCookiesPermitted.test.js
@@ -1,0 +1,34 @@
+import CookieHelper from 'js-cookie';
+
+import areCookiesPermitted from '../areCookiesPermitted';
+
+jest.mock('js-cookie');
+
+describe('f-braze-adapter › areCookiesPermitted', () => {
+    it('should be a function', () => {
+        // Assert
+        expect(areCookiesPermitted).toBeInstanceOf(Function);
+    });
+
+    describe('when called', () => {
+        it('should query the value of `je-cookieConsent` cookie', () => {
+            // Act
+            areCookiesPermitted();
+
+            // Assert
+            expect(CookieHelper.get).toHaveBeenCalledWith('je-cookieConsent');
+        });
+
+        it.each([
+            [true, 'full'],
+            [false, 'necessary'],
+            [false, null]
+        ])('should return `%p` when `je-cookieConsent` is `%p`', (expected, cookieValue) => {
+            // Arrange
+            CookieHelper.get.mockReturnValue(cookieValue);
+
+            // Act & Assert
+            expect(areCookiesPermitted()).toBe(expected);
+        });
+    });
+});

--- a/packages/services/f-braze-adapter/src/utils/areCookiesPermitted.js
+++ b/packages/services/f-braze-adapter/src/utils/areCookiesPermitted.js
@@ -1,0 +1,8 @@
+import CookieHelper from 'js-cookie';
+
+const consentCookieName = 'je-cookieConsent';
+
+export default () => {
+    const cookieConsent = CookieHelper.get(consentCookieName);
+    return cookieConsent === 'full';
+};

--- a/packages/services/f-braze-adapter/src/utils/areCookiesPermitted.js
+++ b/packages/services/f-braze-adapter/src/utils/areCookiesPermitted.js
@@ -1,8 +1,12 @@
 import CookieHelper from 'js-cookie';
 
-const consentCookieName = 'je-cookieConsent';
+export const consentCookieName = 'je-cookieConsent';
+export const consentCookieValue = 'full';
+
+export const legacyBannerCookieName = 'je-banner_cookie';
+export const legacyBannerCookieValue = '130315';
 
 export default () => {
-    const cookieConsent = CookieHelper.get(consentCookieName);
-    return cookieConsent === 'full';
+    return (CookieHelper.get(consentCookieName) === consentCookieValue)
+        || (CookieHelper.get(legacyBannerCookieName) === legacyBannerCookieValue);
 };

--- a/packages/services/f-braze-adapter/src/utils/areCookiesPermitted.js
+++ b/packages/services/f-braze-adapter/src/utils/areCookiesPermitted.js
@@ -6,7 +6,5 @@ export const consentCookieValue = 'full';
 export const legacyBannerCookieName = 'je-banner_cookie';
 export const legacyBannerCookieValue = '130315';
 
-export default () => {
-    return (CookieHelper.get(consentCookieName) === consentCookieValue)
+export default () => (CookieHelper.get(consentCookieName) === consentCookieValue)
         || (CookieHelper.get(legacyBannerCookieName) === legacyBannerCookieValue);
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2119,18 +2119,6 @@
     eslint-config-airbnb-base "14.1.0"
     eslint-plugin-vue "6.2.2"
 
-"@justeat/f-braze-adapter@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-braze-adapter/-/f-braze-adapter-3.2.0.tgz#dedb16870c7e314cee49c96816620c1ebe7ed928"
-  integrity sha512-vDmaCCoX4nN8jJovHta7ASrb46OaDakvhJmHfIvp7umnlk74QjGOt68USH/+xu3W6fDh7djU6JVNEnWkKRgZPQ==
-  dependencies:
-    appboy-web-sdk "2.5.2"
-    date-fns "2.16.1"
-    lodash.findindex "4.6.0"
-    lodash.orderby "4.6.0"
-    lodash.startswith "4.2.1"
-    lodash.uniq "4.5.0"
-
 "@justeat/f-button@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-0.4.1.tgz#6b735093286422f579bd41cee93400a4d32d1b2d"


### PR DESCRIPTION
## f-braze-adapter@v3.4.0

### Changed
- If the `je-cookieConsent` cookie is unset, or set to something other than `"full"`, and if the legacy `je-banner_cookie` cookie is not set, the `noCookies` option will be set on initialisation of the braze SDK.

## f-content-cards@v4.5.0

### Changed
- Bumped version of f-braze-adapter to respect cookie preferences

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] ~This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)~ N/A - no markup changed

## Browsers Tested

- [x] Chrome (latest)
- [x] Firefox (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
