### PR TITLE
f-cookie-banner@v0.15.0: Reduce impact of GTM resendEvents method

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.14.0
+------------------------------
+*June 10, 2021*
+
+### Changed
+- Hide banner action wrapped in Promise to call the resendEvents asynchronously
+- Tests updated accordingly
+
+
 v0.13.0
 ------------------------------
 *May 27, 2021*

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,21 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v0.14.0
-------------------------------
-*June 9, 2021*
-
-### Added
-- Percy Visual Regression tests for Legacy and ConsentBanner
-
-
-v0.14.0
+v0.15.0
 ------------------------------
 *June 10, 2021*
 
 ### Changed
 - Hide banner action wrapped in Promise to call the resendEvents asynchronously
 - Tests updated accordingly
+
+
+v0.14.0
+------------------------------
+*June 9, 2021*
+
+### Added
+- Percy Visual Regression tests for Legacy and ConsentBanner
 
 
 v0.13.0

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -171,25 +171,27 @@ export default {
          * Actions for "Accept all cookies" button
          */
         acceptAllCookiesActions () {
-            this.setCookieBannerCookie('full');
-            this.setLegacyCookieBannerCookie();
-            this.dataLayerPush('full');
-            this.resendEvents();
-            this.hideAllBanners();
-            this.shouldHideBanner = true;
+            this.hideBanner().then(() => {
+                this.setCookieBannerCookie('full');
+                this.setLegacyCookieBannerCookie();
+                this.dataLayerPush('full');
+                this.resendEvents();
+                this.hideAllBanners();
+            });
         },
 
         /**
          * Actions for "Accept only required cookies" button
          */
         acceptOnlyNecessaryCookiesActions () {
-            this.setCookieBannerCookie('necessary');
-            this.setLegacyCookieBannerCookie();
-            this.dataLayerPush('necessary');
-            this.resendEvents();
-            this.removeUnnecessaryCookies();
-            this.hideAllBanners();
-            this.shouldHideBanner = true;
+            this.hideBanner().then(() => {
+                this.setCookieBannerCookie('necessary');
+                this.setLegacyCookieBannerCookie();
+                this.dataLayerPush('necessary');
+                this.resendEvents();
+                this.removeUnnecessaryCookies();
+                this.hideAllBanners();
+            });
         },
 
         /**
@@ -205,7 +207,9 @@ export default {
          * Hide the banner
          */
         hideBanner () {
-            this.shouldHideBanner = true;
+            return new Promise(resolve => {
+                resolve(this.shouldHideBanner = true);
+            });
         },
 
         /**

--- a/packages/components/organisms/f-cookie-banner/src/components/_tests/CookieBanner.test.js
+++ b/packages/components/organisms/f-cookie-banner/src/components/_tests/CookieBanner.test.js
@@ -208,8 +208,8 @@ describe('CookieBanner', () => {
             });
         });
 
-        xdescribe('acceptAllCookiesActions', () => {
-            it('should set the banner consent cookie to `full`', () => {
+        describe('acceptAllCookiesActions', () => {
+            it('should set the banner consent cookie to `full`', async () => {
                 // Arrange
                 const propsData = {};
 
@@ -219,18 +219,15 @@ describe('CookieBanner', () => {
                     i18n,
                     propsData
                 });
+
                 const cookieSpy = jest.spyOn(wrapper.vm, 'setCookieBannerCookie');
 
-                // jest.spyOn(wrapper.vm,'hideBanner').mockImpletmentation(() => true);
-
-                wrapper.vm.hideBanner = jest.fn(() => Promise.resolve());
-
-                wrapper.vm.acceptAllCookiesActions();
+                await wrapper.vm.acceptAllCookiesActions();
 
                 // Assert
                 expect(cookieSpy).toHaveBeenCalledWith('full');
             });
-            it('should push `full` to dataLayer', () => {
+            it('should push `full` to dataLayer', async () => {
                 // Arrange
                 const propsData = {};
 
@@ -242,7 +239,7 @@ describe('CookieBanner', () => {
                 });
                 const dataLayerSpy = jest.spyOn(wrapper.vm, 'dataLayerPush');
 
-                wrapper.vm.acceptAllCookiesActions();
+                await wrapper.vm.acceptAllCookiesActions();
 
                 // Assert
                 expect(dataLayerSpy).toHaveBeenCalledWith('full');
@@ -265,8 +262,8 @@ describe('CookieBanner', () => {
             });
         });
 
-        xdescribe('acceptOnlyNecessaryCookiesActions', () => {
-            it('should set the banner consent cookie to `necessary`', () => {
+        describe('acceptOnlyNecessaryCookiesActions', () => {
+            it('should set the banner consent cookie to `necessary`', async () => {
                 // Arrange
                 const propsData = {};
 
@@ -278,12 +275,12 @@ describe('CookieBanner', () => {
                 });
                 const cookieSpy = jest.spyOn(wrapper.vm, 'setCookieBannerCookie');
 
-                wrapper.vm.acceptOnlyNecessaryCookiesActions();
+                await wrapper.vm.acceptOnlyNecessaryCookiesActions();
 
                 // Assert
                 expect(cookieSpy).toHaveBeenCalledWith('necessary');
             });
-            it('should push `necessary` to dataLayer', () => {
+            it('should push `necessary` to dataLayer', async () => {
                 // Arrange
                 const propsData = {};
 
@@ -295,12 +292,12 @@ describe('CookieBanner', () => {
                 });
                 const dataLayerSpy = jest.spyOn(wrapper.vm, 'dataLayerPush');
 
-                wrapper.vm.acceptOnlyNecessaryCookiesActions();
+                await wrapper.vm.acceptOnlyNecessaryCookiesActions();
 
                 // Assert
                 expect(dataLayerSpy).toHaveBeenCalledWith('necessary');
             });
-            it('should remove unnecessary cookies', () => {
+            it('should remove unnecessary cookies', async () => {
                 // Arrange
                 const propsData = {};
 
@@ -312,12 +309,12 @@ describe('CookieBanner', () => {
                 });
                 const removeCookiesSpy = jest.spyOn(wrapper.vm, 'removeUnnecessaryCookies');
 
-                wrapper.vm.acceptOnlyNecessaryCookiesActions();
+                await wrapper.vm.acceptOnlyNecessaryCookiesActions();
 
                 // Assert
                 expect(removeCookiesSpy).toHaveBeenCalled();
             });
-            it('should resend GTM events', () => {
+            it('should resend GTM events', async () => {
                 // Arrange
                 const propsData = {};
 
@@ -329,7 +326,7 @@ describe('CookieBanner', () => {
                 });
                 const resendSpy = jest.spyOn(wrapper.vm, 'resendEvents');
 
-                wrapper.vm.acceptOnlyNecessaryCookiesActions();
+                await wrapper.vm.acceptOnlyNecessaryCookiesActions();
 
                 // Assert
                 expect(resendSpy).toHaveBeenCalled();

--- a/packages/components/organisms/f-cookie-banner/src/components/_tests/CookieBanner.test.js
+++ b/packages/components/organisms/f-cookie-banner/src/components/_tests/CookieBanner.test.js
@@ -208,7 +208,7 @@ describe('CookieBanner', () => {
             });
         });
 
-        describe('acceptAllCookiesActions', () => {
+        xdescribe('acceptAllCookiesActions', () => {
             it('should set the banner consent cookie to `full`', () => {
                 // Arrange
                 const propsData = {};
@@ -220,6 +220,10 @@ describe('CookieBanner', () => {
                     propsData
                 });
                 const cookieSpy = jest.spyOn(wrapper.vm, 'setCookieBannerCookie');
+
+                // jest.spyOn(wrapper.vm,'hideBanner').mockImpletmentation(() => true);
+
+                wrapper.vm.hideBanner = jest.fn(() => Promise.resolve());
 
                 wrapper.vm.acceptAllCookiesActions();
 
@@ -261,7 +265,7 @@ describe('CookieBanner', () => {
             });
         });
 
-        describe('acceptOnlyNecessaryCookiesActions', () => {
+        xdescribe('acceptOnlyNecessaryCookiesActions', () => {
             it('should set the banner consent cookie to `necessary`', () => {
                 // Arrange
                 const propsData = {};


### PR DESCRIPTION
Wrapped the hide banner action in a promise to ensure that the banner closes with no lag before the GTM resendEvents fires - resendEvents can be resource-intensive, causing laggy UI response