### PR TITLE
f-form-field@1.15.1 - Fix click behaviour for dropdown icon

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.15.1
+------------------------------
+*June 15, 2021*
+
+### Fixed
+- Clicking exactly on the arrow icon did not open the dropdown
+
+
 v1.15.0
 ------------------------------
 *June 11, 2021*

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
@@ -76,6 +76,7 @@ export default {
     right: spacing(x3);
     bottom: 20px;
     transform: rotate(180deg);
+    pointer-events: none;
 
     path {
         fill: $color-content-subdued;


### PR DESCRIPTION
### Fixed
- Clicking exactly on the arrow icon did not open the dropdown

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Edge
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
