### PR TITLE
f-cookie-banner@v0.16.1 - Set useGreyBackground default to true

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.16.1
+------------------------------
+*June 15, 2021*
+
+### Changed
+- Set default of useGreyBackground to true (most JE apps need this set to true)
+
+
 v0.16.0
 ------------------------------
 *June 14, 2021*

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "main": "dist/f-cookie-banner.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -135,7 +135,7 @@ export default {
         },
         useGreyBackground: {
             type: Boolean,
-            default: false
+            default: true
         }
     },
 


### PR DESCRIPTION
Change useGreyBackground prop to default to true, as most JE apps have the grey background