### PR TITLE
f-card@1.2.0 - add hasFullWidthFooter prop

### DIFF
--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -9,9 +9,9 @@ v1.2.0
 *May 20, 2021*
 
 ### Added
-- `hasFullWidthBottomElement` prop
-- Named slot `full-width-bottom-element` to render full width content at the bottom of the card without card paddings when `hasFullWidthBottomElement` set to true
-- `.c-card--innerSpacing` css class for card paddings to be able to separate card content paddings from the card itself
+- `hasFullWidthFooter` prop
+- Named slot `cardFooter` to render full width content at the bottom of the card without card paddings when `hasFullWidthFooter` set to true
+- `.c-card-innerSpacing` css class for card paddings to be able to separate card content paddings from the card itself
 
 ### Removed
 - `.c-card--separated`, `.c-card--center`, `.c-card--right` css classes as unused

--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.2.0
+------------------------------
+*May 20, 2021*
+
+### Added
+- `hasFullWidthBottomElement` prop
+- Named slot `full-width-bottom-element` to render full width content at the bottom of the card without card paddings when `hasFullWidthBottomElement` set to true
+- `.c-card--innerSpacing` css class for card paddings to be able to separate card content paddings from the card itself
+
+### Removed
+- `.c-card--separated`, `.c-card--center`, `.c-card--right` css classes as unused
+
 v1.1.0
 ------------------------------
 *March 17, 2021*

--- a/packages/components/atoms/f-card/README.md
+++ b/packages/components/atoms/f-card/README.md
@@ -72,7 +72,7 @@ The props that can be defined are as follows:
 | `hasOutline`              | `Boolean`  |  No        | `false` | When set to `true`, an outline is applied to the card component.  |
 | `isPageContentWrapper`    | `Boolean`  |  No        | `false` | When set to `true`, applies styles to make the card act like a page content wrapper.<br><br>The card will be full width on narrow devices, and then a fixed width above a certain breakpoint width (about 480px), when the card will be centred on the page. |
 | `isRounded`               | `Boolean`  |  No        | `false` | When set to `true`, rounded corners are applied to the card component. |
-| `hasFullWidthBottomElement` | `Boolean` | No | `false` | When set to `true`, named slot `full-width-bottom-element` can be passed to render full width content at the bottom of the card without card paddings. |
+| `hasFullWidthFooter` | `Boolean` | No | `false` | When set to `true`, named slot `full-width-bottom-element` can be passed to render full width content at the bottom of the card without card paddings. |
 
 ### CSS Classes
 

--- a/packages/components/atoms/f-card/README.md
+++ b/packages/components/atoms/f-card/README.md
@@ -72,6 +72,7 @@ The props that can be defined are as follows:
 | `hasOutline`              | `Boolean`  |  No        | `false` | When set to `true`, an outline is applied to the card component.  |
 | `isPageContentWrapper`    | `Boolean`  |  No        | `false` | When set to `true`, applies styles to make the card act like a page content wrapper.<br><br>The card will be full width on narrow devices, and then a fixed width above a certain breakpoint width (about 480px), when the card will be centred on the page. |
 | `isRounded`               | `Boolean`  |  No        | `false` | When set to `true`, rounded corners are applied to the card component. |
+| `hasFullWidthBottomElement` | `Boolean` | No | `false` | When set to `true`, named slot `full-width-bottom-element` can be passed to render full width content at the bottom of the card without card paddings. |
 
 ### CSS Classes
 

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card",
   "description": "Fozzie Card Component – Used for providing wrapper card styling to an element (or group of elements)",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "dist/f-card.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -2,24 +2,31 @@
     <div
         data-test-id="card-component"
         :class="[
-            $style['c-card'],
-            (isRounded ? $style['c-card--rounded'] : ''),
-            (hasOutline ? $style['c-card--outline'] : ''),
-            (isPageContentWrapper ? $style['c-card--pageContentWrapper'] : '')
-        ]"
-    >
-        <component
-            :is="cardHeadingTag"
-            v-if="cardHeading"
-            :class="[
-                $style['c-card-heading'],
-                (cardHeadingPosition !== 'left' ? $style[`c-card--${cardHeadingPosition}`] : '')
-            ]"
-            data-test-id="card-heading"
-        >
-            {{ cardHeading }}
-        </component>
-        <slot />
+            $style['c-card'], {
+                [$style['c-card--rounded']]: isRounded,
+                [$style['c-card--outline']]: hasOutline,
+                [$style['c-card--pageContentWrapper']]: isPageContentWrapper
+            }]">
+        <div :class="[$style['c-card--innerSpacing']]">
+            <component
+                :is="cardHeadingTag"
+                v-if="cardHeading"
+                :class="[
+                    $style['c-card-heading'],
+                    (cardHeadingPosition !== 'left' ? $style[`c-card--${cardHeadingPosition}`] : '')
+                ]"
+                data-test-id="card-heading">
+                {{ cardHeading }}
+            </component>
+            <slot />
+        </div>
+
+        <div
+            v-if="hasFullWidthBottomElement"
+            data-test-id="card-component-fullWidthBottomElement">
+            <slot
+                name="full-width-bottom-element" />
+        </div>
     </div>
 </template>
 
@@ -53,6 +60,10 @@ export default {
         isRounded: {
             type: Boolean,
             default: false
+        },
+        hasFullWidthBottomElement: {
+            type: Boolean,
+            default: false
         }
     }
 };
@@ -70,11 +81,9 @@ $card--pageContentWrapper-width           : 472px; // so that it falls on our 8p
 .c-card {
     background-color: $card-bgColor;
     display: block;
-    padding: $card-padding;
 }
-
-    .c-card--separated {
-        margin-bottom: spacing();
+    .c-card--innerSpacing {
+        padding: $card-padding;
     }
 
     .c-card--rounded {
@@ -92,32 +101,27 @@ $card--pageContentWrapper-width           : 472px; // so that it falls on our 8p
     .c-card--pageContentWrapper {
         width: 100%;
         transition: 250ms padding ease-in-out;
-        padding-left: 6%;
-        padding-right: 6%;
         margin: spacing(x5) 0;
-
-        @include media('>=narrow') {
-            padding-left: 10%;
-            padding-right: 10%;
-        }
 
         @include media('>=#{$card--pageContentWrapper-width}') {
             width: $card--pageContentWrapper-width;
             margin: spacing(x5) auto;
-            padding-left: spacing(x10);
-            padding-right: spacing(x10);
+        }
+
+        .c-card--innerSpacing {
+            padding: spacing(x3) 6% 0;
+
+            @include media('>=narrow') {
+                padding: spacing(x6) 10%;
+            }
+
+            @include media('>=#{$card--pageContentWrapper-width}') {
+                padding: spacing(x6) spacing(x10);
+            }
         }
     }
 
     .c-card-heading {
         margin-bottom: spacing(x2);
-    }
-
-    .c-card--center {
-        text-align: center;
-    }
-
-    .c-card--right {
-        text-align: right;
     }
 </style>

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -7,7 +7,7 @@
                 [$style['c-card--outline']]: hasOutline,
                 [$style['c-card--pageContentWrapper']]: isPageContentWrapper
             }]">
-        <div :class="[$style['c-card--innerSpacing']]">
+        <div :class="[$style['c-card-innerSpacing']]">
             <component
                 :is="cardHeadingTag"
                 v-if="cardHeading"
@@ -22,10 +22,10 @@
         </div>
 
         <div
-            v-if="hasFullWidthBottomElement"
-            data-test-id="card-component-fullWidthBottomElement">
+            v-if="hasFullWidthFooter"
+            data-test-id="card-footer">
             <slot
-                name="full-width-bottom-element" />
+                name="cardFooter" />
         </div>
     </div>
 </template>
@@ -61,7 +61,7 @@ export default {
             type: Boolean,
             default: false
         },
-        hasFullWidthBottomElement: {
+        hasFullWidthFooter: {
             type: Boolean,
             default: false
         }
@@ -82,7 +82,7 @@ $card--pageContentWrapper-width           : 472px; // so that it falls on our 8p
     background-color: $card-bgColor;
     display: block;
 }
-    .c-card--innerSpacing {
+    .c-card-innerSpacing {
         padding: $card-padding;
     }
 
@@ -108,7 +108,7 @@ $card--pageContentWrapper-width           : 472px; // so that it falls on our 8p
             margin: spacing(x5) auto;
         }
 
-        .c-card--innerSpacing {
+        .c-card-innerSpacing {
             padding: spacing(x3) 6% 0;
 
             @include media('>=narrow') {

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -24,8 +24,7 @@
         <div
             v-if="hasFullWidthFooter"
             data-test-id="card-footer">
-            <slot
-                name="cardFooter" />
+            <slot name="cardFooter" />
         </div>
     </div>
 </template>

--- a/packages/components/atoms/f-card/src/components/_tests/Card.test.js
+++ b/packages/components/atoms/f-card/src/components/_tests/Card.test.js
@@ -210,4 +210,24 @@ describe('Card', () => {
             });
         });
     });
+
+    describe.each([
+        [true, true],
+        [false, false]
+    ])('`hasFullWidthBottomElement` is %s', (passedValue, expected) => {
+        // Arrange
+        const propsData = {
+            hasFullWidthBottomElement: passedValue
+        };
+
+        // Act
+        const wrapper = shallowMount(Card, { propsData });
+
+        // Act
+        const testedElement = wrapper.find('[data-test-id="card-component-fullWidthBottomElement"]');
+
+        it(`should ${wrapper.vm.hasFullWidthBottomElement ? '' : 'not '}display a bottom positioned full width element`, () => {
+            expect(testedElement.exists()).toBe(expected);
+        });
+    });
 });

--- a/packages/components/atoms/f-card/src/components/_tests/Card.test.js
+++ b/packages/components/atoms/f-card/src/components/_tests/Card.test.js
@@ -214,7 +214,7 @@ describe('Card', () => {
     describe.each([
         [true, true],
         [false, false]
-    ])('`hasFullWidthBottomElement` is %s', (passedValue, expected) => {
+    ])('if `hasFullWidthBottomElement` prop is %s', (passedValue, expected) => {
         // Arrange
         const propsData = {
             hasFullWidthBottomElement: passedValue

--- a/packages/components/atoms/f-card/src/components/_tests/Card.test.js
+++ b/packages/components/atoms/f-card/src/components/_tests/Card.test.js
@@ -214,19 +214,19 @@ describe('Card', () => {
     describe.each([
         [true, true],
         [false, false]
-    ])('if `hasFullWidthBottomElement` prop is %s', (passedValue, expected) => {
+    ])('if `hasFullWidthFooter` prop is %s', (passedValue, expected) => {
         // Arrange
         const propsData = {
-            hasFullWidthBottomElement: passedValue
+            hasFullWidthFooter: passedValue
         };
 
         // Act
         const wrapper = shallowMount(Card, { propsData });
 
         // Act
-        const testedElement = wrapper.find('[data-test-id="card-component-fullWidthBottomElement"]');
+        const testedElement = wrapper.find('[data-test-id="card-footer"]');
 
-        it(`should ${wrapper.vm.hasFullWidthBottomElement ? '' : 'not '}display a bottom positioned full width element`, () => {
+        it(`should ${wrapper.vm.hasFullWidthFooter ? '' : 'not '}display a bottom positioned full width element`, () => {
             expect(testedElement.exists()).toBe(expected);
         });
     });

--- a/packages/components/atoms/f-card/stories/card.stories.js
+++ b/packages/components/atoms/f-card/stories/card.stories.js
@@ -19,7 +19,21 @@ export const CardComponent = (args, { argTypes }) => ({
     components: { Card },
     props: Object.keys(argTypes),
     template:
-        '<card :cardHeading="cardHeading" :cardHeadingPosition="cardHeadingPosition" :cardHeadingTag="cardHeadingTag" :isRounded="isRounded" :hasOutline="hasOutline" :isPageContentWrapper="isPageContentWrapper"><p>Some Card Content</p></card>'
+        `<card
+            :card-heading="cardHeading"
+            :card-heading-position="cardHeadingPosition"
+            :card-heading-tag="cardHeadingTag"
+            :is-rounded="isRounded"
+            :has-outline="hasOutline"
+            :is-page-content-wrapper="isPageContentWrapper"
+            :has-full-width-bottom-element="hasFullWidthBottomElement">
+            <p>Some Card Content</p>
+            <template v-slot:full-width-bottom-element>
+                <div>
+                    I am a bottom positioned full width element
+                </div>
+            </template>
+        </card>`
 });
 
 CardComponent.args = {
@@ -28,7 +42,8 @@ CardComponent.args = {
     cardHeadingTag: 'h1',
     isRounded: false,
     hasOutline: false,
-    isPageContentWrapper: false
+    isPageContentWrapper: false,
+    hasFullWidthBottomElement: false
 };
 
 CardComponent.argTypes = {

--- a/packages/components/atoms/f-card/stories/card.stories.js
+++ b/packages/components/atoms/f-card/stories/card.stories.js
@@ -26,12 +26,10 @@ export const CardComponent = (args, { argTypes }) => ({
             :is-rounded="isRounded"
             :has-outline="hasOutline"
             :is-page-content-wrapper="isPageContentWrapper"
-            :has-full-width-bottom-element="hasFullWidthBottomElement">
+            :has-full-width-footer="hasFullWidthFooter">
             <p>Some Card Content</p>
-            <template v-slot:full-width-bottom-element>
-                <div>
-                    I am a bottom positioned full width element
-                </div>
+            <template v-slot:cardFooter>
+                    <p>I am a bottom positioned full width element</p>
             </template>
         </card>`
 });
@@ -43,7 +41,7 @@ CardComponent.args = {
     isRounded: false,
     hasOutline: false,
     isPageContentWrapper: false,
-    hasFullWidthBottomElement: false
+    hasFullWidthFooter: false
 };
 
 CardComponent.argTypes = {


### PR DESCRIPTION
### Added
- `hasFullWidthFooter` prop
- Named slot `cardFooter` to render full width content at the bottom of the card without card paddings when `hasFullWidthFooter` set to true
- `.c-card-innerSpacing` css class for card paddings to be able to separate card content paddings from the card itself

### Removed
- `.c-card--separated`, `.c-card--center`, `.c-card--right` css classes as unused

![Screenshot 2021-05-20 at 14 25 17](https://user-images.githubusercontent.com/19548183/118986400-3d8f9980-b977-11eb-9bb1-15998be5ebc9.png)
