### PR TITLE
f-http@v0.4.1 - Return status code

### DIFF
--- a/packages/services/f-http/CHANGELOG.md
+++ b/packages/services/f-http/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.4.1
+------------------------------
+*May 11, 2021*
+
+### Changed
+- Return entire response, not just response body; to support PACT tests further down the stack
+
+
 v0.4.0
 ------------------------------
 *May 6, 2021*

--- a/packages/services/f-http/CHANGELOG.md
+++ b/packages/services/f-http/CHANGELOG.md
@@ -8,7 +8,7 @@ v0.4.1
 *May 11, 2021*
 
 ### Changed
-- Return entire response, not just response body; to support PACT tests further down the stack
+- Return status code to support PACT tests further down the stack
 
 
 v0.4.0

--- a/packages/services/f-http/package.json
+++ b/packages/services/f-http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-http",
   "description": "Javascript HTTP client for interacting with restful services",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "src/index.js",
   "files": [
     "src"

--- a/packages/services/f-http/src/requestDispatcher.js
+++ b/packages/services/f-http/src/requestDispatcher.js
@@ -15,7 +15,10 @@ const sendRequest = async (method, resource, headers = {}) => {
     try {
         const response = await _axiosInstance[method.toLowerCase()](resource, configBuilder(headers));
 
-        return response.data;
+        return {
+            statusCode: response.status,
+            data: response.data
+        };
     } catch (error) {
         return handleError(error, _configuration.errorCallback);
     }
@@ -33,7 +36,10 @@ const sendRequestWithBody = async (method, resource, body, headers = {}) => {
     try {
         const response = await _axiosInstance[method.toLowerCase()](resource, body, configBuilder(headers));
 
-        return response.data;
+        return {
+            statusCode: response.status,
+            data: response.data
+        };
     } catch (error) {
         return handleError(error, _configuration.errorCallback);
     }


### PR DESCRIPTION
- Some systems are using `PACT` testing and directly asserting on status codes. I wasn't exposing this, so I am now exposing it.
- I didn't return the full response object as I wanted to avoid the lock in with Axios, so if we need more bits later; we can add the bits we need - for now this resolves the use case.

v0.4.1
------------------------------
*May 11, 2021*

### Changed
- Return status code to support PACT tests further down the stack