### PR TITLE
f-http@v0.4.0 - Support all HTTP methods

### DIFF
--- a/packages/services/f-http/CHANGELOG.md
+++ b/packages/services/f-http/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.4.0
+------------------------------
+*May 6, 2021*
+
+### Added
+- Expose HTTPVerbs for PUT, PATCH, DELETE
+- Expose methods for PUT, PATCH, DELETE on client
+- Expose a method for setting authorisation token for all requests from a client
+- Ability to name a client - useful when we can push stats and logs by API or grouping name
+
 v0.3.0
 ------------------------------
 *April 30, 2021*

--- a/packages/services/f-http/README.md
+++ b/packages/services/f-http/README.md
@@ -106,7 +106,7 @@ export default {
 ```
 
 ### Alternative Implementation
-If you would rather create the HTTPClient when you use it, thats fine too; its just means it can't be reused as easily and you will need to filter the configuration options down to the component.
+If you would rather create the HTTPClient when you use it, that's fine too; it just means it can't be reused as easily and you will need to filter the configuration options down to the component.
 
 ```js
 export default {
@@ -190,10 +190,10 @@ These are all of the methods exposed by the httpClient
 
 Method | Description | Parameters
 ------------- | ------------- | -------------
-get | Perform a GET request for a resource | resource URL _[string]_, headers _[array]_
+get | GET a resource | resource URL _[string]_, headers _[array]_
 post | POST a resource | resource URL _[string]_, body _[object]_, headers _[array]_
-put | Perform a PUT on a resource | resource URL _[string]_, body _[object]_, headers _[array]_
-patch | Perform a PATCH on a resource | resource URL _[string]_, body _[object]_, headers _[array]_
-get | DELETE a resource | resource URL _[string]_, headers _[array]_
+put | PUT a resource | resource URL _[string]_, body _[object]_, headers _[array]_
+patch | PATCH a resource | resource URL _[string]_, body _[object]_, headers _[array]_
+delete | DELETE a resource | resource URL _[string]_, headers _[array]_
 setAuthorisationToken | Set the authorisation token for all requests | authorisationToken _[string]_
 readConfiguration | Returns the configuration which has been applied | None

--- a/packages/services/f-http/README.md
+++ b/packages/services/f-http/README.md
@@ -17,16 +17,18 @@ Javascript HTTP client for interacting with restful services
 
 This package exposes methods for interacting with restful services, it may abstract any number of popular NPM packages which provide the ability to perform GET, PUT, POST, PATH, DELETE requests; while also adding lots of additional benefits.
 
-## Benefits (Now and later)
-- Automatically collect stats showing how long real API calls take
+## Benefits (Now)
 - Easy configuration of reusable clients which can be retrieved from context
-- Opt-in automatic logging of errors
-- Opt-in ability to use dynamic timeouts
-- Opt-in automatic providing of diagnostic headers, such as Conversation ID
 - Enables us to switch to alternative HTTP packages when desired
 - Sensible defaults, with the ability to override everything
-- Opt-in Automatic providing of bearer tokens
+- Ability to set authorisation tokens for all requests for specific clients
+- Ability to name each client, so output from it is grouped and labelled
 
+## Benefits (Soon)
+- _Automatically collect stats showing how long real API calls take_
+- _Opt-in automatic logging of errors_
+- _Opt-in ability to use dynamic timeouts_
+- _Opt-in automatic providing of diagnostic headers, such as Conversation ID_
 
 ## Usage
 
@@ -52,6 +54,7 @@ const errorCallback = error => { // This is optional
 
 export default (context, inject) => {
     const options = { // Options are described later
+        instanceName: 'Example Nuxt client'
         baseUrl: 'https://jsonplaceholder.typicode.com',
         errorCallback
     };
@@ -74,6 +77,7 @@ const errorCallback = error => { // This is optional
 
 export default () => {
     const configuration = { // Options are described later
+        instanceName: 'Example client'
         baseUrl: 'https://jsonplaceholder.typicode.com',
         errorCallback
     };
@@ -102,6 +106,21 @@ export default {
 }
 ```
 
+### Setting Authorisation Token
+If you need to call an authorised endpoint, you could pass the authorisation token through as a header in every request; but if you group clients correctly you may be able to benefit from applying it once for the lifetime of that client.
+
+```js
+// Some event happened that means we now have a token
+export default {
+  async mounted () {
+    this.$http.setAuthorisationToken('my token');
+
+    // This and all future requests will use the provided token
+    const result = await this.$http.get('/todos/1');
+  }
+}
+```
+
 ### Unit Testing Guidance
 Because $http exists in context, it should be really easy to mock it in any way you want. Check out the example below
 
@@ -123,9 +142,10 @@ import httpModule from '@justeat/f-http';
 
 const { mockFactory, httpVerbs } = httpModule;
 
-mockFactory.setupMockResponse(httpVerbs.METHOD_POST, '/URL', REQUEST_DATA, 201);
+mockFactory.setupMockResponse(httpVerbs.POST, '/URL', REQUEST_DATA, 201);
 
-const $http = mockFactory.createMockClient();
+// Accepts options payload
+const $http = mockFactory.createMockClient({ instanceName: 'Integration Test Client'});
 
 const wrapper = mount(MyComponent, {
   mocks: {
@@ -144,3 +164,19 @@ baseUrl | Ensure all requests from this client use a relative url | string | ''
 timeout | How long each request takes to timeout | number | 10000
 errorCallback | A function you can use to globally handle errors (accepts error object) | function | null
 contentType | Specify a value for the content type header | string | 'application/json'
+instanceName | Name the client so that stats and logs can be grouped by a specific API | string | 'Generic Front End'
+
+<hr>
+
+## Client Methods
+These are all of the methods exposed by the httpClient
+
+Method | Description | Parameters
+------------- | ------------- | -------------
+get | Perform a GET request for a resource | resource URL _[string]_, headers _[array]_
+post | POST a resource | resource URL _[string]_, body _[object]_, headers _[array]_
+put | Perform a PUT on a resource | resource URL _[string]_, body _[object]_, headers _[array]_
+patch | Perform a PATCH on a resource | resource URL _[string]_, body _[object]_, headers _[array]_
+get | DELETE a resource | resource URL _[string]_, headers _[array]_
+setAuthorisationToken | Set the authorisation token for all requests | authorisationToken _[string]_
+readConfiguration | Returns the configuration which has been applied | None

--- a/packages/services/f-http/README.md
+++ b/packages/services/f-http/README.md
@@ -89,7 +89,6 @@ export default () => {
 
 ```
 
-
 ### Basic Implementation
 **Recommended**: Using the prototype (Vue) or context (Nuxt). You can access $http in components, or anywhere the context is available including VueX
 
@@ -102,6 +101,24 @@ export default {
   },
   async mounted () {
     this.apiResult = await this.$http.get('/todos/1');
+  }
+}
+```
+
+### Alternative Implementation
+If you would rather create the HTTPClient when you use it, thats fine too; its just means it can't be reused as easily and you will need to filter the configuration options down to the component.
+
+```js
+export default {
+  async mounted () {
+    const configuration = { // Options are described later
+        instanceName: 'Example client'
+        baseUrl: 'https://jsonplaceholder.typicode.com'
+    };
+
+    const httpClient = httpModule.createClient(configuration);
+
+    const result = await httpClient.get('/todos/1');
   }
 }
 ```

--- a/packages/services/f-http/package.json
+++ b/packages/services/f-http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-http",
   "description": "Javascript HTTP client for interacting with restful services",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "src/index.js",
   "files": [
     "src"

--- a/packages/services/f-http/package.json
+++ b/packages/services/f-http/package.json
@@ -36,7 +36,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "axios": "0.21.1"
+    "axios": "0.21.1",
+    "axios-mock-adapter": "1.19.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/services/f-http/src/authorisationHandler.js
+++ b/packages/services/f-http/src/authorisationHandler.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+/**
+ * Set authorisation header for all requests made by this client
+ * @param {string} authorisationToken - The value of the authorisation token
+ */
+const setAuthorisationToken = authorisationToken => {
+    axios.defaults.headers.common.Authorization = authorisationToken;
+};
+
+export default setAuthorisationToken;

--- a/packages/services/f-http/src/configBuilder.js
+++ b/packages/services/f-http/src/configBuilder.js
@@ -1,0 +1,14 @@
+/**
+ * Build Axios Config payload
+ * @param {object} headers - Any additional request headers you want to provide
+ * @return {object} - Returns config object
+ */
+const configBuilder = (headers = {}) => {
+    const config = {
+        headers
+    };
+
+    return config;
+};
+
+export default configBuilder;

--- a/packages/services/f-http/src/createClient.js
+++ b/packages/services/f-http/src/createClient.js
@@ -1,11 +1,15 @@
 import axios from 'axios';
 import defaultOptions from './defaultOptions';
-import handleError from './errorHandler';
-import configBuilder from './configBuilder';
 import setAuthorisationToken from './authorisationHandler';
+import httpVerbs from './httpVerbs';
+
+import requestDispatcher from './requestDispatcher';
 
 let _configuration = null;
 let _axiosInstance = null;
+
+let _sendRequest,
+    _sendRequestWithBody;
 
 /**
  * Get a resource
@@ -13,15 +17,7 @@ let _axiosInstance = null;
  * @param {object} headers - Any additional request headers you want to provide
  * @return {object} - Returns data from response
  */
-const getResource = async (resource, headers = {}) => {
-    try {
-        const response = await _axiosInstance.get(resource, configBuilder(headers));
-
-        return response.data;
-    } catch (error) {
-        return handleError(error, _configuration.errorCallback);
-    }
-};
+const getResource = async (resource, headers = {}) => _sendRequest(httpVerbs.GET, resource, headers);
 
 /**
  * Post a resource
@@ -30,15 +26,7 @@ const getResource = async (resource, headers = {}) => {
  * @param {object} headers - Any additional request headers you want to provide
  * @return {object} - Returns data from response
  */
-const postResource = async (resource, body, headers = {}) => {
-    try {
-        const response = await _axiosInstance.post(resource, body, configBuilder(headers));
-
-        return response.data;
-    } catch (error) {
-        return handleError(error, _configuration.errorCallback);
-    }
-};
+const postResource = async (resource, body, headers = {}) => _sendRequestWithBody(httpVerbs.POST, resource, body, headers);
 
 /**
  * Patch a resource
@@ -47,15 +35,7 @@ const postResource = async (resource, body, headers = {}) => {
  * @param {object} headers - Any additional request headers you want to provide
  * @return {object} - Returns data from response
  */
-const patchResource = async (resource, body, headers = {}) => {
-    try {
-        const response = await _axiosInstance.patch(resource, body, configBuilder(headers));
-
-        return response.data;
-    } catch (error) {
-        return handleError(error, _configuration.errorCallback);
-    }
-};
+const patchResource = async (resource, body, headers = {}) => _sendRequestWithBody(httpVerbs.PATCH, resource, body, headers);
 
 /**
  * Put a resource
@@ -64,15 +44,7 @@ const patchResource = async (resource, body, headers = {}) => {
  * @param {object} headers - Any additional request headers you want to provide
  * @return {object} - Returns data from response
  */
-const putResource = async (resource, body, headers = {}) => {
-    try {
-        const response = await _axiosInstance.put(resource, body, configBuilder(headers));
-
-        return response.data;
-    } catch (error) {
-        return handleError(error, _configuration.errorCallback);
-    }
-};
+const putResource = async (resource, body, headers = {}) => _sendRequestWithBody(httpVerbs.PUT, resource, body, headers);
 
 /**
  * Delete a resource
@@ -80,15 +52,7 @@ const putResource = async (resource, body, headers = {}) => {
  * @param {object} headers - Any additional request headers you want to provide
  * @return {object} - Returns data from response
  */
-const deleteResource = async (resource, headers = {}) => {
-    try {
-        const response = await _axiosInstance.delete(resource, configBuilder(headers));
-
-        return response.data;
-    } catch (error) {
-        return handleError(error, _configuration.errorCallback);
-    }
-};
+const deleteResource = async (resource, headers = {}) => _sendRequest(httpVerbs.DELETE, resource, headers);
 
 /**
  * Create a httpClient
@@ -109,6 +73,10 @@ export default (options = {}) => {
             'Content-Type': _configuration.contentType
         }
     });
+
+    const requestDispatchMethods = requestDispatcher(_axiosInstance, _configuration);
+    _sendRequest = requestDispatchMethods.sendRequest;
+    _sendRequestWithBody = requestDispatchMethods.sendRequestWithBody;
 
     return {
         get: getResource,

--- a/packages/services/f-http/src/createClient.js
+++ b/packages/services/f-http/src/createClient.js
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import defaultOptions from './defaultOptions';
 import handleError from './errorHandler';
+import configBuilder from './configBuilder';
+import setAuthorisationToken from './authorisationHandler';
 
 let _configuration = null;
 let _axiosInstance = null;
@@ -11,13 +13,9 @@ let _axiosInstance = null;
  * @param {object} headers - Any additional request headers you want to provide
  * @return {object} - Returns data from response
  */
-const get = async (resource, headers = {}) => {
+const getResource = async (resource, headers = {}) => {
     try {
-        const config = {
-            headers
-        };
-
-        const response = await _axiosInstance.get(resource, config);
+        const response = await _axiosInstance.get(resource, configBuilder(headers));
 
         return response.data;
     } catch (error) {
@@ -32,13 +30,59 @@ const get = async (resource, headers = {}) => {
  * @param {object} headers - Any additional request headers you want to provide
  * @return {object} - Returns data from response
  */
-const post = async (resource, body, headers = {}) => {
+const postResource = async (resource, body, headers = {}) => {
     try {
-        const config = {
-            headers
-        };
+        const response = await _axiosInstance.post(resource, body, configBuilder(headers));
 
-        const response = await _axiosInstance.post(resource, body, config);
+        return response.data;
+    } catch (error) {
+        return handleError(error, _configuration.errorCallback);
+    }
+};
+
+/**
+ * Patch a resource
+ * @param {string} resource - The resource to patch (URL)
+ * @param {object} body - The request body, contents of the resource
+ * @param {object} headers - Any additional request headers you want to provide
+ * @return {object} - Returns data from response
+ */
+const patchResource = async (resource, body, headers = {}) => {
+    try {
+        const response = await _axiosInstance.patch(resource, body, configBuilder(headers));
+
+        return response.data;
+    } catch (error) {
+        return handleError(error, _configuration.errorCallback);
+    }
+};
+
+/**
+ * Put a resource
+ * @param {string} resource - The resource to put (URL)
+ * @param {object} body - The request body, contents of the resource
+ * @param {object} headers - Any additional request headers you want to provide
+ * @return {object} - Returns data from response
+ */
+const putResource = async (resource, body, headers = {}) => {
+    try {
+        const response = await _axiosInstance.put(resource, body, configBuilder(headers));
+
+        return response.data;
+    } catch (error) {
+        return handleError(error, _configuration.errorCallback);
+    }
+};
+
+/**
+ * Delete a resource
+ * @param {string} resource - The resource to delete (URL)
+ * @param {object} headers - Any additional request headers you want to provide
+ * @return {object} - Returns data from response
+ */
+const deleteResource = async (resource, headers = {}) => {
+    try {
+        const response = await _axiosInstance.delete(resource, configBuilder(headers));
 
         return response.data;
     } catch (error) {
@@ -67,8 +111,12 @@ export default (options = {}) => {
     });
 
     return {
-        get,
-        post,
+        get: getResource,
+        post: postResource,
+        patch: patchResource,
+        put: putResource,
+        delete: deleteResource,
+        setAuthorisationToken,
         readConfiguration: () => _configuration
     };
 };

--- a/packages/services/f-http/src/defaultOptions.js
+++ b/packages/services/f-http/src/defaultOptions.js
@@ -2,7 +2,8 @@ const defaultConfig = {
     baseUrl: '',
     timeout: 10000,
     errorCallback: null,
-    contentType: 'application/json'
+    contentType: 'application/json',
+    instanceName: 'Generic Front End'
 };
 
 export default defaultConfig;

--- a/packages/services/f-http/src/httpVerbs.js
+++ b/packages/services/f-http/src/httpVerbs.js
@@ -1,7 +1,13 @@
 const GET = 'GET';
 const POST = 'POST';
+const PUT = 'PUT';
+const PATCH = 'PATCH';
+const DELETE = 'DELETE';
 
 export default {
     GET,
-    POST
+    POST,
+    PUT,
+    PATCH,
+    DELETE
 };

--- a/packages/services/f-http/src/mockFactory.js
+++ b/packages/services/f-http/src/mockFactory.js
@@ -2,7 +2,6 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import createClient from './createClient';
-import httpVerbs from './httpVerbs';
 
 let _axiosMockAdapter;
 
@@ -17,18 +16,15 @@ let _axiosMockAdapter;
 const setupMockResponse = async (method, url, requestData, statusCode, data) => {
     if (!_axiosMockAdapter) _axiosMockAdapter = new MockAdapter(axios);
 
-    switch (method) {
-        case httpVerbs.METHOD_GET:
-            _axiosMockAdapter.onGet(url, requestData).reply(statusCode, data);
-            break;
+    const mockFunctions = {
+        GET: _axiosMockAdapter.onGet,
+        POST: _axiosMockAdapter.onPost,
+        PUT: _axiosMockAdapter.onPut,
+        PATCH: _axiosMockAdapter.onPatch,
+        DELETE: _axiosMockAdapter.onDelete
+    };
 
-        case httpVerbs.METHOD_POST:
-            _axiosMockAdapter.onPost(url, requestData).reply(statusCode, data);
-            break;
-
-        default:
-            throw new Error('Method not provided');
-    }
+    mockFunctions[method](url, requestData).reply(statusCode, data);
 };
 
 /**

--- a/packages/services/f-http/src/mockFactory.js
+++ b/packages/services/f-http/src/mockFactory.js
@@ -2,10 +2,9 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import createClient from './createClient';
+import httpVerbs from './httpVerbs';
 
 let _axiosMockAdapter;
-
-const convertToPascalCase = string => string.replace(/\S*/g, word => word.charAt(0) + word.slice(1).toLowerCase());
 
 /**
  * Setup a mock response
@@ -18,9 +17,17 @@ const convertToPascalCase = string => string.replace(/\S*/g, word => word.charAt
 const setupMockResponse = async (method, url, requestData, statusCode, data) => {
     if (!_axiosMockAdapter) _axiosMockAdapter = new MockAdapter(axios);
 
-    const methodName = `on${convertToPascalCase(method)}`;
+    const supportedFunctions = {
+        [httpVerbs.GET]: 'onGet',
+        [httpVerbs.POST]: 'onPost',
+        [httpVerbs.PUT]: 'onPut',
+        [httpVerbs.PATCH]: 'onPatch',
+        [httpVerbs.DELETE]: 'onDelete'
+    };
 
-    _axiosMockAdapter[methodName](url, requestData).reply(statusCode, data);
+    const mockMethod = supportedFunctions[method];
+
+    _axiosMockAdapter[mockMethod](url, requestData).reply(statusCode, data);
 };
 
 /**

--- a/packages/services/f-http/src/mockFactory.js
+++ b/packages/services/f-http/src/mockFactory.js
@@ -2,9 +2,10 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import createClient from './createClient';
-import httpVerbs from './httpVerbs';
 
 let _axiosMockAdapter;
+
+const convertToPascalCase = string => string.replace(/\S*/g, word => word.charAt(0) + word.slice(1).toLowerCase());
 
 /**
  * Setup a mock response
@@ -17,15 +18,9 @@ let _axiosMockAdapter;
 const setupMockResponse = async (method, url, requestData, statusCode, data) => {
     if (!_axiosMockAdapter) _axiosMockAdapter = new MockAdapter(axios);
 
-    const mockFunctions = {
-        [httpVerbs.GET]: _axiosMockAdapter.onGet,
-        [httpVerbs.POST]: _axiosMockAdapter.onPost,
-        [httpVerbs.PUT]: _axiosMockAdapter.onPut,
-        [httpVerbs.PATCH]: _axiosMockAdapter.onPatch,
-        [httpVerbs.DELETE]: _axiosMockAdapter.onDelete
-    };
+    const methodName = `on${convertToPascalCase(method)}`;
 
-    mockFunctions[method](url, requestData).reply(statusCode, data);
+    _axiosMockAdapter[methodName](url, requestData).reply(statusCode, data);
 };
 
 /**

--- a/packages/services/f-http/src/mockFactory.js
+++ b/packages/services/f-http/src/mockFactory.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import createClient from './createClient';
+import httpVerbs from './httpVerbs';
 
 let _axiosMockAdapter;
 
@@ -17,11 +18,11 @@ const setupMockResponse = async (method, url, requestData, statusCode, data) => 
     if (!_axiosMockAdapter) _axiosMockAdapter = new MockAdapter(axios);
 
     const mockFunctions = {
-        GET: _axiosMockAdapter.onGet,
-        POST: _axiosMockAdapter.onPost,
-        PUT: _axiosMockAdapter.onPut,
-        PATCH: _axiosMockAdapter.onPatch,
-        DELETE: _axiosMockAdapter.onDelete
+        [httpVerbs.GET]: _axiosMockAdapter.onGet,
+        [httpVerbs.POST]: _axiosMockAdapter.onPost,
+        [httpVerbs.PUT]: _axiosMockAdapter.onPut,
+        [httpVerbs.PATCH]: _axiosMockAdapter.onPatch,
+        [httpVerbs.DELETE]: _axiosMockAdapter.onDelete
     };
 
     mockFunctions[method](url, requestData).reply(statusCode, data);

--- a/packages/services/f-http/src/requestDispatcher.js
+++ b/packages/services/f-http/src/requestDispatcher.js
@@ -25,6 +25,7 @@ const sendRequest = async (method, resource, headers = {}) => {
  * Send a request with a request body
  * @param {string} method - The HTTP Method of the request (post, put, patch)
  * @param {string} resource - The resource to get (URL)
+ * @param {object} body - The request body, contents of the resource
  * @param {object} headers - Any additional request headers you want to provide
  * @return {object} - Returns data from response
  */

--- a/packages/services/f-http/src/requestDispatcher.js
+++ b/packages/services/f-http/src/requestDispatcher.js
@@ -1,0 +1,49 @@
+import handleError from './errorHandler';
+import configBuilder from './configBuilder';
+
+let _configuration = null;
+let _axiosInstance = null;
+
+/**
+ * Send a request without a request body
+ * @param {string} method - The HTTP Method of the request (get or delete)
+ * @param {string} resource - The resource to get (URL)
+ * @param {object} headers - Any additional request headers you want to provide
+ * @return {object} - Returns data from response
+ */
+const sendRequest = async (method, resource, headers = {}) => {
+    try {
+        const response = await _axiosInstance[method.toLowerCase()](resource, configBuilder(headers));
+
+        return response.data;
+    } catch (error) {
+        return handleError(error, _configuration.errorCallback);
+    }
+};
+
+/**
+ * Send a request with a request body
+ * @param {string} method - The HTTP Method of the request (post, put, patch)
+ * @param {string} resource - The resource to get (URL)
+ * @param {object} headers - Any additional request headers you want to provide
+ * @return {object} - Returns data from response
+ */
+const sendRequestWithBody = async (method, resource, body, headers = {}) => {
+    try {
+        const response = await _axiosInstance[method.toLowerCase()](resource, body, configBuilder(headers));
+
+        return response.data;
+    } catch (error) {
+        return handleError(error, _configuration.errorCallback);
+    }
+};
+
+export default (axiosInstance, configuration) => {
+    _axiosInstance = axiosInstance;
+    _configuration = configuration;
+
+    return {
+        sendRequest,
+        sendRequestWithBody
+    };
+};

--- a/packages/services/f-http/src/tests/authorisationHandler.test.js
+++ b/packages/services/f-http/src/tests/authorisationHandler.test.js
@@ -1,0 +1,20 @@
+import axios from 'axios';
+import setAuthorisationToken from '../authorisationHandler';
+
+describe('setAuthorisationToken', () => {
+    it('should be defined', async () => {
+        // Arrange, Act & Assert
+        expect(setAuthorisationToken).toBeDefined();
+    });
+
+    it('should set the provided authorisation token', async () => {
+        // Arrange
+        const expectedAuthorisationToken = 'Granola';
+
+        // Act
+        setAuthorisationToken(expectedAuthorisationToken);
+
+        // Assert
+        expect(axios.defaults.headers.common.Authorization).toBe(expectedAuthorisationToken);
+    });
+});

--- a/packages/services/f-http/src/tests/authorisationHandler.test.js
+++ b/packages/services/f-http/src/tests/authorisationHandler.test.js
@@ -7,6 +7,11 @@ describe('setAuthorisationToken', () => {
         expect(setAuthorisationToken).toBeDefined();
     });
 
+    it('should not have an authorisation token set by default', async () => {
+        // Arrange, Act & Assert
+        expect(axios.defaults.headers.common.Authorization).not.toBeDefined();
+    });
+
     it('should set the provided authorisation token', async () => {
         // Arrange
         const expectedAuthorisationToken = 'Granola';

--- a/packages/services/f-http/src/tests/configBuilder.test.js
+++ b/packages/services/f-http/src/tests/configBuilder.test.js
@@ -1,0 +1,28 @@
+import configBuilder from '../configBuilder';
+
+describe('configBuilder', () => {
+    it('should be defined', async () => {
+        // Arrange, Act & Assert
+        expect(configBuilder).toBeDefined();
+    });
+
+    it('should return empty headers when not provided', async () => {
+        // Arrange & Act
+        const config = configBuilder();
+
+        expect(config).toBeDefined();
+        expect(config.headers).toStrictEqual({});
+    });
+
+    it('should return headers when provided', async () => {
+        // Arrange
+        const expectedHeaders = {
+            'x-test': 'My test header'
+        };
+
+        // Act
+        const config = configBuilder(expectedHeaders);
+
+        expect(config.headers).toStrictEqual(expectedHeaders);
+    });
+});

--- a/packages/services/f-http/src/tests/createClient.test.js
+++ b/packages/services/f-http/src/tests/createClient.test.js
@@ -7,13 +7,29 @@ describe('createClient', () => {
             expect(createClient).toBeDefined();
         });
 
+        it('should expose expected methods', async () => {
+            // Arrange & Act
+            const httpClient = createClient();
+
+            // Assert
+            expect(httpClient).toBeDefined();
+            expect(httpClient.get).toBeDefined();
+            expect(httpClient.post).toBeDefined();
+            expect(httpClient.put).toBeDefined();
+            expect(httpClient.patch).toBeDefined();
+            expect(httpClient.delete).toBeDefined();
+            expect(httpClient.setAuthorisationToken).toBeDefined();
+            expect(httpClient.readConfiguration).toBeDefined();
+        });
+
         it('should use default options when not overridden', async () => {
             // Arrange
             const expectedResult = {
                 baseUrl: '',
                 timeout: 10000,
                 errorCallback: null,
-                contentType: 'application/json'
+                contentType: 'application/json',
+                instanceName: 'Generic Front End'
             };
 
             // Act
@@ -30,12 +46,14 @@ describe('createClient', () => {
             const expectedTimeout = 2000;
             const expectedErrorCallback = () => {};
             const expectedContentType = 'application/mpeg';
+            const expectedInstanceName = 'Test Test Test';
 
             const expectedResult = {
                 baseUrl: expectedBaseUrl,
                 timeout: expectedTimeout,
                 errorCallback: expectedErrorCallback,
-                contentType: expectedContentType
+                contentType: expectedContentType,
+                instanceName: expectedInstanceName
             };
 
             // Act

--- a/packages/services/f-http/src/tests/httpVerbs.test.js
+++ b/packages/services/f-http/src/tests/httpVerbs.test.js
@@ -1,0 +1,17 @@
+import httpVerbs from '../httpVerbs';
+
+describe('httpVerbs', () => {
+    it('should be defined', async () => {
+        // Arrange, Act & Assert
+        expect(httpVerbs).toBeDefined();
+    });
+
+    it('should define expected properties with correct values', async () => {
+        // Arrange, Act & Assert
+        expect(httpVerbs.GET).toBe('GET');
+        expect(httpVerbs.POST).toBe('POST');
+        expect(httpVerbs.PUT).toBe('PUT');
+        expect(httpVerbs.PATCH).toBe('PATCH');
+        expect(httpVerbs.DELETE).toBe('DELETE');
+    });
+});

--- a/packages/services/f-http/src/tests/index.test.js
+++ b/packages/services/f-http/src/tests/index.test.js
@@ -1,21 +1,17 @@
-import createClient from '../createClient';
+import httpModule from '../index';
 
-describe('createClient', () => {
+describe('httpModule', () => {
     beforeEach(() => {});
 
     it('should be defined', async () => {
         // Arrange, Act & Assert
-        expect(createClient).toBeDefined();
+        expect(httpModule).toBeDefined();
     });
 
-    it('should expose expected methods', async () => {
-        // Arrange & Act
-        const httpClient = createClient();
-
-        // Assert
-        expect(httpClient).toBeDefined();
-        expect(httpClient.get).toBeDefined();
-        expect(httpClient.post).toBeDefined();
-        expect(httpClient.readConfiguration).toBeDefined();
+    it('should define expected properties', async () => {
+        // Arrange, Act & Assert
+        expect(httpModule.createClient).toBeDefined();
+        expect(httpModule.mockFactory).toBeDefined();
+        expect(httpModule.httpVerbs).toBeDefined();
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5247,6 +5247,15 @@
   dependencies:
     "@wdio/logger" "6.0.16"
 
+"@webassemblyjs/ast@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.7.11.tgz#b988582cafbb2b095e8b556526f30c90d057cace"
+  integrity sha512-ZEzy4vjvTzScC+SH8RBssQUawpaInUdMTYwYYLh54/s8TuT0gBLuyUnppKsVyZEi876VmmStKsUs28UxPgdvrA==
+  dependencies:
+    "@webassemblyjs/helper-module-context" "1.7.11"
+    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
+    "@webassemblyjs/wast-parser" "1.7.11"
+
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
@@ -5256,20 +5265,66 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
     "@webassemblyjs/wast-parser" "1.8.5"
 
+"@webassemblyjs/ast@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
+  integrity sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==
+  dependencies:
+    "@webassemblyjs/helper-module-context" "1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
+    "@webassemblyjs/wast-parser" "1.9.0"
+
+"@webassemblyjs/floating-point-hex-parser@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz#a69f0af6502eb9a3c045555b1a6129d3d3f2e313"
+  integrity sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg==
+
 "@webassemblyjs/floating-point-hex-parser@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz#1ba926a2923613edce496fd5b02e8ce8a5f49721"
   integrity sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==
+
+"@webassemblyjs/floating-point-hex-parser@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz#3c3d3b271bddfc84deb00f71344438311d52ffb4"
+  integrity sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==
+
+"@webassemblyjs/helper-api-error@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz#c7b6bb8105f84039511a2b39ce494f193818a32a"
+  integrity sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg==
 
 "@webassemblyjs/helper-api-error@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz#c49dad22f645227c5edb610bdb9697f1aab721f7"
   integrity sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==
 
+"@webassemblyjs/helper-api-error@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz#203f676e333b96c9da2eeab3ccef33c45928b6a2"
+  integrity sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==
+
+"@webassemblyjs/helper-buffer@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz#3122d48dcc6c9456ed982debe16c8f37101df39b"
+  integrity sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w==
+
 "@webassemblyjs/helper-buffer@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz#fea93e429863dd5e4338555f42292385a653f204"
   integrity sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==
+
+"@webassemblyjs/helper-buffer@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz#a1442d269c5feb23fcbc9ef759dac3547f29de00"
+  integrity sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==
+
+"@webassemblyjs/helper-code-frame@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz#cf8f106e746662a0da29bdef635fcd3d1248364b"
+  integrity sha512-T8ESC9KMXFTXA5urJcyor5cn6qWeZ4/zLPyWeEXZ03hj/x9weSokGNkVCdnhSabKGYWxElSdgJ+sFa9G/RdHNw==
+  dependencies:
+    "@webassemblyjs/wast-printer" "1.7.11"
 
 "@webassemblyjs/helper-code-frame@1.8.5":
   version "1.8.5"
@@ -5278,10 +5333,32 @@
   dependencies:
     "@webassemblyjs/wast-printer" "1.8.5"
 
+"@webassemblyjs/helper-code-frame@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz#647f8892cd2043a82ac0c8c5e75c36f1d9159f27"
+  integrity sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==
+  dependencies:
+    "@webassemblyjs/wast-printer" "1.9.0"
+
+"@webassemblyjs/helper-fsm@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz#df38882a624080d03f7503f93e3f17ac5ac01181"
+  integrity sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A==
+
 "@webassemblyjs/helper-fsm@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz#ba0b7d3b3f7e4733da6059c9332275d860702452"
   integrity sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==
+
+"@webassemblyjs/helper-fsm@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz#c05256b71244214671f4b08ec108ad63b70eddb8"
+  integrity sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==
+
+"@webassemblyjs/helper-module-context@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz#d874d722e51e62ac202476935d649c802fa0e209"
+  integrity sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg==
 
 "@webassemblyjs/helper-module-context@1.8.5":
   version "1.8.5"
@@ -5291,10 +5368,37 @@
     "@webassemblyjs/ast" "1.8.5"
     mamacro "^0.0.3"
 
+"@webassemblyjs/helper-module-context@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz#25d8884b76839871a08a6c6f806c3979ef712f07"
+  integrity sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==
+  dependencies:
+    "@webassemblyjs/ast" "1.9.0"
+
+"@webassemblyjs/helper-wasm-bytecode@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz#dd9a1e817f1c2eb105b4cf1013093cb9f3c9cb06"
+  integrity sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ==
+
 "@webassemblyjs/helper-wasm-bytecode@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz#537a750eddf5c1e932f3744206551c91c1b93e61"
   integrity sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==
+
+"@webassemblyjs/helper-wasm-bytecode@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz#4fed8beac9b8c14f8c58b70d124d549dd1fe5790"
+  integrity sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==
+
+"@webassemblyjs/helper-wasm-section@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz#9c9ac41ecf9fbcfffc96f6d2675e2de33811e68a"
+  integrity sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-buffer" "1.7.11"
+    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
+    "@webassemblyjs/wasm-gen" "1.7.11"
 
 "@webassemblyjs/helper-wasm-section@1.8.5":
   version "1.8.5"
@@ -5306,12 +5410,43 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
     "@webassemblyjs/wasm-gen" "1.8.5"
 
+"@webassemblyjs/helper-wasm-section@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz#5a4138d5a6292ba18b04c5ae49717e4167965346"
+  integrity sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==
+  dependencies:
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-buffer" "1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
+    "@webassemblyjs/wasm-gen" "1.9.0"
+
+"@webassemblyjs/ieee754@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz#c95839eb63757a31880aaec7b6512d4191ac640b"
+  integrity sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
 "@webassemblyjs/ieee754@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz#712329dbef240f36bf57bd2f7b8fb9bf4154421e"
   integrity sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/ieee754@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz#15c7a0fbaae83fb26143bbacf6d6df1702ad39e4"
+  integrity sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/leb128@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.7.11.tgz#d7267a1ee9c4594fd3f7e37298818ec65687db63"
+  integrity sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==
+  dependencies:
+    "@xtuc/long" "4.2.1"
 
 "@webassemblyjs/leb128@1.8.5":
   version "1.8.5"
@@ -5320,10 +5455,41 @@
   dependencies:
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/leb128@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.9.0.tgz#f19ca0b76a6dc55623a09cffa769e838fa1e1c95"
+  integrity sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==
+  dependencies:
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/utf8@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.7.11.tgz#06d7218ea9fdc94a6793aa92208160db3d26ee82"
+  integrity sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA==
+
 "@webassemblyjs/utf8@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.8.5.tgz#a8bf3b5d8ffe986c7c1e373ccbdc2a0915f0cedc"
   integrity sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==
+
+"@webassemblyjs/utf8@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.9.0.tgz#04d33b636f78e6a6813227e82402f7637b6229ab"
+  integrity sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==
+
+"@webassemblyjs/wasm-edit@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz#8c74ca474d4f951d01dbae9bd70814ee22a82005"
+  integrity sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-buffer" "1.7.11"
+    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
+    "@webassemblyjs/helper-wasm-section" "1.7.11"
+    "@webassemblyjs/wasm-gen" "1.7.11"
+    "@webassemblyjs/wasm-opt" "1.7.11"
+    "@webassemblyjs/wasm-parser" "1.7.11"
+    "@webassemblyjs/wast-printer" "1.7.11"
 
 "@webassemblyjs/wasm-edit@1.8.5":
   version "1.8.5"
@@ -5339,6 +5505,31 @@
     "@webassemblyjs/wasm-parser" "1.8.5"
     "@webassemblyjs/wast-printer" "1.8.5"
 
+"@webassemblyjs/wasm-edit@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz#3fe6d79d3f0f922183aa86002c42dd256cfee9cf"
+  integrity sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==
+  dependencies:
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-buffer" "1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
+    "@webassemblyjs/helper-wasm-section" "1.9.0"
+    "@webassemblyjs/wasm-gen" "1.9.0"
+    "@webassemblyjs/wasm-opt" "1.9.0"
+    "@webassemblyjs/wasm-parser" "1.9.0"
+    "@webassemblyjs/wast-printer" "1.9.0"
+
+"@webassemblyjs/wasm-gen@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz#9bbba942f22375686a6fb759afcd7ac9c45da1a8"
+  integrity sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
+    "@webassemblyjs/ieee754" "1.7.11"
+    "@webassemblyjs/leb128" "1.7.11"
+    "@webassemblyjs/utf8" "1.7.11"
+
 "@webassemblyjs/wasm-gen@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz#54840766c2c1002eb64ed1abe720aded714f98bc"
@@ -5350,6 +5541,27 @@
     "@webassemblyjs/leb128" "1.8.5"
     "@webassemblyjs/utf8" "1.8.5"
 
+"@webassemblyjs/wasm-gen@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz#50bc70ec68ded8e2763b01a1418bf43491a7a49c"
+  integrity sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==
+  dependencies:
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
+    "@webassemblyjs/ieee754" "1.9.0"
+    "@webassemblyjs/leb128" "1.9.0"
+    "@webassemblyjs/utf8" "1.9.0"
+
+"@webassemblyjs/wasm-opt@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz#b331e8e7cef8f8e2f007d42c3a36a0580a7d6ca7"
+  integrity sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-buffer" "1.7.11"
+    "@webassemblyjs/wasm-gen" "1.7.11"
+    "@webassemblyjs/wasm-parser" "1.7.11"
+
 "@webassemblyjs/wasm-opt@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz#b24d9f6ba50394af1349f510afa8ffcb8a63d264"
@@ -5359,6 +5571,28 @@
     "@webassemblyjs/helper-buffer" "1.8.5"
     "@webassemblyjs/wasm-gen" "1.8.5"
     "@webassemblyjs/wasm-parser" "1.8.5"
+
+"@webassemblyjs/wasm-opt@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz#2211181e5b31326443cc8112eb9f0b9028721a61"
+  integrity sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==
+  dependencies:
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-buffer" "1.9.0"
+    "@webassemblyjs/wasm-gen" "1.9.0"
+    "@webassemblyjs/wasm-parser" "1.9.0"
+
+"@webassemblyjs/wasm-parser@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz#6e3d20fa6a3519f6b084ef9391ad58211efb0a1a"
+  integrity sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-api-error" "1.7.11"
+    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
+    "@webassemblyjs/ieee754" "1.7.11"
+    "@webassemblyjs/leb128" "1.7.11"
+    "@webassemblyjs/utf8" "1.7.11"
 
 "@webassemblyjs/wasm-parser@1.8.5":
   version "1.8.5"
@@ -5372,6 +5606,30 @@
     "@webassemblyjs/leb128" "1.8.5"
     "@webassemblyjs/utf8" "1.8.5"
 
+"@webassemblyjs/wasm-parser@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz#9d48e44826df4a6598294aa6c87469d642fff65e"
+  integrity sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==
+  dependencies:
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-api-error" "1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
+    "@webassemblyjs/ieee754" "1.9.0"
+    "@webassemblyjs/leb128" "1.9.0"
+    "@webassemblyjs/utf8" "1.9.0"
+
+"@webassemblyjs/wast-parser@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz#25bd117562ca8c002720ff8116ef9072d9ca869c"
+  integrity sha512-lEyVCg2np15tS+dm7+JJTNhNWq9yTZvi3qEhAIIOaofcYlUp0UR5/tVqOwa/gXYr3gjwSZqw+/lS9dscyLelbQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/floating-point-hex-parser" "1.7.11"
+    "@webassemblyjs/helper-api-error" "1.7.11"
+    "@webassemblyjs/helper-code-frame" "1.7.11"
+    "@webassemblyjs/helper-fsm" "1.7.11"
+    "@xtuc/long" "4.2.1"
+
 "@webassemblyjs/wast-parser@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz#e10eecd542d0e7bd394f6827c49f3df6d4eefb8c"
@@ -5384,6 +5642,27 @@
     "@webassemblyjs/helper-fsm" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/wast-parser@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz#3031115d79ac5bd261556cecc3fa90a3ef451914"
+  integrity sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==
+  dependencies:
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/floating-point-hex-parser" "1.9.0"
+    "@webassemblyjs/helper-api-error" "1.9.0"
+    "@webassemblyjs/helper-code-frame" "1.9.0"
+    "@webassemblyjs/helper-fsm" "1.9.0"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/wast-printer@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz#c4245b6de242cb50a2cc950174fdbf65c78d7813"
+  integrity sha512-m5vkAsuJ32QpkdkDOUPGSltrg8Cuk3KBx4YrmAGQwCZPRdUHXxG4phIOuuycLemHFr74sWL9Wthqss4fzdzSwg==
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/wast-parser" "1.7.11"
+    "@xtuc/long" "4.2.1"
+
 "@webassemblyjs/wast-printer@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz#114bbc481fd10ca0e23b3560fa812748b0bae5bc"
@@ -5393,10 +5672,24 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/wast-printer@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz#4935d54c85fef637b00ce9f52377451d00d47899"
+  integrity sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==
+  dependencies:
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/wast-parser" "1.9.0"
+    "@xtuc/long" "4.2.2"
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
   integrity sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==
+
+"@xtuc/long@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
+  integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
 "@xtuc/long@4.2.2":
   version "4.2.2"
@@ -5444,6 +5737,13 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   dependencies:
     mime-types "~2.1.24"
     negotiator "0.6.2"
+
+acorn-dynamic-import@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
+  integrity sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==
+  dependencies:
+    acorn "^5.0.0"
 
 acorn-dynamic-import@^4.0.0:
   version "4.0.0"
@@ -5493,7 +5793,7 @@ acorn-walk@^7.0.0, acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-"acorn@>= 2.5.2 <= 5.7.5", acorn@^5.5.0, acorn@^5.5.3:
+"acorn@>= 2.5.2 <= 5.7.5", acorn@^5.0.0, acorn@^5.5.0, acorn@^5.5.3, acorn@^5.6.2:
   version "5.7.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
   integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
@@ -5503,7 +5803,7 @@ acorn@^3.0.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
   integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
 
-acorn@^6.0.1, acorn@^6.1.1, acorn@^6.2.0:
+acorn@^6.0.1, acorn@^6.1.1, acorn@^6.2.0, acorn@^6.2.1, acorn@^6.4.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
@@ -5597,7 +5897,7 @@ ajv-keywords@^2.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
   integrity sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=
 
-ajv-keywords@^3.1.0, ajv-keywords@^3.5.2:
+ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
@@ -6177,7 +6477,7 @@ axios-mock-adapter@1.18.2:
     fast-deep-equal "^3.1.1"
     is-buffer "^2.0.3"
 
-axios-mock-adapter@1.19.0:
+axios-mock-adapter@1.19.0, axios-mock-adapter@^1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz#9d72e321a6c5418e1eff067aa99761a86c5188a4"
   integrity sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==
@@ -7854,7 +8154,7 @@ chrome-launcher@^0.13.1:
     mkdirp "^0.5.3"
     rimraf "^3.0.2"
 
-chrome-trace-event@^1.0.0:
+chrome-trace-event@^1.0.0, chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
@@ -10130,7 +10430,7 @@ enhanced-resolve@^0.9.1:
     memory-fs "^0.2.0"
     tapable "^0.1.8"
 
-enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0, enhanced-resolve@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz#2f3cfd84dbe3b487f18f2db2ef1e064a571ca5ec"
   integrity sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==
@@ -10472,7 +10772,7 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^4.0.0:
+eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
   integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
@@ -15820,7 +16120,7 @@ loader-fs-cache@^1.0.0:
     find-cache-dir "^0.1.1"
     mkdirp "^0.5.1"
 
-loader-runner@^2.3.0, loader-runner@^2.3.1:
+loader-runner@^2.3.0, loader-runner@^2.3.1, loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
@@ -17273,7 +17573,7 @@ node-ipc@^9.1.1:
     js-message "1.0.7"
     js-queue "2.0.2"
 
-"node-libs-browser@^1.0.0 || ^2.0.0", node-libs-browser@^2.0.0:
+"node-libs-browser@^1.0.0 || ^2.0.0", node-libs-browser@^2.0.0, node-libs-browser@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
   integrity sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
@@ -21281,6 +21581,14 @@ scheduler@^0.19.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+schema-utils@^0.4.4:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
+  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
@@ -22741,7 +23049,7 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser-webpack-plugin@^1.1.0:
+terser-webpack-plugin@^1.1.0, terser-webpack-plugin@^1.4.3:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz#a217aefaea330e734ffacb6120ec1fa312d6040b"
   integrity sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==
@@ -24163,7 +24471,7 @@ watchpack-chokidar2@^2.0.1:
   dependencies:
     chokidar "^2.1.8"
 
-watchpack@^1.5.0:
+watchpack@^1.5.0, watchpack@^1.6.0, watchpack@^1.7.4:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
@@ -24465,7 +24773,7 @@ webpack-merge@^4.1.4, webpack-merge@^4.2.2:
   dependencies:
     lodash "^4.17.15"
 
-webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-sources@^1.4.3:
+webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
@@ -24480,7 +24788,66 @@ webpack-virtual-modules@^0.2.2:
   dependencies:
     debug "^3.0.0"
 
-webpack@4.36.0, webpack@4.42.1, "webpack@>=4 < 4.29", webpack@^4.0.0, webpack@^4.26.0, webpack@^4.43.0:
+webpack@4.42.1:
+  version "4.42.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.42.1.tgz#ae707baf091f5ca3ef9c38b884287cfe8f1983ef"
+  integrity sha512-SGfYMigqEfdGchGhFFJ9KyRpQKnipvEvjc1TwrXEPCM6H5Wywu10ka8o3KGrMzSMxMQKt8aCHUFh5DaQ9UmyRg==
+  dependencies:
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-module-context" "1.9.0"
+    "@webassemblyjs/wasm-edit" "1.9.0"
+    "@webassemblyjs/wasm-parser" "1.9.0"
+    acorn "^6.2.1"
+    ajv "^6.10.2"
+    ajv-keywords "^3.4.1"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^4.1.0"
+    eslint-scope "^4.0.3"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.4.0"
+    loader-utils "^1.2.3"
+    memory-fs "^0.4.1"
+    micromatch "^3.1.10"
+    mkdirp "^0.5.3"
+    neo-async "^2.6.1"
+    node-libs-browser "^2.2.1"
+    schema-utils "^1.0.0"
+    tapable "^1.1.3"
+    terser-webpack-plugin "^1.4.3"
+    watchpack "^1.6.0"
+    webpack-sources "^1.4.1"
+
+"webpack@>=4 < 4.29":
+  version "4.28.4"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.28.4.tgz#1ddae6c89887d7efb752adf0c3cd32b9b07eacd0"
+  integrity sha512-NxjD61WsK/a3JIdwWjtIpimmvE6UrRi3yG54/74Hk9rwNj5FPkA4DJCf1z4ByDWLkvZhTZE+P3C/eh6UD5lDcw==
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-module-context" "1.7.11"
+    "@webassemblyjs/wasm-edit" "1.7.11"
+    "@webassemblyjs/wasm-parser" "1.7.11"
+    acorn "^5.6.2"
+    acorn-dynamic-import "^3.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chrome-trace-event "^1.0.0"
+    enhanced-resolve "^4.1.0"
+    eslint-scope "^4.0.0"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    micromatch "^3.1.8"
+    mkdirp "~0.5.0"
+    neo-async "^2.5.0"
+    node-libs-browser "^2.0.0"
+    schema-utils "^0.4.4"
+    tapable "^1.1.0"
+    terser-webpack-plugin "^1.1.0"
+    watchpack "^1.5.0"
+    webpack-sources "^1.3.0"
+
+webpack@^4.0.0, webpack@^4.26.0:
   version "4.36.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.36.0.tgz#d49474e54acd6eed51c3aff70333cbd172f21101"
   integrity sha512-UGcu9VQMjs9CxYfDEMe7UYkMgSVx9eSgcmj8ksveJk0b7/CxPW4B0HOk+yF0CLQg8p0sxynUS4PHQtjEDSZSmg==
@@ -24508,6 +24875,35 @@ webpack@4.36.0, webpack@4.42.1, "webpack@>=4 < 4.29", webpack@^4.0.0, webpack@^4
     terser-webpack-plugin "^1.1.0"
     watchpack "^1.5.0"
     webpack-sources "^1.3.0"
+
+webpack@^4.43.0:
+  version "4.46.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
+  integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==
+  dependencies:
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-module-context" "1.9.0"
+    "@webassemblyjs/wasm-edit" "1.9.0"
+    "@webassemblyjs/wasm-parser" "1.9.0"
+    acorn "^6.4.1"
+    ajv "^6.10.2"
+    ajv-keywords "^3.4.1"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^4.5.0"
+    eslint-scope "^4.0.3"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.4.0"
+    loader-utils "^1.2.3"
+    memory-fs "^0.4.1"
+    micromatch "^3.1.10"
+    mkdirp "^0.5.3"
+    neo-async "^2.6.1"
+    node-libs-browser "^2.2.1"
+    schema-utils "^1.0.0"
+    tapable "^1.1.3"
+    terser-webpack-plugin "^1.4.3"
+    watchpack "^1.7.4"
+    webpack-sources "^1.4.1"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"


### PR DESCRIPTION
I think this is the last PR I need to enable F-Registration to consume this package
Should also put us in a good place to start collecting dependency stats

v0.4.0
------------------------------
*May 6, 2021*

### Added
- Expose HTTPVerbs for PUT, PATCH, DELETE
- Expose methods for PUT, PATCH, DELETE on client
- Expose a method for setting authorisation token for all requests from a client
- Ability to name a client - useful when we can push stats and logs by API or grouping name