### PR TITLE
f-button@1.3.0 - Fix disabled styling

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.3.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- Cascade to fix disabled styling.
+
+### Added
+- Storybook control to show enabled/disabled styles.
+
+
 v1.2.0
 ------------------------------
 *March 11, 2021*

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/f-button.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -177,18 +177,6 @@ $btn-icon-sizeXSmall-iconSize    : 18px;
     &:visited {
         text-decoration: none;
     }
-
-    // Disabled state
-    &.is-disabled,
-    &[disabled] {
-        cursor: not-allowed;
-
-        &,
-        &:hover {
-            background-color: $btn-disabled-bgColor;
-            color: $btn-disabled-textColor;
-        }
-    }
 }
 
 /**
@@ -477,6 +465,25 @@ $btn-icon-sizeXSmall-iconSize    : 18px;
     // same as .o-btn--fullWidth + .o-btn--fullWidth
     & + & {
         margin-top: spacing();
+    }
+}
+
+/**
+ * ==========================================================================
+ * Disabled state styling
+ * ==========================================================================
+ */
+
+.o-btn {
+    &.is-disabled,
+    &[disabled] {
+        cursor: not-allowed;
+
+        &,
+        &:hover {
+            background-color: $btn-disabled-bgColor;
+            color: $btn-disabled-textColor;
+        }
     }
 }
 </style>

--- a/packages/components/atoms/f-button/stories/Button.stories.js
+++ b/packages/components/atoms/f-button/stories/Button.stories.js
@@ -26,6 +26,10 @@ export const ButtonComponent = () => ({
             default: select('Button Size', ['xsmall', 'small', 'medium', 'large'], 'medium')
         },
 
+        disabled: {
+            default: boolean('disabled', false)
+        },
+
         isFullWidth: {
             default: boolean('isFullWidth', false)
         },
@@ -43,6 +47,7 @@ export const ButtonComponent = () => ({
         <f-button
             :buttonType="buttonType"
             :buttonSize="buttonSize"
+            :disabled="disabled"
             :isFullWidth="isFullWidth"
             :actionType="actionType"
             :href="href"


### PR DESCRIPTION
| Before | After |
| ------- | ----- |
| ![20210525T103938](https://user-images.githubusercontent.com/26894168/119482629-02f97880-bd4c-11eb-896e-30f847ddbc3a.png) | ![20210525T112335](https://user-images.githubusercontent.com/26894168/119482645-07259600-bd4c-11eb-9a86-7ca60fb67753.png) |

### Changed
- Cascade to fix disabled styling.

### Added
- Storybook control to show enabled/disabled styles.

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
