### PR TITLE
f-form-field@1.16.0 - Fix hover state

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.16.0
+------------------------------
+*June 28, 2021*
+
+### Fixed
+- Hover state to be consistent across all field types.
+- First grouped field to have correct `border-radius`.
+
+
 v1.15.1
 ------------------------------
 *June 15, 2021*

--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -10,7 +10,7 @@ v1.16.0
 
 ### Fixed
 - Hover state to be consistent across all field types.
-- First grouped field to have correct `border-radius`.
+- First grouped form field to have correct `border-radius`.
 
 
 v1.15.1

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "main": "dist/f-form-field.umd.min.js",
   "files": [
     "dist"

--- a/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
@@ -70,6 +70,9 @@ export default {
 </script>
 
 <style lang="scss" module>
+$form-input-bg                            : $color-container-default;
+$form-input-bg--hover                     : darken($form-input-bg, $color-hover-01);
+
 .c-formDropdown-icon {
     width: spacing(x1.5);
     position: absolute;
@@ -95,5 +98,9 @@ export default {
     /* Remove default styling */
     border: none;
     appearance: none;
+
+    &:hover {
+        background-color: $form-input-bg--hover;
+    }
 }
 </style>

--- a/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
@@ -70,8 +70,7 @@ export default {
 </script>
 
 <style lang="scss" module>
-$form-input-bg                            : $color-container-default;
-$form-input-bg--hover                     : darken($form-input-bg, $color-hover-01);
+$form-input-bg--hover                     : darken($color-container-default, $color-hover-01);
 
 .c-formDropdown-icon {
     width: spacing(x1.5);

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -294,6 +294,12 @@ $form-input-focus--boxShadow              : 0 0 0 2px $form-input-focus;
     & + & {
         margin-top: spacing(x2);
     }
+
+    &:hover {
+        .c-formField-field {
+            background-color: $form-input-bg--hover;
+        }
+    }
 }
 
     .c-formField-fieldWrapper {
@@ -317,9 +323,6 @@ $form-input-focus--boxShadow              : 0 0 0 2px $form-input-focus;
         background-clip: padding-box;
         padding: $form-input-padding;
 
-        &:hover {
-            background-color: $form-input-bg--hover;
-        }
 
         &:focus,
         &:active,
@@ -380,7 +383,7 @@ $form-input-focus--boxShadow              : 0 0 0 2px $form-input-focus;
         }
     }
 
-    .c-formField--grouped:first-child {
+    .c-formField--grouped:nth-of-type(1) {
         .c-formField-field {
             border-radius: $form-input-borderRadius $form-input-borderRadius 0 0;
         }

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -17,13 +17,18 @@
                 :is-inline="isInline"
                 :data-test-id="testId.label">
                 {{ labelText }}
+                <template #description>
+                    <p
+                        v-if="hasInputDescription"
+                        :class="[
+                            'u-spacingTop',
+                            'u-spacingBottom--large',
+                            $style['c-formField-labelDescription']
+                        ]">
+                        <slot />
+                    </p>
+                </template>
             </form-label>
-
-            <p
-                v-if="hasInputDescription"
-                class="u-spacingTop u-spacingBottom--large">
-                <slot />
-            </p>
 
             <form-dropdown
                 v-if="isDropdown"
@@ -70,6 +75,7 @@
                 ]"
                 v-on="listeners"
             >
+
             <form-label
                 v-if="isInline"
                 :id="`label-${uniqueId}`"
@@ -294,12 +300,6 @@ $form-input-focus--boxShadow              : 0 0 0 2px $form-input-focus;
     & + & {
         margin-top: spacing(x2);
     }
-
-    &:hover {
-        .c-formField-field {
-            background-color: $form-input-bg--hover;
-        }
-    }
 }
 
     .c-formField-fieldWrapper {
@@ -323,6 +323,9 @@ $form-input-focus--boxShadow              : 0 0 0 2px $form-input-focus;
         background-clip: padding-box;
         padding: $form-input-padding;
 
+        &:hover {
+            background-color: $form-input-bg--hover;
+        }
 
         &:focus,
         &:active,
@@ -387,5 +390,9 @@ $form-input-focus--boxShadow              : 0 0 0 2px $form-input-focus;
         .c-formField-field {
             border-radius: $form-input-borderRadius $form-input-borderRadius 0 0;
         }
+    }
+
+    .c-formField-labelDescription {
+        font-weight: normal;
     }
 </style>

--- a/packages/components/atoms/f-form-field/src/components/FormLabel.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormLabel.vue
@@ -9,6 +9,7 @@
             (isInline ? $style['c-formField-label--inline'] : '')
         ]">
         <slot />
+        <slot name="description" />
     </label>
 </template>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2235,6 +2235,14 @@
   dependencies:
     "@justeat/f-vue-icons" "1.10.0"
 
+"@justeat/f-form-field@1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-1.15.1.tgz#b7acf9e76975df9122dd8c4835ec8664c1f79eae"
+  integrity sha512-MRWQ+m1E5qT5irTLLhNwyf0RZIhNaF7TEWMHtgPWzGooPxtzMcco6zh+XvZ8mNp9QjosV+tl09+EDSTbxFIcmQ==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+    "@justeat/f-vue-icons" "1.11.0"
+
 "@justeat/f-form-field@1.6.1":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-1.6.1.tgz#47b014847a42467737b65997cfcab212d0385ba7"


### PR DESCRIPTION
### Fixed
- Hover state to be consistent across all field types.
- First grouped field to have correct `border-radius`.

| Before | After | 
| --- | --- |
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/24740015/123638643-506b7880-d817-11eb-9506-06319f85de06.gif) |  ![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/24740015/123781842-96364880-d8cc-11eb-9e75-a917bb8ffe99.gif) | 
