### PR TITLE
f-checkout@0.133.0 - separate page for 403 error

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.133.0
+------------------------------
+*June 8, 2021*
+
+### Added
+- Separate content for 403 error
+
+
 v0.130.0
 ------------------------------
 *June 7, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.130.0",
+  "version": "0.133.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -145,7 +145,11 @@
             </card>
         </div>
 
-        <error-page v-else-if="shouldShowErrorPage" />
+        <error-page
+            v-else-if="shouldShowErrorPage"
+            :header="$t(`errorMessages.${getCheckoutError}.heading`)"
+            :description="$t(`errorMessages.${getCheckoutError}.description`)"
+        />
     </div>
 </template>
 
@@ -308,7 +312,8 @@ export default {
             tenantConfigs,
             hasCheckoutLoadedSuccessfully: true,
             shouldShowSpinner: false,
-            isLoading: false
+            isLoading: false,
+            hasAccessForbiddenError: false
         };
     },
 
@@ -443,6 +448,10 @@ export default {
 
         formattedMobileNumberForScreenReader () {
             return this.customer.mobileNumber ? [...this.customer.mobileNumber].join(' ') : '';
+        },
+
+        getCheckoutError () {
+            return this.hasAccessForbiddenError ? 'accessForbiddenError' : 'pageLoad';
         }
     },
 
@@ -685,6 +694,9 @@ export default {
 
                 this.$emit(EventNames.CheckoutGetSuccess);
             } catch (error) {
+                if (error.response.status === 403) {
+                    this.hasAccessForbiddenError = true;
+                }
                 this.$emit(EventNames.CheckoutGetFailure, error);
                 this.hasCheckoutLoadedSuccessfully = false;
 

--- a/packages/components/organisms/f-checkout/src/components/Error.vue
+++ b/packages/components/organisms/f-checkout/src/components/Error.vue
@@ -14,13 +14,13 @@
         <h1
             :class="$style['c-checkout-error-heading']"
             data-test-id="checkout-error-page-heading">
-            {{ $t('errorMessages.pageLoad.heading') }}
+            {{ header }}
         </h1>
 
         <p
             :class="$style['c-checkout-error-description']"
             data-test-id="checkout-error-page-description">
-            {{ $t('errorMessages.pageLoad.description') }}
+            {{ description }}
         </p>
     </card>
 </template>
@@ -34,6 +34,16 @@ export default {
     components: {
         Card,
         SadBagIconDecorator
+    },
+    props: {
+        header: {
+            type: String,
+            required: true
+        },
+        description: {
+            type: String,
+            required: true
+        }
     }
 };
 </script>

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -1911,11 +1911,17 @@ describe('Checkout', () => {
             describe('when `getCheckout` request fails', () => {
                 let wrapper;
 
+                const error = {
+                    response: {
+                        status: 400
+                    }
+                };
+
                 beforeEach(() => {
                     jest.spyOn(VueCheckout.methods, 'initialise').mockImplementation();
 
                     wrapper = mount(VueCheckout, {
-                        store: createStore(defaultCheckoutState, { ...defaultCheckoutActions, getCheckout: jest.fn(async () => Promise.reject()) }),
+                        store: createStore(defaultCheckoutState, { ...defaultCheckoutActions, getCheckout: jest.fn(async () => Promise.reject(error)) }),
                         i18n,
                         localVue,
                         propsData,

--- a/packages/components/organisms/f-checkout/src/components/_tests/Error.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Error.test.js
@@ -1,41 +1,33 @@
 import Vuex from 'vuex';
-import { VueI18n } from '@justeat/f-globalisation';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Error from '../Error.vue';
-import {
-    i18n, createStore
-} from './helpers/setup';
 
 const localVue = createLocalVue();
 
-localVue.use(VueI18n);
 localVue.use(Vuex);
 
 describe('Error', () => {
-    const propsData = {};
+    let wrapper;
+
+    beforeEach(() => {
+        // Arrange & Act
+        wrapper = shallowMount(Error, {
+            localVue,
+            propsData: {
+                header: 'Test header',
+                description: 'Test description'
+            }
+        });
+    });
+
 
     it('should be defined', () => {
-        // Arrange & Act
-        const wrapper = shallowMount(Error, {
-            store: createStore(),
-            i18n,
-            localVue,
-            propsData
-        });
-
         // Assert
         expect(wrapper.exists()).toBe(true);
     });
 
     it('should show the heading', () => {
-        // Arrange & Act
-        const wrapper = shallowMount(Error, {
-            store: createStore(),
-            i18n,
-            localVue,
-            propsData
-        });
-
+        // Act
         const heading = wrapper.find('[data-test-id="checkout-error-page-heading"]');
 
         // Assert
@@ -43,14 +35,7 @@ describe('Error', () => {
     });
 
     it('should show the description', () => {
-        // Arrange & Act
-        const wrapper = shallowMount(Error, {
-            store: createStore(),
-            i18n,
-            localVue,
-            propsData
-        });
-
+        // Act
         const description = wrapper.find('[data-test-id="checkout-error-page-description"]');
 
         // Assert

--- a/packages/components/organisms/f-checkout/src/components/_tests/__snapshots__/Error.test.js.snap
+++ b/packages/components/organisms/f-checkout/src/components/_tests/__snapshots__/Error.test.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Error should show the description 1`] = `"It’s a problem at our end, sorry. Your basket is safe and sound, though, so try again soon."`;
+exports[`Error should show the description 1`] = `"Test description"`;
 
-exports[`Error should show the heading 1`] = `"We can’t show you this page"`;
+exports[`Error should show the heading 1`] = `"Test header"`;

--- a/packages/components/organisms/f-checkout/src/demo/checkout-403-error.json
+++ b/packages/components/organisms/f-checkout/src/demo/checkout-403-error.json
@@ -1,0 +1,9 @@
+{
+    "traceId": "0HLOCKDKQPKIU",
+    "faultId": "72d7036d-990a-4f84-9efa-ef5f40f6044b",
+    "errors": [
+        {
+            "description": "Access to the resource is forbidden"
+        }
+    ]
+  }

--- a/packages/components/organisms/f-checkout/src/demo/checkoutMock.js
+++ b/packages/components/organisms/f-checkout/src/demo/checkoutMock.js
@@ -15,6 +15,7 @@ import checkoutServerError from './checkout-server-error.json';
 import getAddress from './get-address.json';
 import placeOrder from './place-order.json';
 import placeOrderDuplicate from './place-order-duplicate.json';
+import accessForbiddenError from './checkout-403-error.json';
 import getGeoLocation from './get-geo-location.json';
 
 const mock = new MockAdapter(axios);
@@ -66,6 +67,9 @@ export default {
                 break;
             case '/place-order-duplicate.json':
                 mock.onPost(path).reply(400, placeOrderDuplicate);
+                break;
+            case '/checkout-403-error.json':
+                mock.onGet(path).reply(403, accessForbiddenError);
                 break;
             case '/get-geo-location.json':
                 mock.onPost(path).reply(200, getGeoLocation);

--- a/packages/components/organisms/f-checkout/src/tenants/en-GB.js
+++ b/packages/components/organisms/f-checkout/src/tenants/en-GB.js
@@ -53,7 +53,13 @@ const messages = {
         multipleFieldErrors: 'There are {errorCount} errors in the form',
         pageLoad: {
             heading: 'We can’t show you this page',
-            description: 'It’s a problem at our end, sorry. Your basket is safe and sound, though, so try again soon.'
+            description: 'It’s a problem at our end, sorry. Your basket is safe and sound, though, so try again soon.',
+            buttonText: 'Go back to order'
+        },
+        accessForbiddenError: {
+            heading: 'Something went wrong',
+            description: 'This basket was created with a different account so we can’t proceed, sorry. Please add your items again.',
+            buttonText: 'Go back to order'
         },
 
         guestUserCreationFailure: 'Guest checkout isn’t available, sorry. Try again soon or sign up',

--- a/packages/components/organisms/f-checkout/stories/Checkout.stories.js
+++ b/packages/components/organisms/f-checkout/stories/Checkout.stories.js
@@ -31,6 +31,7 @@ const updateCheckoutServerErrorUrl = '/update-checkout-server-error.json';
 const getAddressUrl = '/get-address.json';
 const placeOrderUrl = '/place-order.json';
 const placeOrderDuplicateUrl = '/place-order-duplicate.json';
+const accessForbiddenErrorUrl = '/checkout-403-error.json';
 const paymentPageUrlPrefix = '#/pay'; // Adding the "#" so we don't get redirect out of the component in Storybook
 const getGeoLocationUrl = '/get-geo-location.json';
 
@@ -49,19 +50,26 @@ CheckoutMock.setupCheckoutMethod(updateCheckoutServerErrorUrl);
 CheckoutMock.setupCheckoutMethod(getAddressUrl);
 CheckoutMock.setupCheckoutMethod(placeOrderUrl);
 CheckoutMock.setupCheckoutMethod(placeOrderDuplicateUrl);
+CheckoutMock.setupCheckoutMethod(accessForbiddenErrorUrl);
 CheckoutMock.setupCheckoutMethod(getGeoLocationUrl);
 CheckoutMock.passThroughAny();
 
 const checkoutIssues = 'Checkout Issues (Response from server but order not fulfillable)';
 const checkoutServerError = 'Checkout Error (Response from server is an error)';
 const placeOrderError = 'Place Order Duplicate Error (Response from server is an error)';
+const accessForbiddenError = 'Get checkout error - access is forbidden';
 const ISSUES = 'ISSUES';
 const SERVER = 'SERVER';
 
-const checkoutErrorOptions = {
+const patchCheckoutErrorOptions = {
     None: null,
     [checkoutIssues]: ISSUES,
     [checkoutServerError]: SERVER
+};
+
+const getCheckoutErrorOptions = {
+    None: null,
+    [accessForbiddenError]: SERVER
 };
 
 const placeOrderErrorOptions = {
@@ -105,8 +113,12 @@ export const CheckoutComponent = () => ({
             default: boolean('Is ASAP available', true)
         },
 
-        checkoutError: {
-            default: select('Checkout Errors', checkoutErrorOptions)
+        patchCheckoutError: {
+            default: select('Patch Checkout Errors', patchCheckoutErrorOptions)
+        },
+
+        getCheckoutError: {
+            default: select('Get Checkout Errors', getCheckoutErrorOptions)
         },
 
         placeOrderError: {
@@ -116,6 +128,10 @@ export const CheckoutComponent = () => ({
 
     computed: {
         getCheckoutUrl () {
+            if (this.getCheckoutError) {
+                return accessForbiddenErrorUrl;
+            }
+
             return `/checkout-${this.serviceType}.json`;
         },
 
@@ -128,8 +144,8 @@ export const CheckoutComponent = () => ({
         },
 
         updateCheckoutUrl () {
-            if (this.checkoutError) {
-                return this.checkoutError === SERVER ? updateCheckoutServerErrorUrl : updateCheckoutErrorsUrl;
+            if (this.patchCheckoutError) {
+                return this.patchCheckoutError === SERVER ? updateCheckoutServerErrorUrl : updateCheckoutErrorsUrl;
             }
 
             return updateCheckoutUrl;


### PR DESCRIPTION
This is a first PR for adding separate 403 error page. It covers rendering different content for 403 error. Showing the button and tests will be covered in the next PR.