### PR TITLE
f-checkout@v0.114.0 - fixed error modal so that the title and the close button don't overlap 

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.114.0
+------------------------------
+*May 17, 2021*
+
+### Fixed
+- Error modal spacing so that the title and the close button don't overlap
+
+### Changed
+- Updated `f-mega-modal` version
+
+
 v0.113.0
 ------------------------------
 *May 12, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.113.0",
+  "version": "0.114.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",
@@ -65,7 +65,7 @@
     "@justeat/f-card": "0.8.0",
     "@justeat/f-error-message": "0.3.1",
     "@justeat/f-form-field": "1.11.0",
-    "@justeat/f-mega-modal": "0.6.0",
+    "@justeat/f-mega-modal": "0.8.0",
     "@justeat/f-wdio-utils": "0.1.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-checkout/src/components/ErrorDialog.vue
+++ b/packages/components/organisms/f-checkout/src/components/ErrorDialog.vue
@@ -7,7 +7,7 @@
     >
         <h3
             data-test-id="checkout-issue-modal-title"
-            class="u-noSpacing"
+            :class="$style['c-checkout-errorTitle']"
         >
             {{ $t(`errorMessages.checkoutIssues.${errorCode}.title`, { serviceType: serviceTypeText }) }}
         </h3>
@@ -90,6 +90,10 @@ export default {
 </script>
 
 <style lang="scss" module>
+.c-checkout-errorTitle {
+    margin: 0 spacing(x3);
+}
+
 .c-checkout-redirectButton {
     margin: spacing(x4) 0 spacing(x0.5);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2236,11 +2236,6 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.3.0.tgz#58a88476ee204264988640b3cd47ac5d295bde4a"
   integrity sha512-Cr6CDlrZAHoM3ZUJ2sOMLYAVYz+cka5R6THi24va3mhI8kgOSA4ZVzvx607QskTyasIX4xNfrju0HKity1Lq9w==
 
-"@justeat/f-mega-modal@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.6.0.tgz#2933f1744b1fbde9636a366df73c1626f9cd2a83"
-  integrity sha512-l94zXHEDgXhUq98DJJb6UK7fJfr2xZ7r3CgxcSnFUjBCYPi+tpxQUuO9wcoFPBTVM9HSrVIFJ2dNm/u0A+bOzg==
-
 "@justeat/f-mega-modal@0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.7.0.tgz#e7f4aedfbaa614386f7fe5a180111e884c7db694"


### PR DESCRIPTION
### Fixed
- Error modal spacing so that the title and the close button don't overlap

### Changed
- Updated `f-mega-modal` version

Before:

<img width="449" alt="Screenshot 2021-05-17 at 13 46 22" src="https://user-images.githubusercontent.com/3179649/118490863-54838100-b716-11eb-83f2-041a98651cc8.png">

After:

<img width="461" alt="Screenshot 2021-05-17 at 13 46 11" src="https://user-images.githubusercontent.com/3179649/118490884-5a796200-b716-11eb-82ca-f4c5abfcbb5a.png">

