### PR TITLE
f-checkout@0.118.1 - Check mobile number exists before formatting

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -11,6 +11,7 @@ v0.118.1
 ### Changed
 - check mobile number exists before formatting for screen reader
 
+
 v0.118.0
 ------------------------------
 *May 21, 2021*

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.118.1
 ------------------------------
-*May 21, 2021*
+*May 24, 2021*
 
 ### Changed
-- check mobile number exists before formatting for screen reader
+- Check mobile number exists before formatting for screen reader
 
 
 v0.118.0

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.118.1
+------------------------------
+*May 21, 2021*
+
+### Changed
+- check mobile number exists before formatting for screen reader
+
 v0.118.0
 ------------------------------
 *May 21, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.118.0",
+  "version": "0.118.1",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -399,7 +399,7 @@ export default {
         },
 
         formattedMobileNumberForScreenReader () {
-            return [...this.customer.mobileNumber].join(' ');
+            return this.customer.mobileNumber ? [...this.customer.mobileNumber].join(' ') : '';
         }
     },
 


### PR DESCRIPTION
### Changed
- Check mobile number exists before formatting for screen reader


- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
