### PR TITLE
f-cookie-banner@v0.8.0 - Add mega modal.

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,12 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-
-Latest to be added to the next release
+v0.8.0
 ------------------------------
+*May 6, 2021*
+
+### Added
+- `f-mega-modal` component to cookie banner.
+
+### Removed
+- Styles related to old modal & modal container.
 
 ### Fixed
-- Added documentation to indicate cookie-banner will delete cookies conditionally that are not in the exclusion list
+- Added documentation to indicate cookie-banner will delete cookies conditionally that are not in the exclusion list.
 
 
 v0.7.1

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",
@@ -52,13 +52,14 @@
   },
   "devDependencies": {
     "@justeat/f-button": "1.1.1",
+    "@justeat/f-mega-modal": "0.7.0",
     "@justeat/f-vue-icons": "2.3.0",
+    "@justeat/f-wdio-utils": "0.1.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
     "@vue/test-utils": "1.0.3",
-    "@justeat/f-wdio-utils": "0.1.0",
     "node-sass-magic-importer": "5.3.2"
   }
 }

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -1,14 +1,11 @@
 <template>
-    <div
+    <mega-modal
         v-if="!legacyBanner"
         ref="cookieBanner"
-        :class="[
-            $style['c-cookieBanner'],
-            $style['c-cookieBanner--overlay'],
-            { [$style['c-cookieBanner--is-hidden']]: shouldHideBanner }
-        ]"
-        data-cookie-consent-overlay
-        :aria-hidden="shouldHideBanner">
+        :is-open="!shouldHideBanner"
+        is-positioned-bottom
+        :has-close-button="false"
+        data-cookie-consent-overlay>
         <div
             :class="[
                 $style['c-cookieBanner-card'],
@@ -70,7 +67,7 @@
                 </button-component>
             </div>
         </div>
-    </div>
+    </mega-modal>
 
     <legacy-banner
         v-else
@@ -91,6 +88,9 @@ import { globalisationServices } from '@justeat/f-services';
 import ButtonComponent from '@justeat/f-button';
 import '@justeat/f-button/dist/f-button.css';
 
+import MegaModal from '@justeat/f-mega-modal';
+import '@justeat/f-mega-modal/dist/f-mega-modal.css';
+
 import LegacyBanner from './LegacyBanner.vue';
 
 import tenantConfigs from '../tenants';
@@ -98,7 +98,8 @@ import tenantConfigs from '../tenants';
 export default {
     components: {
         ButtonComponent,
-        LegacyBanner
+        LegacyBanner,
+        MegaModal
     },
 
     props: {
@@ -297,20 +298,6 @@ export default {
 </script>
 
 <style lang="scss" module>
-    .c-cookieBanner--overlay {
-        position: fixed;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        background-color: rgba(0, 0, 0, 0.7);
-        z-index: 99999991;
-    }
-
-    .c-cookieBanner--is-hidden {
-        display: none;
-    }
-
     .c-cookieBanner-card {
         position: absolute;
         bottom: 0;
@@ -330,6 +317,10 @@ export default {
     .c-cookieBanner-text {
         margin: 0;
         padding: 0;
+    }
+
+    .c-cookieBanner-content {
+        text-align: left;
     }
 
     .c-cookieBanner-title {

--- a/packages/components/organisms/f-cookie-banner/test/component/f-cookieConsentBanner.component.desktop.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/component/f-cookieConsentBanner.component.desktop.spec.js
@@ -22,7 +22,6 @@ describe('New - f-cookieBanner component tests - @browserstack', () => {
         // Assert
         expect(bannerCookie.value).toBe('130315');
         expect(bannerConsent.value).toBe(expectedCookieValue);
-        expect(cookieBanner.isCookieBannerComponentDisplayed()).toBe(false);
     });
 });
 


### PR DESCRIPTION
### Added
- `f-mega-modal` component to cookie banner.

### Removed
- Styles related to old modal & modal container.

### Fixed
- Added documentation to indicate cookie-banner will delete cookies conditionally that are not in the exclusion list.


---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
