### PR TITLE
f-checkout@0.99.0, f-header@4.14.0: make header in mobile on checkout look as designed

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.99.0
+------------------------------
+*May 4, 2021*
+
+### Changed
+- make header in mobile look as designed
+
 
 v0.98.0
 ------------------------------

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -925,8 +925,9 @@ export default {
 
     @include media('<=narrow') {
         border: none;
-        padding-top: spacing(x2);
-        padding-bottom: spacing(x2);
+        padding-top: spacing(x3);
+        padding-bottom: spacing(x5);
+        margin-top: 0;
     }
 }
 

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.14.0
+------------------------------
+*May 4, 2021*
+
+### Changed
+- replace `border-bottom` with `box-shadow` to reflect the design
+
+
 v4.13.0
 ------------------------------
 *April 16, 2021*

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "4.13.0",
+  "version": "4.14.0",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-header/src/assets/scss/common.scss
+++ b/packages/components/organisms/f-header/src/assets/scss/common.scss
@@ -19,6 +19,7 @@ $header-bg                          : $white;
 $header-separator                   : 1px;
 $header-separator                   : 4px;
 $header-border-color                : $grey--lighter;
+$header-box-shadow                  : 0 3px 4px 0 rgba(0, 0, 0, 0.12);
 $header-buttonIcon-color            : $blue;
 $header-buttonCount-bg              : $blue;
 $header-buttonCount-color           : $white;

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -187,6 +187,7 @@ html:global(.is-navInView) {
     min-width : 300px;
     position: relative;
     z-index: zIndex(mid);
+    box-shadow: $header-box-shadow;
 
     // Styles for a sticky header on mobile
     @include media('<=mid') {
@@ -200,21 +201,17 @@ html:global(.is-navInView) {
             top: 0;
         }
     }
-
-    @include media('>mid') {
-        border-bottom: $header-separator solid $header-border-color;
-    }
 }
 
     // Adds a border to the header to separate it from the
     // main content at all widths
     .c-header--bordered {
-        border-bottom: $header-separator solid $header-border-color;
+        box-shadow: $header-box-shadow;
     }
 
     .c-header--transparent {
         background-color: transparent;
-        border: none;
+        box-shadow: none;
         position: absolute;
         width: 100%;
     }


### PR DESCRIPTION
### Changed
- f-header: replace `border-bottom` with `box-shadow` to reflect the design
- f-checkout: fix spacing on mobile


Before:
<img width="295" alt="Screenshot 2021-05-04 at 14 30 32" src="https://user-images.githubusercontent.com/3179649/117011096-64966c00-ace5-11eb-81bd-c6292eb4e055.png">
<img width="1387" alt="Screenshot 2021-05-04 at 14 30 17" src="https://user-images.githubusercontent.com/3179649/117011108-67915c80-ace5-11eb-9fd6-c954c14cd491.png">

After:
<img width="305" alt="Screenshot 2021-05-04 at 14 28 46" src="https://user-images.githubusercontent.com/3179649/117011138-6fe99780-ace5-11eb-958d-3cd37de7110c.png">
<img width="1246" alt="Screenshot 2021-05-04 at 14 29 02" src="https://user-images.githubusercontent.com/3179649/117011159-75df7880-ace5-11eb-937c-d7504d339c6d.png">


