### PR TITLE
f-form-field@1.12.1 - added back missed css class to the textarea element

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.12.1
+------------------------------
+*May 18, 2021*
+
+### Added
+- Added back missed css class to the textarea element
+
+
 v1.12.0
 ------------------------------
 *May 17, 2021*

--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -10,6 +10,7 @@ v1.12.1
 
 ### Added
 - Added back missed css class to the textarea element
+- Wrapped input description slot into a p html element
 
 
 v1.12.0

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -44,7 +44,8 @@
                 v-bind="$attrs"
                 :class="[
                     $style['c-formField-field'],
-                    $style['c-formField-field--focus']
+                    $style['c-formField-field--focus'],
+                    $style['c-formField-field--textarea']
                 ]"
                 data-test-id="formfield-textarea"
                 v-on="listeners" />
@@ -335,7 +336,7 @@ $form-input-focus--boxShadow              : 0 0 0 2px $form-input-focus;
         }
     }
 
-    .c-formField-textarea {
+    .c-formField-field--textarea {
         background-clip: padding-box;
         padding: spacing(x2);
         resize: none;

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -19,7 +19,11 @@
                 {{ labelText }}
             </form-label>
 
-            <slot v-if="hasInputDescription" />
+            <p
+                v-if="hasInputDescription"
+                class="u-spacingTop u-spacingBottom--large">
+                <slot />
+            </p>
 
             <form-dropdown
                 v-if="isDropdown"

--- a/packages/components/atoms/f-form-field/stories/FormField.stories.js
+++ b/packages/components/atoms/f-form-field/stories/FormField.stories.js
@@ -57,9 +57,7 @@ export const FormFieldComponent = () => ({
             :rows="7"
             :maxlength="200"
             :has-input-description="hasInputDescription">
-            <div>
                 Here is a bit more text to show
-            </div>
         </form-field>`
 });
 


### PR DESCRIPTION
### Added
- Added back missed css class to the textarea element
- Wrapped input description slot into a p html element