### PR TITLE
Update documentation for generator component + fix component object #trivial

### DIFF
--- a/packages/tools/generator-component/CHANGELOG.md
+++ b/packages/tools/generator-component/CHANGELOG.md
@@ -3,6 +3,19 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.2.1
+------------------------------
+*May 18, 2021*
+
+### Fixed
+- Issue with `open` function in component object.
+
+### Removed
+- Incorrect documentation
+
+### Removed
+- DA and NO tenants.
+
 v2.2.0
 ------------------------------
 *March 14, 2021*

--- a/packages/tools/generator-component/generators/app/templates/README.md
+++ b/packages/tools/generator-component/generators/app/templates/README.md
@@ -97,34 +97,30 @@ $ cd <%= componentFolder %>f-<%= name.default %>
 
 ## Testing
 
-### Unit, Integration and Contract
-
 To test all components, run from root directory.
 To test only `f-<%= name.default %>`, run from the `./fozzie-components/<%= componentFolder %>f-<%= name.default %>` directory.
+
+### Unit and Integration tests
 
 ```sh
 yarn test
 ```
 
-### Component Tests
+### Component and Accessibility Tests
 
 ```bash
-# Run Component tests for all components
-# Note: Ensure Storybook is not running when running the following commands
+# Note: Ensure Storybook is running when running the following commands
 cd ./fozzie-components
 
 yarn storybook:build
 yarn storybook:serve-static
-yarn test-component:chrome
 ```
 
-OR
-
-```bash
-# Run Component tests for f-<%= name.default %>
-# Note: Ensure Storybook is not running when running the following commands
-cd ./fozzie-components/<%= componentFolder %>f-<%= name.default %>
 yarn test-component:chrome
+```
+### Accessibility tests
+```bash
+yarn test-a11y:chrome
 ```
 ## Documentation to be completed once module is in stable state.
 

--- a/packages/tools/generator-component/generators/app/templates/test-utils/component-objects/f-skeleton.component.js
+++ b/packages/tools/generator-component/generators/app/templates/test-utils/component-objects/f-skeleton.component.js
@@ -6,7 +6,7 @@ module.exports = class <%= name.filename %> extends Page {
     get component () { return $(COMPONENT); }
 
     open () {
-        super.openComponent('<%= storybook.componentCategory.toLowerCase().replace('s','') %>', '<%= name.class %>-component');
+        super.openComponent('<%= storybook.componentCategory.toLowerCase().slice(0, -1) %>', '<%= name.class %>-component');
     }
 
     waitForComponent () {

--- a/packages/tools/generator-component/package.json
+++ b/packages/tools/generator-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/generator-component",
   "description": "Generator Component – A generator for Fozzie components",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "files": [
     "generators"
   ],


### PR DESCRIPTION
- Removes old documentation
- Fixes bug in the generated component object that was causing component / a11y tests to fail