### PR TITLE
f-checkout@v0.118.0 - updated f-mega-modal, pass ErrorDialog title via prop in…

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.118.0
+------------------------------
+*May 21, 2021*
+
+### Updated
+- `f-mega-modal` to version 0.9.0 to include `title` prop
+
+### Changed
+- Refactor ErrorDialog to use `title` prop in `f-mega-modal`
+
 
 v0.117.0
 ------------------------------

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.117.0",
+  "version": "0.118.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",
@@ -65,7 +65,7 @@
     "@justeat/f-card": "0.8.0",
     "@justeat/f-error-message": "0.3.1",
     "@justeat/f-form-field": "1.12.1",
-    "@justeat/f-mega-modal": "0.8.0",
+    "@justeat/f-mega-modal": "0.9.0",
     "@justeat/f-wdio-utils": "0.1.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-checkout/src/components/ErrorDialog.vue
+++ b/packages/components/organisms/f-checkout/src/components/ErrorDialog.vue
@@ -2,16 +2,10 @@
     <mega-modal
         data-test-id="checkout-issue-modal"
         has-overlay
+        :title="$t(`errorMessages.checkoutIssues.${errorCode}.title`, { serviceType: serviceTypeText })"
         :is-open="isOpen"
         @close="closeErrorDialog"
     >
-        <h3
-            data-test-id="checkout-issue-modal-title"
-            :class="$style['c-checkout-errorTitle']"
-        >
-            {{ $t(`errorMessages.checkoutIssues.${errorCode}.title`, { serviceType: serviceTypeText }) }}
-        </h3>
-
         <p data-test-id="checkout-issue-modal-message">
             {{ $t(`errorMessages.checkoutIssues.${errorCode}.message`, { serviceType: serviceTypeText }) }}
         </p>
@@ -90,10 +84,6 @@ export default {
 </script>
 
 <style lang="scss" module>
-.c-checkout-errorTitle {
-    margin: 0 spacing(x3);
-}
-
 .c-checkout-redirectButton {
     margin: spacing(x4) 0 spacing(x0.5);
 }


### PR DESCRIPTION
v0.118.0
------------------------------
*May 21, 2021*

### Updated
- `f-mega-modal` to version 0.9.0 to include `title` prop

### Changed
- Refactor ErrorDialog to use `title` prop in `f-mega-modal`