### PR TITLE
f-checkout@0.135.0 - Fixing redirect from error dialog.

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.135.0
+------------------------------
+*June 11, 2021*
+
+### Changed
+- Fixed the error dialog "Back to order" redirect.
+
+
 v0.134.0
 ------------------------------
 *June 10, 2021*

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.132.0
+------------------------------
+*June 10, 2021*
+
+### Changed
+- Fixed the error dialog "Back to order" redirect.
+
+
 v0.131.0
 ------------------------------
 *June 9, 2021*

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.132.0
+v0.135.0
 ------------------------------
 *June 10, 2021*
 

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.132.0",
+  "version": "0.135.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.131.0",
+  "version": "0.132.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.134.0",
+  "version": "0.135.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/components/ErrorDialog.vue
+++ b/packages/components/organisms/f-checkout/src/components/ErrorDialog.vue
@@ -71,7 +71,7 @@ export default {
         },
 
         restaurantMenuPageUrl () {
-            return `restaurant-${this.restaurant.seoName}/menu`;
+            return `restaurants-${this.restaurant.seoName}/menu`;
         },
 
         serviceTypeText () {

--- a/packages/components/organisms/f-checkout/src/components/_tests/ErrorDialog.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/ErrorDialog.test.js
@@ -90,7 +90,7 @@ describe('ErrorDialog', () => {
                 });
 
                 // Assert
-                expect(wrapper.vm.restaurantMenuPageUrl).toEqual(`restaurant-${restaurant.seoName}/menu`);
+                expect(wrapper.vm.restaurantMenuPageUrl).toEqual(`restaurants-${restaurant.seoName}/menu`);
             });
         });
 
@@ -177,7 +177,7 @@ describe('ErrorDialog', () => {
                 wrapper.vm.closeErrorDialog();
 
                 // Assert
-                expect(windowLocationSpy).toHaveBeenCalledWith(`restaurant-${restaurant.seoName}/menu`);
+                expect(windowLocationSpy).toHaveBeenCalledWith(`restaurants-${restaurant.seoName}/menu`);
             });
 
             it('should not redirect to the restaurant menu if `shouldRedirectToMenu` is false', () => {


### PR DESCRIPTION
v0.135.0
------------------------------
*June 11, 2021*

### Changed
- Fixed the error dialog "Back to order" redirect.