### PR TITLE
f-header@4.16.0 - Add ability to disable Just Eat logo nav in header

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.16.0
+------------------------------
+*May 12, 2021*
+
+### Added
+- Ability to disable Just Eat logo navigation
+
+
 v4.15.0
 ------------------------------
 *May 6, 2021*

--- a/packages/components/organisms/f-header/README.md
+++ b/packages/components/organisms/f-header/README.md
@@ -74,6 +74,7 @@ The props that can be defined are as follows:
 | errorLog                  | `Function`    | `-`    | Function passed in for logging errors with the `fetchUserInfo` method. |
 | headerBackgroundTheme     | `String`      | `white` | Sets the background theme for the header component.<br><br>When set to `white` the header will be white with the default logo colour.<br>When set to `transparent` the header will be transparent with a white logo.<br>When set to `highlight` the header will use the primary brand colour as the background colour with a white logo. |
 | isOrderCountSupported     | `Boolean`     | `true` | ?? |
+| isLogoLinkDisabled        | `Boolean`     | `false` | Whether the company logo is disabled from allowing the user to navigate home
 | orderCountUrl             | `String`      | `false` | ?? |
 | showDeliveryEnquiry       | `Boolean`     | `false` | Defines if it is necessary to show the "Deliver with Just Eat" link in the header. |
 | showOffersLink            | `Boolean`     | `false` | Defines whether the offers link should be shown in the navigation. |

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -17,7 +17,7 @@
             <logo
                 :theme="theme"
                 :company-name="copy.companyName"
-                :link-disabled="logoLinkDisabled"
+                :is-logo-disabled="isLogoLinkDisabled"
                 :logo-gtm-label="copy.logo.gtm"
                 :header-background-theme="headerBackgroundTheme"
                 :is-open="mobileNavIsOpen" />
@@ -77,7 +77,7 @@ export default {
             default: true
         },
 
-        logoLinkDisabled: {
+        isLogoLinkDisabled: {
             type: Boolean,
             default: false
         },

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -17,6 +17,7 @@
             <logo
                 :theme="theme"
                 :company-name="copy.companyName"
+                :link-disabled="logoLinkDisabled"
                 :logo-gtm-label="copy.logo.gtm"
                 :header-background-theme="headerBackgroundTheme"
                 :is-open="mobileNavIsOpen" />
@@ -74,6 +75,11 @@ export default {
         isOrderCountSupported: {
             type: Boolean,
             default: true
+        },
+
+        logoLinkDisabled: {
+            type: Boolean,
+            default: false
         },
 
         orderCountUrl: {

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -2,14 +2,8 @@
     <component
         :is="wrapperComponent"
         :aria-label="linkAltText"
-        href="/"
         :class="$style['c-logo']"
-        :data-trak='`{
-            "trakEvent": "click",
-            "category": "engagement",
-            "action": "header",
-            "label": "${logoGtmLabel}"
-        }`'>
+        v-bind="linkProperties">
         <component
             :is="iconComponent"
             :class="[
@@ -68,6 +62,21 @@ export default {
         },
         linkAltText () {
             return `Go to ${this.companyName} homepage`;
+        },
+        linkProperties () {
+            return this.isLogoDisabled ? {
+                'data-test-id': 'disabled-wrapper-element'
+            } : {
+                'data-test-id': 'wrapper-element',
+                'aria-label': this.linkAltText,
+                href: '/',
+                'data-trak': `{
+                    "trakEvent": "click",
+                    "category": "engagement",
+                    "action": "header",
+                    "label": "${this.logoGtmLabel}"
+                }`
+            };
         },
         isAltLogo () {
             const isHighlight = this.headerBackgroundTheme === 'highlight';

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -2,7 +2,11 @@
     <a
         :aria-label="linkAltText"
         href="/"
-        :class="$style['c-logo']"
+        :aria-disabled="linkDisabled"
+        :class="[
+            $style['c-logo'],
+            { [$style['disabled']]: linkDisabled }
+        ]"
         :data-trak='`{
             "trakEvent": "click",
             "category": "engagement",
@@ -40,6 +44,10 @@ export default {
         companyName: {
             type: String,
             required: true
+        },
+        linkDisabled: {
+            type: Boolean,
+            default: false
         },
         logoGtmLabel: {
             type: String,
@@ -96,6 +104,10 @@ export default {
             @include theme(ml) {
                 padding-top: 16px;
             }
+        }
+
+        &.disabled {
+            pointer-events: none;
         }
     }
 

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -1,7 +1,6 @@
 <template>
     <component
         :is="wrapperComponent"
-        :aria-label="linkAltText"
         :class="$style['c-logo']"
         v-bind="linkProperties">
         <component

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -1,12 +1,9 @@
 <template>
-    <a
+    <component
+        :is="wrapperComponent"
         :aria-label="linkAltText"
         href="/"
-        :aria-disabled="linkDisabled"
-        :class="[
-            $style['c-logo'],
-            { [$style['disabled']]: linkDisabled }
-        ]"
+        :class="$style['c-logo']"
         :data-trak='`{
             "trakEvent": "click",
             "category": "engagement",
@@ -22,7 +19,7 @@
             ]"
             :data-theme-logo="iconClassName"
             data-test-id="header-logo" />
-    </a>
+    </component>
 </template>
 
 <script>
@@ -45,9 +42,9 @@ export default {
             type: String,
             required: true
         },
-        linkDisabled: {
+        isLogoDisabled: {
             type: Boolean,
-            default: false
+            required: true
         },
         logoGtmLabel: {
             type: String,
@@ -77,6 +74,9 @@ export default {
             const isTransparent = this.headerBackgroundTheme === 'transparent';
 
             return isHighlight || (isTransparent && !this.isOpen);
+        },
+        wrapperComponent () {
+            return this.isLogoDisabled ? 'span' : 'a';
         }
     }
 };
@@ -104,10 +104,6 @@ export default {
             @include theme(ml) {
                 padding-top: 16px;
             }
-        }
-
-        &.disabled {
-            pointer-events: none;
         }
     }
 

--- a/packages/components/organisms/f-header/src/components/_tests/Logo.test.js
+++ b/packages/components/organisms/f-header/src/components/_tests/Logo.test.js
@@ -44,6 +44,31 @@ describe('Logo', () => {
         expect(logo).toBeDefined();
     });
 
+    it('should disable the logo link if linkDisabled prop is provided', () => {
+        const $style = {
+            disabled: 'disabled'
+        };
+        // Arrange
+        const propsData = {
+            theme: 'je',
+            companyName: 'Just Eat',
+            linkDisabled: true
+        };
+
+        // Act
+        const wrapper = shallowMount(Logo, {
+            propsData,
+            mocks: {
+                $style
+            }
+        });
+
+        const logo = wrapper.find('a');
+
+        // Assert
+        expect(logo.classes()).toContain('disabled');
+    });
+
     describe('header logo :: ', () => {
         const $style = {
             'c-logo-img--alt': 'c-logo-img--alt'

--- a/packages/components/organisms/f-header/src/components/_tests/Logo.test.js
+++ b/packages/components/organisms/f-header/src/components/_tests/Logo.test.js
@@ -6,7 +6,8 @@ describe('Logo', () => {
         const propsData = {
             theme: 'je',
             headerBackgroundTheme: 'transparent',
-            companyName: 'Just Eat'
+            companyName: 'Just Eat',
+            isLogoDisabled: false
         };
         const wrapper = shallowMount(Logo, { propsData });
         expect(wrapper.exists()).toBe(true);
@@ -17,7 +18,8 @@ describe('Logo', () => {
         const propsData = {
             theme: 'ml',
             headerBackgroundTheme: 'transparent',
-            companyName: 'MenuLog'
+            companyName: 'MenuLog',
+            isLogoDisabled: false
         };
 
         // Act
@@ -33,7 +35,8 @@ describe('Logo', () => {
         const propsData = {
             theme: 'je',
             headerBackgroundTheme: 'transparent',
-            companyName: 'Just Eat'
+            companyName: 'Just Eat',
+            isLogoDisabled: false
         };
 
         // Act
@@ -42,6 +45,32 @@ describe('Logo', () => {
 
         // Assert
         expect(logo).toBeDefined();
+    });
+
+    it('should render an anchor tag around the logo if isLogoDisabled is false', () => {
+        const $style = {
+            disabled: 'disabled'
+        };
+        // Arrange
+        const propsData = {
+            theme: 'je',
+            companyName: 'Just Eat',
+            isLogoDisabled: false
+        };
+
+        // Act
+        const wrapper = shallowMount(Logo, {
+            propsData,
+            mocks: {
+                $style
+            }
+        });
+
+        const disabledLogo = wrapper.find('[data-test-id="wrapper-element"]');
+
+        // Assert
+        expect(disabledLogo.exists()).toBe(true);
+        expect(disabledLogo.element.tagName).toBe('A');
     });
 
     it('should change the logo link to a span if linkDisabled prop is provided', () => {
@@ -63,10 +92,11 @@ describe('Logo', () => {
             }
         });
 
-        const logo = wrapper.find('span');
+        const disabledLogo = wrapper.find('[data-test-id="disabled-wrapper-element"]');
 
         // Assert
-        expect(logo.exists()).toBe(true);
+        expect(disabledLogo.exists()).toBe(true);
+        expect(disabledLogo.element.tagName).toBe('SPAN');
     });
 
     describe('header logo :: ', () => {
@@ -82,7 +112,8 @@ describe('Logo', () => {
             const propsData = {
                 theme: 'je',
                 headerBackgroundTheme: theme,
-                companyName: 'Just Eat'
+                companyName: 'Just Eat',
+                isLogoDisabled: false
             };
 
             // Act
@@ -106,7 +137,8 @@ describe('Logo', () => {
             const propsData = {
                 theme: 'je',
                 headerBackgroundTheme: theme,
-                companyName: 'Just Eat'
+                companyName: 'Just Eat',
+                isLogoDisabled: false
             };
 
             // Act

--- a/packages/components/organisms/f-header/src/components/_tests/Logo.test.js
+++ b/packages/components/organisms/f-header/src/components/_tests/Logo.test.js
@@ -44,7 +44,7 @@ describe('Logo', () => {
         expect(logo).toBeDefined();
     });
 
-    it('should disable the logo link if linkDisabled prop is provided', () => {
+    it('should change the logo link to a span if linkDisabled prop is provided', () => {
         const $style = {
             disabled: 'disabled'
         };
@@ -52,7 +52,7 @@ describe('Logo', () => {
         const propsData = {
             theme: 'je',
             companyName: 'Just Eat',
-            linkDisabled: true
+            isLogoDisabled: true
         };
 
         // Act
@@ -63,10 +63,10 @@ describe('Logo', () => {
             }
         });
 
-        const logo = wrapper.find('a');
+        const logo = wrapper.find('span');
 
         // Assert
-        expect(logo.classes()).toContain('disabled');
+        expect(logo.exists()).toBe(true);
     });
 
     describe('header logo :: ', () => {

--- a/packages/components/organisms/f-header/stories/header.stories.js
+++ b/packages/components/organisms/f-header/stories/header.stories.js
@@ -61,7 +61,7 @@ export const HeaderComponent = () => ({
             :showOffersLink="showOffersLink"
             :showHelpLink="showHelpLink"
             :locale="locale"
-            :logoLinkDisabled="logoLinkDisabled"
+            :isLogoLinkDisabled="logoLinkDisabled"
             :headerBackgroundTheme="headerBackgroundTheme"
             :showDeliveryEnquiry="showDeliveryEnquiry"
             :showLoginInfo="showLoginInfo"

--- a/packages/components/organisms/f-header/stories/header.stories.js
+++ b/packages/components/organisms/f-header/stories/header.stories.js
@@ -1,8 +1,8 @@
 import {
     withKnobs, boolean, select, object
 } from '@storybook/addon-knobs';
-import VueHeader from '../src/components/Header.vue';
 import { withA11y } from '@storybook/addon-a11y';
+import VueHeader from '../src/components/Header.vue';
 
 const userInfo = {
     friendlyName: 'John',
@@ -26,6 +26,9 @@ export const HeaderComponent = () => ({
     props: {
         locale: {
             default: select('Locale', ['en-GB', 'en-AU', 'da-DK', 'en-IE', 'en-NZ', 'es-ES', 'it-IT', 'nb-NO'])
+        },
+        logoLinkDisabled: {
+            default: boolean('Disable logo link', false)
         },
         showOffersLink: {
             default: boolean('Show offers link', false)
@@ -58,6 +61,7 @@ export const HeaderComponent = () => ({
             :showOffersLink="showOffersLink"
             :showHelpLink="showHelpLink"
             :locale="locale"
+            :logoLinkDisabled="logoLinkDisabled"
             :headerBackgroundTheme="headerBackgroundTheme"
             :showDeliveryEnquiry="showDeliveryEnquiry"
             :showLoginInfo="showLoginInfo"


### PR DESCRIPTION
### Added
- Ability to disable Just Eat logo navigation

This is an addition I thought was best accompanied by an explanation, but not sure if I should be mentioning new unreleased features in an open forum on Github?

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [x] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
