### PR TITLE
f-checkout@v0.115.0 Decrease user notes fonts

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.115.0
+------------------------------
+*May 18, 2021*
+
+### Fixed
+- User notes label and description font size decreased
+
+
 v0.114.0
 ------------------------------
 *May 17, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/UserNote.vue
+++ b/packages/components/organisms/f-checkout/src/components/UserNote.vue
@@ -43,7 +43,7 @@ $userNote-textArea-height                        : 188px;
 
 .c-userNote {
     margin-top: spacing(x3);
-    @include font-size(body-l);
+    @include font-size(body-s);
     color: $userNote-textColour;
 
     .c-userNote-title {
@@ -61,6 +61,7 @@ $userNote-textArea-height                        : 188px;
         padding: spacing() spacing(x2);
         margin-top: spacing(x2);
         font: inherit;
+        @include font-size(body-l);
         color: inherit;
         background-color: $userNote-textArea-bg;
         border: $userNote-textArea-borderWidth solid $userNote-textArea-borderColour;


### PR DESCRIPTION
Decrease font size of user notes label and description

---

## UI Review Checks
Before:
<img width="300" alt="before" src="https://user-images.githubusercontent.com/6950110/118652485-8cee9200-b7de-11eb-83c5-bef40727aaa4.png">

After:
<img width="300" alt="after" src="https://user-images.githubusercontent.com/6950110/118652498-8f50ec00-b7de-11eb-97d8-1751df52fc2f.png">

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
