### PR TITLE
#trivial – fixing circle storybook deploy and vue.pie.design links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
       - build_packages
       - run:
           name: Deploy
-          command: yarn storybook:deploy --packages packages
+          command: lerna run storybook:deploy
       - slack_notify_fail
       - slack_notify_success
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-*_[This contributing guide can also be viewed in our Storybook documentation](https://justeat.github.io/fozzie-components/@justeat/storybook/index.html?path=/story/documentation-getting-started-contributing--page)_*
+*_[This contributing guide can also be viewed in our Storybook documentation](https://vue.pie.design/?path=/story/documentation-getting-started-contributing--page)_*
 
 - Before creating a new component, please discuss it with us in #help-web
 - New components should use [generator-component](https://github.com/justeat/fozzie-components/tree/master/packages/tools/generator-component) to create the base structure of the component. It's usually a good idea to PR this base structure as a `v0.1.0` before adding any significant custom component code.
@@ -12,10 +12,10 @@ If you want to learn more about fozzie-components and how it's structured, these
 Resources |
 ------------- |
 [Guide to mono-repos](https://www.toptal.com/front-end/guide-to-monorepos) |
-[Our Development Principles](https://justeat.github.io/fozzie-components/@justeat/storybook/index.html?path=/story/documentation-getting-started-development-principles--page) |
+[Our Development Principles](https://vue.pie.design/?path=/story/documentation-getting-started-development-principles--page) |
 [Fozzie CSS Naming Scheme](https://fozzie.just-eat.com/documentation/css/css-naming) |
 [Fozzie Accessibility Guide](https://fozzie.just-eat.com/documentation/general/accessibility/) |
-[What not to do guide](https://justeat.github.io/fozzie-components/@justeat/storybook/index.html?path=/story/documentation-standards-accessibility-overview--page) |
+[What not to do guide](https://vue.pie.design/?path=/story/documentation-standards-accessibility-overview--page) |
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,6 @@ For example: `git commit -m "Refactor f-button" --no-verify `.
 
 ## Publishing Components
 
-More information about how to contribute to this repo can be found in our Storybook [Documentation section](https://justeat.github.io/fozzie-components/@justeat/storybook/index.html?path=/story/documentation-getting-started-contributing--page)
+More information about how to contribute to this repo can be found in our Storybook [Documentation section](https://vue.pie.design/?path=/story/documentation-getting-started-contributing--page)
 
-### [Just Eat Storybook production](https://justeat.github.io/fozzie-components/@justeat/storybook/index.html)
+### [Just Eat Storybook production](https://vue.pie.design/)

--- a/packages/storybook/README.md
+++ b/packages/storybook/README.md
@@ -21,6 +21,6 @@ If you need to add styles that should be available in every story you can add th
 
 ## More Info
 
-### [Just Eat Storybook production](https://justeat.github.io/fozzie-components/@justeat/storybook/index.html)
+### [Just Eat Storybook production](https://vue.pie.design/)
 
 ### [Storybook Documentation - Writing Stories](https://storybook.js.org/docs/basics/writing-stories/)

--- a/packages/tools/f-vue-icons/README.md
+++ b/packages/tools/f-vue-icons/README.md
@@ -66,7 +66,7 @@ The component extends [@justeat/browserslist-config-fozzie](https://github.com/j
 
 ## Contributing
 
-Before staring please read our [contributing guide](https://justeat.github.io/fozzie-components/@justeat/storybook/index.html?path=/story/documentation-getting-started-contributing--page)
+Before staring please read our [contributing guide](https://vue.pie.design/?path=/story/documentation-getting-started-contributing--page)
 
 ### Adding new icons
 
@@ -84,7 +84,7 @@ Run `yarn test` to run the tests.
 
 ## Icon list
 
-You can check the list of all the icons in our [Storybook](https://justeat.github.io/fozzie-components/@justeat/storybook/index.html?path=/story/components-atoms--icons).
+You can check the list of all the icons in our [Storybook](https://vue.pie.design/?path=/story/components-atoms--icons).
 
 
 ## Credits


### PR DESCRIPTION
- Fixing the CircleCI deploy step for deploying to via CI and updating some links to the new documentation URL.