### PR TITLE
f-checkout@0.123.0  Log error code when placing order

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.123.0
+------------------------------
+*May 27, 2021*
+
+### Added
+- Logging of place order error code
+
+
 v0.122.0
 ------------------------------
 *May 27, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.122.0",
+  "version": "0.123.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -1699,6 +1699,38 @@ describe('Checkout', () => {
                     // Assert
                     expect($logger.logInfo).toHaveBeenCalled();
                 });
+
+                it('should call `$logger` with the correct arguments', () => {
+                    // Arrange
+                    const eventData = {
+                        isLoggedIn: true,
+                        serviceType: CHECKOUT_METHOD_DELIVERY
+                    };
+                    const error = new Error();
+                    error.name = 'Test name';
+                    error.message = 'Test message';
+                    error.stack = 'Test stack';
+                    error.errorCode = 'Test error code';
+
+                    const expectedError = {
+                        exception: error.name,
+                        exceptionMessage: error.message,
+                        exceptionStackTrace: error.stack,
+                        errorCode: error.errorCode
+                    };
+                    const logMessage = 'Logger says hi';
+
+                    // Act
+                    wrapper.vm.logInvoker({
+                        message: logMessage,
+                        data: eventData,
+                        logMethod: $logger.logError,
+                        error
+                    });
+
+                    // Assert
+                    expect($logger.logError).toHaveBeenCalledWith(logMessage, store, { data: eventData, tags: 'checkout', ...expectedError });
+                });
             });
         });
 

--- a/packages/components/organisms/f-checkout/src/exceptions/exceptions.js
+++ b/packages/components/organisms/f-checkout/src/exceptions/exceptions.js
@@ -29,7 +29,7 @@ class PlaceOrderError extends Error {
         this.messageKey = 'errorMessages.genericServerError';
         this.eventToEmit = EventNames.CheckoutPlaceOrderFailure;
         this.logMessage = 'Place Order Failure';
-
+        this.errorCode = errorCode;
         const issue = checkoutIssues[errorCode] || {};
         this.shouldShowInDialog = issue.shouldShowInDialog || false;
     }

--- a/packages/components/organisms/f-checkout/src/mixins/logger.mixin.js
+++ b/packages/components/organisms/f-checkout/src/mixins/logger.mixin.js
@@ -4,7 +4,8 @@ function buildErrorLogFields (error) {
             exception: error.name,
             exceptionMessage: error.message,
             exceptionStackTrace: error.stack,
-            traceId: error.traceId || (error.response && error.response.data.traceId)
+            traceId: error.traceId || (error.response && error.response.data.traceId),
+            errorCode: error.errorCode
         })
     };
 }


### PR DESCRIPTION

Currently we do not log the error from underlying API when placing orders which makes it hard to diagnose issues.
This PR adds error code like 'DuplicateOrder' to the log message.

---

## UI Review Checks
No UI changes

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
