### PR TITLE
f-form-field@v1.13.0 – Fix for `isSelectionControl`

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.13.0
+------------------------------
+*May 25, 2021*
+
+### Fixed
+- `isSelectionControl` was back-to-front and was true when not a selector like checkbox or radio. This has been fixed.
+- `c-formField-field--focus` switched to `c-formField-field--noFocus` class.
+
+
 v1.12.1
 ------------------------------
 *May 18, 2021*

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -34,8 +34,7 @@
                 :class="[
                     $style['c-formField-field'],
                     $style['c-formField-field--defaultHeight'],
-                    $style['c-formField-dropdownContainer'],
-                    $style['c-formField-field--focus']
+                    $style['c-formField-dropdownContainer']
                 ]"
                 :dropdown-options="dropdownOptions"
                 v-on="listeners" />
@@ -48,7 +47,6 @@
                 v-bind="$attrs"
                 :class="[
                     $style['c-formField-field'],
-                    $style['c-formField-field--focus'],
                     $style['c-formField-field--textarea']
                 ]"
                 data-test-id="formfield-textarea"
@@ -68,7 +66,7 @@
                 :class="[
                     $style['c-formField-field'],
                     $style['c-formField-field--defaultHeight'],
-                    { [$style['c-formField-field--focus']]: isSelectionControl }
+                    { [$style['c-formField-field--noFocus']]: isSelectionControl }
                 ]"
                 v-on="listeners"
             >
@@ -235,7 +233,7 @@ export default {
         },
 
         isSelectionControl () {
-            return !(this.inputType === 'radio' || this.inputType === 'checkbox');
+            return this.inputType === 'radio' || this.inputType === 'checkbox';
         },
 
         isFieldGrouped () {
@@ -323,6 +321,13 @@ $form-input-focus--boxShadow              : 0 0 0 2px $form-input-focus;
             background-color: $form-input-bg--hover;
         }
 
+        &:focus,
+        &:active,
+        &:focus-within {
+            box-shadow: $form-input-focus--boxShadow;
+            outline: none;
+        }
+
         .c-formField--invalid & {
             border-color: $form-input-borderColour--invalid;
         }
@@ -346,12 +351,11 @@ $form-input-focus--boxShadow              : 0 0 0 2px $form-input-focus;
         resize: none;
     }
 
-    .c-formField-field--focus {
+    .c-formField-field--noFocus {
         &:focus,
         &:active,
         &:focus-within {
-            box-shadow: $form-input-focus--boxShadow;
-            outline: none;
+            box-shadow: none;
         }
     }
 

--- a/packages/components/atoms/f-form-field/src/components/_tests/FormField.test.js
+++ b/packages/components/atoms/f-form-field/src/components/_tests/FormField.test.js
@@ -5,6 +5,10 @@ import {
     DEFAULT_INPUT_TYPE, VALID_INPUT_TYPES, VALID_LABEL_STYLES
 } from '../../constants';
 
+const $style = {
+    'c-formField-field--noFocus': 'c-formField-field--noFocus'
+};
+
 describe('FormField', () => {
     it('should be defined', () => {
         const propsData = {};
@@ -195,6 +199,26 @@ describe('FormField', () => {
                     expect(defaultLabel.exists()).toBe(false);
                     expect(inlineLabel.exists()).toBe(true);
                 });
+            });
+        });
+    });
+
+    describe('computed :: ', () => {
+        describe('isSelectionControl :: ', () => {
+            it('should capitalise to first letter of `buttonSize` prop :: ', () => {
+                // Arrange & Act
+                const wrapper = shallowMount(FormField, {
+                    propsData: {
+                        inputType: 'checkbox'
+                    },
+                    mocks: {
+                        $style
+                    }
+                });
+                const formInput = wrapper.find('input'); // change to .c-formField when CSS Modules is working
+
+                // Assert
+                expect(formInput.attributes('class')).toContain('c-formField-field--noFocus');
             });
         });
     });


### PR DESCRIPTION
### Fixed
- `isSelectionControl` was back-to-front and was true when not a selector like checkbox or radio. This has been fixed.
- `c-formField-field--focus` switched to `c-formField-field--noFocus` class.

---

## UI Review Checks

- [x] Unit tests have been created

## Browsers Tested

- [x] Chrome (latest)
