### PR TITLE
f-cookie-banner@0.14.0 - Added percy visual regression tests for f-cookiebanner

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.14.0
+------------------------------
+*June 9, 2021*
+
+### Added
+- Percy Visual Regression tests for Legacy and ConsentBanner
+
 
 v0.13.0
 ------------------------------

--- a/packages/components/organisms/f-cookie-banner/jest.config.js
+++ b/packages/components/organisms/f-cookie-banner/jest.config.js
@@ -7,7 +7,8 @@ module.exports = {
 
     modulePathIgnorePatterns: [
         './test/component/',
-        './test/accessibility'
+        './test/accessibility',
+        './test/visual'
     ],
 
     transform: {

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-cookie-banner/test/visual/f-cookieConsentBanner.visual.shared.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/visual/f-cookieConsentBanner.visual.shared.spec.js
@@ -1,0 +1,35 @@
+import forEach from 'mocha-each';
+
+const { buildUrl } = require('@justeat/f-wdio-utils/src/storybook-extensions');
+const CookieBanner = require('../../test-utils/component-objects/f-cookieConsentBanner.component');
+
+let cookieBanner;
+
+describe('New - f-cookieBanner component tests - @browserstack', () => {
+    beforeEach(() => {
+        cookieBanner = new CookieBanner('organism', 'cookie-banner-component');
+        cookieBanner.withQuery('&knob-Locale', 'en-IE');
+        const pageUrl = buildUrl(cookieBanner.componentType, cookieBanner.componentName, cookieBanner.path);
+
+        cookieBanner.open(pageUrl);
+        cookieBanner.waitForComponent();
+    });
+
+    // 'dk' and 'no' disabled for now
+    forEach(['es-ES', 'en-IE', 'it-IT'])
+    .it('should display the f-cookieBanner component for "%s"', tenant => {
+        // Arrange
+        cookieBanner = new CookieBanner('organism', 'cookie-banner-component');
+        cookieBanner.withQuery('&knob-Locale', tenant);
+        const pageUrl = buildUrl(cookieBanner.componentType, cookieBanner.componentName, cookieBanner.path);
+
+        // Act
+        cookieBanner.open(pageUrl);
+        browser.deleteAllCookies();
+        browser.refresh();
+        cookieBanner.waitForComponent();
+
+        // Assert
+        browser.percyScreenshot(`f-cookiebanner - CookieConsent - ${tenant}`, 'shared');
+    });
+});

--- a/packages/components/organisms/f-cookie-banner/test/visual/f-cookiebanner-legacy.visual.shared.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/visual/f-cookiebanner-legacy.visual.shared.spec.js
@@ -1,0 +1,19 @@
+const { buildUrl } = require('@justeat/f-wdio-utils/src/storybook-extensions');
+
+const CookieBanner = require('../../test-utils/component-objects/f-cookieBanner-legacy.component');
+
+const cookieBanner = new CookieBanner('organism', 'cookie-banner-component');
+
+describe('Legacy - f-cookieBanner component tests', () => {
+    it('should display the f-cookieBanner component', () => {
+        // Arrange
+        cookieBanner.withQuery('&knob-Locale', 'en-GB');
+        const pageUrl = buildUrl(cookieBanner.componentType, cookieBanner.componentName, cookieBanner.path);
+
+        cookieBanner.open(pageUrl);
+        cookieBanner.waitForComponent();
+
+        // Assert
+        browser.percyScreenshot('f-cookiebanner - Legacy', 'shared');
+    });
+});


### PR DESCRIPTION
v0.14.0
------------------------------
*June 9, 2021*

### Added
- Percy Visual Regression tests for Legacy and ConsentBanner