### PR TITLE
f-checkout@0.117.0 - Add mobile number aria label

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.117.0
+------------------------------
+*May 20, 2021*
+
+### Added
+- Aria label with structured mobile number for screen readers
+
+
 v0.116.0
 ------------------------------
 *May 18, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.116.0",
+  "version": "0.117.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -399,12 +399,7 @@ export default {
         },
 
         formattedMobileNumberForScreenReader () {
-            return Array.from(this.customer.mobileNumber, (digit, index) => {
-                if (index > 0 && (index + 1) % 3 === 0) {
-                    return `${digit}.`;
-                }
-                return digit;
-            }).join(' ');
+            return [...this.customer.mobileNumber].join(' ');
         }
     },
 

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -399,10 +399,8 @@ export default {
         },
 
         formattedMobileNumberForScreenReader () {
-            const usesAreaCode = this.customer.mobileNumber.startsWith('+');
-            const pauseIndices = usesAreaCode ? [6, 9] : [4, 7]; // TODO: Split the number at different indices depending on country
             return Array.from(this.customer.mobileNumber, (digit, index) => {
-                if (pauseIndices.includes(index)) {
+                if (index > 0 && (index + 1) % 3 === 0) {
                     return `${digit}.`;
                 }
                 return digit;

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -57,6 +57,7 @@
                         :has-error="isMobileNumberEmpty || isMobileNumberInvalid"
                         aria-describedby="mobile-number-error"
                         :aria-invalid="!isMobileNumberValid"
+                        :aria-label="formattedMobileNumberForScreenReader"
                         @input="updateCustomerDetails({ mobileNumber: $event })">
                         <template #error>
                             <error-message
@@ -395,6 +396,17 @@ export default {
             return invalidFieldCount === 1 ?
                 this.$t('errorMessages.singleFieldError') :
                 this.$t('errorMessages.multipleFieldErrors', { errorCount: invalidFieldCount });
+        },
+
+        formattedMobileNumberForScreenReader () {
+            const usesAreaCode = this.customer.mobileNumber.startsWith('+');
+            const pauseIndices = usesAreaCode ? [6, 9] : [4, 7]; // TODO: Split the number at different indices depending on country
+            return Array.from(this.customer.mobileNumber, (digit, index) => {
+                if (pauseIndices.includes(index)) {
+                    return `${digit}.`;
+                }
+                return digit;
+            }).join(' ');
         }
     },
 
@@ -423,6 +435,10 @@ export default {
 
         await this.initialise();
         this.trackInitialLoad();
+    },
+
+    updated () {
+        console.log(this.customer.mobileNumber);
     },
 
     methods: {

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -437,10 +437,6 @@ export default {
         this.trackInitialLoad();
     },
 
-    updated () {
-        console.log(this.customer.mobileNumber);
-    },
-
     methods: {
         ...mapActions(VUEX_CHECKOUT_MODULE, [
             'createGuestUser',

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -56,7 +56,7 @@
                         :label-text="$t('labels.mobileNumber')"
                         :has-error="isMobileNumberEmpty || isMobileNumberInvalid"
                         aria-describedby="mobile-number-error"
-                        :aria-invalid="!isMobileNumberValid"
+                        :aria-invalid="isMobileNumberInvalid"
                         :aria-label="formattedMobileNumberForScreenReader"
                         @input="updateCustomerDetails({ mobileNumber: $event })">
                         <template #error>

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -297,31 +297,12 @@ describe('Checkout', () => {
 
     describe('computed ::', () => {
         describe('formattedMobileNumberForScreenReader ::', () => {
-            it('should return the mobile number with spaces and periods after the 7th and 10th digit if number starts with `+`', () => {
-                const expectedMobileNumber = '+ 4 4 7 1 1 1. 1 1 1. 1 1 1';
+            it('should return the mobile number with spaces, and periods after every third character', () => {
+                const expectedMobileNumber = '+ 4 4. 7 1 1. 1 1 1. 1 1 1. 1';
                 // Act
                 const wrapper = shallowMount(VueCheckout, {
                     store: createStore({
                         ...defaultCheckoutState
-                    }),
-                    i18n,
-                    localVue,
-                    propsData
-                });
-
-                // Assert
-                expect(wrapper.vm.formattedMobileNumberForScreenReader).toEqual(expectedMobileNumber);
-            });
-
-            it('should return the mobile number with spaces and periods after the 5th and 8th digit if number does not start with `+`', () => {
-                const expectedMobileNumber = '0 7 1 1 1. 1 1 1. 1 1 1';
-                // Act
-                const wrapper = shallowMount(VueCheckout, {
-                    store: createStore({
-                        ...defaultCheckoutState,
-                        customer: {
-                            mobileNumber: '07111111111'
-                        }
                     }),
                     i18n,
                     localVue,

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -298,7 +298,7 @@ describe('Checkout', () => {
     describe('computed ::', () => {
         describe('formattedMobileNumberForScreenReader ::', () => {
             it('should return the mobile number with spaces, and periods after every third character', () => {
-                const expectedMobileNumber = '+ 4 4. 7 1 1. 1 1 1. 1 1 1. 1';
+                const expectedMobileNumber = '+ 4 4 7 1 1 1 1 1 1 1 1 1';
                 // Act
                 const wrapper = shallowMount(VueCheckout, {
                     store: createStore({

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -296,6 +296,43 @@ describe('Checkout', () => {
     });
 
     describe('computed ::', () => {
+        describe('formattedMobileNumberForScreenReader ::', () => {
+            it('should return the mobile number with spaces and periods after the 7th and 10th digit if number starts with `+`', () => {
+                const expectedMobileNumber = '+ 4 4 7 1 1 1. 1 1 1. 1 1 1';
+                // Act
+                const wrapper = shallowMount(VueCheckout, {
+                    store: createStore({
+                        ...defaultCheckoutState
+                    }),
+                    i18n,
+                    localVue,
+                    propsData
+                });
+
+                // Assert
+                expect(wrapper.vm.formattedMobileNumberForScreenReader).toEqual(expectedMobileNumber);
+            });
+
+            it('should return the mobile number with spaces and periods after the 5th and 8th digit if number does not start with `+`', () => {
+                const expectedMobileNumber = '0 7 1 1 1. 1 1 1. 1 1 1';
+                // Act
+                const wrapper = shallowMount(VueCheckout, {
+                    store: createStore({
+                        ...defaultCheckoutState,
+                        customer: {
+                            mobileNumber: '07111111111'
+                        }
+                    }),
+                    i18n,
+                    localVue,
+                    propsData
+                });
+
+                // Assert
+                expect(wrapper.vm.formattedMobileNumberForScreenReader).toEqual(expectedMobileNumber);
+            });
+        });
+
         describe('isMobileNumberEmpty ::', () => {
             let wrapper;
 

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -297,7 +297,7 @@ describe('Checkout', () => {
 
     describe('computed ::', () => {
         describe('formattedMobileNumberForScreenReader ::', () => {
-            it('should return the mobile number with spaces, and periods after every third character', () => {
+            it('should return the mobile number with spaces after every character', () => {
                 const expectedMobileNumber = '+ 4 4 7 1 1 1 1 1 1 1 1 1';
                 // Act
                 const wrapper = shallowMount(VueCheckout, {


### PR DESCRIPTION
### Added
- Aria label with structured mobile number for screen readers

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
