### PR TITLE
f-button@v1.6.1 – Small class naming fix

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.6.1
+------------------------------
+*June 15, 2021*
+
+### Fixed
+- Small tweak to class-naming of `o-btn-text--flex` > `o-btn-text` so it matches our naming scheme.
+
+
 v1.6.0
 ------------------------------
 *June 7, 2021*

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "dist/f-button.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -23,8 +23,8 @@
 
         <span
             :class="[
-                (isLoading ? $style['o-btn-text--hidden'] : ''),
-                $style['o-btn-text--flex']
+                $style['o-btn-text'],
+                (isLoading ? $style['o-btn-text--hidden'] : '')
             ]">
             <slot />
         </span>
@@ -216,20 +216,16 @@ $btn-icon-sizeXSmall-iconSize       : 18px;
     }
 }
 
-/**
- * ==========================================================================
- * Btn Type modifiers
- * ==========================================================================
- */
+    .o-btn-text {
+        display: flex;
+        justify-content: center;
+    }
+    // Visually hide button text (used for loading states)
+    .o-btn-text--hidden {
+        visibility: hidden;
+    }
 
-.o-btn-text--hidden {
-    visibility: hidden;
-}
 
-.o-btn-text--flex {
-    display: flex;
-    justify-content: center;
-}
 
 /**
  * Modifier – .o-btn--primary


### PR DESCRIPTION
### Fixed
- Small tweak to class-naming of `o-btn-text--flex` > `o-btn-text` so it matches our naming scheme.

