### PR TITLE
f-link@v0.2.0 - Add props and styles

### DIFF
--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.2.0
 ------------------------------
-*May 19, 2021*
+*May 20, 2021*
 
 ### Added
-- Props `isExternalLink` and `opensInNewLocation` to set `target`, `rel`, and `arialLabel`.
-- Props `isBold`, `isFullWidth` and `hadTextDecoration` to toggle link style.
+- Props `isExternalLink` and `opensInNewLocation` to set `target`, `rel`, and `ariaLabel`.
+- Props `isBold`, `isFullWidth` and `hasTextDecoration` to toggle link style.
 - Tests to cover changes.
 
 

--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.2.0
 ------------------------------
-*May 20, 2021*
+*May 21, 2021*
 
 ### Added
 - Props `isExternalLink` and `opensInNewLocation` to set `target`, `rel`, and `ariaLabel`.

--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.2.0
 ------------------------------
-*May 21, 2021*
+*May 24, 2021*
 
 ### Added
-- Props `isExternalLink` and `opensInNewLocation` to set `target`, `rel`, and `ariaLabel`.
-- Props `isBold`, `isFullWidth` and `hasTextDecoration` to toggle link style.
+- Props `isExternalLink` and `opensInNewLocation` to set `target`, `rel`, and `ariaDescription`.
+- Props `isBold`, `isFullWidth`, `noLineBreak` and `hasTextDecoration` to toggle link style.
 - Tests to cover changes.
 
 

--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -9,7 +9,6 @@ v0.2.0
 *May 19, 2021*
 
 ### Added
-- Props to set `linkText` and `url`.
 - Props `isExternalLink` and `opensInNewLocation` to set `target`, `rel`, and `arialLabel`.
 - Props `isBold`, `isFullWidth` and `hadTextDecoration` to toggle link style.
 - Tests to cover changes.

--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.2.0
+------------------------------
+*May 19, 2021*
+
+### Added
+- Props to set `linkText` and `url`.
+- Props `isExternalLink` and `opensInNewLocation` to set `target`, `rel`, and `arialLabel`.
+- Props `isBold`, `isFullWidth` and `hadTextDecoration` to toggle link style.
+- Tests to cover changes.
+
+
 v0.1.0
 ------------------------------
 *May 14, 2021*

--- a/packages/components/atoms/f-link/package.json
+++ b/packages/components/atoms/f-link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-link",
   "description": "Fozzie Link - Fozzie link component",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/f-link.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-link/package.json
+++ b/packages/components/atoms/f-link/package.json
@@ -5,7 +5,7 @@
   "main": "dist/f-link.umd.min.js",
   "files": [
     "dist",
-    "test-utils" 
+    "test-utils"
   ],
   "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/components/atoms/f-link",
   "contributors": [
@@ -33,12 +33,13 @@
     "lint:style": "vue-cli-service lint:style",
     "test": "vue-cli-service test:unit",
     "test-component:chrome": "cross-env-shell JE_ENV=local TEST_TYPE=component wdio ../../../../wdio-chrome.conf.js",
-    "test-a11y:chrome": "cross-env-shell JE_ENV=local TEST_TYPE=a11y wdio ../../../../wdio-chrome.conf.js --suite a11y" 
+    "test-a11y:chrome": "cross-env-shell JE_ENV=local TEST_TYPE=a11y wdio ../../../../wdio-chrome.conf.js --suite a11y"
   },
   "browserslist": [
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
+    "@justeat/f-globalisation": "1.0.0",
     "@justeat/f-services": "1.7.0"
   },
   "peerDependencies": {

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -6,7 +6,7 @@
             { [$style['o-link--noDecoration']]: !hasTextDecoration },
             { [$style['o-link--full']]: isFullWidth }
         ]"
-        :data-test-id="`${linkText} link`"
+        :data-test-id="dataTestId"
         :href="url"
         :target="target"
         :aria-label="ariaLabel"
@@ -27,6 +27,11 @@ export default {
         locale: {
             type: String,
             default: 'en-GB'
+        },
+
+        dataTestId: {
+            type: String,
+            required: true
         },
 
         linkText: {

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -17,9 +17,9 @@
             <slot />
         </a>
         <span
+            v-if="ariaDescription"
             id=description
             class="is-visuallyHidden"
-            v-if="ariaDescription"
         >
             {{ ariaDescription }}
         </span>

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -84,7 +84,7 @@ export default {
             const locationType = this.isExternalLink ? 'opensExternalSiteInNew' : 'openInNew';
             const type = this.target === DEFAULT_LINK_TARGET ? 'opensExternal' : locationType;
 
-            return this.linkText + " - " + this.$t(`ariaDescribedBy['${type}']`) || null;
+            return `${this.linkText} - ${this.$t(`ariaDescribedBy['${type}']`)}` || null;
         }
     }
 };

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -7,23 +7,16 @@
             { [$style['o-link--full']]: isFullWidth }
         ]"
         data-test-id="link"
-        :href="linkHref"
+        :href="url"
         :target="target"
-        rel="noopener"
         :aria-label="ariaLabel"
-    >
-        {{ linkText }}
-    </a>
+        :rel="rel"
+    >{{ linkText }}</a>
 </template>
 
 <script>
-// import { globalisationServices } from '@justeat/f-services';
 import { VueGlobalisationMixin } from '@justeat/f-globalisation';
 import tenantConfigs from '../tenants';
-import {
-    DEFAULT_LINK_TARGET,
-    VALID_LINK_TARGETS
-} from '../constants';
 
 export default {
     name: 'VLink',
@@ -41,9 +34,19 @@ export default {
             required: true
         },
 
-        linkHref: {
+        url: {
             type: String,
             required: true
+        },
+
+        isExternalLink: {
+            type: Boolean,
+            default: false
+        },
+
+        opensInNew: {
+            type: Boolean,
+            default: false
         },
 
         isBold: {
@@ -59,17 +62,6 @@ export default {
         isFullWidth: {
             type: Boolean,
             default: false
-        },
-
-        target: {
-            type: String,
-            default: DEFAULT_LINK_TARGET,
-            validator: value => (VALID_LINK_TARGETS.indexOf(value) !== -1) // The prop value must match one of the valid link types
-        },
-
-        isExternalLink: {
-            type: Boolean,
-            default: false
         }
     },
 
@@ -81,10 +73,24 @@ export default {
 
     computed: {
         ariaLabel () {
-            const locationType = this.isExternalLink ? 'opensExternalSiteInNew' : 'openInNew';
-            const type = this.target === DEFAULT_LINK_TARGET ? 'opensExternal' : locationType;
+            let message = this.$t('ariaLabel.prefix');
 
-            return `${this.linkText} - ${this.$t(`ariaDescribedBy['${type}']`)}` || null;
+            if (this.isExternalLink) {
+                message += this.$t('ariaLabel.externalSite');
+            }
+            if (this.opensInNew) {
+                message += this.$t('ariaLabel.newLocation');
+            }
+
+            return message === this.$t('ariaLabel.prefix') ? this.linkText : this.linkText + message;
+        },
+
+        target () {
+            return this.isExternalLink ? '_blank' : null;
+        },
+
+        rel () {
+            return this.opensInNew ? 'noopener' : null;
         }
     }
 };

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -1,13 +1,14 @@
 <template>
     <a
         :class="[
-            $style['o-link'],
-            { [$style['o-link--bold']]: isBold },
-            { [$style['o-link--noDecoration']]: !hasTextDecoration },
-            { [$style['o-link--full']]: isFullWidth }
-        ]"
-        :target="target"
+            $style['o-link'], {
+                [$style['o-link--bold']]: isBold,
+                [$style['o-link--noDecoration']]: !hasTextDecoration,
+                [$style['o-link--full']]: isFullWidth
+            }]"
+        :data-test-id="'link-component'"
         :aria-label="ariaLabel"
+        :target="target"
         :rel="rel"
         v-bind="$attrs"
     >{{ linkText }}</a>
@@ -27,12 +28,6 @@ export default {
             type: String,
             required: true
         },
-
-        url: {
-            type: String,
-            required: true
-        },
-
         isExternal: {
             type: Boolean,
             default: false

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -10,8 +10,9 @@
         :aria-label="ariaLabel"
         :target="target"
         :rel="rel"
-        v-bind="$attrs"
-    >{{ linkText }}</a>
+        v-bind="$attrs">
+        <slot />
+    </a>
 </template>
 
 <script>
@@ -24,10 +25,6 @@ export default {
     mixins: [VueGlobalisationMixin],
 
     props: {
-        linkText: {
-            type: String,
-            required: true
-        },
         isExternal: {
             type: Boolean,
             default: false
@@ -61,6 +58,10 @@ export default {
     },
 
     computed: {
+        linkText () {
+            return this.$slots.default[0].children[0].text.trim();
+        },
+
         ariaLabel () {
             let message;
 

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -9,7 +9,7 @@
                     [$style['o-link--noBreak']]: noLineBreak
                 }]"
             data-test-id="link-component"
-            aria-describedby="description"
+            :aria-describedby="descriptionId"
             :target="target"
             :rel="rel"
             v-bind="$attrs"
@@ -18,7 +18,7 @@
         </a>
         <span
             v-if="ariaDescription"
-            id=description
+            :id="descriptionId"
             class="is-visuallyHidden"
         >
             {{ ariaDescription }}
@@ -29,6 +29,8 @@
 <script>
 import { VueGlobalisationMixin } from '@justeat/f-globalisation';
 import tenantConfigs from '../tenants';
+
+let uid = 0;
 
 export default {
     name: 'VLink',
@@ -68,8 +70,11 @@ export default {
     },
 
     data () {
+        uid += 1;
+
         return {
-            tenantConfigs
+            tenantConfigs,
+            uid: `link-${uid}-description`
         };
     },
 
@@ -89,6 +94,10 @@ export default {
 
         rel () {
             return this.isExternal ? 'noopener' : null;
+        },
+
+        descriptionId () {
+            return this.ariaDescription ? this.uid : null;
         }
     }
 };

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -1,22 +1,35 @@
 <template>
     <a
-        :class="$style['o-link']"
+        :class="[
+            $style['o-link'],
+            { [$style['o-link--bold']]: isBold },
+            { [$style['o-link--noDecoration']]: !hasDecoration },
+            { [$style['o-link--full']]: isFullWidth }
+        ]"
         data-test-id="link"
         :href="linkHref"
+        :target="target"
         rel="noopener"
-        :aria-describedby="`copy.ariaDescribedBy['${linkType}']`"
+        :aria-describedby="ariaLabel"
     >
         {{ linkText }}
     </a>
 </template>
 
 <script>
-import { globalisationServices } from '@justeat/f-services';
+// import { globalisationServices } from '@justeat/f-services';
+import { VueGlobalisationMixin } from '@justeat/f-globalisation';
 import tenantConfigs from '../tenants';
+import {
+    DEFAULT_LINK_TARGET,
+    VALID_LINK_TARGETS
+} from '../constants';
 
 export default {
     name: 'VLink',
-    components: {},
+
+    mixins: [VueGlobalisationMixin],
+
     props: {
         locale: {
             type: String,
@@ -31,21 +44,56 @@ export default {
         linkHref: {
             type: String,
             required: true
+        },
+
+        isBold: {
+            type: Boolean,
+            default: false
+        },
+
+        hasDecoration: {
+            type: Boolean,
+            default: true
+        },
+
+        isFullWidth: {
+            type: Boolean,
+            default: false
+        },
+
+        target: {
+            type: String,
+            default: DEFAULT_LINK_TARGET,
+            validator: value => (VALID_LINK_TARGETS.indexOf(value) !== -1) // The prop value must match one of the valid link types
+        },
+
+        isExternalLink: {
+            type: Boolean,
+            default: false
         }
-
-        // linkType: {
-        //     type: String,
-        //     default: DEFAULT_LINK_TYPE,
-        //     validator: value => (VALID_LINK_STYLES.indexOf(value) !== -1) // The prop value must match one of the valid link types
-        // }
     },
-    data () {
-        const locale = globalisationServices.getLocale(tenantConfigs, this.locale, this.$i18n);
-        const localeConfig = tenantConfigs[locale];
 
+    data () {
         return {
-            copy: { ...localeConfig }
+            tenantConfigs
         };
+    },
+
+    computed: {
+        ariaLabel () {
+            console.log(this.target); // eslint-disable-line no-console
+            const locationType = this.isExternalLink ? 'opensExternalSiteInNew' : 'openInNew';
+            console.log(locationType); // eslint-disable-line no-console
+            const type = this.target === DEFAULT_LINK_TARGET ? 'opensExternal' : locationType;
+            console.log(type); // eslint-disable-line no-console
+            console.log(this.$t(`ariaDescribedBy['${type}']`)); // eslint-disable-line no-console
+            return this.$t(`ariaDescribedBy['${type}']`) || null;
+        },
+
+        linkTarget () {
+            // _blank|_self|_parent|_top|framename
+            return '_top';
+        }
     }
 };
 </script>

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -10,7 +10,7 @@
         :href="linkHref"
         :target="target"
         rel="noopener"
-        :aria-describedby="ariaLabel"
+        :aria-label="ariaLabel"
     >
         {{ linkText }}
     </a>
@@ -81,18 +81,10 @@ export default {
 
     computed: {
         ariaLabel () {
-            console.log(this.target); // eslint-disable-line no-console
             const locationType = this.isExternalLink ? 'opensExternalSiteInNew' : 'openInNew';
-            console.log(locationType); // eslint-disable-line no-console
             const type = this.target === DEFAULT_LINK_TARGET ? 'opensExternal' : locationType;
-            console.log(type); // eslint-disable-line no-console
-            console.log(this.$t(`ariaDescribedBy['${type}']`)); // eslint-disable-line no-console
-            return this.$t(`ariaDescribedBy['${type}']`) || null;
-        },
 
-        linkTarget () {
-            // _blank|_self|_parent|_top|framename
-            return '_top';
+            return this.linkText + " - " + this.$t(`ariaDescribedBy['${type}']`) || null;
         }
     }
 };

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -1,10 +1,13 @@
 <template>
-    <div
+    <a
         :class="$style['o-link']"
         data-test-id="link"
+        :href="linkHref"
+        rel="noopener"
+        :aria-describedby="`copy.ariaDescribedBy['${linkType}']`"
     >
-        {{ copy.text }}
-    </div>
+        {{ linkText }}
+    </a>
 </template>
 
 <script>
@@ -17,8 +20,24 @@ export default {
     props: {
         locale: {
             type: String,
-            default: ''
+            default: 'en-GB'
+        },
+
+        linkText: {
+            type: String,
+            required: true
+        },
+
+        linkHref: {
+            type: String,
+            required: true
         }
+
+        // linkType: {
+        //     type: String,
+        //     default: DEFAULT_LINK_TYPE,
+        //     validator: value => (VALID_LINK_STYLES.indexOf(value) !== -1) // The prop value must match one of the valid link types
+        // }
     },
     data () {
         const locale = globalisationServices.getLocale(tenantConfigs, this.locale, this.$i18n);
@@ -33,13 +52,42 @@ export default {
 
 <style lang="scss" module>
 .o-link {
-    display: flex;
-    justify-content: center;
-    min-height: 80vh;
-    width: 80vw;
-    margin: auto;
-    border: 1px solid $red;
-    font-family: $font-family-base;
-    @include font-size(heading-m);
+    & {
+        color: $color-link-default;
+    }
+
+    &:hover,
+    &:focus {
+        color: $color-link-hover;
+    }
+
+    &:active {
+        color: $color-link-active;
+    }
+    // have left in in case we want to use eventually
+    // &:visited {
+    //     color: $color-link-visited;
+    //     text-decoration: none;
+    // }
+}
+
+.o-link--full {
+    width: 100%;
+    display: block;
+}
+
+.o-link--noDecoration {
+    text-decoration: none;
+
+    // for accessibility reasons we are leaving
+    // text-decoration on hover and focus
+    &:hover,
+    &:focus {
+        text-decoration: underline;
+    }
+}
+
+.o-link--bold {
+    font-weight: $font-weight-bold;
 }
 </style>

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -3,10 +3,10 @@
         :class="[
             $style['o-link'],
             { [$style['o-link--bold']]: isBold },
-            { [$style['o-link--noDecoration']]: !hasDecoration },
+            { [$style['o-link--noDecoration']]: !hasTextDecoration },
             { [$style['o-link--full']]: isFullWidth }
         ]"
-        data-test-id="link"
+        :data-test-id="`${linkText} link`"
         :href="url"
         :target="target"
         :aria-label="ariaLabel"
@@ -39,12 +39,12 @@ export default {
             required: true
         },
 
-        isExternalLink: {
+        isExternal: {
             type: Boolean,
             default: false
         },
 
-        opensInNew: {
+        opensInNewLocation: {
             type: Boolean,
             default: false
         },
@@ -54,7 +54,7 @@ export default {
             default: false
         },
 
-        hasDecoration: {
+        hasTextDecoration: {
             type: Boolean,
             default: true
         },
@@ -73,24 +73,23 @@ export default {
 
     computed: {
         ariaLabel () {
-            let message = this.$t('ariaLabel.prefix');
+            let message;
 
-            if (this.isExternalLink) {
-                message += this.$t('ariaLabel.externalSite');
-            }
-            if (this.opensInNew) {
-                message += this.$t('ariaLabel.newLocation');
+            if (this.isExternal) {
+                message = this.$t('ariaLabel.externalSite');
+            } else if (this.opensInNewLocation) {
+                message = this.$t('ariaLabel.newLocation');
             }
 
-            return message === this.$t('ariaLabel.prefix') ? this.linkText : this.linkText + message;
+            return message ? this.linkText + message : this.linkText;
         },
 
         target () {
-            return this.isExternalLink ? '_blank' : null;
+            return this.isExternal || this.opensInNewLocation ? '_blank' : null;
         },
 
         rel () {
-            return this.opensInNew ? 'noopener' : null;
+            return this.isExternal ? 'noopener' : null;
         }
     }
 };

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -1,20 +1,28 @@
 <template>
-    <a
-        v-aria-label="newWindowMessage"
-        :class="[
-            $style['o-link'], {
-                [$style['o-link--bold']]: isBold,
-                [$style['o-link--noDecoration']]: !hasTextDecoration,
-                [$style['o-link--full']]: isFullWidth,
-                [$style['o-link--noBreak']]: noLineBreak
-            }]"
-        data-test-id="link-component"
-        :target="target"
-        :rel="rel"
-        v-bind="$attrs"
-    >
-        <slot />
-    </a>
+    <span>
+        <a
+            :class="[
+                $style['o-link'], {
+                    [$style['o-link--bold']]: isBold,
+                    [$style['o-link--noDecoration']]: !hasTextDecoration,
+                    [$style['o-link--full']]: isFullWidth,
+                    [$style['o-link--noBreak']]: noLineBreak
+                }]"
+            data-test-id="link-component"
+            aria-describedby="description"
+            :target="target"
+            :rel="rel"
+            v-bind="$attrs"
+        >
+            <slot />
+        </a>
+        <span
+            id=description
+            class="is-visuallyHidden"
+        >
+            {{ ariaDescription }}
+        </span>
+    </span>
 </template>
 
 <script>
@@ -23,20 +31,6 @@ import tenantConfigs from '../tenants';
 
 export default {
     name: 'VLink',
-
-    directives: {
-        /**
-         * Called when the slot is updated.
-         * Applies the `innerText` of the slot with `newWindowMessage` to link `aria-label`
-         * https://vuejs.org/v2/guide/custom-directive.html#Hook-Functions
-         *
-         * */
-        ariaLabel: {
-            componentUpdated (el, { value }) {
-                el.ariaLabel = el.innerText + value || null;
-            }
-        }
-    },
 
     mixins: [VueGlobalisationMixin],
 
@@ -79,11 +73,11 @@ export default {
     },
 
     computed: {
-        newWindowMessage () {
+        ariaDescription () {
             if (this.isExternal) {
-                return this.$t('ariaLabel.externalSite');
+                return this.$t('ariaDescription.externalSite');
             } else if (this.opensInNewLocation) {
-                return this.$t('ariaLabel.newLocation');
+                return this.$t('ariaDescription.newLocation');
             }
             return null;
         },

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -19,6 +19,7 @@
         <span
             id=description
             class="is-visuallyHidden"
+            v-if="ariaDescription"
         >
             {{ ariaDescription }}
         </span>

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -1,16 +1,18 @@
 <template>
     <a
+        v-aria-label="newWindowMessage"
         :class="[
             $style['o-link'], {
                 [$style['o-link--bold']]: isBold,
                 [$style['o-link--noDecoration']]: !hasTextDecoration,
-                [$style['o-link--full']]: isFullWidth
+                [$style['o-link--full']]: isFullWidth,
+                [$style['o-link--noBreak']]: noLineBreak
             }]"
-        :data-test-id="'link-component'"
-        :aria-label="ariaLabel"
+        data-test-id="link-component"
         :target="target"
         :rel="rel"
-        v-bind="$attrs">
+        v-bind="$attrs"
+    >
         <slot />
     </a>
 </template>
@@ -21,6 +23,20 @@ import tenantConfigs from '../tenants';
 
 export default {
     name: 'VLink',
+
+    directives: {
+        /**
+         * Called when the slot is updated.
+         * Applies the `innerText` of the slot with `newWindowMessage` to link `aria-label`
+         * https://vuejs.org/v2/guide/custom-directive.html#Hook-Functions
+         *
+         * */
+        ariaLabel: {
+            componentUpdated (el, { value }) {
+                el.ariaLabel = el.innerText + value || null;
+            }
+        }
+    },
 
     mixins: [VueGlobalisationMixin],
 
@@ -48,6 +64,11 @@ export default {
         isFullWidth: {
             type: Boolean,
             default: false
+        },
+
+        noLineBreak: {
+            type: Boolean,
+            default: false
         }
     },
 
@@ -62,16 +83,13 @@ export default {
             return this.$slots.default[0].children[0].text.trim();
         },
 
-        ariaLabel () {
-            let message;
-
+        newWindowMessage () {
             if (this.isExternal) {
-                message = this.$t('ariaLabel.externalSite');
+                return this.$t('ariaLabel.externalSite');
             } else if (this.opensInNewLocation) {
-                message = this.$t('ariaLabel.newLocation');
+                return this.$t('ariaLabel.newLocation');
             }
-
-            return message ? this.linkText + message : null;
+            return null;
         },
 
         target () {
@@ -119,5 +137,9 @@ export default {
 
 .o-link--bold {
     font-weight: $font-weight-bold;
+}
+
+.o-link--noBreak {
+    white-space: nowrap;
 }
 </style>

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -79,10 +79,6 @@ export default {
     },
 
     computed: {
-        linkText () {
-            return this.$slots.default[0].children[0].text.trim();
-        },
-
         newWindowMessage () {
             if (this.isExternal) {
                 return this.$t('ariaLabel.externalSite');

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -6,11 +6,10 @@
             { [$style['o-link--noDecoration']]: !hasTextDecoration },
             { [$style['o-link--full']]: isFullWidth }
         ]"
-        :data-test-id="dataTestId"
-        :href="url"
         :target="target"
         :aria-label="ariaLabel"
         :rel="rel"
+        v-bind="$attrs"
     >{{ linkText }}</a>
 </template>
 
@@ -24,16 +23,6 @@ export default {
     mixins: [VueGlobalisationMixin],
 
     props: {
-        locale: {
-            type: String,
-            default: 'en-GB'
-        },
-
-        dataTestId: {
-            type: String,
-            required: true
-        },
-
         linkText: {
             type: String,
             required: true
@@ -86,7 +75,7 @@ export default {
                 message = this.$t('ariaLabel.newLocation');
             }
 
-            return message ? this.linkText + message : this.linkText;
+            return message ? this.linkText + message : null;
         },
 
         target () {
@@ -114,11 +103,6 @@ export default {
     &:active {
         color: $color-link-active;
     }
-    // have left in in case we want to use eventually
-    // &:visited {
-    //     color: $color-link-visited;
-    //     text-decoration: none;
-    // }
 }
 
 .o-link--full {

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -1,10 +1,104 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import { VueI18n } from '@justeat/f-globalisation';
 import VLink from '../Link.vue';
+import tenantConfigs from '../../tenants';
 
-xdescribe('Link', () => {
+const localVue = createLocalVue();
+localVue.use(VueI18n);
+
+const i18n = {
+    locale: 'en-GB',
+    messages: {
+        'en-GB': tenantConfigs['en-GB'].messages
+    }
+};
+
+const linkText = 'This is a Link';
+const url = 'https://www.just-eat.com';
+
+describe('Link', () => {
     it('should be defined', () => {
-        const propsData = {};
-        const wrapper = shallowMount(VLink, { propsData });
+        const propsData = {
+            linkText: 'This is a Link',
+            url: 'https://www.just-eat.com'
+        };
+        const wrapper = shallowMount(VLink, {
+            propsData,
+            i18n,
+            localVue
+        });
         expect(wrapper.exists()).toBe(true);
+    });
+
+    describe('computed :: ', () => {
+        describe('ariaLabel :: ', () => {
+            const fullMessage = `${linkText} - Opens an external site in a new location`;
+            const newLocationMessage = `${linkText} - Opens in a new location`;
+            const externalLinkMessage = `${linkText} - Opens an external site`;
+
+            it.each([
+                [linkText, false, false],
+                [fullMessage, true, true],
+                [newLocationMessage, false, true],
+                [externalLinkMessage, true, false]
+            ])('should return `%s` when `isExternalLink` is %s AND `opensInNewTab` is $s', (expected, isExternalLink, opensInNew) => {
+                const propsData = {
+                    linkText: 'This is a Link',
+                    url: 'https://www.just-eat.com',
+                    isExternalLink,
+                    opensInNew
+                };
+
+                const wrapper = shallowMount(VLink, {
+                    propsData,
+                    i18n,
+                    localVue
+                });
+
+                expect(wrapper.vm.ariaLabel).toEqual(expected);
+            });
+        });
+
+        describe('target :: ', () => {
+            it.each([
+                ['_blank', true],
+                [null, false]
+            ])('should return %s when `isExternalLink` is %s', (expected, isExternalLink) => {
+                const propsData = {
+                    linkText,
+                    url,
+                    isExternalLink
+                };
+
+                const wrapper = shallowMount(VLink, {
+                    propsData,
+                    i18n,
+                    localVue
+                });
+
+                expect(wrapper.vm.target).toEqual(expected);
+            });
+        });
+
+        describe('rel :: ', () => {
+            it.each([
+                ['noopener', true],
+                [null, false]
+            ])('should return %s when `opensInNew` is %s', (expected, opensInNew) => {
+                const propsData = {
+                    linkText,
+                    url,
+                    opensInNew
+                };
+
+                const wrapper = shallowMount(VLink, {
+                    propsData,
+                    i18n,
+                    localVue
+                });
+
+                expect(wrapper.vm.rel).toEqual(expected);
+            });
+        });
     });
 });

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -17,7 +17,6 @@ const i18n = {
 const linkText = 'This is a Link';
 const slot = `<span>${linkText}</span>`;
 
-
 const $style = {
     'o-link--bold': 'o-link--bold',
     'o-link--noDecoration': 'o-link--noDecoration',
@@ -57,14 +56,10 @@ describe('Link', () => {
                     propsData,
                     i18n,
                     localVue,
-                    slots: {
-                        default: slot
-                    },
                     mocks: {
                         $style
                     }
                 });
-
 
                 // Assert
                 expect(wrapper.attributes('class')).toContain('o-link--bold');
@@ -83,14 +78,10 @@ describe('Link', () => {
                     propsData,
                     i18n,
                     localVue,
-                    slots: {
-                        default: slot
-                    },
                     mocks: {
                         $style
                     }
                 });
-
 
                 // Assert
                 expect(wrapper.attributes('class')).toContain('o-link--noDecoration');
@@ -109,14 +100,10 @@ describe('Link', () => {
                     propsData,
                     i18n,
                     localVue,
-                    slots: {
-                        default: slot
-                    },
                     mocks: {
                         $style
                     }
                 });
-
 
                 // Assert
                 expect(wrapper.attributes('class')).toContain('o-link--full');
@@ -135,14 +122,10 @@ describe('Link', () => {
                     propsData,
                     i18n,
                     localVue,
-                    slots: {
-                        default: slot
-                    },
                     mocks: {
                         $style
                     }
                 });
-
 
                 // Assert
                 expect(wrapper.attributes('class')).toContain('o-link--noBreak');
@@ -191,10 +174,7 @@ describe('Link', () => {
                 const wrapper = shallowMount(VLink, {
                     propsData,
                     i18n,
-                    localVue,
-                    slots: {
-                        default: slot
-                    }
+                    localVue
                 });
 
                 // Assert
@@ -216,10 +196,7 @@ describe('Link', () => {
                 const wrapper = shallowMount(VLink, {
                     propsData,
                     i18n,
-                    localVue,
-                    slots: {
-                        default: slot
-                    }
+                    localVue
                 });
 
                 // Assert
@@ -239,10 +216,7 @@ describe('Link', () => {
                 const wrapper = shallowMount(VLink, {
                     propsData,
                     i18n,
-                    localVue,
-                    slots: {
-                        default: slot
-                    }
+                    localVue
                 });
 
                 // Assert
@@ -264,10 +238,7 @@ describe('Link', () => {
                 const wrapper = shallowMount(VLink, {
                     propsData,
                     i18n,
-                    localVue,
-                    slots: {
-                        default: slot
-                    }
+                    localVue
                 });
 
                 // Assert

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -54,7 +54,7 @@ describe('Link', () => {
                     }
                 });
 
-                const link = wrapper.find('[data-test-id="link-component"]')
+                const link = wrapper.find('[data-test-id="link-component"]');
 
                 // Assert
                 expect(link.attributes('class')).toContain('o-link--bold');
@@ -78,7 +78,7 @@ describe('Link', () => {
                     }
                 });
 
-                const link = wrapper.find('[data-test-id="link-component"]')
+                const link = wrapper.find('[data-test-id="link-component"]');
 
                 // Assert
                 expect(link.attributes('class')).toContain('o-link--noDecoration');
@@ -102,7 +102,7 @@ describe('Link', () => {
                     }
                 });
 
-                const link = wrapper.find('[data-test-id="link-component"]')
+                const link = wrapper.find('[data-test-id="link-component"]');
 
                 // Assert
                 expect(link.attributes('class')).toContain('o-link--full');
@@ -126,7 +126,7 @@ describe('Link', () => {
                     }
                 });
 
-                const link = wrapper.find('[data-test-id="link-component"]')
+                const link = wrapper.find('[data-test-id="link-component"]');
 
                 // Assert
                 expect(link.attributes('class')).toContain('o-link--noBreak');

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -32,21 +32,20 @@ describe('Link', () => {
 
     describe('computed :: ', () => {
         describe('ariaLabel :: ', () => {
-            const fullMessage = `${linkText} - Opens an external site in a new location`;
             const newLocationMessage = `${linkText} - Opens in a new location`;
-            const externalLinkMessage = `${linkText} - Opens an external site`;
+            const externalLinkMessage = `${linkText} - Opens an external site in a new location`;
 
             it.each([
                 [linkText, false, false],
-                [fullMessage, true, true],
                 [newLocationMessage, false, true],
-                [externalLinkMessage, true, false]
-            ])('should return `%s` when `isExternalLink` is %s AND `opensInNewTab` is $s', (expected, isExternalLink, opensInNew) => {
+                [externalLinkMessage, true, false],
+                [externalLinkMessage, true, true]
+            ])('should return `%s` when `isExternal` is %s AND `opensInNewLocationTab` is $s', (expected, isExternal, opensInNewLocation) => {
                 const propsData = {
                     linkText: 'This is a Link',
                     url: 'https://www.just-eat.com',
-                    isExternalLink,
-                    opensInNew
+                    isExternal,
+                    opensInNewLocation
                 };
 
                 const wrapper = shallowMount(VLink, {
@@ -63,11 +62,30 @@ describe('Link', () => {
             it.each([
                 ['_blank', true],
                 [null, false]
-            ])('should return %s when `isExternalLink` is %s', (expected, isExternalLink) => {
+            ])('should return %s when `isExternal` is %s', (expected, isExternal) => {
                 const propsData = {
                     linkText,
                     url,
-                    isExternalLink
+                    isExternal
+                };
+
+                const wrapper = shallowMount(VLink, {
+                    propsData,
+                    i18n,
+                    localVue
+                });
+
+                expect(wrapper.vm.target).toEqual(expected);
+            });
+
+            it.each([
+                ['_blank', true],
+                [null, false]
+            ])('should return %s when `opensInNewLocation` is %s', (expected, opensInNewLocation) => {
+                const propsData = {
+                    linkText,
+                    url,
+                    opensInNewLocation
                 };
 
                 const wrapper = shallowMount(VLink, {
@@ -84,11 +102,11 @@ describe('Link', () => {
             it.each([
                 ['noopener', true],
                 [null, false]
-            ])('should return %s when `opensInNew` is %s', (expected, opensInNew) => {
+            ])('should return %s when `isExternal` is %s', (expected, isExternal) => {
                 const propsData = {
                     linkText,
                     url,
-                    opensInNew
+                    isExternal
                 };
 
                 const wrapper = shallowMount(VLink, {

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -4,7 +4,6 @@ import VLink from '../Link.vue';
 import tenantConfigs from '../../tenants';
 
 const localVue = createLocalVue();
-localVue.directive('aria-label', VLink.directives.ariaLabel);
 localVue.use(VueI18n);
 
 const i18n = {
@@ -55,8 +54,10 @@ describe('Link', () => {
                     }
                 });
 
+                const link = wrapper.find('[data-test-id="link-component"]')
+
                 // Assert
-                expect(wrapper.attributes('class')).toContain('o-link--bold');
+                expect(link.attributes('class')).toContain('o-link--bold');
             });
         });
 
@@ -77,8 +78,10 @@ describe('Link', () => {
                     }
                 });
 
+                const link = wrapper.find('[data-test-id="link-component"]')
+
                 // Assert
-                expect(wrapper.attributes('class')).toContain('o-link--noDecoration');
+                expect(link.attributes('class')).toContain('o-link--noDecoration');
             });
         });
 
@@ -99,8 +102,10 @@ describe('Link', () => {
                     }
                 });
 
+                const link = wrapper.find('[data-test-id="link-component"]')
+
                 // Assert
-                expect(wrapper.attributes('class')).toContain('o-link--full');
+                expect(link.attributes('class')).toContain('o-link--full');
             });
         });
 
@@ -121,16 +126,18 @@ describe('Link', () => {
                     }
                 });
 
+                const link = wrapper.find('[data-test-id="link-component"]')
+
                 // Assert
-                expect(wrapper.attributes('class')).toContain('o-link--noBreak');
+                expect(link.attributes('class')).toContain('o-link--noBreak');
             });
         });
     });
 
     describe('computed :: ', () => {
-        describe('newWindowMessage :: ', () => {
-            const newLocationMessage = ' - Opens in a new window/screen/tab';
-            const externalLinkMessage = ' - Opens an external site in a new window/screen/tab';
+        describe('ariaDescription :: ', () => {
+            const newLocationMessage = 'Opens in a new window/screen/tab';
+            const externalLinkMessage = 'Opens an external site in a new window/screen/tab';
 
             it.each([
                 [null, false, false],
@@ -152,7 +159,7 @@ describe('Link', () => {
                 });
 
                 // Assert
-                expect(wrapper.vm.newWindowMessage).toEqual(expected);
+                expect(wrapper.vm.ariaDescription).toEqual(expected);
             });
         });
 
@@ -217,31 +224,6 @@ describe('Link', () => {
 
                 // Assert
                 expect(wrapper.vm.rel).toEqual(expected);
-            });
-        });
-    });
-
-    describe('ariaLabel directive', () => {
-        let ariaLabel;
-
-        beforeEach(() => {
-            ariaLabel = VLink.directives.ariaLabel;
-        });
-
-        describe('the `componentUpdated` hook', () => {
-            it('should set the passed elements ariaLabel attribute', () => {
-                // Arrange
-                const el = document.createElement('div');
-                const labelText = 'my test link content';
-                const suffix = ' - a suffix message';
-
-                el.innerText = labelText;
-
-                // Act
-                ariaLabel.componentUpdated(el, { value: suffix });
-
-                // Assert
-                expect(el.ariaLabel).toEqual(labelText + suffix);
             });
         });
     });

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -14,9 +14,6 @@ const i18n = {
     }
 };
 
-const linkText = 'This is a Link';
-const slot = `<span>${linkText}</span>`;
-
 const $style = {
     'o-link--bold': 'o-link--bold',
     'o-link--noDecoration': 'o-link--noDecoration',
@@ -33,10 +30,7 @@ describe('Link', () => {
         const wrapper = shallowMount(VLink, {
             propsData,
             i18n,
-            localVue,
-            slots: {
-                default: slot
-            }
+            localVue
         });
 
         // Assert
@@ -134,26 +128,6 @@ describe('Link', () => {
     });
 
     describe('computed :: ', () => {
-        describe('linkText :: ', () => {
-            it('should return `text` of the first slot`', () => {
-                // Arrange
-                const propsData = {};
-
-                // Act
-                const wrapper = shallowMount(VLink, {
-                    propsData,
-                    i18n,
-                    localVue,
-                    slots: {
-                        default: slot
-                    }
-                });
-
-                // Assert
-                expect(wrapper.vm.linkText).toEqual(linkText);
-            });
-        });
-
         describe('newWindowMessage :: ', () => {
             const newLocationMessage = ' - Opens in a new window/screen/tab';
             const externalLinkMessage = ' - Opens an external site in a new window/screen/tab';

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -4,6 +4,7 @@ import VLink from '../Link.vue';
 import tenantConfigs from '../../tenants';
 
 const localVue = createLocalVue();
+localVue.directive('aria-label', VLink.directives.ariaLabel);
 localVue.use(VueI18n);
 
 const i18n = {
@@ -15,6 +16,14 @@ const i18n = {
 
 const linkText = 'This is a Link';
 const slot = `<span>${linkText}</span>`;
+
+
+const $style = {
+    'o-link--bold': 'o-link--bold',
+    'o-link--noDecoration': 'o-link--noDecoration',
+    'o-link--full': 'o-link--full',
+    'o-link--noBreak': 'o-link--noBreak'
+};
 
 describe('Link', () => {
     it('should be defined', () => {
@@ -33,6 +42,112 @@ describe('Link', () => {
 
         // Assert
         expect(wrapper.exists()).toBe(true);
+    });
+
+    describe('props :: ', () => {
+        describe('isBold :: ', () => {
+            it('should apply `o-link--bold` class to link if true', () => {
+                // Arrange
+                const propsData = {
+                    isBold: true
+                };
+
+                // Act
+                const wrapper = shallowMount(VLink, {
+                    propsData,
+                    i18n,
+                    localVue,
+                    slots: {
+                        default: slot
+                    },
+                    mocks: {
+                        $style
+                    }
+                });
+
+
+                // Assert
+                expect(wrapper.attributes('class')).toContain('o-link--bold');
+            });
+        });
+
+        describe('hasTextDecoration :: ', () => {
+            it('should apply `o-link--noDecoration` class to link if false', () => {
+                // Arrange
+                const propsData = {
+                    hasTextDecoration: false
+                };
+
+                // Act
+                const wrapper = shallowMount(VLink, {
+                    propsData,
+                    i18n,
+                    localVue,
+                    slots: {
+                        default: slot
+                    },
+                    mocks: {
+                        $style
+                    }
+                });
+
+
+                // Assert
+                expect(wrapper.attributes('class')).toContain('o-link--noDecoration');
+            });
+        });
+
+        describe('isFullWidth :: ', () => {
+            it('should apply `o-link--full` class to link if true', () => {
+                // Arrange
+                const propsData = {
+                    isFullWidth: true
+                };
+
+                // Act
+                const wrapper = shallowMount(VLink, {
+                    propsData,
+                    i18n,
+                    localVue,
+                    slots: {
+                        default: slot
+                    },
+                    mocks: {
+                        $style
+                    }
+                });
+
+
+                // Assert
+                expect(wrapper.attributes('class')).toContain('o-link--full');
+            });
+        });
+
+        describe('noLineBreak :: ', () => {
+            it('should apply `o-link--noBreak` class to link if true', () => {
+                // Arrange
+                const propsData = {
+                    noLineBreak: true
+                };
+
+                // Act
+                const wrapper = shallowMount(VLink, {
+                    propsData,
+                    i18n,
+                    localVue,
+                    slots: {
+                        default: slot
+                    },
+                    mocks: {
+                        $style
+                    }
+                });
+
+
+                // Assert
+                expect(wrapper.attributes('class')).toContain('o-link--noBreak');
+            });
+        });
     });
 
     describe('computed :: ', () => {
@@ -56,9 +171,9 @@ describe('Link', () => {
             });
         });
 
-        describe('ariaLabel :: ', () => {
-            const newLocationMessage = `${linkText} - Opens in a new window/screen/tab`;
-            const externalLinkMessage = `${linkText} - Opens an external site in a new window/screen/tab`;
+        describe('newWindowMessage :: ', () => {
+            const newLocationMessage = ' - Opens in a new window/screen/tab';
+            const externalLinkMessage = ' - Opens an external site in a new window/screen/tab';
 
             it.each([
                 [null, false, false],
@@ -83,7 +198,7 @@ describe('Link', () => {
                 });
 
                 // Assert
-                expect(wrapper.vm.ariaLabel).toEqual(expected);
+                expect(wrapper.vm.newWindowMessage).toEqual(expected);
             });
         });
 
@@ -157,6 +272,31 @@ describe('Link', () => {
 
                 // Assert
                 expect(wrapper.vm.rel).toEqual(expected);
+            });
+        });
+    });
+
+    describe('ariaLabel directive', () => {
+        let ariaLabel;
+
+        beforeEach(() => {
+            ariaLabel = VLink.directives.ariaLabel;
+        });
+
+        describe('the `componentUpdated` hook', () => {
+            it('should set the passed elements ariaLabel attribute', () => {
+                // Arrange
+                const el = document.createElement('div');
+                const labelText = 'my test link content';
+                const suffix = ' - a suffix message';
+
+                el.innerText = labelText;
+
+                // Act
+                ariaLabel.componentUpdated(el, { value: suffix });
+
+                // Assert
+                expect(el.ariaLabel).toEqual(labelText + suffix);
             });
         });
     });

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -14,20 +14,48 @@ const i18n = {
 };
 
 const linkText = 'This is a Link';
+const slot = `<span>${linkText}</span>`;
 
 describe('Link', () => {
     it('should be defined', () => {
-        const propsData = {linkText};
+        // Arrange
+        const propsData = { };
 
+        // Act
         const wrapper = shallowMount(VLink, {
             propsData,
             i18n,
-            localVue
+            localVue,
+            slots: {
+                default: slot
+            }
         });
+
+        // Assert
         expect(wrapper.exists()).toBe(true);
     });
 
     describe('computed :: ', () => {
+        describe('linkText :: ', () => {
+            it('should return `text` of the first slot`', () => {
+                // Arrange
+                const propsData = {};
+
+                // Act
+                const wrapper = shallowMount(VLink, {
+                    propsData,
+                    i18n,
+                    localVue,
+                    slots: {
+                        default: slot
+                    }
+                });
+
+                // Assert
+                expect(wrapper.vm.linkText).toEqual(linkText);
+            });
+        });
+
         describe('ariaLabel :: ', () => {
             const newLocationMessage = `${linkText} - Opens in a new window/screen/tab`;
             const externalLinkMessage = `${linkText} - Opens an external site in a new window/screen/tab`;
@@ -38,18 +66,23 @@ describe('Link', () => {
                 [externalLinkMessage, true, false],
                 [externalLinkMessage, true, true]
             ])('should return `%s` when `isExternal` is %s AND `opensInNewLocationTab` is $s', (expected, isExternal, opensInNewLocation) => {
+                // Arrange
                 const propsData = {
-                    linkText,
                     isExternal,
                     opensInNewLocation
                 };
 
+                // Act
                 const wrapper = shallowMount(VLink, {
                     propsData,
                     i18n,
-                    localVue
+                    localVue,
+                    slots: {
+                        default: slot
+                    }
                 });
 
+                // Assert
                 expect(wrapper.vm.ariaLabel).toEqual(expected);
             });
         });
@@ -59,17 +92,22 @@ describe('Link', () => {
                 ['_blank', true],
                 [null, false]
             ])('should return %s when `isExternal` is %s', (expected, isExternal) => {
+                // Arrange
                 const propsData = {
-                    linkText,
                     isExternal
                 };
 
+                // Act
                 const wrapper = shallowMount(VLink, {
                     propsData,
                     i18n,
-                    localVue
+                    localVue,
+                    slots: {
+                        default: slot
+                    }
                 });
 
+                // Assert
                 expect(wrapper.vm.target).toEqual(expected);
             });
 
@@ -77,17 +115,22 @@ describe('Link', () => {
                 ['_blank', true],
                 [null, false]
             ])('should return %s when `opensInNewLocation` is %s', (expected, opensInNewLocation) => {
+                // Arrange
                 const propsData = {
-                    linkText,
                     opensInNewLocation
                 };
 
+                // Act
                 const wrapper = shallowMount(VLink, {
                     propsData,
                     i18n,
-                    localVue
+                    localVue,
+                    slots: {
+                        default: slot
+                    }
                 });
 
+                // Assert
                 expect(wrapper.vm.target).toEqual(expected);
             });
         });
@@ -97,17 +140,22 @@ describe('Link', () => {
                 ['noopener', true],
                 [null, false]
             ])('should return %s when `isExternal` is %s', (expected, isExternal) => {
+                // Arrange
                 const propsData = {
-                    linkText,
                     isExternal
                 };
 
+                // Act
                 const wrapper = shallowMount(VLink, {
                     propsData,
                     i18n,
-                    localVue
+                    localVue,
+                    slots: {
+                        default: slot
+                    }
                 });
 
+                // Assert
                 expect(wrapper.vm.rel).toEqual(expected);
             });
         });

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -14,14 +14,11 @@ const i18n = {
 };
 
 const linkText = 'This is a Link';
-const url = 'https://www.just-eat.com';
 
 describe('Link', () => {
     it('should be defined', () => {
-        const propsData = {
-            linkText: 'This is a Link',
-            url: 'https://www.just-eat.com'
-        };
+        const propsData = {linkText};
+
         const wrapper = shallowMount(VLink, {
             propsData,
             i18n,
@@ -42,8 +39,7 @@ describe('Link', () => {
                 [externalLinkMessage, true, true]
             ])('should return `%s` when `isExternal` is %s AND `opensInNewLocationTab` is $s', (expected, isExternal, opensInNewLocation) => {
                 const propsData = {
-                    linkText: 'This is a Link',
-                    url: 'https://www.just-eat.com',
+                    linkText,
                     isExternal,
                     opensInNewLocation
                 };
@@ -65,7 +61,6 @@ describe('Link', () => {
             ])('should return %s when `isExternal` is %s', (expected, isExternal) => {
                 const propsData = {
                     linkText,
-                    url,
                     isExternal
                 };
 
@@ -84,7 +79,6 @@ describe('Link', () => {
             ])('should return %s when `opensInNewLocation` is %s', (expected, opensInNewLocation) => {
                 const propsData = {
                     linkText,
-                    url,
                     opensInNewLocation
                 };
 
@@ -105,7 +99,6 @@ describe('Link', () => {
             ])('should return %s when `isExternal` is %s', (expected, isExternal) => {
                 const propsData = {
                     linkText,
-                    url,
                     isExternal
                 };
 

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -1,7 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import VLink from '../Link.vue';
 
-describe('Link', () => {
+xdescribe('Link', () => {
     it('should be defined', () => {
         const propsData = {};
         const wrapper = shallowMount(VLink, { propsData });

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -32,8 +32,8 @@ describe('Link', () => {
 
     describe('computed :: ', () => {
         describe('ariaLabel :: ', () => {
-            const newLocationMessage = `${linkText} - Opens in a new location`;
-            const externalLinkMessage = `${linkText} - Opens an external site in a new location`;
+            const newLocationMessage = `${linkText} - Opens in a new window/screen/tab`;
+            const externalLinkMessage = `${linkText} - Opens an external site in a new window/screen/tab`;
 
             it.each([
                 [linkText, false, false],

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -36,7 +36,7 @@ describe('Link', () => {
             const externalLinkMessage = `${linkText} - Opens an external site in a new window/screen/tab`;
 
             it.each([
-                [linkText, false, false],
+                [null, false, false],
                 [newLocationMessage, false, true],
                 [externalLinkMessage, true, false],
                 [externalLinkMessage, true, true]

--- a/packages/components/atoms/f-link/src/constants.js
+++ b/packages/components/atoms/f-link/src/constants.js
@@ -1,0 +1,8 @@
+export const DEFAULT_LINK_TYPE = 'openInNew';
+export const VALID_LINK_TYPES = ['openInNew', 'opensExternal', 'opensExternalSiteInNew'];
+
+export const DEFAULT_LINK_LOCATION = 'self';
+export const VALID_LINK_LOCATIONS = ['self', 'window', 'tab', 'location'];
+
+export const DEFAULT_LINK_TARGET = '_self';
+export const VALID_LINK_TARGETS = ['_self', '_blank'];

--- a/packages/components/atoms/f-link/src/constants.js
+++ b/packages/components/atoms/f-link/src/constants.js
@@ -1,8 +1,0 @@
-export const DEFAULT_LINK_TYPE = 'openInNew';
-export const VALID_LINK_TYPES = ['openInNew', 'opensExternal', 'opensExternalSiteInNew'];
-
-export const DEFAULT_LINK_LOCATION = 'self';
-export const VALID_LINK_LOCATIONS = ['self', 'window', 'tab', 'location'];
-
-export const DEFAULT_LINK_TARGET = '_self';
-export const VALID_LINK_TARGETS = ['_self', '_blank'];

--- a/packages/components/atoms/f-link/src/tenants/en-AU.js
+++ b/packages/components/atoms/f-link/src/tenants/en-AU.js
@@ -1,8 +1,7 @@
 const messages = {
     ariaLabel: {
-        prefix: ' - Opens',
-        newLocation: ' in a new location',
-        externalSite: ' an external site'
+        newLocation: ' - Opens in a new location',
+        externalSite: ' - Opens an external site in a new location'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-AU.js
+++ b/packages/components/atoms/f-link/src/tenants/en-AU.js
@@ -1,8 +1,8 @@
 const messages = {
-    ariaDescribedBy: {
-        openInNew: 'Opens new location',
-        opensExternal: 'Opens an external site',
-        opensExternalSiteInNew: 'Opens an external site in a new location'
+    ariaLabel: {
+        prefix: ' - Opens',
+        newLocation: ' in a new location',
+        externalSite: ' an external site'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-AU.js
+++ b/packages/components/atoms/f-link/src/tenants/en-AU.js
@@ -1,7 +1,11 @@
-export default {
+const messages = {
     ariaDescribedBy: {
-        openInNew: 'Opens new {location}', // window/screen/tab
+        openInNew: 'Opens new location',
         opensExternal: 'Opens an external site',
-        opensExternalSiteInNew: 'Opens an external site in a new {location}'
+        opensExternalSiteInNew: 'Opens an external site in a new location'
     }
+};
+
+export default {
+    messages
 };

--- a/packages/components/atoms/f-link/src/tenants/en-AU.js
+++ b/packages/components/atoms/f-link/src/tenants/en-AU.js
@@ -1,7 +1,7 @@
 const messages = {
     ariaLabel: {
-        newLocation: ' - Opens in a new location',
-        externalSite: ' - Opens an external site in a new location'
+        newLocation: ' - Opens in a new window/screen/tab',
+        externalSite: ' - Opens an external site in a new window/screen/tab'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-AU.js
+++ b/packages/components/atoms/f-link/src/tenants/en-AU.js
@@ -1,7 +1,7 @@
 const messages = {
-    ariaLabel: {
-        newLocation: ' - Opens in a new window/screen/tab',
-        externalSite: ' - Opens an external site in a new window/screen/tab'
+    ariaDescription: {
+        newLocation: 'Opens in a new window/screen/tab',
+        externalSite: 'Opens an external site in a new window/screen/tab'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-AU.js
+++ b/packages/components/atoms/f-link/src/tenants/en-AU.js
@@ -1,4 +1,7 @@
 export default {
-    locale: 'en-AU',
-    text: 'I am a VLink Component (AU)'
+    ariaDescribedBy: {
+        openInNew: 'Opens new {location}', // window/screen/tab
+        opensExternal: 'Opens an external site',
+        opensExternalSiteInNew: 'Opens an external site in a new {location}'
+    }
 };

--- a/packages/components/atoms/f-link/src/tenants/en-GB.js
+++ b/packages/components/atoms/f-link/src/tenants/en-GB.js
@@ -1,8 +1,7 @@
 const messages = {
     ariaLabel: {
-        prefix: ' - Opens',
-        newLocation: ' in a new location',
-        externalSite: ' an external site'
+        newLocation: ' - Opens in a new location',
+        externalSite: ' - Opens an external site in a new location'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-GB.js
+++ b/packages/components/atoms/f-link/src/tenants/en-GB.js
@@ -1,8 +1,8 @@
 const messages = {
-    ariaDescribedBy: {
-        openInNew: 'Opens new location',
-        opensExternal: 'Opens an external site',
-        opensExternalSiteInNew: 'Opens an external site in a new location'
+    ariaLabel: {
+        prefix: ' - Opens',
+        newLocation: ' in a new location',
+        externalSite: ' an external site'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-GB.js
+++ b/packages/components/atoms/f-link/src/tenants/en-GB.js
@@ -1,4 +1,7 @@
 export default {
-    locale: 'en-GB',
-    text: 'I am a VLink Component (GB)'
+    ariaDescribedBy: {
+        openInNew: 'Opens new {location}', // window/screen/tab
+        opensExternal: 'Opens an external site',
+        opensExternalSiteInNew: 'Opens an external site in a new {location}'
+    }
 };

--- a/packages/components/atoms/f-link/src/tenants/en-GB.js
+++ b/packages/components/atoms/f-link/src/tenants/en-GB.js
@@ -1,7 +1,11 @@
-export default {
+const messages = {
     ariaDescribedBy: {
-        openInNew: 'Opens new {location}', // window/screen/tab
+        openInNew: 'Opens new location',
         opensExternal: 'Opens an external site',
-        opensExternalSiteInNew: 'Opens an external site in a new {location}'
+        opensExternalSiteInNew: 'Opens an external site in a new location'
     }
+};
+
+export default {
+    messages
 };

--- a/packages/components/atoms/f-link/src/tenants/en-GB.js
+++ b/packages/components/atoms/f-link/src/tenants/en-GB.js
@@ -1,7 +1,7 @@
 const messages = {
     ariaLabel: {
-        newLocation: ' - Opens in a new location',
-        externalSite: ' - Opens an external site in a new location'
+        newLocation: ' - Opens in a new window/screen/tab',
+        externalSite: ' - Opens an external site in a new window/screen/tab'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-GB.js
+++ b/packages/components/atoms/f-link/src/tenants/en-GB.js
@@ -1,7 +1,7 @@
 const messages = {
-    ariaLabel: {
-        newLocation: ' - Opens in a new window/screen/tab',
-        externalSite: ' - Opens an external site in a new window/screen/tab'
+    ariaDescription: {
+        newLocation: 'Opens in a new window/screen/tab',
+        externalSite: 'Opens an external site in a new window/screen/tab'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-IE.js
+++ b/packages/components/atoms/f-link/src/tenants/en-IE.js
@@ -1,8 +1,7 @@
 const messages = {
     ariaLabel: {
-        prefix: ' - Opens',
-        newLocation: ' in a new location',
-        externalSite: ' an external site'
+        newLocation: ' - Opens in a new location',
+        externalSite: ' - Opens an external site in a new location'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-IE.js
+++ b/packages/components/atoms/f-link/src/tenants/en-IE.js
@@ -1,8 +1,8 @@
 const messages = {
-    ariaDescribedBy: {
-        openInNew: 'Opens new location',
-        opensExternal: 'Opens an external site',
-        opensExternalSiteInNew: 'Opens an external site in a new location'
+    ariaLabel: {
+        prefix: ' - Opens',
+        newLocation: ' in a new location',
+        externalSite: ' an external site'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-IE.js
+++ b/packages/components/atoms/f-link/src/tenants/en-IE.js
@@ -1,4 +1,7 @@
 export default {
-    locale: 'en-IE',
-    text: 'I am a VLink Component (IE)'
+    ariaDescribedBy: {
+        openInNew: 'Opens new {location}', // window/screen/tab
+        opensExternal: 'Opens an external site',
+        opensExternalSiteInNew: 'Opens an external site in a new {location}'
+    }
 };

--- a/packages/components/atoms/f-link/src/tenants/en-IE.js
+++ b/packages/components/atoms/f-link/src/tenants/en-IE.js
@@ -1,7 +1,11 @@
-export default {
+const messages = {
     ariaDescribedBy: {
-        openInNew: 'Opens new {location}', // window/screen/tab
+        openInNew: 'Opens new location',
         opensExternal: 'Opens an external site',
-        opensExternalSiteInNew: 'Opens an external site in a new {location}'
+        opensExternalSiteInNew: 'Opens an external site in a new location'
     }
+};
+
+export default {
+    messages
 };

--- a/packages/components/atoms/f-link/src/tenants/en-IE.js
+++ b/packages/components/atoms/f-link/src/tenants/en-IE.js
@@ -1,7 +1,7 @@
 const messages = {
     ariaLabel: {
-        newLocation: ' - Opens in a new location',
-        externalSite: ' - Opens an external site in a new location'
+        newLocation: ' - Opens in a new window/screen/tab',
+        externalSite: ' - Opens an external site in a new window/screen/tab'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-IE.js
+++ b/packages/components/atoms/f-link/src/tenants/en-IE.js
@@ -1,7 +1,7 @@
 const messages = {
-    ariaLabel: {
-        newLocation: ' - Opens in a new window/screen/tab',
-        externalSite: ' - Opens an external site in a new window/screen/tab'
+    ariaDescription: {
+        newLocation: 'Opens in a new window/screen/tab',
+        externalSite: 'Opens an external site in a new window/screen/tab'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-NZ.js
+++ b/packages/components/atoms/f-link/src/tenants/en-NZ.js
@@ -1,8 +1,7 @@
 const messages = {
     ariaLabel: {
-        prefix: ' - Opens',
-        newLocation: ' in a new location',
-        externalSite: ' an external site'
+        newLocation: ' - Opens in a new location',
+        externalSite: ' - Opens an external site in a new location'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-NZ.js
+++ b/packages/components/atoms/f-link/src/tenants/en-NZ.js
@@ -1,8 +1,8 @@
 const messages = {
-    ariaDescribedBy: {
-        openInNew: 'Opens new location',
-        opensExternal: 'Opens an external site',
-        opensExternalSiteInNew: 'Opens an external site in a new location'
+    ariaLabel: {
+        prefix: ' - Opens',
+        newLocation: ' in a new location',
+        externalSite: ' an external site'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-NZ.js
+++ b/packages/components/atoms/f-link/src/tenants/en-NZ.js
@@ -1,7 +1,11 @@
-export default {
+const messages = {
     ariaDescribedBy: {
-        openInNew: 'Opens new {location}', // window/screen/tab
+        openInNew: 'Opens new location',
         opensExternal: 'Opens an external site',
-        opensExternalSiteInNew: 'Opens an external site in a new {location}'
+        opensExternalSiteInNew: 'Opens an external site in a new location'
     }
+};
+
+export default {
+    messages
 };

--- a/packages/components/atoms/f-link/src/tenants/en-NZ.js
+++ b/packages/components/atoms/f-link/src/tenants/en-NZ.js
@@ -1,7 +1,7 @@
 const messages = {
     ariaLabel: {
-        newLocation: ' - Opens in a new location',
-        externalSite: ' - Opens an external site in a new location'
+        newLocation: ' - Opens in a new window/screen/tab',
+        externalSite: ' - Opens an external site in a new window/screen/tab'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/en-NZ.js
+++ b/packages/components/atoms/f-link/src/tenants/en-NZ.js
@@ -1,4 +1,7 @@
 export default {
-    locale: 'en-NZ',
-    text: 'I am a VLink Component (NZ)'
+    ariaDescribedBy: {
+        openInNew: 'Opens new {location}', // window/screen/tab
+        opensExternal: 'Opens an external site',
+        opensExternalSiteInNew: 'Opens an external site in a new {location}'
+    }
 };

--- a/packages/components/atoms/f-link/src/tenants/en-NZ.js
+++ b/packages/components/atoms/f-link/src/tenants/en-NZ.js
@@ -1,7 +1,7 @@
 const messages = {
-    ariaLabel: {
-        newLocation: ' - Opens in a new window/screen/tab',
-        externalSite: ' - Opens an external site in a new window/screen/tab'
+    ariaDescription: {
+        newLocation: 'Opens in a new window/screen/tab',
+        externalSite: 'Opens an external site in a new window/screen/tab'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/es-ES.js
+++ b/packages/components/atoms/f-link/src/tenants/es-ES.js
@@ -1,7 +1,7 @@
 const messages = {
-    ariaLabel: {
-        newLocation: ' - Abrir una nueva ventana/pestaña',
-        externalSite: ' - Abrir a una web externa en una nueva ventana/pestaña'
+    ariaDescription: {
+        newLocation: 'una nueva ventana/pestaña',
+        externalSite: 'a una web externa en una nueva ventana/pestaña'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/es-ES.js
+++ b/packages/components/atoms/f-link/src/tenants/es-ES.js
@@ -1,8 +1,8 @@
 const messages = {
-    ariaDescribedBy: {
-        openInNew: 'Abrir una nueva posición',
-        opensExternal: 'Abrir a una web externa',
-        opensExternalSiteInNew: 'Abrir a una web externa en una nueva posición'
+    ariaLabel: {
+        prefix: ' - Abrir',
+        newLocation: ' una nueva posición',
+        externalSite: ' a una web externa'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/es-ES.js
+++ b/packages/components/atoms/f-link/src/tenants/es-ES.js
@@ -1,4 +1,7 @@
 export default {
-    locale: 'es-ES',
-    text: 'I am a VLink Component (ES)'
+    ariaDescribedBy: {
+        openInNew: 'Abrir una nueva {location}', // ventana/pestaña
+        opensExternal: 'Abrir a una web externa',
+        opensExternalSiteInNew: 'Abrir a una web externa en una nueva {location}'
+    }
 };

--- a/packages/components/atoms/f-link/src/tenants/es-ES.js
+++ b/packages/components/atoms/f-link/src/tenants/es-ES.js
@@ -1,7 +1,11 @@
-export default {
+const messages = {
     ariaDescribedBy: {
-        openInNew: 'Abrir una nueva {location}', // ventana/pestaña
+        openInNew: 'Abrir una nueva posición',
         opensExternal: 'Abrir a una web externa',
-        opensExternalSiteInNew: 'Abrir a una web externa en una nueva {location}'
+        opensExternalSiteInNew: 'Abrir a una web externa en una nueva posición'
     }
+};
+
+export default {
+    messages
 };

--- a/packages/components/atoms/f-link/src/tenants/es-ES.js
+++ b/packages/components/atoms/f-link/src/tenants/es-ES.js
@@ -1,7 +1,7 @@
 const messages = {
     ariaDescription: {
-        newLocation: 'una nueva ventana/pestaña',
-        externalSite: 'a una web externa en una nueva ventana/pestaña'
+        newLocation: 'Abrir una nueva ventana/pestaña',
+        externalSite: 'Abrir a una web externa en una nueva ventana/pestaña'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/es-ES.js
+++ b/packages/components/atoms/f-link/src/tenants/es-ES.js
@@ -1,8 +1,7 @@
 const messages = {
     ariaLabel: {
-        prefix: ' - Abrir',
-        newLocation: ' una nueva posición',
-        externalSite: ' a una web externa'
+        newLocation: ' - Abrir una nueva posición',
+        externalSite: ' - Abrir a una web externa'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/es-ES.js
+++ b/packages/components/atoms/f-link/src/tenants/es-ES.js
@@ -1,7 +1,7 @@
 const messages = {
     ariaLabel: {
-        newLocation: ' - Abrir una nueva posición',
-        externalSite: ' - Abrir a una web externa'
+        newLocation: ' - Abrir una nueva ventana/pestaña',
+        externalSite: ' - Abrir a una web externa en una nueva ventana/pestaña'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/it-IT.js
+++ b/packages/components/atoms/f-link/src/tenants/it-IT.js
@@ -1,8 +1,7 @@
 const messages = {
     ariaLabel: {
-        prefix: ' - Stai aprendo',
-        newLocation: '  una nuova posizione',
-        externalSite: ' aprendo un sito esterno'
+        newLocation: ' - Stai aprendo una nuova posizione',
+        externalSite: ' - Stai aprendo aprendo un sito esterno'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/it-IT.js
+++ b/packages/components/atoms/f-link/src/tenants/it-IT.js
@@ -1,4 +1,7 @@
 export default {
-    locale: 'it-IT',
-    text: 'I am a VLink Component (IT)'
+    ariaDescribedBy: {
+        openInNew: 'Stai aprendo una nuova {location}', // finestra / schermata / scheda
+        opensExternal: 'Stai aprendo un sito esterno',
+        opensExternalSiteInNew: 'Stai aprendo un sito esterno in una {location}'
+    }
 };

--- a/packages/components/atoms/f-link/src/tenants/it-IT.js
+++ b/packages/components/atoms/f-link/src/tenants/it-IT.js
@@ -1,7 +1,7 @@
 const messages = {
     ariaDescription: {
-        newLocation: 'aprendo una nuova finestra/schermata/scheda',
-        externalSite: 'aprendo un sito esterno in una nuova finestra/schermata/scheda'
+        newLocation: 'Stai aprendo una nuova finestra/schermata/scheda',
+        externalSite: 'Stai aprendo un sito esterno in una nuova finestra/schermata/scheda'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/it-IT.js
+++ b/packages/components/atoms/f-link/src/tenants/it-IT.js
@@ -1,7 +1,7 @@
 const messages = {
-    ariaLabel: {
-        newLocation: ' - Stai aprendo una nuova finestra/schermata/scheda',
-        externalSite: ' - Stai aprendo un sito esterno in una nuova finestra/schermata/scheda'
+    ariaDescription: {
+        newLocation: 'aprendo una nuova finestra/schermata/scheda',
+        externalSite: 'aprendo un sito esterno in una nuova finestra/schermata/scheda'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/it-IT.js
+++ b/packages/components/atoms/f-link/src/tenants/it-IT.js
@@ -1,8 +1,8 @@
 const messages = {
-    ariaDescribedBy: {
-        openInNew: 'Stai aprendo una nuova posizione',
-        opensExternal: 'Stai aprendo un sito esterno',
-        opensExternalSiteInNew: 'Stai aprendo un sito esterno in una posizione'
+    ariaLabel: {
+        prefix: ' - Stai aprendo',
+        newLocation: '  una nuova posizione',
+        externalSite: ' aprendo un sito esterno'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/it-IT.js
+++ b/packages/components/atoms/f-link/src/tenants/it-IT.js
@@ -1,7 +1,7 @@
 const messages = {
     ariaLabel: {
-        newLocation: ' - Stai aprendo una nuova posizione',
-        externalSite: ' - Stai aprendo aprendo un sito esterno'
+        newLocation: ' - Stai aprendo una nuova finestra/schermata/scheda',
+        externalSite: ' - Stai aprendo un sito esterno in una nuova finestra/schermata/scheda'
     }
 };
 

--- a/packages/components/atoms/f-link/src/tenants/it-IT.js
+++ b/packages/components/atoms/f-link/src/tenants/it-IT.js
@@ -1,7 +1,11 @@
-export default {
+const messages = {
     ariaDescribedBy: {
-        openInNew: 'Stai aprendo una nuova {location}', // finestra / schermata / scheda
+        openInNew: 'Stai aprendo una nuova posizione',
         opensExternal: 'Stai aprendo un sito esterno',
-        opensExternalSiteInNew: 'Stai aprendo un sito esterno in una {location}'
+        opensExternalSiteInNew: 'Stai aprendo un sito esterno in una posizione'
     }
+};
+
+export default {
+    messages
 };

--- a/packages/components/atoms/f-link/stories/Link.stories.js
+++ b/packages/components/atoms/f-link/stories/Link.stories.js
@@ -1,7 +1,6 @@
-// Uncomment the import below to add prop controls to your Story (and add `withKnobs` to the decorators array)
-// import {
-//     withKnobs, select, boolean
-// } from '@storybook/addon-knobs';
+import {
+    withKnobs, text
+} from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
 import VLink from '../src/components/Link.vue';
 
@@ -13,8 +12,15 @@ export default {
 export const VLinkComponent = () => ({
     components: { VLink },
     props: {
+        linkText: {
+            default: text('Link Text', 'This is a link')
+        },
+
+        linkHref: {
+            default: text('Link Destination', 'https://www.just-eat.co.uk/')
+        },
     },
-    template: `<v-link />`
+    template: `<v-link :linkText="linkText" :linkHref="linkHref"/>`
 });
 
 VLinkComponent.storyName = 'f-link';

--- a/packages/components/atoms/f-link/stories/Link.stories.js
+++ b/packages/components/atoms/f-link/stories/Link.stories.js
@@ -22,6 +22,11 @@ const availableLocales = [
 
 export const VLinkComponent = () => ({
     components: { VLink },
+    data () {
+        return {
+            dataTestId: 'link-component'
+        }
+    },
     props: {
         locale: {
             default: select('Locale', availableLocales)
@@ -58,6 +63,7 @@ export const VLinkComponent = () => ({
     },
     template: `<v-link ` +
                 ':locale="locale" ' +
+                ':dataTestId="dataTestId" ' +
                 ':linkText="linkText" ' +
                 ':url="url" ' +
                 ':isExternal="isExternal" ' +

--- a/packages/components/atoms/f-link/stories/Link.stories.js
+++ b/packages/components/atoms/f-link/stories/Link.stories.js
@@ -3,22 +3,11 @@ import {
 } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
 import VLink from '../src/components/Link.vue';
-import { locales } from '@justeat/storybook/constants/globalisation';
 
 export default {
     title: 'Components/Atoms',
     decorators: [withA11y]
 };
-
-// Removes DK and NO from `@justeat/storybook/constants/globalisation` locales
-const availableLocales = [
-    locales.gb,
-    locales.au,
-    locales.nz,
-    locales.ie,
-    locales.es,
-    locales.it
-]
 
 export const VLinkComponent = () => ({
     components: { VLink },
@@ -28,16 +17,8 @@ export const VLinkComponent = () => ({
         }
     },
     props: {
-        locale: {
-            default: select('Locale', availableLocales)
-        },
-
         linkText: {
             default: text('Link Text', 'This is a link')
-        },
-
-        url: {
-            default: text('Link URL', 'https://www.just-eat.co.uk/')
         },
 
         isExternal: {
@@ -61,17 +42,17 @@ export const VLinkComponent = () => ({
         }
 
     },
-    template: `<v-link ` +
-                ':locale="locale" ' +
-                ':dataTestId="dataTestId" ' +
-                ':linkText="linkText" ' +
-                ':url="url" ' +
-                ':isExternal="isExternal" ' +
-                ':opensInNewLocation="opensInNewLocation" ' +
-                ':isBold="isBold" ' +
-                ':hasTextDecoration="hasTextDecoration"  ' +
-                ':isFullWidth="isFullWidth"  ' +
-                '/>'
+    template: `<v-link
+                    :data-test-id="dataTestId"
+                    href="https://www.just-eat.co.uk/"
+                    :link-text="linkText"
+                    :url="url"
+                    :is-external="isExternal"
+                    :opens-in-new-location="opensInNewLocation"
+                    :is-bold="isBold"
+                    :has-text-decoration="hasTextDecoration"
+                    :is-full-width="isFullWidth"
+                />`
 });
 
 VLinkComponent.storyName = 'f-link';

--- a/packages/components/atoms/f-link/stories/Link.stories.js
+++ b/packages/components/atoms/f-link/stories/Link.stories.js
@@ -35,6 +35,10 @@ export const VLinkComponent = () => ({
 
         isFullWidth: {
             default: boolean('isFullWidth', false)
+        },
+
+        noLineBreak: {
+            default: boolean('noLineBreak', false)
         }
 
     },
@@ -46,6 +50,7 @@ export const VLinkComponent = () => ({
                     :is-bold="isBold"
                     :has-text-decoration="hasTextDecoration"
                     :is-full-width="isFullWidth"
+                    :no-line-break="noLineBreak"
                 >
                     <span>
                         This is a Link

--- a/packages/components/atoms/f-link/stories/Link.stories.js
+++ b/packages/components/atoms/f-link/stories/Link.stories.js
@@ -4,26 +4,43 @@ import {
 import { withA11y } from '@storybook/addon-a11y';
 import VLink from '../src/components/Link.vue';
 import { locales } from '@justeat/storybook/constants/globalisation';
-import { VALID_LINK_TARGETS } from '../src/constants';
 
 export default {
     title: 'Components/Atoms',
     decorators: [withA11y]
 };
 
+// Removes DK and NO from `@justeat/storybook/constants/globalisation` locales
+const availableLocales = [
+    locales.gb,
+    locales.au,
+    locales.nz,
+    locales.ie,
+    locales.es,
+    locales.it
+]
+
 export const VLinkComponent = () => ({
     components: { VLink },
     props: {
         locale: {
-            default: select('Locale', [locales.gb])
+            default: select('Locale', availableLocales)
         },
 
         linkText: {
             default: text('Link Text', 'This is a link')
         },
 
-        linkHref: {
+        url: {
             default: text('Link Destination', 'https://www.just-eat.co.uk/')
+        },
+
+        isExternalLink: {
+            default: boolean('Is external', false)
+        },
+
+        opensInNew: {
+            default: boolean('new', false)
         },
 
         isBold: {
@@ -36,25 +53,17 @@ export const VLinkComponent = () => ({
 
         isFullWidth: {
             default: boolean('Is full-width', false)
-        },
-
-        target: {
-            default: select('Link target', VALID_LINK_TARGETS)
-        },
-
-        isExternalLink: {
-            default: boolean('Is external', false)
         }
+
     },
     template: `<v-link ` +
                 ':locale="locale" ' +
                 ':linkText="linkText" ' +
-                ':linkHref="linkHref" ' +
+                ':url="url" ' +
+                ':isExternalLink="isExternalLink" ' +
+                ':opensInNew="opensInNew" ' +
                 ':isBold="isBold" ' +
                 ':hasDecoration="hasDecoration"  ' +
-                ':isFullWidth="isFullWidth" ' +
-                ':target="target" ' +
-                ':isExternalLink="isExternalLink" ' +
                 '/>'
 });
 

--- a/packages/components/atoms/f-link/stories/Link.stories.js
+++ b/packages/components/atoms/f-link/stories/Link.stories.js
@@ -36,7 +36,7 @@ export const VLinkComponent = () => ({
         },
 
         isExternal: {
-            default: boolean('Is external', false)
+            default: boolean('isExternal', false)
         },
 
         opensInNewLocation: {

--- a/packages/components/atoms/f-link/stories/Link.stories.js
+++ b/packages/components/atoms/f-link/stories/Link.stories.js
@@ -1,8 +1,10 @@
 import {
-    withKnobs, text
+    withKnobs, text, boolean, select
 } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
 import VLink from '../src/components/Link.vue';
+import { locales } from '@justeat/storybook/constants/globalisation';
+import { VALID_LINK_TARGETS } from '../src/constants';
 
 export default {
     title: 'Components/Atoms',
@@ -12,6 +14,10 @@ export default {
 export const VLinkComponent = () => ({
     components: { VLink },
     props: {
+        locale: {
+            default: select('Locale', [locales.gb])
+        },
+
         linkText: {
             default: text('Link Text', 'This is a link')
         },
@@ -19,8 +25,37 @@ export const VLinkComponent = () => ({
         linkHref: {
             default: text('Link Destination', 'https://www.just-eat.co.uk/')
         },
+
+        isBold: {
+            default: boolean('Is bold', false)
+        },
+
+        hasDecoration: {
+            default: boolean('Has text decoration', true)
+        },
+
+        isFullWidth: {
+            default: boolean('Is full-width', false)
+        },
+
+        target: {
+            default: select('Link target', VALID_LINK_TARGETS)
+        },
+
+        isExternalLink: {
+            default: boolean('Is external', false)
+        }
     },
-    template: `<v-link :linkText="linkText" :linkHref="linkHref"/>`
+    template: `<v-link ` +
+                ':locale="locale" ' +
+                ':linkText="linkText" ' +
+                ':linkHref="linkHref" ' +
+                ':isBold="isBold" ' +
+                ':hasDecoration="hasDecoration"  ' +
+                ':isFullWidth="isFullWidth" ' +
+                ':target="target" ' +
+                ':isExternalLink="isExternalLink" ' +
+                '/>'
 });
 
 VLinkComponent.storyName = 'f-link';

--- a/packages/components/atoms/f-link/stories/Link.stories.js
+++ b/packages/components/atoms/f-link/stories/Link.stories.js
@@ -17,10 +17,6 @@ export const VLinkComponent = () => ({
         }
     },
     props: {
-        linkText: {
-            default: text('Link Text', 'This is a link')
-        },
-
         isExternal: {
             default: boolean('isExternal', false)
         },
@@ -45,14 +41,16 @@ export const VLinkComponent = () => ({
     template: `<v-link
                     :data-test-id="dataTestId"
                     href="https://www.just-eat.co.uk/"
-                    :link-text="linkText"
-                    :url="url"
                     :is-external="isExternal"
                     :opens-in-new-location="opensInNewLocation"
                     :is-bold="isBold"
                     :has-text-decoration="hasTextDecoration"
                     :is-full-width="isFullWidth"
-                />`
+                >
+                    <span>
+                        This is a Link
+                    </span>
+                </v-link>`
 });
 
 VLinkComponent.storyName = 'f-link';

--- a/packages/components/atoms/f-link/stories/Link.stories.js
+++ b/packages/components/atoms/f-link/stories/Link.stories.js
@@ -32,27 +32,27 @@ export const VLinkComponent = () => ({
         },
 
         url: {
-            default: text('Link Destination', 'https://www.just-eat.co.uk/')
+            default: text('Link URL', 'https://www.just-eat.co.uk/')
         },
 
-        isExternalLink: {
+        isExternal: {
             default: boolean('Is external', false)
         },
 
-        opensInNew: {
-            default: boolean('new', false)
+        opensInNewLocation: {
+            default: boolean('opensInNewLocation', false)
         },
 
         isBold: {
-            default: boolean('Is bold', false)
+            default: boolean('isBold', false)
         },
 
-        hasDecoration: {
-            default: boolean('Has text decoration', true)
+        hasTextDecoration: {
+            default: boolean('hasTextDecoration', true)
         },
 
         isFullWidth: {
-            default: boolean('Is full-width', false)
+            default: boolean('isFullWidth', false)
         }
 
     },
@@ -60,10 +60,11 @@ export const VLinkComponent = () => ({
                 ':locale="locale" ' +
                 ':linkText="linkText" ' +
                 ':url="url" ' +
-                ':isExternalLink="isExternalLink" ' +
-                ':opensInNew="opensInNew" ' +
+                ':isExternal="isExternal" ' +
+                ':opensInNewLocation="opensInNewLocation" ' +
                 ':isBold="isBold" ' +
-                ':hasDecoration="hasDecoration"  ' +
+                ':hasTextDecoration="hasTextDecoration"  ' +
+                ':isFullWidth="isFullWidth"  ' +
                 '/>'
 });
 

--- a/packages/components/atoms/f-link/test-utils/component-objects/f-link-selectors.js
+++ b/packages/components/atoms/f-link/test-utils/component-objects/f-link-selectors.js
@@ -1,1 +1,1 @@
-export const COMPONENT = '[data-test-id="link"]';
+export const COMPONENT = '[data-test-id="link-component"]';


### PR DESCRIPTION
### Added
- Props `isExternalLink` and `opensInNewLocation` to set `target`, `rel`, and `ariaDescription`.
- Props `isBold`, `isFullWidth`, `noLineBreak` and `hasTextDecoration` to toggle link style.
- Tests to cover changes.

> There will be another PR after this to update the readme 