### PR TITLE
f-checkout@0.113.0 - Fix alert and T&Cs layout in mobile view

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.108.0
+v0.112.0
 ------------------------------
 *May 12, 2021*
 

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.112.0
+------------------------------
+*May 12, 2021*
+
+### Fixed
+- mobile view for alert and t&Cs box.
+
+
 v0.109.0
 ------------------------------
 *May 13, 2021*
@@ -10,14 +18,6 @@ v0.109.0
 ### Added
 - `aria-describedby` and `aria-invalid` for all input fields - for reading error messages
 - hidden `error-summary-section` in checkout to alert errors after submit button (resembles f-registration)
-
-
-v0.112.0
-------------------------------
-*May 12, 2021*
-
-### Fixed
-- mobile view for alert and t&Cs box.
 
 
 v0.108.0

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.108.0
+------------------------------
+*May 12, 2021*
+
+### Fixed
+- mobile view for alert and t&Cs box.
+
+
 v0.107.0
 ------------------------------
 *May 12, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.107.0",
+  "version": "0.108.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.108.0",
+  "version": "0.112.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -924,9 +924,7 @@ export default {
     margin-right: auto;
 
     @include media('<=narrow') {
-        width: Calc(
-            $checkout-width - 120px
-        ); // Matches the padding and margin of `f-card`
+        width: calc(100% - #{spacing(x5)}); // Matches the margin of `f-card`
     }
 }
 /* If these stay the same then just rename the class to something more generic */

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -908,8 +908,9 @@ export default {
     @include media('<=narrow') {
         border: none;
         padding-top: spacing(x3);
-        padding-bottom: spacing(x5);
+        padding-bottom: 0;
         margin-top: 0;
+        margin-bottom: 0;
     }
 }
 
@@ -921,6 +922,12 @@ export default {
     width: $checkout-width;
     margin-left: auto;
     margin-right: auto;
+
+    @include media('<=narrow') {
+        width: Calc(
+            $checkout-width - 120px
+        ); // Matches the padding and margin of `f-card`
+    }
 }
 /* If these stay the same then just rename the class to something more generic */
 .c-checkout-submitButton {

--- a/packages/components/organisms/f-checkout/src/components/TermsAndConditions.vue
+++ b/packages/components/organisms/f-checkout/src/components/TermsAndConditions.vue
@@ -1,14 +1,15 @@
 <template>
     <div
         data-test-id="checkout-terms-and-conditions-component"
-        :class="$style['c-checkoutTermsAndConditions']">
-        <i18n
-            path="checkoutTermsAndConditions">
+        :class="$style['c-checkoutTermsAndConditions']"
+    >
+        <i18n path="checkoutTermsAndConditions">
             <template #termsAndConditions>
                 <a
                     class="o-link--bold"
                     :href="$t('termsAndConditionsLinkUrl')"
-                    target="_blank">
+                    target="_blank"
+                >
                     <span>{{ $t('termsAndConditionsLinkText') }}</span>
                 </a>
             </template>
@@ -16,7 +17,8 @@
                 <a
                     class="o-link--bold"
                     :href="$t('privacyPolicyLinkUrl')"
-                    target="_blank">
+                    target="_blank"
+                >
                     <span>{{ $t('privacyPolicyLinkText') }}</span>
                 </a>
             </template>
@@ -24,7 +26,8 @@
                 <a
                     class="o-link--bold"
                     :href="$t('cookiePolicyLinkUrl')"
-                    target="_blank">
+                    target="_blank"
+                >
                     <span>{{ $t('cookiePolicyLinkText') }}</span>
                 </a>
             </template>
@@ -52,7 +55,7 @@
 
     @include media('<narrow') {
         width: 100vw;
-        margin-left: -(spacing(x5));
+        margin-left: -(spacing(x5)); // removes the margin of f-card
         padding: spacing(x2) spacing(x5);
     }
 }

--- a/packages/components/organisms/f-checkout/src/components/TermsAndConditions.vue
+++ b/packages/components/organisms/f-checkout/src/components/TermsAndConditions.vue
@@ -49,5 +49,11 @@
     a {
         margin-right: none;
     }
+
+    @include media('<narrow') {
+        width: 100vw;
+        margin-left: -(spacing(x5));
+        padding: spacing(x2) spacing(x5);
+    }
 }
 </style>

--- a/packages/components/organisms/f-checkout/src/components/TermsAndConditions.vue
+++ b/packages/components/organisms/f-checkout/src/components/TermsAndConditions.vue
@@ -1,15 +1,14 @@
 <template>
     <div
         data-test-id="checkout-terms-and-conditions-component"
-        :class="$style['c-checkoutTermsAndConditions']"
-    >
-        <i18n path="checkoutTermsAndConditions">
+        :class="$style['c-checkoutTermsAndConditions']">
+        <i18n
+            path="checkoutTermsAndConditions">
             <template #termsAndConditions>
                 <a
                     class="o-link--bold"
                     :href="$t('termsAndConditionsLinkUrl')"
-                    target="_blank"
-                >
+                    target="_blank">
                     <span>{{ $t('termsAndConditionsLinkText') }}</span>
                 </a>
             </template>
@@ -17,8 +16,7 @@
                 <a
                     class="o-link--bold"
                     :href="$t('privacyPolicyLinkUrl')"
-                    target="_blank"
-                >
+                    target="_blank">
                     <span>{{ $t('privacyPolicyLinkText') }}</span>
                 </a>
             </template>
@@ -26,8 +24,7 @@
                 <a
                     class="o-link--bold"
                     :href="$t('cookiePolicyLinkUrl')"
-                    target="_blank"
-                >
+                    target="_blank">
                     <span>{{ $t('cookiePolicyLinkText') }}</span>
                 </a>
             </template>

--- a/packages/storybook/config/storybook/main.js
+++ b/packages/storybook/config/storybook/main.js
@@ -1,7 +1,8 @@
 module.exports = {
     stories: [
-        '../../../**/*.stories.@(js|mdx)',
-        '../../../../stories/**/*.stories.@(js|mdx)'
+        // '../../../**/*.stories.@(js|mdx)',
+        // '../../../../stories/**/*.stories.@(js|mdx)'
+        '../../../components/organisms/f-checkout/stories/Checkout.stories'
     ],
     addons: [
         '@storybook/addon-essentials',

--- a/packages/storybook/config/storybook/main.js
+++ b/packages/storybook/config/storybook/main.js
@@ -1,8 +1,7 @@
 module.exports = {
     stories: [
-        // '../../../**/*.stories.@(js|mdx)',
-        // '../../../../stories/**/*.stories.@(js|mdx)'
-        '../../../components/organisms/f-checkout/stories/Checkout.stories'
+        '../../../**/*.stories.@(js|mdx)',
+        '../../../../stories/**/*.stories.@(js|mdx)'
     ],
     addons: [
         '@storybook/addon-essentials',


### PR DESCRIPTION
### Fixed
- mobile view for alert and t&Cs box.

Alert
![image](https://user-images.githubusercontent.com/24740015/118113838-b3778c00-b3de-11eb-81d5-c767dcda58a0.png)

T&C
![image](https://user-images.githubusercontent.com/24740015/118113865-bbcfc700-b3de-11eb-8e4f-19acb169af9b.png)
