### PR TITLE
#trivial Add description for cookie banner

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -4,11 +4,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.7.2
+Latest to be added to the next release
 ------------------------------
-*April 29, 2021*
 
-### Changed
+### Fixed
 - Added documentation to indicate cookie-banner will delete cookies conditionally that are not in the exclusion list
 
 

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.7.2
+------------------------------
+*April 29, 2021*
+
+### Changed
+- Added documentation to indicate cookie-banner will delete cookies conditionally that are not in the exclusion list
+
+
 v0.7.1
 ------------------------------
 *April 22, 2021*

--- a/packages/components/organisms/f-cookie-banner/README.md
+++ b/packages/components/organisms/f-cookie-banner/README.md
@@ -4,6 +4,7 @@
   <img width="125" alt="Fozzie Bear" src="../../../../bear.png" />
 
   <p>Cookie Banner</p>
+  <p>This component will conditionally remove all cookies that are not in the exclusion list for the <a href="src/tenants">appropriate locale</a>.</p>
 </div>
 
 ---


### PR DESCRIPTION
Add documentation for cookie banner to indicate that users of this component don't need to do the cookie deletion themselves - conditional cookie deletion is handled by this component.
