### PR TITLE
f-mega-modal@v0.9.0 - added the ability to pass `title` and `titleHtmlTag` values

### DIFF
--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.9.0
+------------------------------
+*May 19, 2021*
+
+### Added
+- `title` and `titleHtmlTag` props to allow passing the title value so that we can control the default display of the title inside the component
+- Unit tests
+
 
 v0.8.0
 ------------------------------

--- a/packages/components/molecules/f-mega-modal/README.md
+++ b/packages/components/molecules/f-mega-modal/README.md
@@ -117,6 +117,8 @@ The props that can be defined are as follows:
 | `has-close-button` | `Boolean` | `true` | Controls whether or not to display the modal close button. |
 | `close-on-blur` | `Boolean` | `true` | Controls whether or not to close the modal when the user clicks outside of the modal. |
 | `close-button-copy` | `String` | `"Close modal"` | Sets the hidden text value for the close button which is used by screen-readers. |
+| `title` | `String` | `''` | When set, will add a title to the top of the component. If you need to define a custom heading, ignore this prop.  |
+| `titleHtmlTag` | `String` | `h3` | Sets the tag for the component's title.<br><br>Allowed values are `h1`, `h2`, `h3`, and `h4` |
 
 ### CSS Classes
 

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "dist/f-mega-modal.common.js",
   "files": [
     "dist"

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -47,6 +47,15 @@
                     </f-button>
                 </slot>
 
+                <component
+                    :is="titleHtmlTag"
+                    v-if="title"
+                    :class="$style['c-megaModal-title']"
+                    data-test-id="mega-modal-title"
+                >
+                    {{ title }}
+                </component>
+
                 <slot />
             </div>
         </div>
@@ -128,6 +137,17 @@ export default {
         closeButtonCopy: {
             type: String,
             default: 'Close modal'
+        },
+
+        title: {
+            type: String,
+            default: ''
+        },
+
+        titleHtmlTag: {
+            type: String,
+            default: 'h3',
+            validator: value => ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(value)
         }
     },
 
@@ -384,5 +404,9 @@ export default {
     .c-megaModal-closeIcon * {
         fill: $color-link-default;
     }
+}
+
+.c-megaModal-title {
+    margin: 0 spacing(x3);
 }
 </style>

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -50,9 +50,8 @@
                 <component
                     :is="titleHtmlTag"
                     v-if="title"
-                    :class="$style['c-megaModal-title']"
-                    data-test-id="mega-modal-title"
-                >
+                    :class="['c-megaModal-title', $style['c-megaModal-title']]"
+                    data-test-id="mega-modal-title">
                     {{ title }}
                 </component>
 
@@ -147,7 +146,7 @@ export default {
         titleHtmlTag: {
             type: String,
             default: 'h3',
-            validator: value => ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(value)
+            validator: value => ['h1', 'h2', 'h3', 'h4'].includes(value)
         }
     },
 

--- a/packages/components/molecules/f-mega-modal/src/components/_tests/MegaModal.test.js
+++ b/packages/components/molecules/f-mega-modal/src/components/_tests/MegaModal.test.js
@@ -72,7 +72,7 @@ describe('MegaModal', () => {
                 expect(modalTitle.text()).toBe(propsData.title);
             });
 
-            it.each(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])('should set the tag to be %s, as passed in the `titleHtmlTag` prop', htmlTag => {
+            it.each(['h1', 'h2', 'h3', 'h4'])('should set the tag to be %s, as passed in the `titleHtmlTag` prop', htmlTag => {
                 // Arrange
                 const propsData = {
                     title: 'Test modal title',

--- a/packages/components/molecules/f-mega-modal/src/components/_tests/MegaModal.test.js
+++ b/packages/components/molecules/f-mega-modal/src/components/_tests/MegaModal.test.js
@@ -44,5 +44,62 @@ describe('MegaModal', () => {
                 expect(wrapper.vm.showOverlay).toBe(expected);
             });
         });
+
+        describe('title', () => {
+            it('should not be visible if it’s not set in props', () => {
+                // Arrange
+                const propsData = {};
+
+                // Act
+                const wrapper = shallowMount(MegaModal, { propsData });
+                const modalTitle = wrapper.find('[data-test-id="mega-modal-title"]');
+
+                // Assert
+                expect(modalTitle.exists()).toBe(false);
+            });
+
+            it('should be visible if it’s set in props', () => {
+                // Arrange
+                const propsData = {
+                    title: 'Test modal title'
+                };
+
+                // Act
+                const wrapper = shallowMount(MegaModal, { propsData });
+                const modalTitle = wrapper.find('[data-test-id="mega-modal-title"]');
+
+                // Assert
+                expect(modalTitle.text()).toBe(propsData.title);
+            });
+
+            it.each(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])('should set the tag to be %s, as passed in the `titleHtmlTag` prop', htmlTag => {
+                // Arrange
+                const propsData = {
+                    title: 'Test modal title',
+                    titleHtmlTag: htmlTag
+                };
+
+                // Act
+                const wrapper = shallowMount(MegaModal, { propsData });
+                const modalTitle = wrapper.find('[data-test-id="mega-modal-title"]');
+
+                // Assert
+                expect(modalTitle.element.tagName.toLowerCase()).toBe(htmlTag);
+            });
+
+            it('should set the tag to be h3, if `title` is set in props, but `titleHtmlTag` prop is not set', () => {
+                // Arrange
+                const propsData = {
+                    title: 'Test modal title'
+                };
+
+                // Act
+                const wrapper = shallowMount(MegaModal, { propsData });
+                const modalTitle = wrapper.find('[data-test-id="mega-modal-title"]');
+
+                // Assert
+                expect(modalTitle.element.tagName.toLowerCase()).toBe('h3');
+            });
+        });
     });
 });

--- a/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
+++ b/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
@@ -77,10 +77,8 @@ export const MegaModalComponent = () => ({
             :has-overlay="hasOverlay"
             :has-close-button="hasCloseButton"
             :close-on-blur="closeOnBlur"
-            :close-button-copy="closeButtonCopy">
-            <h3 data-test-id="mega-modal-title" class="u-noSpacing">
-                This place isn't taking orders
-            </h3>
+            :close-button-copy="closeButtonCopy"
+            :title="'This place isn’t taking orders'">
 
             <p data-test-id="mega-modal-content">
                 Let's find another restaurant to order from.


### PR DESCRIPTION
### Added
- `title` and `titleHtmlTag` props to allow passing the title value, so that we can control the default display of the title inside the component
- Unit tests
