### PR TITLE
f-checkout@v0.111.0 Fix fulfilment times drop down not populating on startup 

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.111.0
+------------------------------
+*May 13, 2021*
+
+### Fixed
+- Fulfilment Times drop down not populating on startup
+
+
 v0.110.0
 ------------------------------
 *May 13, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.110.0",
+  "version": "0.111.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Selector.vue
+++ b/packages/components/organisms/f-checkout/src/components/Selector.vue
@@ -6,6 +6,7 @@
         input-type="dropdown"
         :label-text="orderMethod"
         :dropdown-options="fulfilmentTimes"
+        :value="selectedAvailableFulfilmentTime"
         @input="selectionChanged">
         <template #error>
             <alert
@@ -131,6 +132,8 @@ export default {
                     from: times[0].value,
                     to: times[0].value
                 });
+
+                this.selectedAvailableFulfilmentTime = times[0].value;
             }
         },
 

--- a/packages/components/organisms/f-checkout/src/components/_tests/Selector.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Selector.test.js
@@ -290,6 +290,20 @@ describe('Selector', () => {
                             to: '2020-01-01T01:00:00.000Z'
                         });
                     });
+
+                    it('should update `selectedAvailableFulfilmentTime` with the `from` & `to` values', () => {
+                        // Arrange
+                        const times = [{
+                            text: 'Wednesday 01:00',
+                            value: '2020-01-01T01:00:00.000Z'
+                        }];
+
+                        // Act
+                        wrapper.vm.initFulfilmentTime(times);
+
+                        // Assert
+                        expect(wrapper.vm.selectedAvailableFulfilmentTime).toEqual(times[0].value);
+                    });
                 });
             });
         });


### PR DESCRIPTION
Fix fulfilment times drop down not populating on startup 

---

## UI Review Checks
No UI changes

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
