### PR TITLE
f-registration@v0.53.2 - Bumped `f-http` version

### DIFF
--- a/packages/components/organisms/f-registration/CHANGELOG.md
+++ b/packages/components/organisms/f-registration/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.53.2
+------------------------------
+*May 20, 2021*
+
+### Changed
+- Bumped f-http version to 0.5.0
+
+
 v0.53.1
 ------------------------------
 *May 14, 2021*

--- a/packages/components/organisms/f-registration/package.json
+++ b/packages/components/organisms/f-registration/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
-    "@justeat/f-http": ">=0.4.1"
+    "@justeat/f-http": ">=0.5.0"
   },
   "devDependencies": {
     "@justeat/f-wdio-utils": "0.1.0",

--- a/packages/components/organisms/f-registration/package.json
+++ b/packages/components/organisms/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.53.1",
+  "version": "0.53.2",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2204,14 +2204,6 @@
   dependencies:
     "@justeat/f-vue-icons" "1.10.0"
 
-"@justeat/f-form-field@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-1.11.0.tgz#417c67a377965c24e97a5d2ebc863bc901ad9e5b"
-  integrity sha512-i+Oo2weku8UwMyEKpY2NjaJoLKPotiM7IzSM9rRmgsiyBAK5oOAhzjJtplgxl/wMzal+9vo01NrMtn9rRNYDfg==
-  dependencies:
-    "@justeat/f-services" "1.0.0"
-    "@justeat/f-vue-icons" "1.11.0"
-
 "@justeat/f-form-field@1.6.1":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-1.6.1.tgz#47b014847a42467737b65997cfcab212d0385ba7"


### PR DESCRIPTION
v0.53.2
------------------------------
*May 20, 2021*

### Changed
- Bumped f-http version to 0.5.0