### PR TITLE
f-media-element@v0.3.0 - Add slot to component

### DIFF
--- a/packages/components/molecules/f-media-element/CHANGELOG.md
+++ b/packages/components/molecules/f-media-element/CHANGELOG.md
@@ -3,9 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-Latest (add to next release)
+v0.3.0
 ------------------------------
-*February 25, 2021*
+*June 09, 2021*
+
+### Added
+- Slot to enable additional content to be displayed below the text and title
+- Unit tests to test the classes appear when props are set
+- Unit test for checking slot content works
 
 ### Changed
 - Restructured component object into page object model

--- a/packages/components/molecules/f-media-element/package.json
+++ b/packages/components/molecules/f-media-element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-media-element",
   "description": "Fozzie Media Element - provides ability to display text and an image in different orientations",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "main": "dist/f-media-element.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -18,6 +18,7 @@
             <p :class="$style['c-mediaElement-text']">
                 {{ text }}
             </p>
+            <slot></slot>
         </div>
         <div
             :class="[

--- a/packages/components/molecules/f-media-element/src/components/_tests/MediaElement.test.js
+++ b/packages/components/molecules/f-media-element/src/components/_tests/MediaElement.test.js
@@ -1,10 +1,163 @@
 import { shallowMount } from '@vue/test-utils';
 import MediaElement from '../MediaElement.vue';
+import { ALIGN, FONT_SIZE } from '../../constants';
 
-describe('MediaElement', () => {
+const mockTitle = '__TEST_TITLE__';
+const mockText = '__TEST_TEXT__';
+const mockImageUrl = '__TEST_IMAGE_URL__';
+
+describe('MediaElement.vue', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
     it('should be defined', () => {
         const propsData = {};
         const wrapper = shallowMount(MediaElement, { propsData });
         expect(wrapper.exists()).toBe(true);
+    });
+
+    describe('props ::', () => {
+        it('should display the title prop value in a h3 when the title prop is set', () => {
+            // Arrange
+            const wrapper = shallowMount(MediaElement, {
+                propsData: {
+                    title: mockTitle,
+                    text: mockText,
+                    imageUrl: mockImageUrl
+                }
+            });
+
+            // Act
+            const textWrapper = wrapper.find('h3');
+
+            // Assert
+            expect(textWrapper.text()).toEqual(mockTitle);
+        });
+
+        it('should display the text prop value in a p tag when the text prop is set', () => {
+            // Arrange
+            const wrapper = shallowMount(MediaElement, {
+                propsData: {
+                    title: mockTitle,
+                    text: mockText,
+                    imageUrl: mockImageUrl
+                }
+            });
+
+            // Act
+            const textWrapper = wrapper.find('p');
+
+            // Assert
+            expect(textWrapper.text()).toEqual(mockText);
+        });
+
+        it.each([
+            [ALIGN.LEFT, 'c-mediaElement-content--left'],
+            [ALIGN.RIGHT, 'c-mediaElement-content--right'],
+            [ALIGN.CENTER, 'c-mediaElement-content--center'],
+            ['__TEST_DUMMY_VALUE__', 'c-mediaElement-content--left']
+        ])('should when contentAlign prop is %s, set class %s', (contentAlignProp, contentAlignClass) => {
+            // Arrange
+            const wrapper = shallowMount(MediaElement, {
+                propsData: {
+                    title: mockTitle,
+                    text: mockText,
+                    imageUrl: mockImageUrl,
+                    contentAlign: contentAlignProp
+                },
+                mocks: {
+                    $style: {
+                        [contentAlignClass]: contentAlignClass
+                    }
+                }
+            });
+
+            // Act
+            const style = wrapper.find(`.${contentAlignClass}`);
+
+            // Assert
+            expect(style.exists()).toBe(true);
+        });
+
+        it.each([
+            [ALIGN.LEFT, 'c-mediaElement-imgWrapper--left'],
+            [ALIGN.RIGHT, 'c-mediaElement-imgWrapper--right'],
+            [ALIGN.CENTER, 'c-mediaElement-imgWrapper--center'],
+            ['__TEST_DUMMY_VALUE__', 'c-mediaElement-imgWrapper--left']
+        ])('should when imageAlign prop is %s, set class %s', (imageAlignProp, imageAlignClass) => {
+            // Arrange
+            const wrapper = shallowMount(MediaElement, {
+                propsData: {
+                    title: mockTitle,
+                    text: mockText,
+                    imageUrl: mockImageUrl,
+                    imageAlign: imageAlignProp
+                },
+                mocks: {
+                    $style: {
+                        [imageAlignClass]: imageAlignClass
+                    }
+                }
+            });
+
+            // Act
+            const style = wrapper.find(`.${imageAlignClass}`);
+
+            // Assert
+            expect(style.exists()).toBe(true);
+        });
+
+        it.each([
+            [FONT_SIZE.SM, 'c-mediaElement-content--fontSizeSmall'],
+            [FONT_SIZE.MD, 'c-mediaElement-content--fontSizeMedium'],
+            [FONT_SIZE.LG, 'c-mediaElement-content--fontSizeLarge'],
+            [FONT_SIZE.XL, 'c-mediaElement-content--fontSizeXLarge'],
+            [FONT_SIZE.XXL, 'c-mediaElement-content--fontSizeXXLarge'],
+            ['__TEST_DUMMY_VALUE__', 'c-mediaElement-content--fontSizeMedium']
+        ])('should when textSize prop is %s, set class %s', (textSizeProp, textSizeClass) => {
+            // Arrange
+            const wrapper = shallowMount(MediaElement, {
+                propsData: {
+                    title: mockTitle,
+                    text: mockText,
+                    imageUrl: mockImageUrl,
+                    textSize: textSizeProp
+                },
+                mocks: {
+                    $style: {
+                        [textSizeClass]: textSizeClass
+                    }
+                }
+            });
+
+            // Act
+            const style = wrapper.find(`.${textSizeClass}`);
+
+            // Assert
+            expect(style.exists()).toBe(true);
+        });
+    });
+
+    describe('slot', () => {
+        it('should display the contents of the slot when used', () => {
+            // Arrange
+            const wrapper = shallowMount(MediaElement, {
+                propsData: {
+                    title: mockTitle,
+                    text: mockText,
+                    imageUrl: mockImageUrl
+                },
+                slots: {
+                    default: '<div data-test-id="__TEST_SLOT__"></div>'
+                }
+            });
+
+            // Act
+            const slotContent = wrapper.find('[data-test-id="__TEST_SLOT__"]');
+
+            // Assert
+            expect(slotContent.exists()).toBe(true);
+        });
     });
 });


### PR DESCRIPTION
This PR adds a slot into the media element below the text and title to allow custom content to be added into the element. I have also added some additional tests as I did not add them when first creating this component. Also added a test for slot.

- [x] Unit tests have been [created|updated]