### PR TITLE
f-checkout@v0.129.0 - save userNote field to session storage

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.129.0
+------------------------------
+*June 2, 2021*
+
+### Added
+- Populate userNote field from session storage if it exists
+- Save userNote field to session storage when checkout form is submitted
+
 
 v0.128.0
 ------------------------------

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.128.0",
+  "version": "0.129.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -112,6 +112,7 @@
                         :label-text="$t(`userNote.${serviceType}.title`)"
                         input-type="textarea"
                         :placeholder="$t(`userNote.${serviceType}.placeholder`)"
+                        :value="userNote"
                         cols="30"
                         rows="7"
                         maxlength="200"
@@ -487,7 +488,9 @@ export default {
             'updateCustomerDetails',
             'updateTableIdentifier',
             'updateMessage',
-            'updateUserNote'
+            'updateUserNote',
+            'getUserNote',
+            'saveUserNote'
         ]),
 
         ...mapActions(VUEX_CHECKOUT_ANALYTICS_MODULE, [
@@ -515,6 +518,8 @@ export default {
             if (this.shouldLoadAddress) {
                 await this.loadAddress();
             }
+
+            this.getUserNote();
         },
 
         /**
@@ -524,6 +529,8 @@ export default {
          */
         async submitCheckout () {
             try {
+                this.saveUserNote();
+
                 if (!this.isLoggedIn && !this.isGuestCreated) {
                     await this.setupGuestUser();
                 }

--- a/packages/components/organisms/f-checkout/src/components/_tests/helpers/setup.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/helpers/setup.js
@@ -77,7 +77,9 @@ const defaultCheckoutActions = {
     getAddress: jest.fn(),
     placeOrder: jest.fn(),
     getCustomerName: jest.fn(),
-    updateHasAsapSelected: jest.fn()
+    updateHasAsapSelected: jest.fn(),
+    getUserNote: jest.fn(),
+    saveUserNote: jest.fn()
 };
 
 const defaultAnalyticsActions = {

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -65,6 +65,12 @@ const resolveCustomerDetails = (data, state) => {
     }
 };
 
+/**
+ * @param {object} state - The current `checkout` state.
+ * @returns {String} - session storage key where we save user note.
+ */
+const getUserNoteSessionStorageKey = state => `userNote-${state.basket.id}`;
+
 export default {
     namespaced: true,
 
@@ -389,6 +395,23 @@ export default {
         updateUserNote ({ commit, dispatch }, payload) {
             commit(UPDATE_USER_NOTE, payload);
             dispatch(`${VUEX_CHECKOUT_ANALYTICS_MODULE}/updateChangedField`, 'note', { root: true });
+        },
+
+        getUserNote: ({ dispatch, state }) => {
+            if (window.sessionStorage) {
+                const key = getUserNoteSessionStorageKey(state);
+                const note = window.sessionStorage.getItem(key);
+                if (note) {
+                    dispatch('updateUserNote', note);
+                }
+            }
+        },
+
+        saveUserNote ({ state }) {
+            if (window.sessionStorage) {
+                const key = getUserNoteSessionStorageKey(state);
+                window.sessionStorage.setItem(key, state.userNote);
+            }
         },
 
         updateHasAsapSelected ({ commit }, payload) {

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -10,6 +10,7 @@ import {
 } from '../../components/_tests/helpers/setup';
 import { version as applicationVerion } from '../../../package.json';
 import { VUEX_CHECKOUT_ANALYTICS_MODULE, DEFAULT_CHECKOUT_ISSUE } from '../../constants';
+import sessionStorageMock from '../../../test-utils/local-storage/local-storage-mock';
 
 import {
     UPDATE_AUTH,
@@ -43,7 +44,9 @@ const {
     updateCustomerDetails,
     updateFulfilmentTime,
     updateMessage,
-    updateUserNote
+    updateUserNote,
+    getUserNote,
+    saveUserNote
 } = actions;
 
 const mobileNumber = '+447111111111';
@@ -937,6 +940,89 @@ describe('CheckoutModule', () => {
 
             // Assert
             expect(dispatch).toHaveBeenCalledWith(`${VUEX_CHECKOUT_ANALYTICS_MODULE}/updateChangedField`, field, { root: true });
+        });
+
+        describe('getUserNote ::', () => {
+            describe('if sessionStorage exists', () => {
+                beforeEach(() => {
+                    Object.defineProperty(window, 'sessionStorage', { value: sessionStorageMock });
+                });
+
+                afterEach(() => {
+                    window.sessionStorage.clear();
+                    jest.resetAllMocks();
+                });
+
+                describe('when the user note exists in session storage', () => {
+                    it('should call dispatch with updateUserNote action and the user note', () => {
+                        // Arrange
+                        jest.spyOn(window.sessionStorage, 'getItem').mockReturnValue(userNote);
+
+                        // Act
+                        getUserNote({ dispatch, state });
+
+                        // Assert
+                        expect(dispatch).toHaveBeenCalledWith('updateUserNote', userNote);
+                    });
+                });
+
+                describe('when the user note does NOT exist in session storage', () => {
+                    it('should not call dispatch', () => {
+                        // Arrange
+                        jest.spyOn(window.sessionStorage, 'getItem').mockReturnValue(undefined);
+
+                        // Act
+                        getUserNote({ dispatch, state });
+
+                        // Assert
+                        expect(dispatch).not.toHaveBeenCalled();
+                    });
+                });
+            });
+
+            describe('if sessionStorage does NOT exist', () => {
+                beforeAll(() => {
+                    Object.defineProperty(window, 'sessionStorage', { value: null });
+                });
+
+                afterAll(() => {
+                    window.sessionStorage.clear();
+                    jest.resetAllMocks();
+                });
+
+                it('should not call dispatch', () => {
+                    // Act
+                    getUserNote({ dispatch, state });
+
+                    // Assert
+                    expect(dispatch).not.toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('saveUserNote ::', () => {
+            beforeEach(() => {
+                Object.defineProperty(window, 'sessionStorage', { value: sessionStorageMock });
+            });
+
+            afterEach(() => {
+                window.sessionStorage.clear();
+                jest.resetAllMocks();
+            });
+
+
+            it('should save userNote to sessionStorage', () => {
+                // Arrange
+                const spy = jest.spyOn(window.sessionStorage, 'setItem');
+                const testBasketId = '11111';
+                const key = `userNote-${testBasketId}`;
+
+                // Act
+                saveUserNote({ state });
+
+                // Assert
+                expect(spy).toHaveBeenCalledWith(key, state.userNote);
+            });
         });
     });
 });


### PR DESCRIPTION
v0.129.0
------------------------------
*June 2, 2021*

### Added
- Populate userNote field from session storage if it exists
- Save userNote field to session storage when checkout form is submitted