### PR TITLE
f-checkout@v0.108.0 Fix error when address lines are null

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.108.0
+------------------------------
+*May 13, 2021*
+
+### Fixed
+- Error when Checkout endpoint returns address with lines set to `null`
+
+
 v0.107.0
 ------------------------------
 *May 12, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.107.0",
+  "version": "0.108.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/demo/checkout-collection.json
+++ b/packages/components/organisms/f-checkout/src/demo/checkout-collection.json
@@ -12,6 +12,15 @@
     "time": {
       "from": "2020-01-01T00:00+00:00",
       "to": "2020-01-01T00:00+00:00"
+    },
+    "location": {
+      "address": {
+        "lines": null,
+        "locality": null,
+        "administrativeArea": null,
+        "postalCode": null
+      },
+      "geolocation": null
     }
   },
   "isFulfillable": true,

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -415,7 +415,7 @@ export default {
 
             state.time = fulfilment.time;
 
-            if (fulfilment.location && fulfilment.location.address) {
+            if (fulfilment.location && fulfilment.location.address && fulfilment.location.address.lines) {
                 const { address } = fulfilment.location;
                 /* eslint-disable prefer-destructuring */
                 state.address.line1 = address.lines[0];

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -192,6 +192,25 @@ describe('CheckoutModule', () => {
                 // Assert
                 expect(state.address).toEqual(defaultState.address);
             });
+
+            it('should leave address state empty if location data is returned with empty address fields from the API.', () => {
+                // Arrange
+                checkoutDelivery.fulfilment.location = {
+                    address: {
+                        lines: null,
+                        locality: null,
+                        administrativeArea: null,
+                        postalCode: null
+                    },
+                    geolocation: null
+                };
+
+                // Act
+                mutations[UPDATE_STATE](state, checkoutDelivery);
+
+                // Assert
+                expect(state.address).toEqual(defaultState.address);
+            });
         });
 
         describe(`${UPDATE_AUTH} ::`, () => {


### PR DESCRIPTION
When Checkout endpoint returns address, the lines field is set to null. This fixes a null reference error.

---

## UI Review Checks
No UI changes

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
