### PR TITLE
f-registration@0.58.0 - CreateAccountWarning 

### DIFF
--- a/packages/components/organisms/f-registration/CHANGELOG.md
+++ b/packages/components/organisms/f-registration/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.58.0
+------------------------------
+*June 25, 2021*
+
+### Added
+- `CreateAccountWarning` event to be emitted for logging warning instead of errors. Now is used for 409 errors.
+
+
 v0.57.0
 ------------------------------
 *June 18, 2021*

--- a/packages/components/organisms/f-registration/package.json
+++ b/packages/components/organisms/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "main": "dist/f-registration.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/organisms/f-registration/src/components/Registration.vue
+++ b/packages/components/organisms/f-registration/src/components/Registration.vue
@@ -477,7 +477,7 @@ export default {
 
                     if (status === 409) {
                         this.conflictedEmailAddress = this.email;
-                        this.$emit(EventNames.CreateAccountFailure, error);
+                        this.$emit(EventNames.CreateAccountWarning, error);
                         return;
                     }
 

--- a/packages/components/organisms/f-registration/src/components/_tests/Registration.test.js
+++ b/packages/components/organisms/f-registration/src/components/_tests/Registration.test.js
@@ -191,7 +191,7 @@ describe('Registration', () => {
 
                 // Assert
                 expect(wrapper.vm.conflictedEmailAddress).toBe(testEmailAddress);
-                expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+                expect(wrapper.emitted(EventNames.CreateAccountWarning).length).toBe(1);
             });
 
             it('should emit login blocked event when service responds with a 403', async () => {

--- a/packages/components/organisms/f-registration/src/components/_tests/f-registration.integration.test.js
+++ b/packages/components/organisms/f-registration/src/components/_tests/f-registration.integration.test.js
@@ -75,7 +75,7 @@ describe('Registration API service', () => {
         await flushPromises();
 
         // Assert
-        expect(wrapper.emitted(EventNames.CreateAccountFailure).length).toBe(1);
+        expect(wrapper.emitted(EventNames.CreateAccountWarning).length).toBe(1);
         expect(wrapper.vm.conflictedEmailAddress).toBe(CONSUMERS_REQUEST_DATA.emailAddress);
     });
 

--- a/packages/components/organisms/f-registration/src/event-names.js
+++ b/packages/components/organisms/f-registration/src/event-names.js
@@ -1,5 +1,6 @@
 const CreateAccountSuccess = 'registration-create-account-success';
 const CreateAccountFailure = 'registration-create-account-failure';
+const CreateAccountWarning = 'registration-create-account-warning';
 const CreateAccountStart = 'registration-create-account-start';
 const CreateAccountInlineError = 'registration-create-account-inline-error';
 const VisitLoginPage = 'registration-visit-login-page';
@@ -8,6 +9,7 @@ const LoginBlocked = 'registration-login-blocked';
 export default {
     CreateAccountSuccess,
     CreateAccountFailure,
+    CreateAccountWarning,
     CreateAccountStart,
     CreateAccountInlineError,
     VisitLoginPage,


### PR DESCRIPTION
### Added
- `CreateAccountWarning` event to be emitted for logging warning instead of errors. Now is used for 409 errors.
