### PR TITLE
f-tabs@0.8.0 - Reverse animation direction, and don't change direction if the tab isn't changing

### DIFF
--- a/packages/components/molecules/f-tabs/CHANGELOG.md
+++ b/packages/components/molecules/f-tabs/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.8.0
+------------------------------
+*June 4, 2021*
+
+### Fixed
+- Don't *change* direction if tab selection isn't changing.
+
+
 v0.7.0
 ------------------------------
 *June 3, 2021*

--- a/packages/components/molecules/f-tabs/CHANGELOG.md
+++ b/packages/components/molecules/f-tabs/CHANGELOG.md
@@ -8,6 +8,9 @@ v0.8.0
 ------------------------------
 *June 4, 2021*
 
+### Changed
+- Reverse animation direction (when choosing a tab that is further left, its contents should slide in from the left and vice-versa).
+
 ### Fixed
 - Don't *change* direction if tab selection isn't changing.
 

--- a/packages/components/molecules/f-tabs/package.json
+++ b/packages/components/molecules/f-tabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-tabs",
   "description": "Fozzie Tabs – Switchable slots for content",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "dist/f-tabs.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-tabs/src/components/Tabs.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tabs.vue
@@ -89,9 +89,9 @@ export default {
             const newIndex = this.tabs.findIndex(t => t.name === name);
 
             if (newIndex > previousIndex) {
-                this.direction = DIRECTION.RIGHT;
-            } else {
                 this.direction = DIRECTION.LEFT;
+            } else {
+                this.direction = DIRECTION.RIGHT;
             }
 
             this.$emit('change', {

--- a/packages/components/molecules/f-tabs/src/components/Tabs.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tabs.vue
@@ -88,11 +88,7 @@ export default {
             const previousIndex = this.tabs.findIndex(t => t.name === this.activeTab);
             const newIndex = this.tabs.findIndex(t => t.name === name);
 
-            if (newIndex > previousIndex) {
-                this.direction = DIRECTION.LEFT;
-            } else {
-                this.direction = DIRECTION.RIGHT;
-            }
+            this.direction = (newIndex > previousIndex) ? DIRECTION.LEFT : DIRECTION.RIGHT;
 
             this.$emit('change', {
                 new: newIndex,

--- a/packages/components/molecules/f-tabs/src/components/Tabs.vue
+++ b/packages/components/molecules/f-tabs/src/components/Tabs.vue
@@ -83,6 +83,8 @@ export default {
          * @param name
          */
         selectTabIndex (name) {
+            if (this.activeTab === name) return;
+
             const previousIndex = this.tabs.findIndex(t => t.name === this.activeTab);
             const newIndex = this.tabs.findIndex(t => t.name === name);
 
@@ -92,14 +94,12 @@ export default {
                 this.direction = DIRECTION.LEFT;
             }
 
-            if (this.activeTab !== name) {
-                this.$emit('change', {
-                    new: newIndex,
-                    prev: previousIndex
-                });
+            this.$emit('change', {
+                new: newIndex,
+                prev: previousIndex
+            });
 
-                this.activeTab = name;
-            }
+            this.activeTab = name;
         },
 
         /**

--- a/packages/components/molecules/f-tabs/src/components/tests/Tabs.test.js
+++ b/packages/components/molecules/f-tabs/src/components/tests/Tabs.test.js
@@ -1,7 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import Vue from 'vue';
 import Tabs from '../Tabs.vue';
-import { INJECTIONS } from '../../constants';
+import { DIRECTION, INJECTIONS } from '../../constants';
 
 const {
     REGISTER,
@@ -165,21 +165,21 @@ describe('Tabs', () => {
                 expect(tabButton.classes()).toContain('c-tabs-button--active');
             });
 
-            it('should set the direction to RIGHT when new index > old index', async () => {
+            it('should set the direction to LEFT when new index > old index', async () => {
                 // Act
                 await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[1].name}"]`).trigger('click');
 
                 // Assert
-                expect(wrapper.vm.direction).toEqual('RIGHT');
+                expect(wrapper.vm.direction).toEqual(DIRECTION.LEFT);
             });
 
-            it('should set the direction to LEFT when new index <= old index', async () => {
+            it('should set the direction to RIGHT when new index <= old index', async () => {
                 // Act
                 await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[1].name}"]`).trigger('click');
                 await wrapper.find(`[data-test-id="tab-button-${registeredTabsMock[0].name}"]`).trigger('click');
 
                 // Assert
-                expect(wrapper.vm.direction).toEqual('LEFT');
+                expect(wrapper.vm.direction).toEqual(DIRECTION.RIGHT);
             });
 
             it('should emit a `change` event if new index != old index', async () => {
@@ -216,21 +216,21 @@ describe('Tabs', () => {
                 expect(tabButton.classes()).toContain('c-tabs-button--active');
             });
 
-            it('should set the direction to RIGHT when new index > old index', async () => {
+            it('should set the direction to LEFT when new index > old index', async () => {
                 // Act
                 await tabStub.vm[SELECT](registeredTabsMock[1].name);
 
                 // Assert
-                expect(wrapper.vm.direction).toEqual('RIGHT');
+                expect(wrapper.vm.direction).toEqual(DIRECTION.LEFT);
             });
 
-            it('should set the direction to LEFT when new index <= old index', async () => {
+            it('should set the direction to RIGHT when new index <= old index', async () => {
                 // Act
                 await tabStub.vm[SELECT](registeredTabsMock[1].name);
                 await tabStub.vm[SELECT](registeredTabsMock[0].name);
 
                 // Assert
-                expect(wrapper.vm.direction).toEqual('LEFT');
+                expect(wrapper.vm.direction).toEqual(DIRECTION.RIGHT);
             });
 
             it('should emit a `change` event if new index != old index', async () => {


### PR DESCRIPTION
For click (manually triggered) events, the method is being called twice, so on the second call it was seeing `newIndex` and `previousIndex` as equal, so the direction was set to `DIRECTION.LEFT` every time.

I couldn't see a nice way of making sure the method only gets called once (because the mechanism for programmatically triggered events is different), so instead I fixed it so that all of the logic only happens if the tab is actually being changed.

I also swapped the animation direction because it makes more visual sense (at least to me it does).


### Changed
- Reverse animation direction (when choosing a tab that is further left, its contents should slide in from the left and vice-versa).

### Fixed
- Don't *change* direction if tab selection isn't changing.

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
