### PR TITLE
f-checkout@0.144.0 - Check if all storage and form address values match

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.144.0
+------------------------------
+*June 21, 2021*
+
+### Added
+- More thorough check on whether form address and storage address match
+
+
 v0.143.1
 ------------------------------
 *June 21, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.143.1",
+  "version": "0.144.0",
   "main": "dist/f-checkout.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-checkout/src/services/addressService.js
+++ b/packages/components/organisms/f-checkout/src/services/addressService.js
@@ -126,7 +126,20 @@ function getAddressCoordsFromLocalStorage () {
     return null;
 }
 
+
+/**
+ * Checkes whether the address values in local storage match what's is in the form.
+ * @param storedAddress - The address stored in local storage
+ * @param formAddress - The address in form state
+ * @returns {boolean} - Whether the form values match
+ */
+function doesAddressInStorageAndFormMatch (storedAddress, formAddress) {
+    return storedAddress.Line1 === formAddress.line1 && storedAddress.PostalCode === formAddress.postcode
+        && storedAddress.Line2 === formAddress.line2 && storedAddress.City === formAddress.locality;
+}
+
 export default {
+    doesAddressInStorageAndFormMatch,
     getClosestAddress (addresses, tenant) {
         if (tenant !== 'uk') {
             // TODO: Add implementation for other tenants

--- a/packages/components/organisms/f-checkout/src/services/tests/addressService.test.js
+++ b/packages/components/organisms/f-checkout/src/services/tests/addressService.test.js
@@ -272,4 +272,81 @@ describe('addressService', () => {
             });
         });
     });
+
+    describe('doesAddressInStorageAndFormMatch ::', () => {
+        beforeEach(() => {
+            Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+        });
+
+        afterEach(() => {
+            window.localStorage.clear();
+            jest.resetAllMocks();
+        });
+
+        describe('when the address fields are the same', () => {
+            it('should return true', () => {
+                // Arrange
+                const storageAddress = {
+                    Line1: 'Fleet Place House',
+                    Line2: 'Farringdon',
+                    City: 'London',
+                    PostalCode: 'EC4M 7RF'
+                };
+
+                const formAddress = {
+                    line1: 'Fleet Place House',
+                    line2: 'Farringdon',
+                    locality: 'London',
+                    postcode: 'EC4M 7RF'
+                };
+
+                // Act & Assert
+                expect(addressService.doesAddressInStorageAndFormMatch(storageAddress, formAddress)).toEqual(true);
+            });
+        });
+
+        describe('when the city field is different', () => {
+            it('should return false', () => {
+                // Arrange
+                const storageAddress = {
+                    Line1: 'Fleet Place House',
+                    Line2: 'Farringdon',
+                    City: 'Newcastle',
+                    PostalCode: 'EC4M 7RF'
+                };
+
+                const formAddress = {
+                    line1: 'Fleet Place House',
+                    line2: 'Farringdon',
+                    locality: 'London',
+                    postcode: 'EC4M 7RF'
+                };
+
+                // Act & Assert
+                expect(addressService.doesAddressInStorageAndFormMatch(storageAddress, formAddress)).toEqual(false);
+            });
+        });
+
+        describe('when the postcode is different', () => {
+            it('should return false', () => {
+                // Arrange
+                const storageAddress = {
+                    Line1: 'Fleet Place House',
+                    Line2: 'Farringdon',
+                    City: 'London',
+                    PostalCode: 'EC4M 7RF'
+                };
+
+                const formAddress = {
+                    line1: 'Fleet Place House',
+                    line2: 'Farringdon',
+                    locality: 'London',
+                    postcode: 'EC4M 7RE'
+                };
+
+                // Act & Assert
+                expect(addressService.doesAddressInStorageAndFormMatch(storageAddress, formAddress)).toEqual(false);
+            });
+        });
+    });
 });

--- a/packages/components/organisms/f-checkout/src/services/tests/addressService.test.js
+++ b/packages/components/organisms/f-checkout/src/services/tests/addressService.test.js
@@ -274,15 +274,6 @@ describe('addressService', () => {
     });
 
     describe('doesAddressInStorageAndFormMatch ::', () => {
-        beforeEach(() => {
-            Object.defineProperty(window, 'localStorage', { value: localStorageMock });
-        });
-
-        afterEach(() => {
-            window.localStorage.clear();
-            jest.resetAllMocks();
-        });
-
         describe('when the address fields are the same', () => {
             it('should return true', () => {
                 // Arrange

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -355,7 +355,7 @@ export default {
 
             if (isAddressInLocalStorage) {
                 const storedAddress = addressService.getAddressFromLocalStorage(false);
-                if (storedAddress.Line1 === state.address.line1 && storedAddress.PostalCode === state.address.postcode) {
+                if (addressService.doesAddressInStorageAndFormMatch(storedAddress, state.address)) {
                     addressCoords = [storedAddress.Field2, storedAddress.Field1];
                     commit(UPDATE_GEO_LOCATION, addressCoords);
                 }


### PR DESCRIPTION
### Added
- More thorough check on whether form address and storage address match

On ConsumerWeb, the address in local storage is compared with the form data by using a deep equals of the objects. Because our fields are named differently, I had to just check if each field matches individually. 