### PR TITLE
f-tabs@0.6.0 - Change button type from submit to button

### DIFF
--- a/packages/components/molecules/f-tabs/CHANGELOG.md
+++ b/packages/components/molecules/f-tabs/CHANGELOG.md
@@ -4,9 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.6.0
+------------------------------
+*June 2, 2021*
+
+### Changed
+- Button type from `submit` (the default) to `button` to prevent submission when tabs are used inside a form.
+
+
 v0.5.0
 ------------------------------
-*May 25, 2021
+*May 25, 2021*
 
 ### Changed
 - CSS variables to use pie design tokens instead of fozzie-colour-palette vars
@@ -33,12 +41,8 @@ v0.3.0
 - Added supporting code to component object file
 
 ### Changed
-- `Data-test-id` naming for `tab-` to `tab-button-` in `Tabs.vue` and `Tabs.test.js`
-- `Data-test-id` naming for `transition-tab-` to `tab-content-` in `Tab.vue` and `Tab.test.js`
-
-*February 24, 2021*
-
-### Changed
+- `data-test-id` naming for `tab-` to `tab-button-` in `Tabs.vue` and `Tabs.test.js`
+- `data-test-id` naming for `transition-tab-` to `tab-content-` in `Tab.vue` and `Tab.test.js`
 - Restructured component object into page object model
 - Refactored component and accessibility tests
 

--- a/packages/components/molecules/f-tabs/package.json
+++ b/packages/components/molecules/f-tabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-tabs",
-  "description": "Fozzie Tabs – Switchable slots for content&#34;",
-  "version": "0.5.0",
+  "description": "Fozzie Tabs – Switchable slots for content",
+  "version": "0.6.0",
   "main": "dist/f-tabs.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-tabs/src/components/Tabs.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tabs.vue
@@ -7,13 +7,13 @@
                 <button
                     v-for="({ name, title }, i) in tabs"
                     :key="i"
+                    type="button"
                     :class="[
                         { [$style['c-tabs-button--active']]: activeTab === name },
                         $style['c-tabs-button']
                     ]"
                     :data-test-id="`tab-button-${name}`"
-                    @click="selectTabIndex(name)"
-                >
+                    @click="selectTabIndex(name)">
                     {{ title }}
                 </button>
             </div>


### PR DESCRIPTION
### Changed
- Button type from `submit` (the default) to `button` to prevent submission when tabs are used inside a form.

---

## UI Review Checks
- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
