### PR TITLE
f-form-field@1.15.0 - Change default values for minNumber and maxNumber to `undefined`

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.15.0
+------------------------------
+*June 11, 2021*
+
+### Changed
+- Default value of `maxNumber` to `undefined`
+- Default value of `minNumber` to `undefined`
+
+
 v1.14.0
 ------------------------------
 *May 25, 2021*

--- a/packages/components/atoms/f-form-field/README.md
+++ b/packages/components/atoms/f-form-field/README.md
@@ -77,9 +77,9 @@ The props that can be defined are as follows (if any):
 | `hasError` | `Boolean` | `false` | When `true` border colour changes to red. |
 | `dropdownOptions` | `Array` | `null` | The options to be displayed in the dropdown. |
 | `isGrouped` | `Boolean` | `false` | When `true` will remove margin between all grouped form fields. |
-| `minNumber` | `Number` | 0 | Sets the value of the `min` property when `inputType` is `number` |
-| `maxNumber` | `Number` | 0 | Sets the value of the `max` property when `inputType` is `number` |
-| `hasInputDescription` | `Boolean` | `false` | When `true` will add the ability to insert extra html element under form label to the component via slot. | 
+| `minNumber` | `Number` or `undefined` | `undefined` | Sets the value of the `min` property when `inputType` is `number` |
+| `maxNumber` | `Number` or `undefined` | `undefined` | Sets the value of the `max` property when `inputType` is `number` |
+| `hasInputDescription` | `Boolean` | `false` | When `true` will add the ability to insert extra html element under form label to the component via slot. |
 
 ### Events
 

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -152,13 +152,13 @@ export default {
         },
 
         minNumber: {
-            type: Number,
-            default: 0
+            type: [Number, undefined],
+            default: undefined
         },
 
         maxNumber: {
-            type: Number,
-            default: 100
+            type: [Number, undefined],
+            default: undefined
         },
 
         hasInputDescription: {

--- a/packages/components/atoms/f-form-field/src/components/_tests/FormField.test.js
+++ b/packages/components/atoms/f-form-field/src/components/_tests/FormField.test.js
@@ -74,7 +74,24 @@ describe('FormField', () => {
                 expect(formInput.attributes('type')).toBe(definedType);
             });
 
-            it('should include the `min` and `max` attributes if inputType=`number`', () => {
+            it('should include the `min` and `max` attributes if provided for inputType=`number`', () => {
+                // Arrange
+                const propsData = {
+                    inputType: 'number',
+                    minNumber: -10,
+                    maxNumber: 10
+                };
+
+                // Act
+                const wrapper = shallowMount(FormField, { propsData });
+                const formInput = wrapper.find('input');
+
+                // Assert
+                expect(formInput.attributes('min')).toBe('-10');
+                expect(formInput.attributes('max')).toBe('10');
+            });
+
+            it('should not include the `min` and `max` attributes if not provided for inputType=`number`', () => {
                 // Arrange
                 const propsData = {
                     inputType: 'number'
@@ -85,13 +102,29 @@ describe('FormField', () => {
                 const formInput = wrapper.find('input');
 
                 // Assert
-                expect(formInput.attributes('min')).toBeDefined();
-                expect(formInput.attributes('max')).toBeDefined();
+                expect(formInput.attributes('min')).toBeUndefined();
+                expect(formInput.attributes('max')).toBeUndefined();
             });
 
-            it('should not include the `min` and `max` attributes for default inputType', () => {
+            it('should not include the `min` and `max` attributes for default inputType if not provided', () => {
                 // Arrange & Act
                 const wrapper = shallowMount(FormField);
+                const formInput = wrapper.find('input');
+
+                // Assert
+                expect(formInput.attributes('min')).toBeUndefined();
+                expect(formInput.attributes('max')).toBeUndefined();
+            });
+
+            it('should not include the `min` and `max` attributes for default inputType even if provided', () => {
+                // Arrange
+                const propsData = {
+                    minNumber: -10,
+                    maxNumber: 10
+                };
+
+                // Act
+                const wrapper = shallowMount(FormField, { propsData });
                 const formInput = wrapper.find('input');
 
                 // Assert


### PR DESCRIPTION
### Changed
- Default value of `maxNumber` to `undefined`
- Default value of `minNumber` to `undefined`

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
