### PR TITLE
fozzie-components@v3.42.1 – Adding exclusions to circleci full build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
     description: Detects root package.json changes
     steps:
       - run: |
-          changes=`git diff --name-only master...$CIRCLE_BRANCH | grep -v '^packages/'`
+          changes=`git diff --name-only master...$CIRCLE_BRANCH | grep -Ev '^packages/|yarn.lock|bear.png|.editorconfig'`
 
           if [ "${#changes}" > 0 ];
           then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.42.1
+------------------------------
+*June 24, 2021*
+
+## Fixed
+- Added a couple of exclusions to the root entries that don't trigger a full build.
+
+
 v3.42.0
 ------------------------------
 *June 23, 2021*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "3.42.0",
+  "version": "3.42.1",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",


### PR DESCRIPTION
## Fixed
- Added a couple of exclusions to the root entries that don't trigger a full build.