### PR TITLE
f-alert@v0.6.1 - Fix styling issues while rendering the alert header

### DIFF
--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.6.1
+------------------------------
+*June 09, 2021*
+
+### Fixed
+- Alert icon no longer resizes as content around it grows
+- Warning icon no longer receives greater margin than the other alert types
+- Items in the header are no longer vertically aligned as the content may exceed one line
+
+
 v0.6.0
 ------------------------------
 *May 25, 2020*

--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -12,6 +12,7 @@ v0.6.1
 - Alert icon no longer resizes as content around it grows
 - Warning icon no longer receives greater margin than the other alert types
 - Items in the header are no longer vertically aligned as the content may exceed one line
+- Added some spacing below the title so that the component doesn't feel so mushed
 
 
 v0.6.0

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-alert",
   "description": "Fozzie Alert – Fozzie Alert Component",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "dist/f-alert.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/molecules/f-alert/src/components/Alert.vue
+++ b/packages/components/molecules/f-alert/src/components/Alert.vue
@@ -49,7 +49,11 @@ import {
     SuccessIcon,
     WarningIcon
 } from '@justeat/f-vue-icons';
-import { globalisationServices } from '@justeat/f-services';
+
+import {
+    globalisationServices
+} from '@justeat/f-services';
+
 import FButton from '@justeat/f-button';
 import tenantConfigs from '../tenants';
 import '@justeat/f-button/dist/f-button.css';
@@ -146,6 +150,7 @@ $alert-borderRadius: $border-radius;
     .c-alert-heading {
         @include font-size(subheading-s);
         margin-top: -1px;
+        margin-bottom: spacing(x0.5);
     }
 
     .c-alert-content {

--- a/packages/components/molecules/f-alert/src/components/Alert.vue
+++ b/packages/components/molecules/f-alert/src/components/Alert.vue
@@ -120,7 +120,6 @@ $alert-borderRadius: $border-radius;
 }
     .c-alert-headingContainer {
         display: flex;
-        align-items: center;
         padding: spacing(x0.5) 0 0;
     }
 
@@ -155,13 +154,11 @@ $alert-borderRadius: $border-radius;
     }
 
     .c-alert-icon {
+        min-width: 20px;
+        width: 20px;
         height: 20px;
-        margin: 0 spacing(x1.5) 0 spacing();
+        margin: 5px spacing(x1.5) 0 spacing();
     }
-
-        .c-alert-icon--warning {
-            margin-right: 10px;
-        }
 
     .c-alert-dismiss {
         text-indent: 0;


### PR DESCRIPTION
v0.6.1
------------------------------
*June 09, 2021*

### Fixed
- Alert icon no longer resizes as content around it grows
- Warning icon no longer receives greater margin than the other alert types
- Items in the header are no longer vertically aligned as the content may exceed one line
- Added some spacing below the title so that the component doesn't feel so mushed

_Before_
![image](https://user-images.githubusercontent.com/10741583/121330024-9c5c8900-c90d-11eb-81dd-aae14e24bc28.png)
![image](https://user-images.githubusercontent.com/10741583/121330762-36243600-c90e-11eb-921d-f97680ef6652.png)


_After_
![image](https://user-images.githubusercontent.com/10741583/121335105-34f50800-c912-11eb-9e12-8314f9f57006.png)
![image](https://user-images.githubusercontent.com/10741583/121335197-49d19b80-c912-11eb-974b-f162660a5d94.png)
