### PR TITLE
f-card@1.2.1 - css fix

### DIFF
--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -11,6 +11,9 @@ v1.2.1
 ### Added
 - Returned back `.c-card--center`, `.c-card--right` css classes as they are in use for aligning the header. Renamed to `.c-card--centerAlignedText` and `.c-card--rightAlignedText`.
 
+### Changed
+-Refactored unit tests
+
 
 v1.2.0
 ------------------------------

--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -9,7 +9,7 @@ v1.2.1
 *May 20, 2021*
 
 ### Added
-- Returned back `.c-card--center`, `.c-card--right` css classes as they are in use for aligning the header. Renamed to `.c-card--centerAlignedText` and `.c-card--rightAlignedText`.
+- Returned back `.c-card--center`, `.c-card--right` css classes as they are in use for aligning the header. Renamed to `.c-card-heading--centerAligned` and `.c-card-heading--rightAligned`.
 
 ### Changed
 -Refactored unit tests

--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.2.1
+------------------------------
+*May 20, 2021*
+
+### Added
+- Returned back `.c-card--center`, `.c-card--right` css classes as they are in use for aligning the header. Renamed to `.c-card--centerAlignedText` and `.c-card--rightAlignedText`.
+
+
 v1.2.0
 ------------------------------
 *May 20, 2021*

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card",
   "description": "Fozzie Card Component – Used for providing wrapper card styling to an element (or group of elements)",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "dist/f-card.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -13,7 +13,7 @@
                 v-if="cardHeading"
                 :class="[
                     $style['c-card-heading'],
-                    { [$style[`c-card--${cardHeadingPosition}AlignedText`]]: cardHeadingPosition !== 'left' }
+                    { [$style[`c-card-heading--${cardHeadingPosition}Aligned`]]: cardHeadingPosition !== 'left' }
                 ]"
                 data-test-id="card-heading">
                 {{ cardHeading }}
@@ -124,11 +124,11 @@ $card--pageContentWrapper-width           : 472px; // so that it falls on our 8p
         margin-bottom: spacing(x2);
     }
 
-    .c-card--centerAlignedText {
+    .c-card-heading--centerAligned {
         text-align: center;
     }
 
-    .c-card--rightAlignedText {
+    .c-card-heading--rightAligned {
         text-align: right;
     }
 </style>

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -13,7 +13,7 @@
                 v-if="cardHeading"
                 :class="[
                     $style['c-card-heading'],
-                    (cardHeadingPosition !== 'left' ? $style[`c-card--${cardHeadingPosition}`] : '')
+                    (cardHeadingPosition !== 'left' ? $style[`c-card--${cardHeadingPosition}AlignedText`] : '')
                 ]"
                 data-test-id="card-heading">
                 {{ cardHeading }}
@@ -122,5 +122,13 @@ $card--pageContentWrapper-width           : 472px; // so that it falls on our 8p
 
     .c-card-heading {
         margin-bottom: spacing(x2);
+    }
+
+    .c-card--centerAlignedText {
+        text-align: center;
+    }
+
+    .c-card--rightAlignedText {
+        text-align: right;
     }
 </style>

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -13,7 +13,7 @@
                 v-if="cardHeading"
                 :class="[
                     $style['c-card-heading'],
-                    (cardHeadingPosition !== 'left' ? $style[`c-card--${cardHeadingPosition}AlignedText`] : '')
+                    { [$style[`c-card--${cardHeadingPosition}AlignedText`]]: cardHeadingPosition !== 'left' }
                 ]"
                 data-test-id="card-heading">
                 {{ cardHeading }}

--- a/packages/components/atoms/f-card/src/components/_tests/Card.test.js
+++ b/packages/components/atoms/f-card/src/components/_tests/Card.test.js
@@ -5,8 +5,8 @@ const $style = {
     'c-card--rounded': 'c-card--rounded',
     'c-card--outline': 'c-card--outline',
     'c-card--pageContentWrapper': 'c-card--pageContentWrapper',
-    'c-card--centerAlignedText': 'c-card--centerAlignedText',
-    'c-card--rightAlignedText': 'c-card--rightAlignedText'
+    'c-card-heading--centerAligned': 'c-card-heading--centerAligned',
+    'c-card-heading--rightAligned': 'c-card-heading--rightAligned'
 };
 
 describe('Card', () => {
@@ -119,8 +119,8 @@ describe('Card', () => {
             });
 
             it.each([
-                ['c-card--centerAlignedText', 'center'],
-                ['c-card--rightAlignedText', 'right']
+                ['c-card-heading--centerAligned', 'center'],
+                ['c-card-heading--rightAligned', 'right']
             ])('should add %s class to the heading if `cardHeadingPosition` prop is set to %s', (cssClass, propValue) => {
                 // Arrange & Act
                 const wrapper = shallowMount(Card, {

--- a/packages/components/atoms/f-card/src/components/_tests/Card.test.js
+++ b/packages/components/atoms/f-card/src/components/_tests/Card.test.js
@@ -67,10 +67,7 @@ describe('Card', () => {
     describe('props', () => {
         describe.each([
             ['isRounded', 'c-card--rounded'],
-            ['isRounded', 'c-card--rounded'],
             ['hasOutline', 'c-card--outline'],
-            ['hasOutline', 'c-card--outline'],
-            ['isPageContentWrapper', 'c-card--pageContentWrapper'],
             ['isPageContentWrapper', 'c-card--pageContentWrapper']
         ])('%s', (propKey, cssClass) => {
             it(`should not apply ${cssClass} to the card if it is not set`, () => {

--- a/packages/components/atoms/f-card/src/components/_tests/Card.test.js
+++ b/packages/components/atoms/f-card/src/components/_tests/Card.test.js
@@ -1,6 +1,14 @@
 import { shallowMount } from '@vue/test-utils';
 import Card from '../Card.vue';
 
+const $style = {
+    'c-card--rounded': 'c-card--rounded',
+    'c-card--outline': 'c-card--outline',
+    'c-card--pageContentWrapper': 'c-card--pageContentWrapper',
+    'c-card--centerAlignedText': 'c-card--centerAlignedText',
+    'c-card--rightAlignedText': 'c-card--rightAlignedText'
+};
+
 describe('Card', () => {
     it('should be defined', () => {
         // Arrange
@@ -57,107 +65,80 @@ describe('Card', () => {
     });
 
     describe('props', () => {
-        describe('isRounded', () => {
-            it('should default to `false` if it is not set', () => {
-                // Arrange
-                const propsData = {};
-
-                // Act
-                const wrapper = shallowMount(Card, { propsData });
+        describe.each([
+            ['isRounded', 'c-card--rounded'],
+            ['isRounded', 'c-card--rounded'],
+            ['hasOutline', 'c-card--outline'],
+            ['hasOutline', 'c-card--outline'],
+            ['isPageContentWrapper', 'c-card--pageContentWrapper'],
+            ['isPageContentWrapper', 'c-card--pageContentWrapper']
+        ])('%s', (propKey, cssClass) => {
+            it(`should not apply ${cssClass} to the card if it is not set`, () => {
+                // Arrange & Act
+                const wrapper = shallowMount(Card, { propsData: {} });
 
                 // Assert
-                expect(wrapper.vm.isRounded).toBe(false);
+                expect(wrapper.attributes('class')).not.toContain(cssClass);
             });
 
-            it('should be set to `true` if the `isRounded` prop is passed in as `true`', () => {
-                // Arrange
-                const propsData = {
-                    isRounded: true
-                };
-
-                // Act
-                const wrapper = shallowMount(Card, { propsData });
-
-                // Assert
-                expect(wrapper.vm.isRounded).toBe(true);
-            });
-        });
-
-        describe('hasOutline', () => {
-            it('should default to `false` if it is not set', () => {
-                // Arrange
-                const propsData = {};
-
-                // Act
-                const wrapper = shallowMount(Card, { propsData });
+            it(`should apply ${cssClass} class to the card if set to true`, () => {
+                // Arrange & Act
+                const wrapper = shallowMount(Card, {
+                    propsData: {
+                        [propKey]: true
+                    },
+                    mocks: {
+                        $style
+                    }
+                });
 
                 // Assert
-                expect(wrapper.vm.hasOutline).toBe(false);
+                expect(wrapper.attributes('class')).toContain(cssClass);
             });
 
-            it('should be set to `true` if the `hasOutline` prop is passed in as `true`', () => {
-                // Arrange
-                const propsData = {
-                    hasOutline: true
-                };
-
-                // Act
-                const wrapper = shallowMount(Card, { propsData });
-
-                // Assert
-                expect(wrapper.vm.hasOutline).toBe(true);
-            });
-        });
-
-        describe('isPageContentWrapper', () => {
-            it('should default to `false` if it is not set', () => {
-                // Arrange
-                const propsData = {};
-
-                // Act
-                const wrapper = shallowMount(Card, { propsData });
+            it(`should not apply ${cssClass} class to the card if set to false`, () => {
+                // Arrange & Act
+                const wrapper = shallowMount(Card, {
+                    propsData: {
+                        [propKey]: false
+                    },
+                    mocks: {
+                        $style
+                    }
+                });
 
                 // Assert
-                expect(wrapper.vm.isPageContentWrapper).toBe(false);
-            });
-
-            it('should be set to `true` if the `isPageContentWrapper` prop is passed in as `true`', () => {
-                // Arrange
-                const propsData = {
-                    isPageContentWrapper: true
-                };
-
-                // Act
-                const wrapper = shallowMount(Card, { propsData });
-
-                // Assert
-                expect(wrapper.vm.isPageContentWrapper).toBe(true);
+                expect(wrapper.attributes('class')).not.toContain(cssClass);
             });
         });
 
         describe('cardHeadingPosition', () => {
             it('should default to `left` if it is not set', () => {
-                // Arrange
-                const propsData = {};
-
-                // Act
-                const wrapper = shallowMount(Card, { propsData });
+                // Arrange & Act
+                const wrapper = shallowMount(Card, { propsData: {} });
 
                 // Assert
                 expect(wrapper.vm.cardHeadingPosition).toBe('left');
             });
 
-            it('should be set to `center` if the `cardHeadingPosition` prop is passed in as `center`', () => {
-                // Arrange
-                const propsData = {
-                    cardHeadingPosition: 'center'
-                };
-
-                // Act
-                const wrapper = shallowMount(Card, { propsData });
+            it.each([
+                ['c-card--centerAlignedText', 'center'],
+                ['c-card--rightAlignedText', 'right']
+            ])('should add %s class to the heading if `cardHeadingPosition` prop is set to %s', (cssClass, propValue) => {
+                // Arrange & Act
+                const wrapper = shallowMount(Card, {
+                    propsData: {
+                        cardHeadingPosition: propValue,
+                        cardHeading: 'Test Heading'
+                    },
+                    mocks: {
+                        $style
+                    }
+                });
+                const testedElement = wrapper.find('[data-test-id="card-heading"]');
 
                 // Assert
-                expect(wrapper.vm.cardHeadingPosition).toBe('center');
+                expect(testedElement.attributes('class')).toContain(cssClass);
             });
 
             it('should only allow `left`, `right` or `center` to be passed in.', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,6 +2249,11 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.7.0.tgz#e7f4aedfbaa614386f7fe5a180111e884c7db694"
   integrity sha512-IGknAfUH9vExdkY8hg/tcK1iAHFzA1DusKiKMHFOf3obQ/cAMA2hK7I9JCSCGjBUrcBYhpY3WdlLxu9hInJREw==
 
+"@justeat/f-mega-modal@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.8.0.tgz#ec7085b4c4348ed86ebdd448d71b03c435685b69"
+  integrity sha512-tfa95GsfXhtRbOnzQljQtfbGSJZrVI2lSy1WJ8hQppr+ihcG+OtR73C5DJzhDUpKQc1IYsQW2g2DXw78gcNwwA==
+
 "@justeat/f-searchbox@3.10.0":
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-searchbox/-/f-searchbox-3.10.0.tgz#1a6b235494f1e22de14bd1d6eea146fd575f419b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,11 +2249,6 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.7.0.tgz#e7f4aedfbaa614386f7fe5a180111e884c7db694"
   integrity sha512-IGknAfUH9vExdkY8hg/tcK1iAHFzA1DusKiKMHFOf3obQ/cAMA2hK7I9JCSCGjBUrcBYhpY3WdlLxu9hInJREw==
 
-"@justeat/f-mega-modal@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.8.0.tgz#ec7085b4c4348ed86ebdd448d71b03c435685b69"
-  integrity sha512-tfa95GsfXhtRbOnzQljQtfbGSJZrVI2lSy1WJ8hQppr+ihcG+OtR73C5DJzhDUpKQc1IYsQW2g2DXw78gcNwwA==
-
 "@justeat/f-searchbox@3.10.0":
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-searchbox/-/f-searchbox-3.10.0.tgz#1a6b235494f1e22de14bd1d6eea146fd575f419b"


### PR DESCRIPTION
### Added
- Returned back `.c-card--center`, `.c-card--right` css classes as they are in use for aligning the header. Renamed to `.c-card-heading--centerAligned` and `.c-card-heading--rightAligned`.

### Changed
-Refactored unit tests