### PR TITLE
storybook@0.33.0 - make a check for common.scss only inside the repo

### DIFF
--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.33.0
+------------------------------
+*May 12, 2021*
+
+### Changed
+- Limited the check for common.scss files to be only inside the repo
+
+
 v0.32.0
 ------------------------------
 *May 5, 2021*

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "scripts": {
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -s public -p 8080 -c config/storybook",

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -20,8 +20,9 @@ module.exports = {
                  * @param resourcePath
                  * @returns {string}
                  */
-                additionalData (content, { resourcePath }) {
-                    const levelsUpToSrc = resourcePath.split(path.sep).reverse().indexOf('src');
+                additionalData (content, { resourcePath, rootContext }) {
+                    const relativePath = path.relative(rootContext, resourcePath);
+                    const levelsUpToSrc = relativePath.split(path.sep).reverse().indexOf('src');
 
                     // Only attempt to add common styles when under a src dir
                     if (levelsUpToSrc === -1) {


### PR DESCRIPTION
At the moment because of the way we compile styles in `fozzie-components/packages/storybook/vue.config.js` storybook fails to serve/build if fozzie-components repo lives under src folder. This change will make the check to be only from inside the repo