### PR TITLE
f-checkout@0.143.1 - Flip address coordinates from local storage

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.143.1
+------------------------------
+*June 21, 2021*
+
+### Changed
+- Flipped coordinates from local storage
+
+
 v0.143.0
 ------------------------------
 *June 18, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.143.0",
+  "version": "0.143.1",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -356,7 +356,7 @@ export default {
             if (isAddressInLocalStorage) {
                 const storedAddress = addressService.getAddressFromLocalStorage(false);
                 if (storedAddress.Line1 === state.address.line1 && storedAddress.PostalCode === state.address.postcode) {
-                    addressCoords = [storedAddress.Field1, storedAddress.Field2];
+                    addressCoords = [storedAddress.Field2, storedAddress.Field1];
                     commit(UPDATE_GEO_LOCATION, addressCoords);
                 }
             }

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -958,7 +958,7 @@ describe('CheckoutModule', () => {
 
                     // Assert
                     expect(axios.post).not.toHaveBeenCalled();
-                    expect(commit).toHaveBeenCalledWith(UPDATE_GEO_LOCATION, [storedAddress.Field1, storedAddress.Field2]);
+                    expect(commit).toHaveBeenCalledWith(UPDATE_GEO_LOCATION, [storedAddress.Field2, storedAddress.Field1]);
                 });
 
                 it(`should get the geo location details from the backend and call ${UPDATE_GEO_LOCATION} mutation if the form address does not match local storage`, async () => {


### PR DESCRIPTION
### Changed
- Flipped coordinates from local storage

Naively, I passed the coordinates from local storage as [lat, long] which I presumed would be the correct order as that is usually convention. When in fact, the `UPDATE_GEO_LOCATION` mutation expects it [long, lat].