### PR TITLE
f-checkout@0.100.0 - added red outline to input fields when errors are displayed

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.99.0
+------------------------------
+*May 4, 2021*
+
+### Added
+- red outline to input fields when an error is displayed
+
+
 v0.98.0
 ------------------------------
 *April 29, 2021*

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.99.0
+v0.100.0
 ------------------------------
 *May 4, 2021*
 

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.99.0",
+  "version": "0.100.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Guest.vue
+++ b/packages/components/organisms/f-checkout/src/components/Guest.vue
@@ -6,6 +6,7 @@
             :value="customer.firstName"
             name="guest-first-name"
             :label-text="$t('guest.firstName')"
+            :has-error="isFirstNameEmpty"
             @input="updateCustomerDetails({ 'firstName': $event })">
             <template #error>
                 <error-message
@@ -21,6 +22,7 @@
             :value="customer.lastName"
             name="guest-last-name"
             :label-text="$t('guest.lastName')"
+            :has-error="isLastNameEmpty"
             @input="updateCustomerDetails({ 'lastName': $event })">
             <template #error>
                 <error-message
@@ -36,6 +38,7 @@
             :value="customer.email"
             name="guest-email"
             :label-text="$t('guest.email')"
+            :has-error="!isEmailValid"
             @input="updateCustomerDetails({ 'email': $event })">
             <template #error>
                 <error-message


### PR DESCRIPTION
### Added

- red outline to input fields when errors are displayed

I've changed the version bump to @0.100.0 so other checkout PR can be merged first