### PR TITLE
storybook@v0.37.0 - add optional chaining config modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v3.42.7
+------------------------------
+*June 30, 2021*
+
+## Fix
+- Fix to enable optional chaining in storybook
+
+
 v3.42.6
 ------------------------------
 *June 29, 2021*

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,7 +3,7 @@ module.exports = api => {
     const isTest = api.env('test');
     const presets = [];
     const plugins = [
-        '@babel/plugin-proposal-optional-chaining', 
+        '@babel/plugin-proposal-optional-chaining',
         '@babel/plugin-proposal-class-properties'
     ];
     const builtIns = (api.env('development') ? 'entry' : false);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "3.42.6",
+  "version": "3.42.7",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.37.0
+------------------------------
+*June 30, 2021*
+
+### Changed
+- Modified the storybook main.js config to make optional chaining work with babel, had to do in odd way as yarn workspaces affects the way babel works in storybook
+
+
 v0.36.0
 ------------------------------
 *June 24, 2021*

--- a/packages/storybook/config/storybook/main.js
+++ b/packages/storybook/config/storybook/main.js
@@ -14,5 +14,34 @@ module.exports = {
         '@storybook/addon-links',
         '@storybook/addon-a11y',
         '@storybook/addon-controls'
-    ]
+    ],
+    webpackFinal: async config => {
+        const newConfig = {
+            ...config,
+            module: {
+                ...config.module,
+                rules: [
+                    ...config.module.rules,
+                    {
+                        test: /\.js?$/,
+                        use: [
+                            {
+                                loader: require.resolve('babel-loader'),
+                                options: {
+                                    rootMode: 'upward'
+                                }
+                            }
+                        ],
+                        exclude: /node_modules/
+                    }
+                ]
+            },
+            resolve: {
+                ...config.resolve,
+                extensions: [...(config.resolve.extensions || [])]
+            }
+        };
+
+        return newConfig;
+    }
 };

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5856,9 +5856,9 @@ acorn@^7.1.0, acorn@^7.1.1, acorn@^7.2.0:
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 acorn@^8.2.4:
-  version "8.2.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.2.4.tgz#caba24b08185c3b56e3168e97d15ed17f4d31fd0"
-  integrity sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.1.tgz#56c36251fc7cabc7096adc18f05afe814321a28c"
+  integrity sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==
 
 address@1.1.2, address@^1.0.1, address@^1.0.3, address@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This PR fixes / allows babel plugins to work correctly within storybook stories, this enables the use of the optional chaining plugin on storybook serve and build. This approach taken modifies the `main.js` storybook config file to modify the webpack config to force it to make a `rootMode: 'upward'` check for babel config. The reason we have to do this is because babel does not play well with vue-cli-service running outside of root within a mono repo like ours, I have tried to get babel to work correctly, of which you can indeed get storybook to pick up on `babel.config.js` by placing it in the `config` directory. However it does not actually apply any of the plugins for some reason. Hence why this method has been chosen. 
