### PR TITLE
f-tabs@0.7.0 - Emit change event when tab selection is changed

### DIFF
--- a/packages/components/molecules/f-tabs/CHANGELOG.md
+++ b/packages/components/molecules/f-tabs/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.7.0
+------------------------------
+*June 3, 2021*
+
+### Changed
+- Emit `change` event when the tab is changed. Event payload contains the `new` and `prev` tab indices.
+
+
 v0.6.0
 ------------------------------
 *June 2, 2021*

--- a/packages/components/molecules/f-tabs/README.md
+++ b/packages/components/molecules/f-tabs/README.md
@@ -61,6 +61,17 @@
 
     ```
 
+## Configuration
+
+### Events
+
+The events that can be subscribed to are as follows (if any):
+
+| Event | Description |
+| ----- | ----------- |
+| `change` | Fired from `f-tabs` when the selected tab is changed. Payload contains the indices of the `new` and `prev` selected tabs. |
+
+
 ## Development
 It is recommended to run the following commands at the root of the monorepo in order to install dependencies and allow you to view components in isolation via Storybook.
 

--- a/packages/components/molecules/f-tabs/package.json
+++ b/packages/components/molecules/f-tabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-tabs",
   "description": "Fozzie Tabs – Switchable slots for content",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "dist/f-tabs.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-tabs/src/components/Tabs.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tabs.vue
@@ -85,12 +85,21 @@ export default {
         selectTabIndex (name) {
             const previousIndex = this.tabs.findIndex(t => t.name === this.activeTab);
             const newIndex = this.tabs.findIndex(t => t.name === name);
+
             if (newIndex > previousIndex) {
                 this.direction = DIRECTION.RIGHT;
             } else {
                 this.direction = DIRECTION.LEFT;
             }
-            this.activeTab = name;
+
+            if (this.activeTab !== name) {
+                this.$emit('change', {
+                    new: newIndex,
+                    prev: previousIndex
+                });
+
+                this.activeTab = name;
+            }
         },
 
         /**

--- a/packages/components/molecules/f-tabs/src/components/tests/Tab.test.js
+++ b/packages/components/molecules/f-tabs/src/components/tests/Tab.test.js
@@ -17,7 +17,7 @@ const REGISTER_DATA = {
 describe('Tab.vue', () => {
     let activeWrapper;
 
-    function defineActiveCompoment () {
+    function defineActiveComponent () {
         activeWrapper = shallowMount(Tab, {
             propsData: {
                 name: REGISTER_DATA.name,
@@ -38,7 +38,7 @@ describe('Tab.vue', () => {
 
     it('should be defined', () => {
         // Arrange & Act
-        defineActiveCompoment();
+        defineActiveComponent();
 
         // Assert
         expect(activeWrapper.exists()).toBe(true);
@@ -47,7 +47,7 @@ describe('Tab.vue', () => {
     describe('when active', () => {
         beforeEach(() => {
             // Arrange & Act
-            defineActiveCompoment();
+            defineActiveComponent();
         });
 
         it('should call the register callback method when created', () => {

--- a/packages/components/molecules/f-tabs/src/components/tests/Tabs.test.js
+++ b/packages/components/molecules/f-tabs/src/components/tests/Tabs.test.js
@@ -181,6 +181,29 @@ describe('Tabs', () => {
                 // Assert
                 expect(wrapper.vm.direction).toEqual('LEFT');
             });
+
+            it('should emit a `change` event if new index != old index', async () => {
+                // Act
+                await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`).trigger('click');
+                await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[1].name}"]`).trigger('click');
+
+                // Assert
+                expect(wrapper.emitted().change).toBeTruthy();
+                expect(wrapper.emitted().change.length).toBe(1);
+                expect(wrapper.emitted().change[0]).toStrictEqual([{
+                    new: 1,
+                    prev: 0
+                }]);
+            });
+
+            it('should not emit a `change` event if new index = old index', async () => {
+                // Act
+                await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`).trigger('click');
+                await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`).trigger('click');
+
+                // Assert
+                expect(wrapper.emitted().change).toBeFalsy();
+            });
         });
 
         describe('programmatically', () => {
@@ -208,6 +231,29 @@ describe('Tabs', () => {
 
                 // Assert
                 expect(wrapper.vm.direction).toEqual('LEFT');
+            });
+
+            it('should emit a `change` event if new index != old index', async () => {
+                // Act
+                await tabStub.vm[SELECT](registeredTabsMock[0].name);
+                await tabStub.vm[SELECT](registeredTabsMock[1].name);
+
+                // Assert
+                expect(wrapper.emitted().change).toBeTruthy();
+                expect(wrapper.emitted().change.length).toBe(1);
+                expect(wrapper.emitted().change[0]).toStrictEqual([{
+                    new: 1,
+                    prev: 0
+                }]);
+            });
+
+            it('should not emit a `change` event if new index = old index', async () => {
+                // Act
+                await tabStub.vm[SELECT](registeredTabsMock[0].name);
+                await tabStub.vm[SELECT](registeredTabsMock[0].name);
+
+                // Assert
+                expect(wrapper.emitted().change).toBeFalsy();
             });
         });
     });


### PR DESCRIPTION
- Emit `change` event when the tab is changed. Event payload contains the `new` and `prev` tab indices.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
