### PR TITLE
f-media-element@v0.4.0 - modifications to support pre-line in content

### DIFF
--- a/packages/components/molecules/f-media-element/CHANGELOG.md
+++ b/packages/components/molecules/f-media-element/CHANGELOG.md
@@ -3,6 +3,20 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.3.1
+------------------------------
+*June 21, 2021*
+
+### Added
+- stackOnMobile prop to stack when on device sizes <=narrowMid
+- `white-space: pre-line` to enable newlines to be preserved when used in title or text
+- Additional unit tests for new features
+
+### Fixed
+- Styling fix to make sure reverse prop works when not in stacked mode
+
+
 v0.3.0
 ------------------------------
 *June 09, 2021*

--- a/packages/components/molecules/f-media-element/CHANGELOG.md
+++ b/packages/components/molecules/f-media-element/CHANGELOG.md
@@ -4,12 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.3.1
+v0.4.0
 ------------------------------
 *June 21, 2021*
 
 ### Added
-- stackOnMobile prop to stack when on device sizes <=narrowMid
+- stackWhenNarrow prop to stack when on device sizes <=narrowMid
 - `white-space: pre-line` to enable newlines to be preserved when used in title or text
 - Additional unit tests for new features
 

--- a/packages/components/molecules/f-media-element/package.json
+++ b/packages/components/molecules/f-media-element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-media-element",
   "description": "Fozzie Media Element - provides ability to display text and an image in different orientations",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "main": "dist/f-media-element.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-media-element/package.json
+++ b/packages/components/molecules/f-media-element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-media-element",
   "description": "Fozzie Media Element - provides ability to display text and an image in different orientations",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "dist/f-media-element.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -5,7 +5,7 @@
             $style['c-mediaElement'],
             (stacked ? $style['c-mediaElement--stack'] : ''),
             (reverse ? $style['c-mediaElement--reverse'] : ''),
-            (stackOnMobile ? $style['c-mediaElement--stackMobile'] : '')
+            (stackWhenNarrow ? $style['c-mediaElement--stackWhenNarrow'] : '')
         ]">
         <div
             :class="[
@@ -76,7 +76,7 @@ export default {
             type: String,
             default: 'Media Element Image'
         },
-        stackOnMobile: {
+        stackWhenNarrow: {
             type: Boolean,
             default: false
         }
@@ -178,33 +178,27 @@ $font-sizes: (
 }
 
 /**
- * Modifier – .c-mediaElement--stackMobile
+ * Modifier – .c-mediaElement--stackOnNarrow
  *
  * Applies flex direction column on <=narrow
  */
-.c-mediaElement--stackMobile {
-    @include media('<=narrow') {
-        flex-direction: column;
-    }
-    /**
-     * Modifier – .c-mediaElement--reverse
-     *
-     * When stacked in flex col applies col-reverse
-     */
-    &.c-mediaElement--reverse {
-        @include media('<=narrow') {
+@include media('<=narrow') {
+    .c-mediaElement--stackWhenNarrow {
+            flex-direction: column;
+        /**
+         * Modifier – .c-mediaElement--reverse
+         *
+         * When stacked in flex col applies col-reverse
+         */
+        &.c-mediaElement--reverse {
             flex-direction: column-reverse;
-        }
 
-        & .c-mediaElement-text {
-            @include media('<=narrow') {
+            & .c-mediaElement-text {
                 margin-bottom: spacing(x3);
             }
         }
-    }
 
-    & .c-mediaElement-title {
-        @include media('<=narrow') {
+        & .c-mediaElement-title {
             margin-top: spacing(x3);
         }
     }

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -24,7 +24,6 @@
         <div
             :class="[
                 $style['c-mediaElement-imgWrapper'],
-                'c-mediaElement-imgWrapper--override',
                 imageAlignClass
             ]">
             <img

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -19,7 +19,7 @@
             <p :class="$style['c-mediaElement-text']">
                 {{ text }}
             </p>
-            <slot></slot>
+            <slot />
         </div>
         <div
             :class="[

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -4,7 +4,8 @@
         :class="[
             $style['c-mediaElement'],
             (stacked ? $style['c-mediaElement--stack'] : ''),
-            (reverse ? $style['c-mediaElement--reverse'] : '')
+            (reverse ? $style['c-mediaElement--reverse'] : ''),
+            (stackOnMobile ? $style['c-mediaElement--stackMobile'] : '')
         ]">
         <div
             :class="[
@@ -23,6 +24,7 @@
         <div
             :class="[
                 $style['c-mediaElement-imgWrapper'],
+                'c-mediaElement-imgWrapper--override',
                 imageAlignClass
             ]">
             <img
@@ -73,6 +75,10 @@ export default {
         altText: {
             type: String,
             default: 'Media Element Image'
+        },
+        stackOnMobile: {
+            type: Boolean,
+            default: false
         }
     },
     data () {
@@ -165,6 +171,43 @@ $font-sizes: (
 .c-mediaElement {
     display: flex;
     width: 100%;
+
+    &.c-mediaElement--reverse {
+        flex-direction: row-reverse;
+    }
+}
+
+/**
+ * Modifier – .c-mediaElement--stackMobile
+ *
+ * Applies flex direction column on <=narrow
+ */
+.c-mediaElement--stackMobile {
+    @include media('<=narrow') {
+        flex-direction: column;
+    }
+    /**
+     * Modifier – .c-mediaElement--reverse
+     *
+     * When stacked in flex col applies col-reverse
+     */
+    &.c-mediaElement--reverse {
+        @include media('<=narrow') {
+            flex-direction: column-reverse;
+        }
+
+        & .c-mediaElement-text {
+            @include media('<=narrow') {
+                margin-bottom: spacing(x3);
+            }
+        }
+    }
+
+    & .c-mediaElement-title {
+        @include media('<=narrow') {
+            margin-top: spacing(x3);
+        }
+    }
 }
 
 /**
@@ -198,6 +241,7 @@ $font-sizes: (
     flex-direction: column;
     justify-content: center;
     flex: 1 1 0%;
+    white-space: pre-line;
 
     /**
      * Modifier – .c-mediaElement-content--center

--- a/packages/components/molecules/f-media-element/src/components/_tests/MediaElement.test.js
+++ b/packages/components/molecules/f-media-element/src/components/_tests/MediaElement.test.js
@@ -102,24 +102,24 @@ describe('MediaElement.vue', () => {
             expect(style.exists()).toBe(true);
         });
 
-        it('should apply stackOnMobile class when stackOnMobile prop is true', () => {
+        it('should apply stackWhenNarrow class when stackOnMobile prop is true', () => {
             // Arrange
             const wrapper = shallowMount(MediaElement, {
                 propsData: {
                     title: mockTitle,
                     text: mockText,
                     imageUrl: mockImageUrl,
-                    stackOnMobile: true
+                    stackWhenNarrow: true
                 },
                 mocks: {
                     $style: {
-                        'c-mediaElement--stackMobile': 'c-mediaElement--stackMobile'
+                        'c-mediaElement--stackWhenNarrow': 'c-mediaElement--stackWhenNarrow'
                     }
                 }
             });
 
             // Act
-            const style = wrapper.find('.c-mediaElement--stackMobile');
+            const style = wrapper.find('.c-mediaElement--stackWhenNarrow');
 
             // Assert
             expect(style.exists()).toBe(true);

--- a/packages/components/molecules/f-media-element/src/components/_tests/MediaElement.test.js
+++ b/packages/components/molecules/f-media-element/src/components/_tests/MediaElement.test.js
@@ -12,7 +12,11 @@ describe('MediaElement.vue', () => {
     });
 
     it('should be defined', () => {
-        const propsData = {};
+        const propsData = {
+            title: mockTitle,
+            text: mockText,
+            imageUrl: mockImageUrl
+        };
         const wrapper = shallowMount(MediaElement, { propsData });
         expect(wrapper.exists()).toBe(true);
     });
@@ -50,6 +54,75 @@ describe('MediaElement.vue', () => {
 
             // Assert
             expect(textWrapper.text()).toEqual(mockText);
+        });
+
+        it('should apply stack class when stacked prop is true', () => {
+            // Arrange
+            const wrapper = shallowMount(MediaElement, {
+                propsData: {
+                    title: mockTitle,
+                    text: mockText,
+                    imageUrl: mockImageUrl,
+                    stacked: true
+                },
+                mocks: {
+                    $style: {
+                        'c-mediaElement--stack': 'c-mediaElement--stack'
+                    }
+                }
+            });
+
+            // Act
+            const style = wrapper.find('.c-mediaElement--stack');
+
+            // Assert
+            expect(style.exists()).toBe(true);
+        });
+
+        it('should apply reverse class when reverse prop is true', () => {
+            // Arrange
+            const wrapper = shallowMount(MediaElement, {
+                propsData: {
+                    title: mockTitle,
+                    text: mockText,
+                    imageUrl: mockImageUrl,
+                    reverse: true
+                },
+                mocks: {
+                    $style: {
+                        'c-mediaElement--reverse': 'c-mediaElement--reverse'
+                    }
+                }
+            });
+
+            // Act
+            const style = wrapper.find('.c-mediaElement--reverse');
+
+            // Assert
+            expect(style.exists()).toBe(true);
+        });
+
+        it('should apply stackOnMobile class when stackOnMobile prop is true', () => {
+            // Arrange
+            const wrapper = shallowMount(MediaElement, {
+                propsData: {
+                    title: mockTitle,
+                    text: mockText,
+                    imageUrl: mockImageUrl,
+                    stackOnMobile: true
+                },
+                mocks: {
+                    $style: {
+                        'c-mediaElement--stackMobile': 'c-mediaElement--stackMobile'
+                    }
+                }
+            });
+
+            // Act
+            const style = wrapper.find('.c-mediaElement--stackMobile');
+
+            // Assert
+            expect(style.exists()).toBe(true);
         });
 
         it.each([

--- a/packages/components/molecules/f-media-element/src/components/_tests/MediaElement.test.js
+++ b/packages/components/molecules/f-media-element/src/components/_tests/MediaElement.test.js
@@ -102,7 +102,7 @@ describe('MediaElement.vue', () => {
             expect(style.exists()).toBe(true);
         });
 
-        it('should apply stackWhenNarrow class when stackOnMobile prop is true', () => {
+        it('should apply stackWhenNarrow class when stackWhenNarrow prop is true', () => {
             // Arrange
             const wrapper = shallowMount(MediaElement, {
                 propsData: {

--- a/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
+++ b/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
@@ -24,7 +24,7 @@ MediaElementComponent.args = {
     text: 'See the stamps you’ve collected and any discounts you’ve earned.',
     stacked: false,
     reverse: false,
-    stackOnMobile: false,
+    stackWhenNarrow: false,
     altText: 'Test alt text',
     imageUrl: 'https://via.placeholder.com/250',
 };

--- a/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
+++ b/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
@@ -23,7 +23,8 @@ MediaElementComponent.args = {
     title: 'Stampcards',
     text: 'See the stamps you’ve collected and any discounts you’ve earned.',
     stacked: false,
-    reverse: true,
+    reverse: false,
+    stackOnMobile: false,
     altText: 'Test alt text',
     imageUrl: 'https://via.placeholder.com/250',
 };


### PR DESCRIPTION
This PR adds some mobile responsive features to allow media element to stack if stackedOnMobile is true. Also have added a `white-space: pre-line` to enable new lines to be observed. Plus fixed a bug where reverse prop would not work if not in stacked mode.

- [x] Unit tests have been [created|updated]

## Browsers Tested

- [x] Chrome (latest)
