### PR TITLE
f-offers@v0.5.0 - Mirage JS story mocks

### DIFF
--- a/packages/components/organisms/f-offers/CHANGELOG.md
+++ b/packages/components/organisms/f-offers/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.4.1
+v0.5.0
 ------------------------------
 *June 22, 2021*
 

--- a/packages/components/organisms/f-offers/CHANGELOG.md
+++ b/packages/components/organisms/f-offers/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.4.1
+------------------------------
+*June 22, 2021*
+
+### Added
+- Mirage JS server to provide mock cards for storybook
+
+### Changed
+- Updated the story file to get cards based on storybook controls
+
+
 v0.4.0
 ------------------------------
 *June 17, 2021*

--- a/packages/components/organisms/f-offers/package.json
+++ b/packages/components/organisms/f-offers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-offers",
   "description": "Fozzie Offers - displays offers to the customers",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/f-offers.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-offers/package.json
+++ b/packages/components/organisms/f-offers/package.json
@@ -62,6 +62,7 @@
     "@justeat/f-trak": "0.7.1",
     "@justeat/f-media-element": "0.3.0",
     "@justeat/f-button": "1.7.0",
+    "@justeat/f-searchbox": "3.13.0",
     "miragejs": "0.1.41",
     "faker": "5.5.3"
   }

--- a/packages/components/organisms/f-offers/package.json
+++ b/packages/components/organisms/f-offers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-offers",
   "description": "Fozzie Offers - displays offers to the customers",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "main": "dist/f-offers.umd.min.js",
   "files": [
     "dist",
@@ -61,6 +61,8 @@
     "js-cookie": "2.2.1",
     "@justeat/f-trak": "0.7.1",
     "@justeat/f-media-element": "0.3.0",
-    "@justeat/f-button": "1.7.0"
+    "@justeat/f-button": "1.7.0",
+    "miragejs": "0.1.41",
+    "faker": "5.5.3"
   }
 }

--- a/packages/components/organisms/f-offers/stories/Offers.stories.js
+++ b/packages/components/organisms/f-offers/stories/Offers.stories.js
@@ -7,7 +7,22 @@ import Vuex from 'vuex';
 import Vue from 'vue';
 import VOffers from '../src/components/Offers.vue';
 import { offersSearchModule } from '../src/store/offersSearch.module';
+import makeSever from './mocks/server';
+import groupedSeed from './mocks/seeds/grouped';
+import cardsOnlySeed from './mocks/seeds/cardsOnly';
+import noResultsSeed from './mocks/seeds/noResults';
 
+const DISPLAY_STATE = {
+    NO_RESULTS: 'No Results',
+    GROUPED: 'Grouped',
+    CARDS_ONLY: 'Cards Only'
+};
+
+const SEEDS = {
+    NO_RESULTS: noResultsSeed,
+    GROUPED: groupedSeed,
+    CARDS_ONLY: cardsOnlySeed
+};
 
 export default {
     title: 'Components/Organisms',
@@ -16,16 +31,72 @@ export default {
 
 Vue.use(Vuex);
 
-export const VOffersComponent = () => ({
+export const VOffersComponent = (args, { argTypes }) => ({
     components: { VOffers },
-    props: {
+
+    props: Object.keys(argTypes),
+
+    data: () => ({
+        server: undefined
+    }),
+
+    watch: {
+        offersState: function (val) {
+            const displayKey = Object.keys(DISPLAY_STATE).find(key => DISPLAY_STATE[key] === val);
+            this.startServer(SEEDS[displayKey]);
+            this.initialiseAppboyContentCardRefresh();
+        }
     },
+
     store: new Vuex.Store({
         modules: {
             offersSearchModule
         }
     }),
-    template: '<v-offers />'
+
+    methods: {
+        startServer (seed) {
+            // first check to see if we have server already started
+            if (this.server !== undefined) {
+                this.server.shutdown();
+            }
+
+            // now create the server with the seed based on currently selected display state
+            this.server = makeSever(seed);
+        },
+
+        initialiseAppboyContentCardRefresh () {
+            if (window.appboy) {
+                window.appboy.requestContentCardsRefresh();
+            }
+        }
+    },
+
+    created () {
+        const displayKey = Object.keys(DISPLAY_STATE)
+            .find(key => DISPLAY_STATE[key] === DISPLAY_STATE.GROUPED);
+        this.startServer(SEEDS[displayKey]);
+    },
+
+    template: '<v-offers v-bind="$props" />'
 });
 
 VOffersComponent.storyName = 'f-offers';
+
+VOffersComponent.args = {
+    brazeApiKey: '__TEST_API_KEY__'
+};
+
+VOffersComponent.argTypes = {
+    offersState: {
+        control: {
+            type: 'select',
+            options: [
+                DISPLAY_STATE.GROUPED,
+                DISPLAY_STATE.NO_RESULTS,
+                DISPLAY_STATE.CARDS_ONLY
+            ]
+        },
+        defaultValue: DISPLAY_STATE.GROUPED
+    }
+};

--- a/packages/components/organisms/f-offers/stories/mocks/factories/cardFactory.js
+++ b/packages/components/organisms/f-offers/stories/mocks/factories/cardFactory.js
@@ -1,0 +1,56 @@
+import { Factory } from 'miragejs';
+import faker from 'faker';
+import anniversaryCard1Trait from '../traits/anniversaryCard1Trait';
+import headerCardTrait from '../traits/headerCardTrait';
+import homePromotionCard1Trait from '../traits/homePromotionCard1Trait';
+import homePromotionCard2Trait from '../traits/homePromotionCard2Trait';
+import postOrderCard1Trait from '../traits/postOrderCard1Trait';
+import promotionCard1Trait from '../traits/promotionCard1Trait';
+import promotionCard2Trait from '../traits/promotionCard2Trait';
+import recommendationCard1Trait from '../traits/recommendationCard1Trait';
+import restaurantFTCOfferCardTrait from '../traits/restaurantFTCOfferCardTrait';
+import termsAndConditionsCard2Trait from '../traits/termsAndConditionsCard2Trait';
+import voucherCard1Trait from '../traits/voucherCard1Trait';
+import promotionCard2TraitV2 from '../traits/promotionCard2TraitV2';
+
+function timeRange10HoursAroundNow () {
+    const now = Math.floor(Date.now() / 1000);
+    return {
+        nowPlus5Hours: now + 60 * 60 * 5,
+        nowMinus5Hours: now - 60 * 60 * 5
+    };
+}
+
+const { nowMinus5Hours, nowPlus5Hours } = timeRange10HoursAroundNow();
+
+/* eslint-disable camelcase */
+export default Factory.extend({
+    id: () => Buffer.from([`5d79109d167e923a83d3d7db_$_cc=${faker.random.uuid()}`, 'mv=5d79109d167e923a83d3d7dd', 'pi=cmp']
+        .join('&'))
+        .toString('base64'),
+    v: false,
+    cl: false,
+    p: true,
+    db: false,
+    ca: nowMinus5Hours, // created at
+    ea: nowPlus5Hours, // expires at
+    anniversaryCard1: anniversaryCard1Trait,
+    headerCard: headerCardTrait,
+    homePromotionCard1: homePromotionCard1Trait,
+    homePromotionCard2: homePromotionCard2Trait,
+    postOrderCard1: postOrderCard1Trait,
+    promotionCard1: promotionCard1Trait,
+    promotionCard2: promotionCard2Trait,
+    promotionCard2v2: promotionCard2TraitV2,
+    recommendationCard1: recommendationCard1Trait,
+    restaurantFTCOfferCardT: restaurantFTCOfferCardTrait,
+    termsAndConditionsCard2: termsAndConditionsCard2Trait,
+    voucherCard1: voucherCard1Trait,
+    tp: 'short_news',
+    ar: 1,
+    u: null,
+    uw: null,
+    tt: () => faker.lorem.sentence(), // title ?
+    ds: faker.lorem.sentence(), // description ?
+    dm: faker.internet.domainName() // url call to action ?
+});

--- a/packages/components/organisms/f-offers/stories/mocks/factories/cardFactory.js
+++ b/packages/components/organisms/f-offers/stories/mocks/factories/cardFactory.js
@@ -25,7 +25,7 @@ const { nowMinus5Hours, nowPlus5Hours } = timeRange10HoursAroundNow();
 
 /* eslint-disable camelcase */
 export default Factory.extend({
-    id: () => Buffer.from([`5d79109d167e923a83d3d7db_$_cc=${faker.random.uuid()}`, 'mv=5d79109d167e923a83d3d7dd', 'pi=cmp']
+    id: () => Buffer.from([`5d79109d167e923a83d3d7db_$_cc=${faker.datatype.uuid()}`, 'mv=5d79109d167e923a83d3d7dd', 'pi=cmp']
         .join('&'))
         .toString('base64'),
     v: false,

--- a/packages/components/organisms/f-offers/stories/mocks/seeds/cardsOnly.js
+++ b/packages/components/organisms/f-offers/stories/mocks/seeds/cardsOnly.js
@@ -1,0 +1,12 @@
+/**
+ * Below describes the cards that will be created, the number indicates the amount and the order is the
+ * order in which they will be displayed.
+ * @param server
+ */
+export default server => {
+    server.createList('card', 3, 'promotionCard1');
+    server.createList('card', 1, 'promotionCard2v2');
+    server.createList('card', 1, 'promotionCard2');
+    server.createList('card', 1, 'restaurantFTCOfferCardT');
+    server.createList('card', 3, 'voucherCard1');
+};

--- a/packages/components/organisms/f-offers/stories/mocks/seeds/grouped.js
+++ b/packages/components/organisms/f-offers/stories/mocks/seeds/grouped.js
@@ -1,0 +1,17 @@
+/**
+ * Below describes the cards that will be created, the number indicates the amount and the order is the
+ * order in which they will be displayed.
+ * @param server
+ */
+export default server => {
+    server.createList('card', 1, 'headerCard');
+    server.createList('card', 3, 'promotionCard1');
+    server.createList('card', 1, 'headerCard');
+    server.createList('card', 1, 'promotionCard2v2');
+    server.createList('card', 1, 'promotionCard2');
+    server.createList('card', 1, 'restaurantFTCOfferCardT');
+    server.createList('card', 1, 'headerCard');
+    server.createList('card', 3, 'voucherCard1');
+    server.createList('card', 1, 'headerCard');
+    server.createList('card', 1, 'anniversaryCard1');
+};

--- a/packages/components/organisms/f-offers/stories/mocks/seeds/noResults.js
+++ b/packages/components/organisms/f-offers/stories/mocks/seeds/noResults.js
@@ -1,0 +1,1 @@
+export default () => {};

--- a/packages/components/organisms/f-offers/stories/mocks/server.js
+++ b/packages/components/organisms/f-offers/stories/mocks/server.js
@@ -1,0 +1,24 @@
+import { createServer, Model } from 'miragejs';
+import cardFactory from './factories/cardFactory';
+
+const makeSever = seed => createServer({
+    routes () {
+        this.post('https://sdk.iad-01.braze.com/api/v3/data/', () => {});
+        this.post('https://sdk.iad-01.braze.com/api/v3/content_cards/sync', schema => schema.cards.all());
+        this.passthrough();
+    },
+
+    models: {
+        card: Model
+    },
+
+    factories: {
+        card: cardFactory
+    },
+
+    seeds (server) {
+        seed(server);
+    }
+});
+
+export default makeSever;

--- a/packages/components/organisms/f-offers/stories/mocks/traits/anniversaryCard1Trait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/anniversaryCard1Trait.js
@@ -1,0 +1,17 @@
+import { trait } from 'miragejs';
+import faker from 'faker';
+
+const type = 'Anniversary_Card_1';
+
+/* eslint-disable camelcase */
+export default trait({
+    tt: () => 'It’s our anniversary!',
+    ds: () => 'It’s been a year since your first order.',
+    e: () => ({
+        custom_card_type: type,
+        button_1: faker.random.word(),
+        line_3: 'Here’s £5 off to celebrate that!',
+        image_1: `https://picsum.photos/seed/${type}_background_image_1/384/216?blur=3`,
+        voucher_code: 'Code1234455'
+    })
+});

--- a/packages/components/organisms/f-offers/stories/mocks/traits/headerCardTrait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/headerCardTrait.js
@@ -1,0 +1,12 @@
+import { trait } from 'miragejs';
+import faker from 'faker';
+
+const type = 'Header_Card';
+
+/* eslint-disable camelcase */
+export default trait({
+    e: () => ({
+        custom_card_type: type,
+        background_color: faker.random.arrayElement(['#f9fafb', '#f1f2f4', '#e2e6e9', '#c5ccd3', '#929faa', '#5e6b77', '#2a3846'])
+    })
+});

--- a/packages/components/organisms/f-offers/stories/mocks/traits/homePromotionCard1Trait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/homePromotionCard1Trait.js
@@ -1,0 +1,21 @@
+import { trait } from 'miragejs';
+import faker from 'faker';
+
+const type = 'Home_Promotion_Card_1';
+
+/* eslint-disable camelcase */
+export default trait({
+    e: () => ({
+        custom_card_type: type,
+        icon_1: `https://picsum.photos/seed/${type}_icon_1/48/48`,
+        button_1: faker.random.word(),
+        background_color: faker.random.arrayElement(['#f9fafb', '#f1f2f4', '#e2e6e9', '#c5ccd3', '#929faa', '#5e6b77', '#2a3846']),
+        content_container_background: faker.random.arrayElement(['#f9fafb', '#f1f2f4', '#e2e6e9', '#c5ccd3', '#929faa', '#5e6b77', '#2a3846']),
+        display_times_json: () => ({
+            Any: [
+                { Start: '00:00', End: '23:59' }
+            ]
+        }),
+        brand_name: faker.commerce.product()
+    })
+});

--- a/packages/components/organisms/f-offers/stories/mocks/traits/homePromotionCard2Trait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/homePromotionCard2Trait.js
@@ -1,0 +1,19 @@
+import { trait } from 'miragejs';
+import faker from 'faker';
+
+const type = 'Home_Promotion_Card_2';
+
+/* eslint-disable camelcase */
+export default trait({
+    e: () => ({
+        custom_card_type: type,
+        button_1: faker.random.word(),
+        background_color: faker.random.arrayElement(['#f9fafb', '#f1f2f4', '#e2e6e9', '#c5ccd3', '#929faa', '#5e6b77', '#2a3846']),
+        display_times_json: () => ({
+            Any: [
+                { Start: '00:00', End: '23:59' }
+            ]
+        }),
+        brand_name: faker.commerce.product()
+    })
+});

--- a/packages/components/organisms/f-offers/stories/mocks/traits/postOrderCard1Trait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/postOrderCard1Trait.js
@@ -1,0 +1,15 @@
+import { trait } from 'miragejs';
+import faker from 'faker';
+
+const type = 'Post_Order_Card_1';
+
+/* eslint-disable camelcase */
+export default trait({
+    e: () => ({
+        custom_card_type: type,
+        button_1: faker.random.word(),
+        headline: faker.lorem.sentence(),
+        image_1: `https://picsum.photos/seed/${type}_image_1/384/216?blur=3`,
+        icon_1: `https://picsum.photos/seed/${type}_icon_1/48/48`
+    })
+});

--- a/packages/components/organisms/f-offers/stories/mocks/traits/promotionCard1Trait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/promotionCard1Trait.js
@@ -1,0 +1,18 @@
+import { trait } from 'miragejs';
+import faker from 'faker';
+
+const type = 'Promotion_Card_1';
+
+/* eslint-disable camelcase */
+export default trait({
+    e: () => ({
+        custom_card_type: type,
+        button_1: faker.random.word(),
+        line_3: faker.lorem.sentence(),
+        line_4: faker.lorem.sentence(),
+        line_5: faker.lorem.sentence(),
+        line_6: faker.lorem.sentence(),
+        image_1: `https://picsum.photos/seed/${type}_image_1/384/216?blur=3`,
+        offer_auth_required: faker.random.boolean()
+    })
+});

--- a/packages/components/organisms/f-offers/stories/mocks/traits/promotionCard1Trait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/promotionCard1Trait.js
@@ -13,6 +13,6 @@ export default trait({
         line_5: faker.lorem.sentence(),
         line_6: faker.lorem.sentence(),
         image_1: `https://picsum.photos/seed/${type}_image_1/384/216?blur=3`,
-        offer_auth_required: faker.random.boolean()
+        offer_auth_required: faker.datatype.boolean()
     })
 });

--- a/packages/components/organisms/f-offers/stories/mocks/traits/promotionCard2Trait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/promotionCard2Trait.js
@@ -1,0 +1,17 @@
+import { trait } from 'miragejs';
+import faker from 'faker';
+
+const type = 'Promotion_Card_2';
+
+/* eslint-disable camelcase */
+export default trait({
+    tt: () => `KFC I Love You Bacon Burger ${faker.random.number({ min: 1, max: 10 })}`,
+    ds: () => 'Available Tuesdays',
+    e: () => ({
+        custom_card_type: type,
+        button_1: 'Order now', // faker.random.word(),
+        line_3: 'Order the KFC I Love You Bacon Burger, packed with smoked bacon, baconnaise and sweet Bacon Lovers’ Relish.', // faker.lorem.sentence(),
+        image_1: `https://picsum.photos/seed/${type}_image_1/384/216?blur=3`,
+        icon_1: `https://picsum.photos/seed/${type}_icon_1/48/48`
+    })
+});

--- a/packages/components/organisms/f-offers/stories/mocks/traits/promotionCard2Trait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/promotionCard2Trait.js
@@ -5,7 +5,7 @@ const type = 'Promotion_Card_2';
 
 /* eslint-disable camelcase */
 export default trait({
-    tt: () => `KFC I Love You Bacon Burger ${faker.random.number({ min: 1, max: 10 })}`,
+    tt: () => `KFC I Love You Bacon Burger ${faker.datatype.number({ min: 1, max: 10 })}`,
     ds: () => 'Available Tuesdays',
     e: () => ({
         custom_card_type: type,

--- a/packages/components/organisms/f-offers/stories/mocks/traits/promotionCard2TraitV2.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/promotionCard2TraitV2.js
@@ -1,0 +1,17 @@
+import { trait } from 'miragejs';
+import faker from 'faker';
+
+const type = 'Promotion_Card_2';
+
+/* eslint-disable camelcase */
+export default trait({
+    tt: () => `KFC I Love You Bacon Burger ${faker.random.number({ min: 1, max: 10 })}`,
+    ds: () => 'Available Tuesdays',
+    e: () => ({
+        custom_card_type: type,
+        button_1: 'Order now', // faker.random.word(),
+        line_3: 'Order the KFC I Love You Bacon Burger.', // faker.lorem.sentence(),
+        image_1: `https://picsum.photos/seed/${type}_image_1/384/216?blur=3`,
+        icon_1: `https://picsum.photos/seed/${type}_icon_1/48/48`
+    })
+});

--- a/packages/components/organisms/f-offers/stories/mocks/traits/promotionCard2TraitV2.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/promotionCard2TraitV2.js
@@ -5,7 +5,7 @@ const type = 'Promotion_Card_2';
 
 /* eslint-disable camelcase */
 export default trait({
-    tt: () => `KFC I Love You Bacon Burger ${faker.random.number({ min: 1, max: 10 })}`,
+    tt: () => `KFC I Love You Bacon Burger ${faker.datatype.number({ min: 1, max: 10 })}`,
     ds: () => 'Available Tuesdays',
     e: () => ({
         custom_card_type: type,

--- a/packages/components/organisms/f-offers/stories/mocks/traits/recommendationCard1Trait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/recommendationCard1Trait.js
@@ -1,0 +1,13 @@
+import { trait } from 'miragejs';
+import faker from 'faker';
+
+const type = 'Recommendation_Card_1';
+
+/* eslint-disable camelcase */
+export default trait({
+    e: () => ({
+        custom_card_type: type,
+        line_3: faker.lorem.sentence(),
+        image_1: `https://picsum.photos/seed/${type}_image_1/384/216?blur=3`
+    })
+});

--- a/packages/components/organisms/f-offers/stories/mocks/traits/restaurantFTCOfferCardTrait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/restaurantFTCOfferCardTrait.js
@@ -1,0 +1,20 @@
+import { trait } from 'miragejs';
+import faker from 'faker';
+
+const type = 'Restaurant_FTC_Offer_Card';
+
+/* eslint-disable camelcase */
+export default trait({
+    tt: () => 'First time customer',
+    ds: () => 'For first time customers',
+    e: () => ({
+        custom_card_type: type,
+        subtitle: 'Order as much or as little as you like, exclusively on Just Eat.', // faker.lorem.sentence(),
+        banner: '15% discount', // faker.lorem.sentence(),
+        footer: 'Discount automatically applied at the basket', // faker.lorem.sentence(),
+        restaurant_id: faker.random.number({ min: 100, max: 999999 }),
+        restaurant_logo_url: `https://picsum.photos/seed/${type}_restaurant_image_url/384/216?blur=3`,
+        restaurant_image_url: `https://picsum.photos/seed/${type}_restaurant_logo_url/48/48`,
+        offer_auth_required: faker.random.boolean()
+    })
+});

--- a/packages/components/organisms/f-offers/stories/mocks/traits/restaurantFTCOfferCardTrait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/restaurantFTCOfferCardTrait.js
@@ -12,9 +12,9 @@ export default trait({
         subtitle: 'Order as much or as little as you like, exclusively on Just Eat.', // faker.lorem.sentence(),
         banner: '15% discount', // faker.lorem.sentence(),
         footer: 'Discount automatically applied at the basket', // faker.lorem.sentence(),
-        restaurant_id: faker.random.number({ min: 100, max: 999999 }),
+        restaurant_id: faker.datatype.number({ min: 100, max: 999999 }),
         restaurant_logo_url: `https://picsum.photos/seed/${type}_restaurant_image_url/384/216?blur=3`,
         restaurant_image_url: `https://picsum.photos/seed/${type}_restaurant_logo_url/48/48`,
-        offer_auth_required: faker.random.boolean()
+        offer_auth_required: faker.datatype.boolean()
     })
 });

--- a/packages/components/organisms/f-offers/stories/mocks/traits/termsAndConditionsCard2Trait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/termsAndConditionsCard2Trait.js
@@ -1,0 +1,15 @@
+import { trait } from 'miragejs';
+import faker from 'faker';
+
+const type = 'Anniversary_Card_1';
+
+/* eslint-disable camelcase */
+export default trait({
+    e: () => ({
+        custom_card_type: type,
+        button_1: faker.random.word(),
+        line_3: faker.lorem.sentence(),
+        background_image_1: `https://picsum.photos/seed/${type}_background_image_1/384/216?blur=3`,
+        voucher_code: faker.lorem.slug()
+    })
+});

--- a/packages/components/organisms/f-offers/stories/mocks/traits/termsAndConditionsCardTrait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/termsAndConditionsCardTrait.js
@@ -1,0 +1,13 @@
+import { trait } from 'miragejs';
+import faker from 'faker';
+
+const type = 'Terms_And_Conditions_Card';
+
+/* eslint-disable camelcase */
+export default trait({
+    e: () => ({
+        custom_card_type: type,
+        line_3: faker.lorem.sentence(),
+        line_4: faker.lorem.sentence()
+    })
+});

--- a/packages/components/organisms/f-offers/stories/mocks/traits/voucherCard1Trait.js
+++ b/packages/components/organisms/f-offers/stories/mocks/traits/voucherCard1Trait.js
@@ -1,0 +1,16 @@
+import { trait } from 'miragejs';
+import faker from 'faker';
+
+const type = 'Voucher_Card_1';
+
+/* eslint-disable camelcase */
+export default trait({
+    e: () => ({
+        custom_card_type: type,
+        button_1: faker.random.word(),
+        line_3: faker.lorem.sentence(),
+        image_1: `https://picsum.photos/seed/${type}_image_1/384/216?blur=3`,
+        icon_1: `https://picsum.photos/seed/${type}_icon_1/48/48`,
+        voucher_code: 'Code1234455'
+    })
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3188,6 +3188,11 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
+"@miragejs/pretender-node-polyfill@^0.1.0":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@miragejs/pretender-node-polyfill/-/pretender-node-polyfill-0.1.2.tgz#d26b6b7483fb70cd62189d05c95d2f67153e43f2"
+  integrity sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -11313,10 +11318,20 @@ eyeglass@3.0.2:
     node-sass-utils "^1.1.3"
     semver "^5.6.0"
 
+fake-xml-http-request@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-2.1.2.tgz#f1786720cae50bbb46273035a0173414f3e85e74"
+  integrity sha512-HaFMBi7r+oEC9iJNpc3bvcW7Z7iLmM26hPDmlb0mFwyANSsOQAtJxbdWsXITKOzZUyMYK0zYCv3h5yDj9TsiXg==
+
 faker@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
   integrity sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=
+
+faker@5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
+  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 fast-async@^6.3.0:
   version "6.3.8"
@@ -13405,6 +13420,11 @@ infer-owner@^1.0.3, infer-owner@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
+
+inflected@^2.0.4:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/inflected/-/inflected-2.1.0.tgz#2816ac17a570bbbc8303ca05bca8bf9b3f959687"
+  integrity sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -16306,6 +16326,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.assign@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+  integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -16315,6 +16340,11 @@ lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
+lodash.compact@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.compact/-/lodash.compact-3.0.1.tgz#540ce3837745975807471e16b4a2ba21e7256ca5"
+  integrity sha1-VAzjg3dFl1gHRx4WtKK6IeclbKU=
 
 lodash.debounce@4.0.8, lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -16356,20 +16386,50 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
+lodash.forin@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.forin/-/lodash.forin-4.4.0.tgz#5d3f20ae564011fbe88381f7d98949c9c9519731"
+  integrity sha1-XT8grlZAEfvog4H32YlJyclRlzE=
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.has@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
+  integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
 
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
   integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
 
+lodash.invokemap@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.invokemap/-/lodash.invokemap-4.6.0.tgz#1748cda5d8b0ef8369c4eb3ec54c21feba1f2d62"
+  integrity sha1-F0jNpdiw74NpxOs+xUwh/rofLWI=
+
 lodash.isboolean@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
   integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isempty@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
+  integrity sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
+lodash.isfunction@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
 
 lodash.isinteger@^4.0.4:
   version "4.0.4"
@@ -16411,6 +16471,16 @@ lodash.keys@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
   integrity sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=
 
+lodash.lowerfirst@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/lodash.lowerfirst/-/lodash.lowerfirst-4.3.1.tgz#de3c7b12e02c6524a0059c2f6cb7c5c52655a13d"
+  integrity sha1-3jx7EuAsZSSgBZwvbLfFxSZVoT0=
+
+lodash.map@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
+  integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
+
 lodash.mapvalues@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
@@ -16436,6 +16506,11 @@ lodash.orderby@4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.orderby/-/lodash.orderby-4.6.0.tgz#e697f04ce5d78522f54d9338b32b81a3393e4eb3"
   integrity sha1-5pfwTOXXhSL1TZM4syuBozk+TrM=
 
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
+
 lodash.pickby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
@@ -16445,6 +16520,11 @@ lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+
+lodash.snakecase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+  integrity sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -16490,6 +16570,16 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
+
+lodash.uniqby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
+  integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
+
+lodash.values@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
+  integrity sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=
 
 lodash.zip@^4.2.0:
   version "4.2.0"
@@ -17314,6 +17404,38 @@ minizlib@^2.1.1:
   dependencies:
     minipass "^3.0.0"
     yallist "^4.0.0"
+
+miragejs@0.1.41:
+  version "0.1.41"
+  resolved "https://registry.yarnpkg.com/miragejs/-/miragejs-0.1.41.tgz#1b06a2d2d9de65624f5bb1cee7ebb4a208f554d0"
+  integrity sha512-ur8x7sBskgey64vdzKGVCVC3hgKXWl2Cg5lZbxd6OmKrhr9LCCP/Bv7qh4wsQxIMHZnENxybFATXnrQ+rzSOWQ==
+  dependencies:
+    "@miragejs/pretender-node-polyfill" "^0.1.0"
+    inflected "^2.0.4"
+    lodash.assign "^4.2.0"
+    lodash.camelcase "^4.3.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.compact "^3.0.1"
+    lodash.find "^4.6.0"
+    lodash.flatten "^4.4.0"
+    lodash.forin "^4.4.0"
+    lodash.get "^4.4.2"
+    lodash.has "^4.5.2"
+    lodash.invokemap "^4.6.0"
+    lodash.isempty "^4.4.0"
+    lodash.isequal "^4.5.0"
+    lodash.isfunction "^3.0.9"
+    lodash.isinteger "^4.0.4"
+    lodash.isplainobject "^4.0.6"
+    lodash.lowerfirst "^4.3.1"
+    lodash.map "^4.6.0"
+    lodash.mapvalues "^4.6.0"
+    lodash.pick "^4.4.0"
+    lodash.snakecase "^4.1.1"
+    lodash.uniq "^4.5.0"
+    lodash.uniqby "^4.7.0"
+    lodash.values "^4.3.0"
+    pretender "^3.4.3"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -19866,6 +19988,14 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+pretender@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/pretender/-/pretender-3.4.3.tgz#a3b4160516007075d29127262f3a0063d19896e9"
+  integrity sha512-AlbkBly9R8KR+R0sTCJ/ToOeEoUMtt52QVCetui5zoSmeLOU3S8oobFsyPLm1O2txR6t58qDNysqPnA1vVi8Hg==
+  dependencies:
+    fake-xml-http-request "^2.1.1"
+    route-recognizer "^0.3.3"
+
 prettier@^1.18.2:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
@@ -21628,6 +21758,11 @@ rollup@^2.38.5:
   integrity sha512-Ra5JkxSiZPZZFnvE68KWtlrLnZGg5LNaV1n1esq4ch69P7ReeoRVlrTuL/k+L/GJfcowA5An0BEhEq2Hfzwl6w==
   optionalDependencies:
     fsevents "~2.3.1"
+
+route-recognizer@^0.3.3:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.4.tgz#39ab1ffbce1c59e6d2bdca416f0932611e4f3ca3"
+  integrity sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==
 
 rsvp@^4.8.4:
   version "4.8.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2306,6 +2306,13 @@
   dependencies:
     lodash.debounce "4.0.8"
 
+"@justeat/f-searchbox@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-searchbox/-/f-searchbox-3.13.0.tgz#c2d921ace6524af864743e24d890a334ca964186"
+  integrity sha512-dKPJx+1R/HGWJl6fSwNIDmKoBQwswOIzOLbQxnFtMJGTqW506bDRiNPQW3lvP7xmhBpxFHk49xarD2cph+eqvg==
+  dependencies:
+    lodash.debounce "4.0.8"
+
 "@justeat/f-services@0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.13.0.tgz#b0fc67948e94800ba176addb9d92cce444d28c8e"


### PR DESCRIPTION
This PR adds in a new custom mocking solution for `f-offers` using `miragejs`. This will enable users to select (using storybook controls) from a drop down a specific view of content cards. This would show for example what `f-offers` would look like with no results, grouped cards, cards only or in future maybe a special event being hosted on this page. 

Most of this PR is configuration for mirage JS server. If anyone has any questions happy to put in a session to go through it.