### PR TITLE
f-checkout@0.102.0 - Change guest checkout email input type

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.102.0
+------------------------------
+*May 6, 2021*
+
+### Changed
+- Guest checkout email input type to email to prevent capitalising emails on mobile
+
+
 v0.101.0
 ------------------------------
 *May 5, 2021*

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -9,7 +9,7 @@ v0.102.0
 *May 6, 2021*
 
 ### Changed
-- Guest checkout email input type to email to prevent capitalising emails on mobile
+- Guest checkout email input type to `email`
 
 
 v0.101.0

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Guest.vue
+++ b/packages/components/organisms/f-checkout/src/components/Guest.vue
@@ -37,6 +37,7 @@
         <form-field
             :value="customer.email"
             name="guest-email"
+            input-type="email"
             :label-text="$t('guest.email')"
             :has-error="!isEmailValid"
             @input="updateCustomerDetails({ 'email': $event })">


### PR DESCRIPTION
### Changed
- Guest checkout email input type to email to prevent capitalising emails on mobile

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [x] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
