### PR TITLE
f-checkout@v0.107.0 - (d) - Update f-button version

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -6,14 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.107.0
 ------------------------------
-*May 11, 2021*
+*May 12, 2021*
 
 ### Changed
 - `f-button` version to fix focus state on tab.
 
 
-*May 11, 2021*
+Latest – to be added to the next release
+------------------------------
 
+*May 11, 2021*
 ### Fixed
 - `Resturant` to `Restaurant` typo in `en-GB.js` copy text.
 

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,8 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-Latest – to be added to the next release
+
+v0.107.0
 ------------------------------
+*May 11, 2021*
+
+### Changed
+- `f-button` version to fix focus state on tab.
+
+
 *May 11, 2021*
 
 ### Fixed

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -14,7 +14,6 @@ v0.107.0
 
 Latest – to be added to the next release
 ------------------------------
-
 *May 11, 2021*
 ### Fixed
 - `Resturant` to `Restaurant` typo in `en-GB.js` copy text.

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.104.0",
+  "version": "0.107.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.12.13",
     "@justeat/f-alert": "0.5.0",
-    "@justeat/f-button": "0.5.0",
+    "@justeat/f-button": "1.2.0",
     "@justeat/f-card": "0.8.0",
     "@justeat/f-error-message": "0.3.1",
     "@justeat/f-form-field": "1.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2124,11 +2124,6 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-0.4.1.tgz#6b735093286422f579bd41cee93400a4d32d1b2d"
   integrity sha512-SL7eTooEY3gZ0DdpPJvsN9W9EZElgxkSEpjYPfiPBHbkGt31Yfnb8OmDmC6MAtlK3Nq5GM5KaZ7bXybljSlPeA==
 
-"@justeat/f-button@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-0.5.0.tgz#3a2b680b6729c6af8107dbf0a8a35fcf0b51c392"
-  integrity sha512-UTTgcb5IbHIn0k89aO2o4XGu+bFzFKoOAQTTdm63Ew4sgZ0uVQvS+c5A5HsLlmoo5l0iCDyNRCysti1POLUdqg==
-
 "@justeat/f-button@0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-0.7.0.tgz#cb4afe9e8773385e5ad84b50f51de90a8020ce69"


### PR DESCRIPTION
### Changed
- `f-button` version to fix focus state on tab.
 
![image](https://user-images.githubusercontent.com/24740015/117946844-915f0a80-b307-11eb-8b27-06a88bf31b70.png)
