### PR TITLE
fozzie-components@3.34.0 – Updating fozzie version to 5.0.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.34.0
+------------------------------
+*May 18, 2021*
+
+### Updated 
+- fozzie to v5.0.0-beta.7 which uses new pie design tokens instead of fozzie-colour-palette vars
+
+
 v3.33.0
 ------------------------------
 *May 18, 2021*
 
-## Changed
+### Changed
 - `@wdio` to `v7` to fix a Node 14 potential package conflict.
 
 
@@ -16,7 +24,7 @@ v3.32.0
 ------------------------------
 *May 5, 2021*
 
-## Removed
+### Removed
 - `f-utils` and `fozzie-colour-pallete` packages from dependencies as they are available through `fozzie` package
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "3.33.0",
+  "version": "3.34.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",
@@ -34,7 +34,7 @@
     "@babel/preset-env": "7.10.4",
     "@justeat/browserslist-config-fozzie": "1.1.1",
     "@justeat/eslint-config-fozzie": "3.4.1",
-    "@justeat/fozzie": "5.0.0-beta.3",
+    "@justeat/fozzie": "5.0.0-beta.7",
     "@justeat/stylelint-config-fozzie": "2.2.0",
     "@percy/cli": "1.0.0-beta.48",
     "@percy/webdriverio": "2.0.0",

--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -3,12 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-
-Latest – to be added to the next release
+v1.4.0
 ------------------------------
+*May 25, 2021*
 
 ### Added
 - Percy visual regression tests
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
 
 
 v1.3.0

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "dist/f-button.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -78,39 +78,36 @@ export default {
 
 <style lang="scss" module>
 
-$btn-default-bgColor            : $grey--lighter;
-$btn-default-bgColor--hover     : $grey--light;
 $btn-default-borderRadius       : $border-radius;
 $btn-default-font-family        : $font-family-base;
 $btn-default-font-size          : 'body-l';
 $btn-default-weight             : $font-weight-bold;
 $btn-default-padding            : 11px 1.5em 13px;
-$btn-default-outline-color      : $color-focus-outline;
+$btn-default-outline-color      : $color-focus;
 
-$btn-primary-bgColor            : $blue;
-$btn-primary-bgColor--hover     : $blue--dark;
-$btn-primary-bgColor--focus     : $blue--darkest;
-$btn-primary-textColor          : $white;
+$btn-primary-bgColor            : $color-interactive-primary;
+$btn-primary-bgColor--hover     : darken($color-interactive-primary, $color-hover-01);
+$btn-primary-bgColor--active    : darken($color-interactive-primary, $color-active-01);
+$btn-primary-textColor          : $color-content-interactive-primary;
 
-$btn-secondary-bgColor          : $blue--offWhite;
-$btn-secondary-bgColor--hover   : $blue--offWhite--dark;
-$btn-secondary-bgColor--active  : $blue--offWhite--darkest;
-$btn-secondary-textColor        : $blue;
+$btn-secondary-bgColor          : $color-interactive-secondary;
+$btn-secondary-bgColor--hover   : darken($color-interactive-secondary, $color-hover-01);
+$btn-secondary-bgColor--active  : darken($color-interactive-secondary, $color-active-01);
+$btn-secondary-textColor        : $color-content-interactive-secondary;
 
 $btn-outline-bgColor            : transparent;
-$btn-outline-bgColor--hover     : rgba($black, 0.08);
-$btn-outline-bgColor--active    : rgba($black, 0.12);
-$btn-outline-textColor          : $black;
-$btn-outline-border-color       : $grey--light;
-// TODO: checking with design if $btn-outline-border-color should change on hover/active
+$btn-outline-bgColor--hover     : darken($color-white, $color-hover-01);
+$btn-outline-bgColor--active    : darken($color-white, $color-active-01);
+$btn-outline-textColor          : $color-content-interactive-tertiary;
+$btn-outline-border-color       : $color-border-default;
 
 $btn-ghost-bgColor              : transparent;
-$btn-ghost-bgColor--hover       : rgba($black, 0.08);
-$btn-ghost-bgColor--active      : rgba($black, 0.12);
-$btn-ghost-textColor            : $blue;
+$btn-ghost-bgColor--hover       : rgba($color-black, 0.08);
+$btn-ghost-bgColor--active      : rgba($color-black, 0.12);
+$btn-ghost-textColor            : $color-content-interactive-secondary;
 
-$btn-disabled-bgColor           : $grey--light;
-$btn-disabled-textColor         : $grey--midDark;
+$btn-disabled-bgColor           : $color-disabled-01;
+$btn-disabled-textColor         : $color-content-disabled;
 
 $btn-sizeLarge-font-size        : 'heading-s';
 $btn-sizeLarge-padding          : 13px 1.2em 15px;
@@ -140,17 +137,11 @@ $btn-icon-sizeXSmall-iconSize    : 18px;
     overflow: visible;
     text-align: center;
     font-weight: $btn-default-weight;
-    background-color: $btn-default-bgColor;
     border-radius: $btn-default-borderRadius;
     border: 1px solid transparent;
     user-select: none;
-    color: $grey--dark;
+    color: $color-grey-50;
     text-decoration: none;
-
-    &:hover,
-    &:active {
-        background-color: $btn-default-bgColor--hover;
-    }
 
     // Hide focus styles if they're not needed, for example, when an element receives focus via the mouse.
     &:focus:not(:focus-visible) {
@@ -212,7 +203,7 @@ $btn-icon-sizeXSmall-iconSize    : 18px;
     }
 
     &:active {
-        background-color: $btn-primary-bgColor--focus;
+        background-color: $btn-primary-bgColor--active;
     }
 }
 
@@ -299,18 +290,18 @@ $btn-icon-sizeXSmall-iconSize    : 18px;
     border: 0;
     background-color: transparent;
     padding: 0;
-    color: $color-link-default;
+    color: $color-content-link;
     font-weight: $font-weight-bold;
 
     &:hover {
         cursor: pointer;
-        color: $color-link-hover;
+        color: darken($color-content-link, $color-hover-01);
         background-color: transparent;
         text-decoration: underline;
     }
     &:active,
     &:focus {
-        color: $color-link-active;
+        color: darken($color-content-link, $color-active-02);
         background-color: transparent;
     }
 }
@@ -355,19 +346,19 @@ $btn-icon-sizeXSmall-iconSize    : 18px;
 
     &.o-btn--link {
         path {
-            fill: $color-link-default;
+            fill: $color-content-link;
         }
 
         &:hover {
             path {
-                fill: $color-link-hover;
+                fill: darken($color-content-link, $color-hover-01);
             }
         }
 
         &:active,
         &:focus {
             path {
-                fill: $color-link-active;
+                fill: darken($color-content-link, $color-active-02);
             }
         }
     }
@@ -425,13 +416,13 @@ $btn-icon-sizeXSmall-iconSize    : 18px;
     padding: $btn-sizeLarge-padding;
 
     &.o-btn--primary {
-        background-color: $orange;
+        background-color: $color-interactive-brand;
 
         &:hover {
-            background-color: $orange--dark;
+            background-color: darken($color-interactive-brand, $color-hover-01);
         }
         &:active {
-            background-color: $orange--darkest;
+            background-color: darken($color-interactive-brand, $color-active-01);
         }
     }
 }

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -301,7 +301,7 @@ $btn-icon-sizeXSmall-iconSize    : 18px;
     }
     &:active,
     &:focus {
-        color: darken($color-content-link, $color-active-02);
+        color: darken($color-content-link, $color-active-01);
         background-color: transparent;
     }
 }
@@ -358,7 +358,7 @@ $btn-icon-sizeXSmall-iconSize    : 18px;
         &:active,
         &:focus {
             path {
-                fill: darken($color-content-link, $color-active-02);
+                fill: darken($color-content-link, $color-active-01);
             }
         }
     }

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -102,8 +102,8 @@ $btn-outline-textColor          : $color-content-interactive-tertiary;
 $btn-outline-border-color       : $color-border-default;
 
 $btn-ghost-bgColor              : transparent;
-$btn-ghost-bgColor--hover       : rgba($color-black, 0.08);
-$btn-ghost-bgColor--active      : rgba($color-black, 0.12);
+$btn-ghost-bgColor--hover       : darken($color-white, $color-hover-01);
+$btn-ghost-bgColor--active      : darken($color-white, $color-active-01);
 $btn-ghost-textColor            : $color-content-interactive-secondary;
 
 $btn-disabled-bgColor           : $color-disabled-01;

--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.3.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v1.2.1
 ------------------------------
 *May 20, 2021*

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card",
   "description": "Fozzie Card Component – Used for providing wrapper card styling to an element (or group of elements)",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "main": "dist/f-card.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -70,8 +70,8 @@ export default {
 
 <style lang="scss" module>
 
-$card-bgColor                             : $color-bg--component;
-$card-borderColor                         : $color-border;
+$card-bgColor                             : $color-container-default;
+$card-borderColor                         : $color-border-strong;
 $card-borderRadius                        : $border-radius;
 $card-padding                             : spacing(x2);
 

--- a/packages/components/atoms/f-error-message/CHANGELOG.md
+++ b/packages/components/atoms/f-error-message/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.5.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v0.4.0
 ------------------------------
 *March 3, 2021*

--- a/packages/components/atoms/f-error-message/package.json
+++ b/packages/components/atoms/f-error-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-error-message",
   "description": "Fozzie Error Message – Generic inline error message",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/f-error-message.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-error-message/src/components/ErrorMessage.vue
+++ b/packages/components/atoms/f-error-message/src/components/ErrorMessage.vue
@@ -37,7 +37,7 @@ export default {
 <style lang="scss" module>
 .c-errorMessage {
     position: relative;
-    color: $color-text--danger;
+    color: $color-content-error;
     @include font-size();
     margin-top: spacing();
 }

--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.14.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v1.13.0
 ------------------------------
 *May 25, 2021*

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-form-field/src/assets/scss/common.scss
+++ b/packages/components/atoms/f-form-field/src/assets/scss/common.scss
@@ -4,8 +4,3 @@
 $theme: 'jet' !default;
 
 @import  '~@justeat/fozzie/src/scss/fozzie';
-
-/**
- * Component Variables
- */
-// $formField-background-color: $brand--orange;

--- a/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
@@ -78,7 +78,7 @@ export default {
     transform: rotate(180deg);
 
     path {
-        fill: $grey--dark;
+        fill: $color-content-subdued;
     }
 }
 

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -273,21 +273,21 @@ export default {
 </script>
 
 <style lang="scss" module>
-$form-input-textColour                    : $color-text;
-$form-input-textColour--disabled          : $grey--midDark;
-$form-input-bg                            : $white;
-$form-input-bg--hover                     : rgba($black, 0.04);
-$form-input-bg--disabled                  : $color-disabled;
+$form-input-textColour                    : $color-content-default;
+$form-input-textColour--disabled          : $color-content-disabled;
+$form-input-bg                            : $color-container-default;
+$form-input-bg--hover                     : darken($form-input-bg, $color-hover-02);
+$form-input-bg--disabled                  : $color-disabled-01;
 $form-input-borderRadius                  : $border-radius;
 $form-input-borderWidth                   : 1px;
-$form-input-borderColour                  : $color-border;
-$form-input-borderColour--focus           : $color-border--interactive;
-$form-input-borderColour--invalid         : $red;
-$form-input-borderColour--disabled        : $color-disabled;
+$form-input-borderColour                  : $color-border-strong;
+$form-input-borderColour--focus           : $color-grey-50;
+$form-input-borderColour--invalid         : $color-support-error;
+$form-input-borderColour--disabled        : $color-disabled-01;
 $form-input-height                        : 46px; // height is 46px + 1px border = 48px
 $form-input-padding                       : spacing(x1.5) spacing(x2);
 $form-input-fontSize                      : 'body-l';
-$form-input-focus                         : $blue--light;
+$form-input-focus                         : $color-focus;
 $form-input-focus--boxShadow              : 0 0 0 2px $form-input-focus;
 
 .c-formField {
@@ -308,7 +308,7 @@ $form-input-focus--boxShadow              : 0 0 0 2px $form-input-focus;
         width: 100%;
         font-family: $font-family-base;
         @include font-size($form-input-fontSize);
-        font-weight: $font-weight-base;
+        font-weight: $font-weight-regular;
         color: $form-input-textColour;
 
         background-color: $form-input-bg;

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -276,7 +276,7 @@ export default {
 $form-input-textColour                    : $color-content-default;
 $form-input-textColour--disabled          : $color-content-disabled;
 $form-input-bg                            : $color-container-default;
-$form-input-bg--hover                     : darken($form-input-bg, $color-hover-02);
+$form-input-bg--hover                     : darken($form-input-bg, $color-hover-01);
 $form-input-bg--disabled                  : $color-disabled-01;
 $form-input-borderRadius                  : $border-radius;
 $form-input-borderWidth                   : 1px;

--- a/packages/components/atoms/f-form-field/src/components/FormLabel.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormLabel.vue
@@ -43,14 +43,14 @@ export default {
 
 <style lang="scss" module>
 
-$form-label-colour              : $grey--darkest; // Text colour of form labels
+$form-label-colour              : $color-content-default; // Text colour of form labels
 $form-label-fontSize            : 'body-s';
 $form-label-weight              : $font-weight-bold;
 
 $form-inlineLabel-padding       : spacing(x1.5) spacing(x2);
-$form-inlineLabel-colour        : $grey--dark;
+$form-inlineLabel-colour        : $color-content-subdued;
 $form-inlineLabel-fontSize      : 'body-l';
-$form-inlineLabel-weight        : $font-weight-base;
+$form-inlineLabel-weight        : $font-weight-regular;
 
 
 .c-formField-label {

--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.3.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v0.2.0
 ------------------------------
 *May 24, 2021*

--- a/packages/components/atoms/f-link/package.json
+++ b/packages/components/atoms/f-link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-link",
   "description": "Fozzie Link - Fozzie link component",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/f-link.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -106,16 +106,16 @@ export default {
 <style lang="scss" module>
 .o-link {
     & {
-        color: $color-link-default;
+        color: $color-content-link;
     }
 
     &:hover,
     &:focus {
-        color: $color-link-hover;
+        color: darken($color-content-link, $color-hover-01);
     }
 
     &:active {
-        color: $color-link-active;
+        color: darken($color-content-link, $color-active-02);
     }
 }
 

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -115,7 +115,7 @@ export default {
     }
 
     &:active {
-        color: darken($color-content-link, $color-active-02);
+        color: darken($color-content-link, $color-active-01);
     }
 }
 

--- a/packages/components/atoms/f-popover/CHANGELOG.md
+++ b/packages/components/atoms/f-popover/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.3.0
+------------------------------
+*May 16, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v0.2.1
 ------------------------------
 *March 15, 2021*

--- a/packages/components/atoms/f-popover/package.json
+++ b/packages/components/atoms/f-popover/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-popover",
   "description": "Fozzie Popover - renders recieved content as a popover",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "main": "dist/f-popover.umd.min.js",
   "files": [
     "dist" 

--- a/packages/components/atoms/f-popover/src/components/Popover.vue
+++ b/packages/components/atoms/f-popover/src/components/Popover.vue
@@ -23,7 +23,7 @@ $tooltip-width                 : 10px;
 
 .c-popover {
     @include media('>mid') {
-        background-color: $color-bg--component;
+        background-color: $color-container-default;
         box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.03),
                     0 1px 10px 1px rgba(0, 0, 0, 0.07),
                     0 2px 4px -1px rgba(0, 0, 0, 0.06);
@@ -35,7 +35,7 @@ $tooltip-width                 : 10px;
         &:before {
             bottom: 100%;
             border: $tooltip-width solid transparent;
-            border-bottom: $tooltip-width solid $color-bg--component;
+            border-bottom: $tooltip-width solid $color-container-default;
             content: '';
             height: 0;
             width: 0;

--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.6.0
+------------------------------
+*May 25, 2020*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v0.5.0
 ------------------------------
 *March 18, 2020*

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-alert",
   "description": "Fozzie Alert – Fozzie Alert Component",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "dist/f-alert.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/molecules/f-alert/src/components/Alert.vue
+++ b/packages/components/molecules/f-alert/src/components/Alert.vue
@@ -129,19 +129,19 @@ $alert-borderRadius: $border-radius;
     }
 
     .c-alert--success {
-        @include alert-variant($color-bg--accept, $color-text);
+        @include alert-variant($color-support-positive-02, $color-content-default);
     }
 
     .c-alert--warning {
-        @include alert-variant($color-bg--notification, $color-text);
+        @include alert-variant($color-support-warning-02, $color-content-default);
     }
 
     .c-alert--danger {
-        @include alert-variant($color-bg--error, $color-text);
+        @include alert-variant($color-support-error-02, $color-content-default);
     }
 
     .c-alert--info {
-        @include alert-variant($color-bg--info, $color-text);
+        @include alert-variant($color-support-info-02, $color-content-default);
     }
 
     .c-alert-heading {
@@ -178,7 +178,7 @@ $alert-borderRadius: $border-radius;
             height: 16px;
 
             * {
-                fill: $color-border--interactive;
+                fill: $color-content-subdued;
             }
         }
 </style>

--- a/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
+++ b/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
@@ -4,11 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (add to next release)
+v0.3.0
 ------------------------------
-*February 25, 2021*
+*May 25, 2021*
 
 ### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
 - Restructured component object into page object model
 - Refactored component tests
 

--- a/packages/components/molecules/f-breadcrumbs/package.json
+++ b/packages/components/molecules/f-breadcrumbs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-breadcrumbs",
   "description": "Fozzie Bread Crumbs – Provides clickable paths back to previous pages",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/f-breadcrumbs.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-breadcrumbs/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-breadcrumbs/src/assets/scss/common.scss
@@ -4,8 +4,3 @@
 $theme: 'jet' !default;
 
 @import '~@justeat/fozzie/src/scss/fozzie';
-
-/**
- * Component Variables
- */
-// $breadcrumbs-background-color: $brand--orange;

--- a/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
+++ b/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
@@ -62,11 +62,11 @@ export default {
 
 <style lang="scss" module>
 
-$breadcrumbs-text-colour: $white;
-$breadcrumbs-background-colour: rgba($black, 0.6);
+$breadcrumbs-text-colour: $color-content-light;
+$breadcrumbs-background-colour: rgba($color-black, 0.6);
 $breadcrumbs-border-radius: 16px;
 $breadcrumbs-not-active-font-weight: $font-weight-bold;
-$breadcrumbs-active-font-weight: $font-weight-base;
+$breadcrumbs-active-font-weight: $font-weight-regular;
 
 .c-breadcrumbs {
     display: flex;

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.10.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v0.9.0
 ------------------------------
 *May 19, 2021*

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "main": "dist/f-mega-modal.common.js",
   "files": [
     "dist"

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -304,7 +304,7 @@ export default {
 }
 
 .c-megaModal-content {
-    background-color: $color-bg--component;
+    background-color: $color-container-default;
     border-radius: $border-radius;
     box-shadow: 0 3px 4px 0 rgba(0, 0, 0, 0.12);
     display: none;
@@ -401,7 +401,7 @@ export default {
     }
 
     .c-megaModal-closeIcon * {
-        fill: $color-link-default;
+        fill: $color-content-link;
     }
 }
 

--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.0.0-beta.30
+------------------------------
+*May 26, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v4.0.0-beta.29
 ------------------------------
 *May 6, 2021*

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-searchbox",
   "description": "Fozzie Searchbox – Just Eat Takeaway Global Searchbox",
-  "version": "4.0.0-beta.29",
+  "version": "4.0.0-beta.30",
   "main": "dist/f-searchbox.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-searchbox/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-searchbox/src/assets/scss/common.scss
@@ -4,8 +4,3 @@
 $theme: 'jet' !default;
 
 @import  '~@justeat/fozzie/src/scss/fozzie';
-
-/**
- * Component Variables
- */
-// $searchbox-background-color: $brand--orange;

--- a/packages/components/molecules/f-searchbox/src/assets/scss/form.scss
+++ b/packages/components/molecules/f-searchbox/src/assets/scss/form.scss
@@ -1,9 +1,7 @@
 
 @import './common';
 
-$search-button-bgColor: $color-primary;
-$search-button-bgColor--hover: $orange--dark;
-$search-button-bgColor--active: $orange--darkest;
+$search-button-bgColor: $color-interactive-brand;
 $search-height-small: 56px;
 $search-height-mid: 60px;
 
@@ -41,14 +39,14 @@ $search-height-mid: 60px;
 
 .c-search-label {
     position: relative;
-    border: 1px solid $grey--light;
+    border: 1px solid $color-border-default;
     display: flex;
     width: 100%;
     align-items: center;
     height: $search-height-small;
     border-radius: $border-radius 0 0 $border-radius;
     @include font-size(body-s, false);
-    font-weight: $font-weight-base;
+    font-weight: $font-weight-regular;
     line-height: 1.3;
 
     @include media('>=narrow') {
@@ -57,7 +55,7 @@ $search-height-mid: 60px;
     }
 
     &.has-error {
-        border-bottom: 1px solid $red;
+        border-bottom: 1px solid $color-content-error;
     }
 }
 
@@ -134,7 +132,7 @@ $search-height-mid: 60px;
     width: 20px;
     height: 20px;
     margin-right: 20px;
-    border: 3px solid $orange;
+    border: 3px solid $color-content-brand;
     border-top: 3px solid rgba(243, 109, 0, 0.2);
     border-radius: 50%;
     animation: spin 1s linear 0s infinite;

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressContinueWithSuggestion.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressContinueWithSuggestion.vue
@@ -110,7 +110,7 @@ export default {
 .c-continueWithSuggestion-btn {
     cursor: pointer;
     @include font-size('body-s', false);
-    color: $grey--dark;
+    color: $color-content-subdued;
     line-height: 30px;
     overflow: hidden;
     text-align: left;
@@ -120,7 +120,7 @@ export default {
     width: 100%;
     border: 0;
     padding: 15px 20px;
-    background-color: $white;
+    background-color: $color-interactive-inverse;
 
     &:hover,
     &:focus,
@@ -140,6 +140,6 @@ export default {
 }
 
 .c-continueWithSuggestion-area {
-    color: $blue;
+    color: $color-support-info;
 }
 </style>

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchModalOverlay.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchModalOverlay.vue
@@ -151,12 +151,12 @@ export default {
 
 .c-search-input-overlay {
     flex: 1 1 auto;
-    border: 1px solid $grey--light;
+    border: 1px solid $color-border-default;
     border-radius: 4px;
     box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.11);
 
     &:focus {
-        border: solid 2px $color-focus-outline;
+        border: solid 2px $color-focus;
     }
 }
 
@@ -166,19 +166,19 @@ export default {
     background-color: transparent;
     padding: 0;
     margin: 0 0 0 25px;
-    color: $color-link-default;
+    color: $color-content-link;
     font-weight: $font-weight-bold;
     @include font-size(body-s, false);
     font-family: $font-family-base;
 
     &:hover {
         cursor: pointer;
-        color: $color-link-hover;
+        color: darken($color-content-link, $color-hover-01);
         background-color: transparent;
     }
     &:active,
     &:focus {
-        color: $color-link-active;
+        color: darken($color-content-link, $color-active-02);
         background-color: transparent;
     }
 }

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchModalOverlay.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchModalOverlay.vue
@@ -178,7 +178,7 @@ export default {
     }
     &:active,
     &:focus {
-        color: darken($color-content-link, $color-active-02);
+        color: darken($color-content-link, $color-active-01);
         background-color: transparent;
     }
 }

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
@@ -326,7 +326,7 @@ export default {
 
     &:hover,
     &.selected {
-        background: $color-background-default;
+        background: $color-grey-10;
     }
 }
 .shell {

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchSuggestions.vue
@@ -326,14 +326,14 @@ export default {
 
     &:hover,
     &.selected {
-        background: $grey--offWhite;
+        background: $color-background-default;
     }
 }
 .shell {
     $shell-top-offset: 96;
     $shell-border-radius: 3px;
 
-    background: $white;
+    background: $color-container-default;
     border-bottom-left-radius: $shell-border-radius;
     border-bottom-right-radius: $shell-border-radius;
     box-sizing: border-box;
@@ -372,7 +372,7 @@ export default {
 .c-fullAddressSuggestion-streetLevelMatch,
 .c-fullAddressSuggestion-noPostcodeMatch {
     font-family: $font-family-base;
-    font-weight: $font-weight-base;
+    font-weight: $font-weight-regular;
     margin: 0 0 4px;
     line-height: 1.4;
 }
@@ -385,7 +385,7 @@ export default {
 .c-fullAddressSuggestion-noPostcodeMatch,
 .c-fullAddressSuggestion-streetLevelMatch {
     font-size: 16px;
-    color: $grey--darkest;
+    color: $color-content-default;
 }
 
 .c-fullAddressSuggestion-postcodeMatch {
@@ -394,7 +394,7 @@ export default {
 
 .c-fullAddressSuggestion-description {
     font-size: 14px;
-    color: $grey--dark;
+    color: $color-content-subdued;
     background: transparent;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchButton.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchButton.vue
@@ -54,7 +54,7 @@ export default {
     border: none;
     border-radius: 0 $border-radius $border-radius 0;
     box-sizing: border-box;
-    color: $color-white;
+    color: $color-content-interactive-brand;
     cursor: pointer;
     font-family: $font-family-base;
     @include font-size(heading-s);

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchButton.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchButton.vue
@@ -124,7 +124,7 @@ export default {
 
     &:hover,
     &:focus {
-        background-color: darken($color-black, $color-hover-01);
+        background-color: darken($color-interactive-inverse, $color-hover-01);
     }
 }
 

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchButton.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchButton.vue
@@ -54,7 +54,7 @@ export default {
     border: none;
     border-radius: 0 $border-radius $border-radius 0;
     box-sizing: border-box;
-    color: $white;
+    color: $color-white;
     cursor: pointer;
     font-family: $font-family-base;
     @include font-size(heading-s);
@@ -71,11 +71,11 @@ export default {
 
     &:focus,
     &:hover {
-        background-color: $search-button-bgColor--hover;
+        background-color: darken($color-interactive-brand, $color-hover-01);
     }
 
     &:active {
-        background-color: $search-button-bgColor--active;
+        background-color: darken($color-interactive-brand, $color-active-01);
     }
 
     @include media('>=narrow') {
@@ -113,7 +113,7 @@ export default {
 .c-search-btn-clear {
     $btn-size: 52px;
 
-    background: $white;
+    background: $color-interactive-inverse;
     border: none;
     width: $btn-size;
     height: $btn-size;
@@ -124,7 +124,7 @@ export default {
 
     &:hover,
     &:focus {
-        background-color: $grey--offWhite;
+        background-color: darken($color-black, $color-hover-01);
     }
 }
 

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchField.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchField.vue
@@ -345,7 +345,7 @@ export default {
 
     &:hover,
     &:focus {
-        background-color: darken($color-black, $color-hover-01);
+        background-color: darken($color-interactive-inverse, $color-hover-01);
     }
 }
 </style>

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchField.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchField.vue
@@ -322,7 +322,7 @@ export default {
     $btn-size: 52px;
     $icon-size: 14px;
 
-    background: $white;
+    background: $color-interactive-inverse;
     border: none;
     width: $btn-size;
     height: $btn-size;
@@ -339,13 +339,13 @@ export default {
         position: absolute;
 
         g {
-            fill: $grey--midDark;
+            fill: $color-content-disabled;
         }
     }
 
     &:hover,
     &:focus {
-        background-color: $grey--offWhite;
+        background-color: darken($color-black, $color-hover-01);
     }
 }
 </style>

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchGeo.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchGeo.vue
@@ -114,7 +114,7 @@ export default {
 .c-geo-fill-icon,
 .c-geo-outline-icon {
     path {
-        fill: $blue;
+        fill: $color-interactive-primary;
     }
 }
 </style>

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchInnerFieldWrapper.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchInnerFieldWrapper.vue
@@ -69,7 +69,6 @@ export default {
 <style lang="scss" module>
 @import '../../assets/scss/form';
 
-$streetInput-border-colour: $grey--lighter 1px solid;
 $streetInput-width: spacing(x6);
 
 .c-search-innerFields {
@@ -82,13 +81,13 @@ $streetInput-width: spacing(x6);
 }
 
 .c-search-streetInput {
-    border-left: $streetInput-border-colour;
+    border-left: $color-border-subtle 1px solid;
     margin-right: spacing(x0.5);
     width: $streetInput-width;
-    outline: $white 2px auto;
+    outline: $color-white 2px auto;
 
     &:focus {
-        outline-color: $color-focus-outline;
+        outline-color: $color-focus;
     }
 }
 

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchSuggestions.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchSuggestions.vue
@@ -56,14 +56,12 @@ export default {
 <style lang="scss" module>
 @import '../../assets/scss/common';
 
-$suggestions-item-highlight-colour: $grey--light;
-$suggestions-bg-colour: $white;
-$suggestions-shadow-colour: $grey--midDark;
+$suggestions-shadow: $color-grey-45 0 5px 6px -2px;
 
 .c-search-suggestions {
     $border-radius: 2px;
-    background: $suggestions-bg-colour;
-    box-shadow: $suggestions-shadow-colour 0 5px 6px -2px;
+    background: $color-container-default;
+    box-shadow: $suggestions-shadow;
     border-bottom-left-radius: $border-radius;
     border-bottom-right-radius: $border-radius;
     position: absolute;
@@ -79,7 +77,7 @@ $suggestions-shadow-colour: $grey--midDark;
     display: block;
     width: 100%;
     border: 0;
-    border-top: $suggestions-item-highlight-colour 1px solid;
+    border-top: $color-border-default 1px solid;
     cursor: pointer;
     font-family: Arial, sans-serif;
     font-size: 11px;
@@ -93,7 +91,7 @@ $suggestions-shadow-colour: $grey--midDark;
 
     &:hover,
     &.selected {
-        background: $suggestions-item-highlight-colour;
+        background: $color-container-strong;
     }
 }
 

--- a/packages/components/molecules/f-searchbox/src/components/shells/Shell.vue
+++ b/packages/components/molecules/f-searchbox/src/components/shells/Shell.vue
@@ -32,13 +32,13 @@ $midWide: 980px;
 
 .c-searchShell {
     -webkit-font-smoothing: antialiased;
-    background-color: $color-bg--component;
+    background-color: $color-container-default;
     border-radius: $border-radius;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.16);
-    color: $grey--dark;
+    color: $color-grey-50;
     @include font-size('heading-xl', false);
     font-family: $font-family-base;
-    font-weight: $font-weight-base;
+    font-weight: $font-weight-regular;
     padding: spacing(x2);
     text-align: center;
     text-rendering: optimizeLegibility;
@@ -66,7 +66,7 @@ $midWide: 980px;
 }
 
 .c-searchShell-title {
-    color: $color-headings--highlight;
+    color: $color-content-brand;
     @include font-size('heading-xxl', true, 'narrow');
     font-weight: $font-weight-bold;
     margin-bottom: spacing();
@@ -82,9 +82,9 @@ $midWide: 980px;
 }
 
 .c-searchShell-subtitle {
-    color: $grey--dark;
+    color: $color-grey-50;
     @include font-size('subheading-s', true, 'narrow');
-    font-weight: $font-weight-base;
+    font-weight: $font-weight-regular;
     margin-bottom: spacing(x2);
 
     @include media('>=narrowMid') {

--- a/packages/components/molecules/f-skeleton-loader/CHANGELOG.md
+++ b/packages/components/molecules/f-skeleton-loader/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+
+v0.6.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v0.5.0
 ------------------------------
 *April 26, 2021*

--- a/packages/components/molecules/f-skeleton-loader/package.json
+++ b/packages/components/molecules/f-skeleton-loader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-skeleton-loader",
   "description": "Fozzie Skeleton Loader - Provides a visual indication that another component is loading. ",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "dist/f-skeleton-loader.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-skeleton-loader/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-skeleton-loader/src/assets/scss/common.scss
@@ -5,10 +5,10 @@ $theme: 'jet' !default;
 
 @import  '~@justeat/fozzie/src/scss/fozzie';
 
-$skeleton-loader-heading-height: spacing(x4);
-$skeleton-loader-text-height: spacing(x2);
-$skeleton-loader-bone-background-color: $grey--mid;
-$skeleton-loader-image-height: spacing(x8);
+$skeleton-loader-heading-height        : spacing(x4);
+$skeleton-loader-text-height           : spacing(x2);
+$skeleton-loader-bone-background-color : $color-skeleton-02;
+$skeleton-loader-image-height          : spacing(x8);
 
 @keyframes loading {
     100% {

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCardHeader.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCardHeader.vue
@@ -23,7 +23,7 @@ $restaurant-logo-width: 48px;
 
 .c-restaurantCardHeader {
     text-align: center;
-    background-color: $white;
+    background-color: $color-container-default;
     margin: auto;
     width: 96%;
     padding-bottom: spacing(x2);
@@ -34,7 +34,7 @@ $restaurant-logo-width: 48px;
     margin: auto;
     width: $restaurant-logo-width;
     height: $restaurant-logo-width;
-    border: 1px solid $white;
+    border: 1px solid $color-white;
     transform: translateY(-50%);
 }
 

--- a/packages/components/molecules/f-tabs/CHANGELOG.md
+++ b/packages/components/molecules/f-tabs/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.5.0
+------------------------------
+*May 25, 2021
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v0.4.0
 ------------------------------
 *April 1, 2021*

--- a/packages/components/molecules/f-tabs/package.json
+++ b/packages/components/molecules/f-tabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-tabs",
   "description": "Fozzie Tabs – Switchable slots for content&#34;",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/f-tabs.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-tabs/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-tabs/src/assets/scss/common.scss
@@ -4,8 +4,3 @@
 $theme: 'jet' !default;
 
 @import '~@justeat/fozzie/src/scss/fozzie';
-
-/**
- * Component Variables
- */
-// $tabs-background-color: $brand--orange;

--- a/packages/components/molecules/f-tabs/src/components/Tabs.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tabs.vue
@@ -109,9 +109,9 @@ export default {
 
 <style lang="scss" module>
 
-$tabs-link-colour         : $grey--darkest;
+$tabs-link-colour         : $color-content-default;
 $tabs-link-font-weight    : $font-weight-bold;
-$tabs-link-border-colour  : $brand--orange;
+$tabs-link-border-colour  : $color-orange-30;
 
 .c-tabs {
     width: 100%;

--- a/packages/components/molecules/f-user-message/CHANGELOG.md
+++ b/packages/components/molecules/f-user-message/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.3.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v1.2.0
 ------------------------------
 *February 9, 2021*

--- a/packages/components/molecules/f-user-message/package.json
+++ b/packages/components/molecules/f-user-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-user-message",
   "description": "Fozzie User Message – Globalised User Message Component",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/f-user-message.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/molecules/f-user-message/src/components/UserMessage.vue
+++ b/packages/components/molecules/f-user-message/src/components/UserMessage.vue
@@ -65,8 +65,8 @@ export default {
 
 <style lang="scss" module>
 .c-userMessage {
-    color: $white;
-    background-color: $orange;
+    color: $color-content-light;
+    background-color: $color-content-brand;
     max-width: 100%;
 }
 
@@ -86,7 +86,7 @@ export default {
     }
 
     svg {
-        fill: $white;
+        fill: $color-content-light;
         min-width: 28px;
         max-width: 28px;
         width: 28px;
@@ -99,7 +99,7 @@ export default {
 .c-userMessage-text {
     margin: 0 0 0 spacing(x2);
     font-family: $font-family-base;
-    font-weight: $font-weight-base;
+    font-weight: $font-weight-regular;
     @include font-size(body-s);
 
     @include media('>=mid') {

--- a/packages/components/molecules/f-user-message/src/components/UserMessage.vue
+++ b/packages/components/molecules/f-user-message/src/components/UserMessage.vue
@@ -66,7 +66,7 @@ export default {
 <style lang="scss" module>
 .c-userMessage {
     color: $color-content-light;
-    background-color: $color-content-brand;
+    background-color: $color-support-brand;
     max-width: 100%;
 }
 

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.120.0
+------------------------------
+*May 26, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v0.119.0
 ------------------------------
 *May 24, 2021*
@@ -11,7 +19,7 @@ v0.119.0
 ### Added
 - Ability to handle orders with the service type `dinein`
 - Table number/name input field
-  
+
 
 v0.118.1
 ------------------------------

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.119.0",
+  "version": "0.120.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Address.vue
+++ b/packages/components/organisms/f-checkout/src/components/Address.vue
@@ -149,7 +149,7 @@ export default {
 </script>
 
 <style lang="scss" module>
-$address-colour          : $color-text;
+$address-colour          : $color-content-default;
 $address-fontSize        : 'body-s';
 $address-weight-bold     : $font-weight-bold;
 

--- a/packages/components/organisms/f-checkout/src/components/Header.vue
+++ b/packages/components/organisms/f-checkout/src/components/Header.vue
@@ -131,7 +131,7 @@ export default {
     margin-bottom: 0;
     @include font-size('body-s');
     font-weight: $font-weight-bold;
-    color: $grey--dark;
+    color: $color-content-subdued;
 }
 
 .c-checkoutHeader-option {
@@ -164,7 +164,7 @@ export default {
             top: 50%;
             width: 9999px;
             height: 1px;
-            background: $grey--mid;
+            background: $color-grey-40;
         }
     }
 }

--- a/packages/components/organisms/f-checkout/src/components/TermsAndConditions.vue
+++ b/packages/components/organisms/f-checkout/src/components/TermsAndConditions.vue
@@ -35,7 +35,7 @@
 <style lang="scss" module>
 .c-checkoutTermsAndConditions {
     width: Calc($checkout-width - 2px); // -2px for border width
-    background: $grey--offWhite;
+    background: $color-background-default;
     margin-left: -(spacing(x10));
     margin-bottom: -(spacing(x6));
     margin-top: spacing(x6);
@@ -43,7 +43,7 @@
     padding: spacing(x2);
     @include font-size('body-s');
     text-align: center;
-    color: $grey--dark;
+    color: $color-grey-50;
     font-weight: $font-weight-bold;
 
     a {

--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.6.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v4.5.0
 ------------------------------
 *April 29, 2021*

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "main": "dist/f-content-cards.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-content-cards/src/assets/scss/_card-styles.scss
+++ b/packages/components/organisms/f-content-cards/src/assets/scss/_card-styles.scss
@@ -29,7 +29,7 @@
   width: 100%;
   background-repeat: repeat;
   background-size: cover;
-  background-color: $grey--lighter;
+  background-color: $color-container-subtle;
   background-position: center;
   border-radius: $border-radius $border-radius 0 0;
 }

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -214,7 +214,7 @@ export default {
 
     .c-contentCard-subTitle {
         @include font-size(body-l);
-        font-weight: $font-weight-base;
+        font-weight: $font-weight-regular;
         margin-top: spacing();
     }
 
@@ -230,7 +230,7 @@ export default {
         flex-direction: column;
         align-items: center;
         min-height: 164px; // min-height set to the height of an card with a one-line title
-        background-color: $white;
+        background-color: $color-container-default;
         padding: spacing(x2);
         box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
         border-radius: 0 0 $border-radius $border-radius;
@@ -244,7 +244,7 @@ export default {
     }
 
     .c-contentCard-thumbnail {
-        border: 1px solid $grey--lighter;
+        border: 1px solid $color-border-subtle;
         margin-top: - (32px + spacing(x2)); // This offsets the thumbnail above the top of the info card
         width: 48px;
         min-height: 48px;
@@ -269,7 +269,7 @@ export default {
             padding: spacing(x3) 0 0 0;
 
             @include media ('<mid') {
-                border: 1px solid $color-border;
+                border: 1px solid $color-border-strong;
                 padding: spacing(x3);
                 border-radius: 0 0 $post-order-card-radius $post-order-card-radius;
             }

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/FirstTimeCustomerCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/FirstTimeCustomerCard.vue
@@ -49,7 +49,7 @@ export default {
 </script>
 
 <style lang="scss" module>
-$banner-bgColour : $color-orange-10;
+$banner-bgColour : $color-support-brand-02;
 $banner-bgColour-legacy : #cd381f;
 
 .c-restaurantCard-banner {

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/FirstTimeCustomerCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/FirstTimeCustomerCard.vue
@@ -49,7 +49,7 @@ export default {
 </script>
 
 <style lang="scss" module>
-$banner-bgColour : $orange--offWhite;
+$banner-bgColour : $color-orange-10;
 $banner-bgColour-legacy : #cd381f;
 
 .c-restaurantCard-banner {

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
@@ -104,7 +104,7 @@ export default {
 
 <style lang="scss" module>
     .c-postOrderCard {
-        border: 1px solid $color-border;
+        border: 1px solid $color-border-strong;
         border-radius: $post-order-card-radius;
         padding: spacing(x3);
         max-width: 100%;

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/PromotionCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/PromotionCard.vue
@@ -69,18 +69,18 @@ export default {
 
 <style lang="scss" module>
 
-    $btn-secondary-bgColor              : $blue--offWhite;
-    $btn-secondary-bgColor--hover       : $blue--offWhite--dark;
-    $btn-secondary-bgColor--active      : $blue--offWhite--darkest;
-    $btn-secondary-textColor            : $blue;
-    $btn-secondary-textColor--hover     : $blue;
-    $btn-secondary-textColor--active    : $blue;
+    $btn-secondary-bgColor              : $color-interactive-secondary;
+    $btn-secondary-bgColor--hover       : darken($color-interactive-secondary, $color-hover-01);
+    $btn-secondary-bgColor--active      : darken($color-interactive-secondary, $color-active-01);
+    $btn-secondary-textColor            : $color-content-interactive-secondary;
+    $btn-secondary-textColor--hover     : $color-content-interactive-secondary;
+    $btn-secondary-textColor--active    : $color-content-interactive-secondary;
 
     .c-contentCard-linkPromo2 {
         font-weight: $font-weight-bold;
         text-decoration: none;
         @include font-size(body-l);
-        color: $color-secondary;
+        color: $color-content-link;
         display: block;
     }
 

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/SkeletonLoader.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/SkeletonLoader.vue
@@ -77,17 +77,17 @@ export default {
     .c-skeletonLoader-card:empty {
         position: relative;
         height: 403px; // 1
-        background-color: $white;
+        background-color: $color-container-default;
         background-repeat: no-repeat;
 
         // 2
-        background-image: radial-gradient(0 at 0 0, $grey--mid 99%, transparent 0),
+        background-image: radial-gradient(0 at 0 0, $color-grey-40 99%, transparent 0),
                           linear-gradient(to right, white 20px, transparent 0), // 2.1 right margin
-                          linear-gradient($grey--mid 20px, transparent 0), // 2.2 title placeholder
-                          linear-gradient($grey--mid 220px, transparent 0), // 2.3 main image placeholder
-                          linear-gradient($grey--mid 20px, transparent 0), // 2.4 line one placeholder
-                          linear-gradient($grey--mid 20px, transparent 0), // 2.5 line two placeholder
-                          linear-gradient($grey--mid 20px, transparent 0); // 2.6 line three placeholder
+                          linear-gradient($color-grey-40 20px, transparent 0), // 2.2 title placeholder
+                          linear-gradient($color-grey-40 220px, transparent 0), // 2.3 main image placeholder
+                          linear-gradient($color-grey-40 20px, transparent 0), // 2.4 line one placeholder
+                          linear-gradient($color-grey-40 20px, transparent 0), // 2.5 line two placeholder
+                          linear-gradient($color-grey-40 20px, transparent 0); // 2.6 line three placeholder
         background-size: 100px 457px,
                          20px 100%, // 2.1
                          50% 20px, // 2.2
@@ -116,12 +116,12 @@ export default {
 
         &.c-skeletonLoader-card--promo {
             // 3
-            background-image: radial-gradient(0 at 0 0, $grey--mid 99%, transparent 0),
-                              linear-gradient(to left, $grey--dark 46px, transparent 0), // 3.1 icon placeholder
-                              linear-gradient($grey--mid 170px, transparent 0), // 3.2 main image placeholder
-                              linear-gradient($grey--mid 20px, transparent 0), //  3.3 line one placeholder
-                              linear-gradient($grey--mid 20px, transparent 0), // 3.4 line two placeholder
-                              linear-gradient($grey--mid 20px, transparent 0); // 3.5 line three placeholder
+            background-image: radial-gradient(0 at 0 0, $color-grey-40 99%, transparent 0),
+                              linear-gradient(to left, $color-grey-50 46px, transparent 0), // 3.1 icon placeholder
+                              linear-gradient($color-grey-40 170px, transparent 0), // 3.2 main image placeholder
+                              linear-gradient($color-grey-40 20px, transparent 0), //  3.3 line one placeholder
+                              linear-gradient($color-grey-40 20px, transparent 0), // 3.4 line two placeholder
+                              linear-gradient($color-grey-40 20px, transparent 0); // 3.5 line three placeholder
 
             background-size: 100px 457px,
                              50% 46px, // 3.1

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
@@ -253,7 +253,7 @@ export default {
 <style lang="scss" module>
 
 $stampCard-subStatus-colour: #017a39; /* $color-green in PIE - not in fozzie-colour-palette yet */
-$stampCard-expiryInfo-colour: $grey--dark;
+$stampCard-expiryInfo-colour: $color-content-subdued;
 
 $stampCard-iconSize-landscape: 56px;
 $stampCard-iconSize-portrait: 48px;
@@ -276,7 +276,7 @@ $stampCard-responsive-tabletViewBreakpoint: '<=mid';
     &:hover,
     &:visited,
     &:focus {
-        color: $color-text;
+        color: $color-content-default;
     }
 
     @include media($stampCard-responsive-tabletViewBreakpoint) {

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCardPromotionCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCardPromotionCard.vue
@@ -125,7 +125,7 @@ $stampCard-promo-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.03),
     left: spacing(x2);
     margin: 0;
     border-radius: $border-radius;
-    border: 0.5px solid $grey--light;
+    border: 0.5px solid $color-border-default;
 
     @include media('>narrowMid') {
         top: spacing(x1.5) - 2px;
@@ -134,7 +134,7 @@ $stampCard-promo-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.03),
 
 .c-stampCardPromotion1-info {
     padding: spacing(x2);
-    background-color: $white;
+    background-color: $color-container-default;
     position: static;
     display: block;
     text-align: left;
@@ -177,15 +177,15 @@ $stampCard-promo-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.03),
     margin-top: spacing();
 
     & {
-        color: $color-link-default;
+        color: $color-content-link;
     }
 
     &:hover, &:focus {
-        color: $color-link-hover;
+        color: darken($color-content-link, $color-hover-01);
     }
 
     &:active {
-        color: $color-link-active;
+        color: darken($color-content-link, $color-active-02);
     }
 }
 

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCardPromotionCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCardPromotionCard.vue
@@ -185,7 +185,7 @@ $stampCard-promo-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.03),
     }
 
     &:active {
-        color: darken($color-content-link, $color-active-02);
+        color: darken($color-content-link, $color-active-01);
     }
 }
 

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
@@ -83,14 +83,14 @@ export default {
 
 <style lang="scss" module>
   .c-contentCards-tnc-card-shell {
-    background-color: $white;
+    background-color: $color-container-default;
     padding: spacing(x3);
     text-align: center;
   }
 
   .c-contentCards-tnc-card-primaryHeader {
     @include font-size(heading-s);
-    color: $grey--darkest;
+    color: $color-content-default;
 
     @include media('>=narrow') {
       @include font-size(heading-xl);
@@ -99,7 +99,7 @@ export default {
 
   .c-contentCards-tnc-card-secondaryHeader {
     @include font-size(body-s);
-    color: $grey--dark;
+    color: $color-content-subdued;
     margin-top: spacing(x2);
 
     @include media('>=narrow') {

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
@@ -188,7 +188,7 @@ export default {
     }
 
         .c-contentCards-homePromotionCard1-subtitle--light {
-            color: $white;
+            color: $color-content-light;
         }
 
     .c-contentCards-homePromotionCard1-innerCard {

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
@@ -176,29 +176,29 @@ export default {
             font-weight: $font-weight-bold;
 
             & {
-                color: $color-link-default;
+                color: $color-content-link;
             }
 
             &:hover, &:focus {
-                color: $color-link-hover;
+                color: darken($color-content-link, $color-hover-01);
             }
 
             &:active {
-                color: $color-link-active;
+                color: darken($color-content-link, $color-active-02);
             }
         }
 
         .c-contentCards-homePromotionCard2-text {
-            color: $grey--dark;
+            color: $color-content-subdued;
         }
 
         &.c-contentCards-homePromotionCard2--light {
             .c-contentCards-homePromotionCard2-text {
-                color: $white;
+                color: $color-content-light;
             }
 
             .c-contentCards-homePromotionCard2-title {
-                color: $grey--lighter;
+                color: $color-grey-20;
             }
         }
     }

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
@@ -184,7 +184,7 @@ export default {
             }
 
             &:active {
-                color: darken($color-content-link, $color-active-02);
+                color: darken($color-content-link, $color-active-01);
             }
         }
 

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/voucherCard/VoucherCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/voucherCard/VoucherCard.vue
@@ -177,7 +177,7 @@ export default {
         display: flex;
         width: 100%;
         font-family: $font-family-base;
-        border: solid $color-border;
+        border: solid $color-border-strong;
         border-width: 1px 0 0;
         padding-top: spacing(x2);
         margin-top: spacing(x2);
@@ -192,19 +192,19 @@ export default {
     }
 
     .c-contentCard-voucher-code {
-        font-weight: $font-weight-base;
-        color: $grey--mid;
+        font-weight: $font-weight-regular;
+        color: $color-grey-40;
         text-align: left;
     }
 
     .c-contentCard-voucher-copy {
         font-weight: $font-weight-bold;
-        color: $color-link-default;
+        color: $color-content-link;
         text-align: right;
     }
 
     .c-contentCard-voucher-copy-copied {
-        color: $orange--aa;
+        color: $color-content-brand-strong;
     }
 
     .c-contentCard-voucher-copy-transition-out {
@@ -220,7 +220,7 @@ export default {
     }
 
     .c-contentCard-voucher-code-cooldown-tick {
-        fill: $orange--aa;
+        fill: $color-content-brand-strong;
         width: spacing(x2);
         height: spacing(x2);
         padding: 0;

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.12.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v0.11.0
 ------------------------------
 *May 24, 2021*
@@ -10,14 +19,6 @@ v0.11.0
 ### Changed
 - Component object export
 - New `policyLinkHref` function in component objects
-
-
-v0.11.0
-------------------------------
-*May 25, 2021*
-
-### Changed
-- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
 
 
 v0.10.0

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -12,6 +12,14 @@ v0.11.0
 - New `policyLinkHref` function in component objects
 
 
+v0.11.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v0.10.0
 ------------------------------
 *May 18, 2021*

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -307,7 +307,7 @@ export default {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
-        background-color: $white;
+        background-color: $color-container-default;
         z-index: 99999992;
     }
 
@@ -329,7 +329,7 @@ export default {
         font-weight: $font-weight-bold;
         margin: spacing() 0;
         padding: 0;
-        color: $color-headings;
+        color: $color-content-default;
         &:hover,
         &:focus {
             a {

--- a/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/LegacyBanner.vue
@@ -58,7 +58,7 @@ export default {
 <style lang="scss" module>
     .c-cookieWarning {
         box-sizing: border-box;
-        background-color: $grey--darkest;
+        background-color: $color-grey;
         position: fixed;
         left: 0;
         right: 0;
@@ -74,12 +74,12 @@ export default {
 
             p {
                 @include font-size(caption);
-                color: $white;
+                color: $color-white;
                 text-align: center;
                 margin: 0 auto;
 
                     a {
-                        color: $white;
+                        color: $color-white;
                     }
             }
 

--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.23.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v4.22.0
 ------------------------------
 *May 13, 2021*

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "4.22.0",
+  "version": "4.23.0",
   "main": "dist/f-footer.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-footer/src/assets/scss/common.scss
+++ b/packages/components/organisms/f-footer/src/assets/scss/common.scss
@@ -8,12 +8,12 @@ $theme: 'jet' !default;
 /**
  * Component Variables
  */
- $footer-bgColor         : $grey--light !default;
- $footer-bgLight         : $grey--lighter !default;
- $footer-textColor       : $color-text !default;
- $footer-borderColor     : $color-border !default;
- $footer-chevronColor    : $grey--darkest !default;
- $footer-socialIconColor : $grey--darkest !default;
+ $footer-bgColor         : $color-container-strong !default;
+ $footer-bgLight         : $color-container-subtle !default;
+ $footer-textColor       : $color-content-default !default;
+ $footer-borderColor     : $color-border-strong !default;
+ $footer-chevronColor    : $color-content-interactive-tertiary !default;
+ $footer-socialIconColor : $color-content-interactive-tertiary !default;
 
 @mixin theme($type) {
     [data-theme-footer="#{$type}"] & {

--- a/packages/components/organisms/f-footer/src/assets/scss/headings.scss
+++ b/packages/components/organisms/f-footer/src/assets/scss/headings.scss
@@ -18,7 +18,7 @@ $footer-heading-font-size  : 'heading-s';
     align-items: center;
     background: none;
     border-style: none;
-    color: $color-headings;
+    color: $color-content-default;
     display: flex;
     font-weight: $font-weight-headings;
     justify-content: space-between;

--- a/packages/components/organisms/f-footer/src/components/ButtonList.vue
+++ b/packages/components/organisms/f-footer/src/components/ButtonList.vue
@@ -47,9 +47,9 @@ $buttonList-font-size: 'subheading-s';
 }
 
 .c-buttonList-button {
-    background-color: $white;
+    background-color: $color-interactive-inverse;
     border-radius: 4px;
-    color: $color-link-default;
+    color: $color-content-interactive-inverse;
     display: inline-block;
     @include font-size($buttonList-font-size, false);
     font-weight: $font-weight-headings;
@@ -67,7 +67,7 @@ $buttonList-font-size: 'subheading-s';
 
     &:hover,
     &:focus {
-        background-color: $grey--lighter;
+        background-color: darken($color-black, $color-hover-01);
     }
 
     @include media('<narrow') {

--- a/packages/components/organisms/f-footer/src/components/ButtonList.vue
+++ b/packages/components/organisms/f-footer/src/components/ButtonList.vue
@@ -67,7 +67,7 @@ $buttonList-font-size: 'subheading-s';
 
     &:hover,
     &:focus {
-        background-color: darken($color-black, $color-hover-01);
+        background-color: darken($color-interactive-inverse, $color-hover-01);
     }
 
     @include media('<narrow') {

--- a/packages/components/organisms/f-footer/src/components/CountrySelector.vue
+++ b/packages/components/organisms/f-footer/src/components/CountrySelector.vue
@@ -149,11 +149,14 @@ $countrySelector-btn-font-size: 'body-s';
     display: flex;
     padding: spacing() spacing(x2);
     text-decoration: none;
-    color: $color-text;
+    color: $color-content-interactive-tertiary;
 
-    &:hover,
+    &:hover {
+        color: darken($color-content-link, $color-hover-01);
+    }
+    &:active,
     &:focus {
-        color: $blue--dark;
+        color: darken($color-content-link, $color-active-02);
     }
 
     p {
@@ -210,7 +213,7 @@ $countrySelector-btn-font-size: 'body-s';
     margin-left: 0;
     margin-bottom: spacing(x6) + 1;
     background-color: $footer-bgLight;
-    box-shadow: 0 2px 28px rgba($grey--darkest, 0.08);
+    box-shadow: 0 2px 28px rgba($color-grey, 0.08);
     list-style: none;
 
     & > li:before {

--- a/packages/components/organisms/f-footer/src/components/CountrySelector.vue
+++ b/packages/components/organisms/f-footer/src/components/CountrySelector.vue
@@ -156,7 +156,7 @@ $countrySelector-btn-font-size: 'body-s';
     }
     &:active,
     &:focus {
-        color: darken($color-content-link, $color-active-02);
+        color: darken($color-content-link, $color-active-01);
     }
 
     p {

--- a/packages/components/organisms/f-footer/src/components/FeedbackBlock.vue
+++ b/packages/components/organisms/f-footer/src/components/FeedbackBlock.vue
@@ -73,19 +73,19 @@ $feedback-btn-font-size: 'body-s';
     background-color: transparent;
     padding: 0;
     margin: 0;
-    color: $color-link-default;
+    color: $color-content-link;
     font-weight: 500;
     @include font-size($feedback-btn-font-size);
     text-decoration: underline;
 
     &:hover {
         cursor: pointer;
-        color: $color-link-hover;
+        color: darken($color-content-link, $color-hover-01);
         background-color: transparent;
     }
     &:active,
     &:focus {
-        color: $color-link-active;
+        color: darken($color-content-link, $color-active-02);
         background-color: transparent;
     }
 }

--- a/packages/components/organisms/f-footer/src/components/FeedbackBlock.vue
+++ b/packages/components/organisms/f-footer/src/components/FeedbackBlock.vue
@@ -85,7 +85,7 @@ $feedback-btn-font-size: 'body-s';
     }
     &:active,
     &:focus {
-        color: darken($color-content-link, $color-active-02);
+        color: darken($color-content-link, $color-active-01);
         background-color: transparent;
     }
 }

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.17.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v4.16.0
 ------------------------------
 *May 12, 2021*

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "main": "dist/f-header.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-header/src/assets/scss/common.scss
+++ b/packages/components/organisms/f-header/src/assets/scss/common.scss
@@ -9,7 +9,7 @@ $theme: 'jet' !default;
  * Component Variables
  */
 $header-logo-color                 : $color-interactive-brand;
-$header-logo-color--alt            : $color-white;
+$header-logo-color--alt            : $color-interactive-inverse;
 
 $header-height--narrow              : 48px;
 $header-button--height              : $header-height--narrow;
@@ -22,7 +22,7 @@ $header-border-color                : $color-border-subtle;
 $header-box-shadow                  : 0 3px 4px 0 rgba(0, 0, 0, 0.12);
 $header-buttonIcon-color            : $color-interactive-primary;
 $header-buttonCount-bg              : $color-interactive-primary;
-$header-buttonCount-color           : $color-white;
+$header-buttonCount-color           : $color-content-interactive-primary;
 $header-buttonCount-borderColor     : $color-white;
 
 $header--transparent-gradient-color : $color-black;

--- a/packages/components/organisms/f-header/src/assets/scss/common.scss
+++ b/packages/components/organisms/f-header/src/assets/scss/common.scss
@@ -8,24 +8,24 @@ $theme: 'jet' !default;
 /**
  * Component Variables
  */
-$header-logo-color                 : $brand--orange;
-$header-logo-color--alt            : $white;
+$header-logo-color                 : $color-interactive-brand;
+$header-logo-color--alt            : $color-white;
 
 $header-height--narrow              : 48px;
 $header-button--height              : $header-height--narrow;
 $header-button--width               : 56px;
 $header-height                      : 76px;
-$header-bg                          : $white;
+$header-bg                          : $color-white;
 $header-separator                   : 1px;
 $header-separator                   : 4px;
-$header-border-color                : $grey--lighter;
+$header-border-color                : $color-border-subtle;
 $header-box-shadow                  : 0 3px 4px 0 rgba(0, 0, 0, 0.12);
-$header-buttonIcon-color            : $blue;
-$header-buttonCount-bg              : $blue;
-$header-buttonCount-color           : $white;
-$header-buttonCount-borderColor     : $white;
+$header-buttonIcon-color            : $color-interactive-primary;
+$header-buttonCount-bg              : $color-interactive-primary;
+$header-buttonCount-color           : $color-white;
+$header-buttonCount-borderColor     : $color-white;
 
-$header--transparent-gradient-color : $black;
+$header--transparent-gradient-color : $color-black;
 $header--transparent-gradient       : 115px;
 $header--transparent-opacity        : 0.7;
 

--- a/packages/components/organisms/f-header/src/assets/scss/common.scss
+++ b/packages/components/organisms/f-header/src/assets/scss/common.scss
@@ -15,7 +15,7 @@ $header-height--narrow              : 48px;
 $header-button--height              : $header-height--narrow;
 $header-button--width               : 56px;
 $header-height                      : 76px;
-$header-bg                          : $color-white;
+$header-bg                          : $color-container-default;
 $header-separator                   : 1px;
 $header-separator                   : 4px;
 $header-border-color                : $color-border-subtle;

--- a/packages/components/organisms/f-header/src/assets/scss/navigation.scss
+++ b/packages/components/organisms/f-header/src/assets/scss/navigation.scss
@@ -1,20 +1,20 @@
 @import './common.scss';
 
-$nav-text-color--hover : $color-link-hover;
-$nav-text-color--transparent : $white;
+$nav-text-color--hover           : darken($color-content-link, $color-hover-01);
+$nav-text-color--transparent     : $color-content-link-light;
 
-$nav-transition-duration : 250ms;
+$nav-transition-duration         : 250ms;
 
-$nav-trigger-width : 56px;
-$nav-trigger-height : 48px;
-$nav-trigger-focus-color : $blue;
-$nav-trigger-focus-bg : $blue--offWhite;
+$nav-trigger-width               : 56px;
+$nav-trigger-height              : 48px;
+$nav-trigger-focus-color         : $color-content-interactive-secondary;
+$nav-trigger-focus-bg            : $color-interactive-secondary;
 
-$nav-popover-transition-delay : 200ms;
+$nav-popover-transition-delay    : 200ms;
 $nav-popover-transition-duration : 200ms;
 
-$countrySelector-flag-width : 16px;
-$countrySelector-flag-height : 16px;
+$countrySelector-flag-width      : 16px;
+$countrySelector-flag-height     : 16px;
 
 @mixin nav-container-visible () {
     overflow-y: auto;
@@ -45,7 +45,7 @@ $countrySelector-flag-height : 16px;
         padding: 0;
         height: calc(100% - (#{$header-height--narrow}));
         border-top: $header-separator solid $header-border-color;
-        background: $white;
+        background: $color-container-default;
         z-index: -1;
         opacity: 0;
         transition: opacity $nav-transition-duration ease-in-out,

--- a/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
+++ b/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
@@ -88,8 +88,8 @@ export default {
 <style lang="scss" module>
 @import '../assets/scss/navigation.scss';
 
-$countrySelector-text-color : $grey--darkest;
-$countrySelector-text-hover : $color-bg--darker;
+$countrySelector-text-color    : $color-content-default;
+$countrySelector-text-bg-hover : $color-container-subtle;
 
 .c-countrySelector {
     @include media('>mid') {
@@ -138,7 +138,7 @@ $countrySelector-text-hover : $color-bg--darker;
     margin-bottom: 0;
 
     &:hover {
-        background: $countrySelector-text-hover;
+        background: $countrySelector-text-bg-hover;
     }
 }
 

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -237,7 +237,7 @@ html:global(.is-navInView) {
     }
 
     .c-header--highlightBg {
-        background-color: $color-content-brand;
+        background-color: $color-support-brand;
         min-height: 88px;
     }
 

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -237,7 +237,7 @@ html:global(.is-navInView) {
     }
 
     .c-header--highlightBg {
-        background-color: $color-primary;
+        background-color: $color-content-brand;
         min-height: 88px;
     }
 

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -630,15 +630,15 @@ export default {
 
 $nav-text-size                     : 'body-l';
 $nav-text-size--narrow             : 'body-s';
-$nav-text-color                    : $color-link-default;
+$nav-text-color                    : $color-content-link;
 
-$nav-text-color--narrow            : $grey--dark;
-$nav-text-color--transparent       : $white;
+$nav-text-color--narrow            : $color-content-subdued;
+$nav-text-color--transparent       : $color-content-link-inverse;
 $nav-text-weight                   : $font-weight-bold;
 $nav-text-subFont                  : $font-family-base;
-$nav-icon-color                    : $color-secondary;
-$nav-icon-color--transparent       : $white;
-$nav-icon-color--mobileWhiteBg     : $grey--darkest;
+$nav-icon-color                    : $color-interactive-primary;
+$nav-icon-color--transparent       : $color-interactive-inverse;
+$nav-icon-color--mobileWhiteBg     : $color-content-interactive-tertiary;
 $nav-transition-duration           : 250ms;
 $nav-icon-size                     : 24px;
 
@@ -649,8 +649,8 @@ $nav-toggleIcon-left               : spacing(x2);
 $nav-toggleIcon-width              : 21px;
 $nav-toggleIcon-height             : 2px;
 $nav-toggleIcon-borderRadius       : 1px;
-$nav-toggleIcon-color              : $color-secondary;
-$nav-toggleIcon-color--transparent : $white;
+$nav-toggleIcon-color              : $nav-icon-color;
+$nav-toggleIcon-color--transparent : $nav-icon-color--transparent;
 $nav-toggleIcon-bg                 : transparent;
 $nav-toggleIcon-space              : 5px;
 
@@ -686,7 +686,7 @@ $nav-popover-width                 : 300px;
             @include font-size($nav-text-size--narrow);
             font-weight: 300;
             text-decoration: none;
-            border-bottom: 1px solid $grey--light;
+            border-bottom: 1px solid $color-border-default;
 
             @include media('>mid') {
                 @include font-size($nav-text-size);
@@ -848,7 +848,7 @@ $nav-popover-width                 : 300px;
             }
 
             .c-nav-toggle--altColour & {
-                background-color: $white;
+                background-color: $color-container-default;
             }
         }
 
@@ -934,7 +934,7 @@ $nav-popover-width                 : 300px;
     }
 
     @include media('>mid') {
-        background-color: $white;
+        background-color: $color-container-default;
         width: 32px;
         height: 32px;
         border-radius: 50%;

--- a/packages/components/organisms/f-header/src/components/SkipToMain.vue
+++ b/packages/components/organisms/f-header/src/components/SkipToMain.vue
@@ -43,7 +43,7 @@ export default {
             display: block;
             margin: 4px;
             padding: 4px;
-            color: $color-link-default;
+            color: $color-content-link;
         }
     }
 }
@@ -52,7 +52,7 @@ export default {
     .c-skipTo-link {
         &:active,
         &:focus {
-            color: $white;
+            color: $color-content-link-inverse;
         }
     }
 }

--- a/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
+++ b/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
@@ -75,17 +75,17 @@ export default {
     margin: 0;
     font-family: $font-family-base;
     font-weight: 300;
-    color: $grey--dark;
+    color: $color-content-subdued;
     height: auto;
     @include font-size('body-s');
     text-decoration: none;
-    border-bottom: 1px solid $grey--light;
+    border-bottom: 1px solid $color-border-default;
 
     &:hover,
     &:focus {
         font-weight: $font-weight-bold;
         text-decoration: none;
-        color: $grey--dark;
+        color: $color-content-subdued;
     }
 
     @include media('>mid') {

--- a/packages/components/organisms/f-registration/CHANGELOG.md
+++ b/packages/components/organisms/f-registration/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.54.0
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variables to use pie design tokens instead of fozzie-colour-palette vars
+
+
 v0.53.2
 ------------------------------
 *May 20, 2021*

--- a/packages/components/organisms/f-registration/package.json
+++ b/packages/components/organisms/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.53.2",
+  "version": "0.54.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-registration/src/assets/scss/common.scss
+++ b/packages/components/organisms/f-registration/src/assets/scss/common.scss
@@ -4,8 +4,3 @@
 $theme: 'jet' !default;
 
 @import  '~@justeat/fozzie/src/scss/fozzie';
-
-/**
- * Component Variables
- */
-// $registration-background-color          : $brand--orange;

--- a/packages/components/organisms/f-registration/src/components/Registration.vue
+++ b/packages/components/organisms/f-registration/src/components/Registration.vue
@@ -544,9 +544,9 @@ $registration-icon-height--narrow : 74px;
 
         @include media('>=narrow') {
             // TODO: box shadow value will eventually come from PIE design tokens, but hard coding here for now
-            box-shadow: 0 1px 1px 0 rgba($black, 0.03),
-                    0 2px 1px -1px rgba($black, 0.07),
-                    0 1px 3px 0 rgba($black, 0.06);
+            box-shadow: 0 1px 1px 0 rgba($color-black, 0.03),
+                    0 2px 1px -1px rgba($color-black, 0.07),
+                    0 1px 3px 0 rgba($color-black, 0.06);
         }
     }
 

--- a/packages/components/organisms/f-takeawaypay-activation/src/components/TakeawaypayActivation.vue
+++ b/packages/components/organisms/f-takeawaypay-activation/src/components/TakeawaypayActivation.vue
@@ -36,7 +36,6 @@ export default {
     min-height: 80vh;
     width: 80vw;
     margin: auto;
-    border: 1px solid $red;
     font-family: $font-family-base;
     @include font-size(heading-m);
 }

--- a/packages/tools/generator-component/CHANGELOG.md
+++ b/packages/tools/generator-component/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.2.2
+------------------------------
+*May 25, 2021*
+
+### Changed
+- CSS variable to use pie design tokens instead of fozzie-colour-palette var
+
 v2.2.1
 ------------------------------
 *May 18, 2021*

--- a/packages/tools/generator-component/generators/app/templates/src/components/Skeleton.vue
+++ b/packages/tools/generator-component/generators/app/templates/src/components/Skeleton.vue
@@ -44,7 +44,7 @@ export default {
     min-height: 80vh;
     width: 80vw;
     margin: auto;
-    border: 1px solid $red;
+    border: 1px solid $color-red;
     font-family: $font-family-base;
     @include font-size(heading-m);
 }

--- a/packages/tools/generator-component/package.json
+++ b/packages/tools/generator-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/generator-component",
   "description": "Generator Component – A generator for Fozzie components",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "files": [
     "generators"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2346,10 +2346,10 @@
     lodash-es "4.17.15"
     window-or-global "1.0.1"
 
-"@justeat/f-utils@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-1.1.0.tgz#7407d0accec0de8c542478f63e0a015ec9098877"
-  integrity sha512-5nR77wCUngMfrBlPsM+nQJiOEh+I/DZWZiqO3cxZaOg9seanKBZnXMwyWnNAfx3ICzhJ3ejkMj2PSrAz2CxNYw==
+"@justeat/f-utils@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-2.0.0.tgz#34e34870f20ec85b5d0aca8a87e2bc2225e2f597"
+  integrity sha512-fFkNH39Qe6sg6e2YZmbh4l4g4qegvpsaEKnj1grCDRspQQvzpmBQBifx6nkHsdaEhetZTJC3LqwOXybmlVJI/g==
 
 "@justeat/f-vue-icons@1.10.0":
   version "1.10.0"
@@ -2407,23 +2407,27 @@
   dependencies:
     "@justeat/f-services" "1.7.0"
 
-"@justeat/fozzie-colour-palette@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.1.0.tgz#3bbe51404025c5ef8c5e8bf8280a266e51d2a640"
-  integrity sha512-QWkVa0Hv1xQ6nqxY3S1V37fAQUdIaTO1RtAhCKIe5YmNKBKEegW0PbmFIcPk3ojBVnL6Q1hzUhs3wGvOLJAMbg==
-
-"@justeat/fozzie@5.0.0-beta.3":
-  version "5.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-5.0.0-beta.3.tgz#13baadeb6774567991bc6f3ed622e8fceb8b1327"
-  integrity sha512-aqgDOC1yvAu5hP1Nxji2cQTGAGFE4e5iLPfRC4VfBMqcHp3iAC4CnQjw5phMpTSw9J9/dducptzEd+yaxmnTLQ==
+"@justeat/fozzie@5.0.0-beta.7":
+  version "5.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-5.0.0-beta.7.tgz#163808cb631686e0fb553d7901e111604142765c"
+  integrity sha512-teAtWDlfun2RTnQFxkciGOCJqqRKkPF80ybwF1zoU3+q8vZh6/DczxNvCUWmIybQIbK9k3I7qkUvzf7oeI2jVA==
   dependencies:
     "@justeat/f-dom" "1.1.0"
     "@justeat/f-logger" "0.8.1"
-    "@justeat/f-utils" "1.1.0"
-    "@justeat/fozzie-colour-palette" "3.1.0"
+    "@justeat/f-utils" "2.0.0"
+    "@justeat/pie-design-tokens" "0.18.0"
     fontfaceobserver "2.1.0"
     include-media "1.4.9"
     normalize-scss "7.0.1"
+
+"@justeat/pie-design-tokens@0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-0.18.0.tgz#0f88859ddf31e6be05f86e42e0c0f7d7b39ed41b"
+  integrity sha512-vxUuc4mdSU8ojIjuE7TtotSmastITeZ5WlUWmvjVl1tvbXzHdr6cJCSJV1WaQ4N2hjjrEpL9FfPAV5kPzGKxwA==
+  dependencies:
+    jsonc-parser "2.2.0"
+    lodash.merge "4.6.2"
+    mkdirp "1.0.3"
 
 "@justeat/stylelint-config-fozzie@2.2.0":
   version "2.2.0"
@@ -15808,6 +15812,11 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+jsonc-parser@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.2.0.tgz#f206f87f9d49d644b7502052c04e82dd6392e9ef"
+  integrity sha512-4fLQxW1j/5fWj6p78vAlAafoCKtuBm6ghv+Ij5W2DrDx0qE+ZdEl2c6Ko1mgJNF5ftX1iEWQQ4Ap7+3GlhjkOA==
+
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
@@ -16373,7 +16382,7 @@ lodash.memoize@4.x, lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.merge@^4.6.1:
+lodash.merge@4.6.2, lodash.merge@^4.6.1:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
@@ -17322,6 +17331,11 @@ mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdir
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
+  integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
 
 mocha-each@2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,6 +2176,13 @@
     eslint-config-airbnb-base "14.1.0"
     eslint-plugin-vue "6.2.2"
 
+"@justeat/f-alert@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-alert/-/f-alert-0.5.0.tgz#a5d53f2b2b0b073d5e0c46c64a67497d4019ff6b"
+  integrity sha512-7aw/1cnfYg9ZGm9j68WIoV7+uOWinrOZ752m8VVdtgECm4NgcXM7gEPEmIQ7rF7HGnvIvOzlL2IVxndaj2gaPQ==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+
 "@justeat/f-button@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-0.4.1.tgz#6b735093286422f579bd41cee93400a4d32d1b2d"
@@ -2281,6 +2288,18 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.7.0.tgz#e7f4aedfbaa614386f7fe5a180111e884c7db694"
   integrity sha512-IGknAfUH9vExdkY8hg/tcK1iAHFzA1DusKiKMHFOf3obQ/cAMA2hK7I9JCSCGjBUrcBYhpY3WdlLxu9hInJREw==
+
+"@justeat/f-mega-modal@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.9.0.tgz#834750c3ca4f66aeabd5b689628ccb5ed2d14db2"
+  integrity sha512-1OZay+2ZpelgdYvlVPV5cveZHY9Cls6yH9aQkGAYxXLzIEgmC8GfiQqtlwvLR0BQSNXr/K83asa0RUays3PE+w==
+
+"@justeat/f-popover@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@justeat/f-popover/-/f-popover-0.2.1.tgz#0c6780bcf8c452f4b0319c14b86a3cc05904dcb0"
+  integrity sha512-myeYCy8uG5k1isc4D3sPRDFeZJnX54jvFm9zbr7b45gdx/FOVLNAiB3tEQobtakTjmfW8Jl1IxiXtuUiqBD7yg==
+  dependencies:
+    "@justeat/f-services" "1.7.0"
 
 "@justeat/f-searchbox@3.10.0":
   version "3.10.0"


### PR DESCRIPTION
### Updated
- fozzie to version 5.0.0-beta.7 which uses new pie design tokens instead of fozzie-colour-palette vars

### Changed
- CSS variables to use pie design tokens instead of fozzie-colour-palette vars