### PR TITLE
f-checkout@v0.110.0 - Display correct error message when mobile number field is empty

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.110.0
 ------------------------------
-*May 12, 2021*
+*May 13, 2021*
 
 ### Changed
 - Display 'Please enter your phone number' when the mobile number field is empty, and invalid phone message when the field is invalid but not empty

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.110.0
+------------------------------
+*May 12, 2021*
+
+### Changed
+- Display 'Please enter your phone number' when the mobile number field is empty, and invalid phone message when the field is invalid but not empty
+
+
 v0.109.0
 ------------------------------
 *May 13, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.109.0",
+  "version": "0.110.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -53,19 +53,26 @@
                         name="mobile-number"
                         input-type="tel"
                         :label-text="$t('labels.mobileNumber')"
-                        :has-error="!isMobileNumberValid"
+                        :has-error="isMobileNumberEmpty || isMobileNumberInvalid"
                         aria-describedby="mobile-number-error"
                         :aria-invalid="!isMobileNumberValid"
                         @input="updateCustomerDetails({ mobileNumber: $event })"
                     >
                         <template #error>
                             <error-message
-                                v-if="!isMobileNumberValid"
+                                v-if="isMobileNumberEmpty"
                                 id="mobile-number-error"
                                 data-js-error-message
-                                data-test-id="error-mobile-number"
+                                data-test-id="error-mobile-number-empty"
                             >
                                 {{ $t('validationMessages.mobileNumber.requiredError') }}
+                            </error-message>
+                            <error-message
+                                v-if="isMobileNumberInvalid"
+                                data-js-error-message
+                                data-test-id="error-mobile-number-invalid"
+                            >
+                                {{ $t('validationMessages.mobileNumber.invalidCharError') }}
                             </error-message>
                         </template>
                     </form-field>
@@ -307,14 +314,16 @@ export default {
             'userNote'
         ]),
 
-        isMobileNumberValid () {
-            /*
-            * Validation methods return true if the validation conditions
-            * have not been met and the field has been `touched` by a user.
-            * The $dirty boolean changes to true when the user has focused/lost
-            * focus on the input field.
-            */
-            return !this.$v.customer.mobileNumber.$dirty || this.$v.customer.mobileNumber.isValidPhoneNumber;
+        wasMobileNumberFocused () {
+            return this.$v.customer.mobileNumber.$dirty;
+        },
+
+        isMobileNumberEmpty () {
+            return this.wasMobileNumberFocused && !this.customer.mobileNumber;
+        },
+
+        isMobileNumberInvalid () {
+            return this.wasMobileNumberFocused && !this.isMobileNumberEmpty && !this.$v.customer.mobileNumber.isValidPhoneNumber;
         },
 
         isCheckoutMethodDelivery () {

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -69,6 +69,7 @@
                             </error-message>
                             <error-message
                                 v-if="isMobileNumberInvalid"
+                                id="mobile-number-error"
                                 data-js-error-message
                                 data-test-id="error-mobile-number-invalid"
                             >

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -296,7 +296,7 @@ describe('Checkout', () => {
     });
 
     describe('computed ::', () => {
-        describe('isMobileNumberValid ::', () => {
+        describe('isMobileNumberEmpty ::', () => {
             let wrapper;
 
             beforeEach(() => {
@@ -309,30 +309,79 @@ describe('Checkout', () => {
                 });
             });
 
-            it('should return `true` if mobileNumber field has not been touched', () => {
+            it('should return `false` if mobileNumber field has not been touched', () => {
                 // Act
                 wrapper.vm.$v.customer.mobileNumber.$dirty = false;
 
                 // Assert
-                expect(wrapper.vm.isMobileNumberValid).toBeTruthy();
+                expect(wrapper.vm.isMobileNumberEmpty).toBeFalsy();
             });
 
-            it('should return `false` if mobileNumber field has been touched but mobileNumber is not valid', () => {
+            it('should return `true` if mobileNumber field has been touched but the field is empty', () => {
                 // Act
                 wrapper.vm.$v.customer.mobileNumber.$dirty = true;
-                wrapper.vm.$v.customer.mobileNumber.isValidPhoneNumber = false;
+                wrapper.vm.customer.mobileNumber = '';
 
                 // Assert
-                expect(wrapper.vm.isMobileNumberValid).toBeFalsy();
+                expect(wrapper.vm.isMobileNumberEmpty).toBeTruthy();
             });
 
-            it('should return `true` if mobileNumber field has been touched and mobileNumber is valid', () => {
+            it('should return `false` if mobileNumber field has been touched and the field is not empty', () => {
                 // Act
                 wrapper.vm.$v.customer.mobileNumber.$dirty = true;
-                wrapper.vm.$v.customer.mobileNumber.isValidPhoneNumber = true;
+                wrapper.vm.customer.mobileNumber = '123';
 
                 // Assert
-                expect(wrapper.vm.isMobileNumberValid).toBeTruthy();
+                expect(wrapper.vm.isMobileNumberEmpty).toBeFalsy();
+            });
+        });
+
+        describe('isMobileNumberInvalid ::', () => {
+            let wrapper;
+
+            beforeEach(() => {
+                wrapper = shallowMount(VueCheckout, {
+                    store: createStore(),
+                    i18n,
+                    localVue,
+                    propsData,
+                    mocks: { $v }
+                });
+            });
+
+            it('should return `false` if mobileNumber field has not been touched', () => {
+                // Act
+                wrapper.vm.$v.customer.mobileNumber.$dirty = false;
+
+                // Assert
+                expect(wrapper.vm.isMobileNumberInvalid).toBeFalsy();
+            });
+
+            it('should return `false` if mobileNumber field has been touched and the field is empty', () => {
+                // Act
+                wrapper.vm.$v.customer.mobileNumber.$dirty = true;
+                wrapper.vm.customer.mobileNumber = '';
+
+                // Assert
+                expect(wrapper.vm.isMobileNumberInvalid).toBeFalsy();
+            });
+
+            it('should return `true` if mobileNumber field has been touched, the field is not empty, but the phone number is invalid', () => {
+                // Act
+                wrapper.vm.$v.customer.mobileNumber.$dirty = true;
+                wrapper.vm.customer.mobileNumber = '123';
+
+                // Assert
+                expect(wrapper.vm.isMobileNumberInvalid).toBeTruthy();
+            });
+
+            it('should return `false` if mobileNumber field has been touched, and the phone number is valid', () => {
+                // Act
+                wrapper.vm.$v.customer.mobileNumber.$dirty = true;
+                wrapper.vm.customer.mobileNumber = '0711111111';
+
+                // Assert
+                expect(wrapper.vm.isMobileNumberInvalid).toBeTruthy();
             });
         });
 

--- a/packages/components/organisms/f-checkout/src/tenants/en-GB.js
+++ b/packages/components/organisms/f-checkout/src/tenants/en-GB.js
@@ -14,7 +14,8 @@ const messages = {
 
     validationMessages: {
         mobileNumber: {
-            requiredError: 'Your phone number should be at least 10 characters long and shouldn’t contain letters or special characters'
+            requiredError: 'Please enter your phone number',
+            invalidCharError: 'Your phone number should be at least 10 characters long and shouldn’t contain letters or special characters'
         },
         addressLine1: {
             requiredError: 'Please enter the first line of your address'

--- a/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout-selectors.js
+++ b/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout-selectors.js
@@ -31,7 +31,7 @@ export const FIELDS = {
     },
     mobileNumber: {
         input: '[data-test-id="formfield-mobile-number-input"]',
-        error: '[data-test-id="error-mobile-number-empty"]',
+        emptyError: '[data-test-id="error-mobile-number-empty"]',
         invalidError: '[data-test-id="error-mobile-number-invalid"]'
     },
     addressLine1: {

--- a/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout-selectors.js
+++ b/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout-selectors.js
@@ -31,7 +31,8 @@ export const FIELDS = {
     },
     mobileNumber: {
         input: '[data-test-id="formfield-mobile-number-input"]',
-        error: '[data-test-id="error-mobile-number"]'
+        error: '[data-test-id="error-mobile-number-empty"]',
+        invalidError: '[data-test-id="error-mobile-number-invalid"]'
     },
     addressLine1: {
         input: '[data-test-id="formfield-address-line-1-input"]',

--- a/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout.component.js
+++ b/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout.component.js
@@ -70,7 +70,7 @@ module.exports = class Checkout extends Page {
         },
         mobileNumber: {
             get input () { return $(FIELDS.mobileNumber.input); },
-            get error () { return $(FIELDS.mobileNumber.error); },
+            get emptyError () { return $(FIELDS.mobileNumber.emptyError); },
             get invalidError () { return $(FIELDS.mobileNumber.invalidError); }
         },
         addressLine1: {
@@ -126,10 +126,6 @@ module.exports = class Checkout extends Page {
 
     isPostcodeTypeErrorDisplayed () {
         return this.fields.addressPostcode.typeError.isDisplayed();
-    }
-
-    isMobileNumberInvalidErrorDisplayed () {
-        return this.fields.mobileNumber.invalidError.isDisplayed();
     }
 
     isOrderTimeDropdownDisplayed () {

--- a/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout.component.js
+++ b/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout.component.js
@@ -70,7 +70,8 @@ module.exports = class Checkout extends Page {
         },
         mobileNumber: {
             get input () { return $(FIELDS.mobileNumber.input); },
-            get error () { return $(FIELDS.mobileNumber.error); }
+            get error () { return $(FIELDS.mobileNumber.error); },
+            get invalidError () { return $(FIELDS.mobileNumber.invalidError); }
         },
         addressLine1: {
             get input () { return $(FIELDS.addressLine1.input); },
@@ -125,6 +126,10 @@ module.exports = class Checkout extends Page {
 
     isPostcodeTypeErrorDisplayed () {
         return this.fields.addressPostcode.typeError.isDisplayed();
+    }
+
+    isMobileNumberInvalidErrorDisplayed () {
+        return this.fields.mobileNumber.invalidError.isDisplayed();
     }
 
     isOrderTimeDropdownDisplayed () {

--- a/packages/components/organisms/f-checkout/test/visual/f-checkout-authenticated.visual.shared.spec.js
+++ b/packages/components/organisms/f-checkout/test/visual/f-checkout-authenticated.visual.shared.spec.js
@@ -67,7 +67,19 @@ describe('f-checkout - Collection - Authenticated - Visual Tests', () => {
         browser.percyScreenshot('f-checkout - Collection - Authenticated - "Restaurant not taking orders" Error Modal', 'shared');
     });
 
+    it('should display the illegal mobile number error message', () => {
+        // Arrange
+        const mobileNumberInfo = {
+            mobileNumber: '123'
+        };
 
+        // Act
+        checkout.populateCollectionCheckoutForm(mobileNumberInfo);
+        checkout.goToPayment();
+
+        // Assert
+        browser.percyScreenshot('f-checkout - Collection - Authenticated - Illegal Mobile Number Error State', 'shared');
+    });
 });
 
 describe('f-checkout - Collection - Authenticated - isAsapAvailable: false Visual Tests', () => {
@@ -131,6 +143,20 @@ describe('f-checkout - Delivery - Authenticated - Visual Tests', () => {
 
         // Assert
         browser.percyScreenshot('f-checkout - Delivery - Authenticated - Illegal Postcode Error State', 'shared');
+    });
+
+    it('should display the illegal mobile number error message', () => {
+        // Arrange
+        const mobileNumberInfo = {
+            mobileNumber: '123'
+        };
+
+        // Act
+        checkout.populateCheckoutForm(mobileNumberInfo);
+        checkout.goToPayment();
+
+        // Assert
+        browser.percyScreenshot('f-checkout - Delivery - Authenticated - Illegal Mobile Number Error State', 'shared');
     });
 });
 

--- a/packages/components/organisms/f-checkout/test/visual/f-checkout-guest.visual.shared.spec.js
+++ b/packages/components/organisms/f-checkout/test/visual/f-checkout-guest.visual.shared.spec.js
@@ -28,6 +28,20 @@ describe('f-checkout - Collection - Guest - Visual Tests', () => {
         // Assert
         browser.percyScreenshot('f-checkout - Collection - Guest - Mandatory Errors State', 'shared');
     });
+
+    it('should display the illegal mobile number error message', () => {
+        // Arrange
+        const mobileNumberInfo = {
+            mobileNumber: '123'
+        };
+
+        // Act
+        checkout.populateCollectionCheckoutForm(mobileNumberInfo);
+        checkout.goToPayment();
+
+        // Assert
+        browser.percyScreenshot('f-checkout - Collection - Guest - Illegal Mobile Number Error State', 'shared');
+    });
 });
 
 describe('f-checkout - Collection - Guest - isAsapAvailable: false Visual Tests', () => {
@@ -77,6 +91,20 @@ describe('f-checkout - Delivery - Guest - Visual Tests', () => {
 
         // Assert
         browser.percyScreenshot('f-checkout - Delivery - Guest - Mandatory Errors State', 'shared');
+    });
+
+    it('should display the illegal mobile number error message', () => {
+        // Arrange
+        const mobileNumberInfo = {
+            mobileNumber: '123'
+        };
+
+        // Act
+        checkout.populateCheckoutForm(mobileNumberInfo);
+        checkout.goToPayment();
+
+        // Assert
+        browser.percyScreenshot('f-checkout - Delivery - Guest - Illegal Mobile Number Error State', 'shared');
     });
 });
 


### PR DESCRIPTION
### Changed
- Display 'Please enter your phone number' when the mobile number field is empty, and invalid phone message when the field is invalid but not empty