### PR TITLE
storybook@v0.35.0 – Fixing storybook deploy command and adding CNAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.41.0
+------------------------------
+*June 18, 2021*
+
+## Fixed
+- Storybook deployer moved to the storybook package (so that it deploys the `index.html` to the root of `gh-pages` correctly).
+
+
 v3.40.0
 ------------------------------
 *June 17, 2021*
@@ -55,7 +63,7 @@ v3.34.0
 ------------------------------
 *May 18, 2021*
 
-### Updated 
+### Updated
 - fozzie to v5.0.0-beta.7 which uses new pie design tokens instead of fozzie-colour-palette vars
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "3.40.0",
+  "version": "3.41.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",
@@ -13,7 +13,7 @@
     "storybook:build": "lerna run storybook:build --stream",
     "storybook:serve": "lerna run storybook:serve --stream",
     "storybook:serve-static": "lerna run storybook:serve-static --stream",
-    "storybook:deploy": "storybook-to-ghpages --script storybook:build",
+    "storybook:deploy": "lerna run storybook:deploy",
     "test": "cross-env-shell \"lerna run $LERNA_ARGS test --stream\"",
     "test-component:chrome": "cross-env-shell JE_ENV=local TEST_TYPE=component lerna run test-component:chrome --concurrency 1 --stream",
     "test-component:browserstack": "cross-env-shell JE_ENV=browserstack TEST_TYPE=component lerna run test-component:browserstack --concurrency 1 --stream",
@@ -38,7 +38,6 @@
     "@justeat/stylelint-config-fozzie": "2.2.0",
     "@percy/cli": "1.0.0-beta.52",
     "@percy/webdriverio": "2.0.0",
-    "@storybook/storybook-deployer": "2.8.6",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.35.0
+------------------------------
+*June 17, 2021*
+
+### Added
+- `CNAME` record for custom `vue.pie.design` domain.
+### Fixed
+- Storybook deployer moved to the storybook package (so that it deploys the `index.html` to the root of `gh-pages` correctly).
+
+
 v0.34.0
 ------------------------------
 *May 14, 2021*

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "scripts": {
+    "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -s public -p 8080 -c config/storybook",
     "storybook:serve-static": "http-server ./storybook-static"
@@ -18,6 +19,7 @@
     "@storybook/addon-essentials": "6.0.28",
     "@storybook/addon-knobs": "6.0.28",
     "@storybook/addon-links": "6.0.28",
+    "@storybook/storybook-deployer": "2.8.6",
     "@storybook/vue": "6.0.28",
     "cookie-universal": "2.1.4",
     "node-sass-magic-importer": "5.3.2",

--- a/packages/storybook/public/CNAME
+++ b/packages/storybook/public/CNAME
@@ -1,0 +1,1 @@
+vue.pie.design


### PR DESCRIPTION
### Added
- `CNAME` record for custom `vue.pie.design` domain.
### Fixed
- Storybook deployer moved to the storybook package (so that it deploys the `index.html` to the root of `gh-pages` correctly).
