### PR TITLE
f-media-element@v1.0.0 - changes to allow more custom control with flexbox using new flex prop

### DIFF
--- a/packages/components/molecules/f-media-element/CHANGELOG.md
+++ b/packages/components/molecules/f-media-element/CHANGELOG.md
@@ -4,6 +4,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.5.0
+------------------------------
+*June 30, 2021*
+
+### Added
+- Added new prop called flex, which allows custom flex rules when implementing
+
+### Removed
+- removed stackOnNarrow as we now allow breakpoints to be passed into flex prop
+- removed stacked as we now allow breakpoints to be passed into flex prop
+- removed reverse as we now allow reverse to be passed into flex prop
+
+
 v0.4.0
 ------------------------------
 *June 21, 2021*

--- a/packages/components/molecules/f-media-element/CHANGELOG.md
+++ b/packages/components/molecules/f-media-element/CHANGELOG.md
@@ -4,9 +4,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.5.0
+v1.0.0
 ------------------------------
-*June 30, 2021*
+*July 02, 2021*
 
 ### Added
 - Added new prop called flex, which allows custom flex rules when implementing

--- a/packages/components/molecules/f-media-element/babel.config.js
+++ b/packages/components/molecules/f-media-element/babel.config.js
@@ -3,7 +3,8 @@ module.exports = api => {
     const isTest = api.env('test');
     const presets = [];
     const plugins = [
-        '@babel/plugin-proposal-optional-chaining' // https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining
+        '@babel/plugin-proposal-optional-chaining', // https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining
+        '@babel/plugin-proposal-class-properties' // https://babeljs.io/docs/en/babel-plugin-proposal-class-properties
     ];
     const builtIns = (api.env('development') ? 'entry' : false);
 

--- a/packages/components/molecules/f-media-element/package.json
+++ b/packages/components/molecules/f-media-element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-media-element",
   "description": "Fozzie Media Element - provides ability to display text and an image in different orientations",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "main": "dist/f-media-element.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-media-element/package.json
+++ b/packages/components/molecules/f-media-element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-media-element",
   "description": "Fozzie Media Element - provides ability to display text and an image in different orientations",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/f-media-element.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-media-element/src/FlexStyles.js
+++ b/packages/components/molecules/f-media-element/src/FlexStyles.js
@@ -1,0 +1,86 @@
+import { MODIFIER_OPPOSITES_RULES_MAP, MODIFIER_RULES_MAP } from './constants';
+
+class FlexStyles {
+    flexDirection = '--row';
+
+    flexReverse = '';
+
+    defaultFlexDirection = '--row';
+
+    defaultFlexReverse = '';
+
+    operator = '';
+
+    operatorOpposite = '';
+
+    mediaSize = '';
+
+    static returnReverseClassSegment (value) {
+        return value ? '--reverse' : '';
+    }
+
+    static returnDirectionClassSegment (value) {
+        return value ? '--col' : '--row';
+    }
+
+    get styles () {
+        const test = [
+            this._createDefaultStyle(),
+            this._createOppositeStyle(),
+            this._createStyle()
+        ];
+
+        console.log(test);
+
+        return test;
+    }
+
+    set column (value) {
+        this.flexDirection = FlexStyles.returnDirectionClassSegment(value);
+    }
+
+    set reverse (value) {
+        this.flexReverse = FlexStyles.returnReverseClassSegment(value);
+    }
+
+    set defaultColumn (value) {
+        this.flexDirection = FlexStyles.returnDirectionClassSegment(value);
+    }
+
+    set defaultReverse (value) {
+        this.flexReverse = FlexStyles.returnReverseClassSegment(value);
+    }
+
+    set rule ([operator, size]) {
+        this.operator = `--${MODIFIER_RULES_MAP[operator]}`;
+        this.operatorOpposite = `--${MODIFIER_OPPOSITES_RULES_MAP[operator]}`;
+        this.mediaSize = `--${size}`;
+    }
+
+    constructor ({
+        default: { column: defaultColumn, reverse: defaultReverse },
+        modifier
+    }) {
+        this.defaultColumn = defaultColumn;
+        this.defaultReverse = defaultReverse;
+        if (modifier) {
+            this.column = modifier?.column;
+            this.reverse = modifier?.reverse;
+            this.rule = modifier?.rule;
+        }
+    }
+
+    _createDefaultStyle () {
+        return `c-mediaElement${this.defaultFlexDirection}${this.defaultFlexReverse}`;
+    }
+
+    _createOppositeStyle () {
+        return `c-mediaElement${this.operatorOpposite}${this.mediaSize}${this.defaultFlexDirection}${this.defaultFlexReverse}`;
+    }
+
+    _createStyle () {
+        return `c-mediaElement${this.operator}${this.mediaSize}${this.flexDirection}${this.flexReverse}`;
+    }
+}
+
+export default FlexStyles;

--- a/packages/components/molecules/f-media-element/src/FlexStyles.js
+++ b/packages/components/molecules/f-media-element/src/FlexStyles.js
@@ -1,104 +1,19 @@
 import { MODIFIER_OPPOSITES_RULES_MAP, MODIFIER_RULES_MAP } from './constants';
 
 class FlexStyles {
-    flexDirection = '--row';
-
-    flexReverse = undefined;
-
     defaultFlexDirection = '--row';
 
     defaultFlexReverse = '';
 
-    operator = undefined;
+    flexDirection = '--row';
 
-    operatorOpposite = undefined;
+    flexReverse;
 
-    mediaSize = undefined;
+    operator;
 
-    /**
-     * Adds the specific part of css class string
-     * @param value
-     * @returns {string}
-     */
-    static returnReverseClassSegment (value) {
-        return value ? '--reverse' : '';
-    }
+    operatorOpposite;
 
-    /**
-     * Adds the specific part of css class string
-     * @param value
-     * @returns {string}
-     */
-    static returnDirectionClassSegment (value) {
-        return value ? '--col' : '--row';
-    }
-
-    /**
-     * Function creates a string (css class name) using the previously set class properties
-     * @returns {*}
-     * @private
-     */
-    static createStyle (...values) {
-        if (!values.some(value => value === undefined)) {
-            return values.reduce((a, c) => `${a}${c}`, 'c-mediaElement');
-        }
-        return undefined;
-    }
-
-    /**
-     * Compiles a list of css classes to be applied
-     * @returns {*[]}
-     */
-    get styles () {
-        return [
-            FlexStyles.createStyle(this.defaultFlexDirection, this.defaultFlexReverse),
-            FlexStyles.createStyle(this.operatorOpposite, this.mediaSize, this.defaultFlexDirection, this.defaultFlexReverse),
-            FlexStyles.createStyle(this.operator, this.mediaSize, this.flexDirection, this.flexReverse)
-        ].filter(value => value !== undefined);
-    }
-
-    /**
-     * Sets the flex direction css string part value
-     * @param value
-     */
-    set column (value) {
-        this.flexDirection = FlexStyles.returnDirectionClassSegment(value);
-    }
-
-    /**
-     * Sets the flex reverse css string part value
-     * @param value
-     */
-    set reverse (value) {
-        this.flexReverse = FlexStyles.returnReverseClassSegment(value);
-    }
-
-    /**
-     * Sets the default flex direction css string part value
-     * @param value
-     */
-    set defaultColumn (value) {
-        this.flexDirection = FlexStyles.returnDirectionClassSegment(value);
-    }
-
-    /**
-     * Sets the default flex reverse css string part value
-     * @param value
-     */
-    set defaultReverse (value) {
-        this.flexReverse = FlexStyles.returnReverseClassSegment(value);
-    }
-
-    /**
-     * This sets the operators within the css class string and the media size on which to apply
-     * @param operator
-     * @param size
-     */
-    set rule ([operator, size]) {
-        this.operator = `--${MODIFIER_RULES_MAP[operator]}`;
-        this.operatorOpposite = `--${MODIFIER_OPPOSITES_RULES_MAP[operator]}`;
-        this.mediaSize = `--${size}`;
-    }
+    mediaSize;
 
     constructor ({
         default: { column: defaultColumn, reverse: defaultReverse },
@@ -111,6 +26,91 @@ class FlexStyles {
         if (modifier?.rule) {
             this.rule = modifier?.rule;
         }
+    }
+
+    /**
+     * Adds the specific part of css class string
+     * @param value
+     * @returns {string}
+     */
+    static getReverseClassSegment (value) {
+        return value ? '--reverse' : '';
+    }
+
+    /**
+     * Adds the specific part of css class string
+     * @param value
+     * @returns {string}
+     */
+    static getDirectionClassSegment (value) {
+        return value ? '--col' : '--row';
+    }
+
+    /**
+     * Function creates a string (css class name) using the previously set class properties
+     * @returns {*}
+     * @private
+     */
+    static createClassName (...values) {
+        if (!values.some(value => value === undefined)) {
+            return values.reduce((a, c) => `${a}${c}`, 'c-mediaElement');
+        }
+        return undefined;
+    }
+
+    /**
+     * Compiles a list of css classes to be applied
+     * @returns {*[]}
+     */
+    get classNames () {
+        return [
+            FlexStyles.createClassName(this.defaultFlexDirection, this.defaultFlexReverse),
+            FlexStyles.createClassName(this.operatorOpposite, this.mediaSize, this.defaultFlexDirection, this.defaultFlexReverse),
+            FlexStyles.createClassName(this.operator, this.mediaSize, this.flexDirection, this.flexReverse)
+        ].filter(value => value !== undefined);
+    }
+
+    /**
+     * Sets the flex direction css string part value
+     * @param value
+     */
+    set column (value) {
+        this.flexDirection = FlexStyles.getDirectionClassSegment(value);
+    }
+
+    /**
+     * Sets the flex reverse css string part value
+     * @param value
+     */
+    set reverse (value) {
+        this.flexReverse = FlexStyles.getReverseClassSegment(value);
+    }
+
+    /**
+     * Sets the default flex direction css string part value
+     * @param value
+     */
+    set defaultColumn (value) {
+        this.defaultFlexDirection = FlexStyles.getDirectionClassSegment(value);
+    }
+
+    /**
+     * Sets the default flex reverse css string part value
+     * @param value
+     */
+    set defaultReverse (value) {
+        this.defaultFlexReverse = FlexStyles.getReverseClassSegment(value);
+    }
+
+    /**
+     * This sets the operators within the css class string and the media size on which to apply
+     * @param operator
+     * @param size
+     */
+    set rule ([operator, size]) {
+        this.operator = `--${MODIFIER_RULES_MAP[operator]}`;
+        this.operatorOpposite = `--${MODIFIER_OPPOSITES_RULES_MAP[operator]}`;
+        this.mediaSize = `--${size}`;
     }
 }
 

--- a/packages/components/molecules/f-media-element/src/FlexStyles.js
+++ b/packages/components/molecules/f-media-element/src/FlexStyles.js
@@ -3,50 +3,97 @@ import { MODIFIER_OPPOSITES_RULES_MAP, MODIFIER_RULES_MAP } from './constants';
 class FlexStyles {
     flexDirection = '--row';
 
-    flexReverse = '';
+    flexReverse = undefined;
 
     defaultFlexDirection = '--row';
 
     defaultFlexReverse = '';
 
-    operator = '';
+    operator = undefined;
 
-    operatorOpposite = '';
+    operatorOpposite = undefined;
 
-    mediaSize = '';
+    mediaSize = undefined;
 
+    /**
+     * Adds the specific part of css class string
+     * @param value
+     * @returns {string}
+     */
     static returnReverseClassSegment (value) {
         return value ? '--reverse' : '';
     }
 
+    /**
+     * Adds the specific part of css class string
+     * @param value
+     * @returns {string}
+     */
     static returnDirectionClassSegment (value) {
         return value ? '--col' : '--row';
     }
 
-    get styles () {
-        return [
-            this._createDefaultStyle(),
-            this._createOppositeStyle(),
-            this._createStyle()
-        ];
+    /**
+     * Function creates a string (css class name) using the previously set class properties
+     * @returns {*}
+     * @private
+     */
+    static createStyle (...values) {
+        if (!values.some(value => value === undefined)) {
+            return values.reduce((a, c) => `${a}${c}`, 'c-mediaElement');
+        }
+        return undefined;
     }
 
+    /**
+     * Compiles a list of css classes to be applied
+     * @returns {*[]}
+     */
+    get styles () {
+        return [
+            FlexStyles.createStyle(this.defaultFlexDirection, this.defaultFlexReverse),
+            FlexStyles.createStyle(this.operatorOpposite, this.mediaSize, this.defaultFlexDirection, this.defaultFlexReverse),
+            FlexStyles.createStyle(this.operator, this.mediaSize, this.flexDirection, this.flexReverse)
+        ].filter(value => value !== undefined);
+    }
+
+    /**
+     * Sets the flex direction css string part value
+     * @param value
+     */
     set column (value) {
         this.flexDirection = FlexStyles.returnDirectionClassSegment(value);
     }
 
+    /**
+     * Sets the flex reverse css string part value
+     * @param value
+     */
     set reverse (value) {
         this.flexReverse = FlexStyles.returnReverseClassSegment(value);
     }
 
+    /**
+     * Sets the default flex direction css string part value
+     * @param value
+     */
     set defaultColumn (value) {
         this.flexDirection = FlexStyles.returnDirectionClassSegment(value);
     }
 
+    /**
+     * Sets the default flex reverse css string part value
+     * @param value
+     */
     set defaultReverse (value) {
         this.flexReverse = FlexStyles.returnReverseClassSegment(value);
     }
 
+    /**
+     * This sets the operators within the css class string and the media size on which to apply
+     * @param operator
+     * @param size
+     */
     set rule ([operator, size]) {
         this.operator = `--${MODIFIER_RULES_MAP[operator]}`;
         this.operatorOpposite = `--${MODIFIER_OPPOSITES_RULES_MAP[operator]}`;
@@ -59,23 +106,11 @@ class FlexStyles {
     }) {
         this.defaultColumn = defaultColumn;
         this.defaultReverse = defaultReverse;
-        if (modifier) {
-            this.column = modifier?.column;
-            this.reverse = modifier?.reverse;
+        this.column = modifier?.column;
+        this.reverse = modifier?.reverse;
+        if (modifier?.rule) {
             this.rule = modifier?.rule;
         }
-    }
-
-    _createDefaultStyle () {
-        return `c-mediaElement${this.defaultFlexDirection}${this.defaultFlexReverse}`;
-    }
-
-    _createOppositeStyle () {
-        return `c-mediaElement${this.operatorOpposite}${this.mediaSize}${this.defaultFlexDirection}${this.defaultFlexReverse}`;
-    }
-
-    _createStyle () {
-        return `c-mediaElement${this.operator}${this.mediaSize}${this.flexDirection}${this.flexReverse}`;
     }
 }
 

--- a/packages/components/molecules/f-media-element/src/FlexStyles.js
+++ b/packages/components/molecules/f-media-element/src/FlexStyles.js
@@ -24,15 +24,11 @@ class FlexStyles {
     }
 
     get styles () {
-        const test = [
+        return [
             this._createDefaultStyle(),
             this._createOppositeStyle(),
             this._createStyle()
         ];
-
-        console.log(test);
-
-        return test;
     }
 
     set column (value) {

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -34,8 +34,9 @@
 
 <script>
 import {
-    ALIGN, FONT_SIZE, MODIFIER_OPPOSITES_RULES_MAP, MODIFIER_RULES_MAP
+    ALIGN, FONT_SIZE
 } from '../constants';
+import FlexStyles from '../FlexStyles';
 
 export default {
     props: {
@@ -121,23 +122,7 @@ export default {
          * @returns {*[]}
          */
         flexClasses () {
-            const classList = [];
-
-            // firstly get the default values and create classes for those
-            const defaultReverse = this.flex?.default?.reverse ? '--reverse' : '';
-
-            classList.push(this.flex.default?.column ? this.$style[`c-flex-col${defaultReverse}`] :
-                this.$style[`c-flex-row${defaultReverse}`]);
-
-            const modifierReverse = this.flex?.modifier?.reverse ? '--reverse' : '';
-
-            classList.push(this.$style[`${this.flex?.modifier?.rule[1]}:c-flex-${this.flex.modifier?.column ? 'col'
-                : 'row'}-${MODIFIER_RULES_MAP[this.flex?.modifier?.rule[0]]}${modifierReverse}`]);
-
-            classList.push(this.$style[`${this.flex?.modifier?.rule[1]}:c-flex-${this.flex.default?.column ? 'col'
-                : 'row'}-${MODIFIER_OPPOSITES_RULES_MAP[this.flex?.modifier?.rule[0]]}${defaultReverse}`]);
-
-            return classList;
+            return (new FlexStyles(this.flex)).styles.map(style => this.$style[style]);
         }
     }
 };
@@ -168,158 +153,158 @@ $font-sizes: (
     )
 );
 
+$flexMargin: spacing(x3);
+
 .c-mediaElement {
     display: flex;
     width: 100%;
 }
 
-.c-flex-col--reverse {
+.c-mediaElement--col--reverse {
     flex-direction: column-reverse;
 
     & .c-mediaElement-content {
-        margin-top: spacing(x3);
+        margin-top: $flexMargin;
     }
 }
-.c-flex-col {
+.c-mediaElement--col {
     flex-direction: column;
 
     & .c-mediaElement-content {
-        margin-bottom: spacing(x3);
+        margin-bottom: $flexMargin;
     }
 }
-.c-flex-row {
+.c-mediaElement--row {
     flex-direction: row;
 }
-.c-flex-row--reverse {
+.c-mediaElement--row--reverse {
     flex-direction: row-reverse;
 }
 
-/**
- * Modifier – .c-mediaElement-stackWhen--$name
- *
- * Applies flex direction column on $name
- */
+
 @each $name, $value in $breakpoints {
 
+    /**
+    * Modifier – .c-mediaElement--gte--$name--col
+    * Modifier – .c-mediaElement--gte--$name--col--reverse
+    * Modifier – .c-mediaElement--gte--$name--row
+    * Modifier – .c-mediaElement--gte--$name--row--reverse
+     *
+     * Applies flex direction column on $name
+     */
     @include media('>='+$name) {
-        .#{$name}\:c-flex-col-gte {
+        .c-mediaElement-col--gte--#{$name} {
             flex-direction: column;
 
             & .c-mediaElement-content {
-                margin-bottom: spacing(x3);
+                margin-bottom: $flexMargin;
             }
         }
-        .#{$name}\:c-flex-col-gte--reverse {
+        .c-mediaElement-col--gte--#{$name}--reverse {
             flex-direction: column-reverse;
 
             & .c-mediaElement-content {
-                margin-top: spacing(x3);
+                margin-top: $flexMargin;
             }
         }
-        .#{$name}\:c-flex-row-gte {
+        .c-mediaElement-row--gte--#{$name} {
             flex-direction: row;
         }
-        .#{$name}\:c-flex-row-gte--reverse {
+        .c-mediaElement-row--gte--#{$name}--reverse {
             flex-direction: row-reverse;
         }
     }
-
-    @include media('>'+$name) {
-        .#{$name}\:c-flex-col-gt {
-            flex-direction: column;
-
-            & .c-mediaElement-content {
-                margin-bottom: spacing(x3);
-            }
-        }
-        .#{$name}\:c-flex-col-gt--reverse {
-            flex-direction: column-reverse;
-
-            & .c-mediaElement-content {
-                margin-top: spacing(x3);
-            }
-        }
-        .#{$name}\:c-flex-row-gt {
-            flex-direction: row;
-        }
-        .#{$name}\:c-flex-row-gt--reverse {
-            flex-direction: row-reverse;
-        }
-    }
-
-    @include media('<='+$name) {
-        .#{$name}\:c-flex-col-lte {
-            flex-direction: column;
-
-            & .c-mediaElement-content {
-                margin-bottom: spacing(x3);
-            }
-        }
-        .#{$name}\:c-flex-col-lte--reverse {
-            flex-direction: column-reverse;
-
-            & .c-mediaElement-content {
-                margin-top: spacing(x3);
-            }
-        }
-        .#{$name}\:c-flex-row-lte {
-            flex-direction: row;
-        }
-        .#{$name}\:c-flex-row-lte--reverse {
-            flex-direction: row-reverse;
-        }
-    }
-
-    @include media('<'+$name) {
-        .#{$name}\:c-flex-col-lt {
-            flex-direction: column;
-
-            & .c-mediaElement-content {
-                margin-bottom: spacing(x3);
-            }
-        }
-        .#{$name}\:c-flex-col-lt--reverse {
-            flex-direction: column-reverse;
-
-            & .c-mediaElement-content {
-                margin-top: spacing(x3);
-            }
-        }
-        .#{$name}\:c-flex-row-lt {
-            flex-direction: row;
-        }
-        .#{$name}\:c-flex-row-lt--reverse {
-            flex-direction: row-reverse;
-        }
-    }
-}
-
-
-/**
- * Modifier – .c-mediaElement--stack
- *
- * Applies flex direction column
- */
-.c-mediaElement-stack {
-    flex-direction: column;
 
     /**
-     * Modifier – .c-mediaElement--reverse
-     *
-     * When stacked in flex col applies col-reverse
-     */
-    &.c-mediaElement-reverse {
-        flex-direction: column-reverse;
+    * Modifier – .c-mediaElement--gt--$name--col
+    * Modifier – .c-mediaElement--gt--$name--col--reverse
+    * Modifier – .c-mediaElement--gt--$name--row
+    * Modifier – .c-mediaElement--gt--$name--row--reverse
+    *
+    * Applies flex direction column on $name
+    */
+    @include media('>'+$name) {
+        .c-mediaElement--gt-#{$name}--col {
+            flex-direction: column;
 
-        & .c-mediaElement-content {
-            margin-top: spacing(x3);
+            & .c-mediaElement-content {
+                margin-bottom: $flexMargin;
+            }
+        }
+        .c-mediaElement--gt--#{$name}--col--reverse {
+            flex-direction: column-reverse;
+
+            & .c-mediaElement-content {
+                margin-top: $flexMargin;
+            }
+        }
+        .c-mediaElement--gt--#{$name}--row {
+            flex-direction: row;
+        }
+        .c-mediaElement--gt--#{$name}--row--reverse {
+            flex-direction: row-reverse;
         }
     }
 
-    &:not(.c-mediaElement-reverse) {
+    /**
+    * Modifier – .c-mediaElement--lte--$name--col
+    * Modifier – .c-mediaElement--lte--$name--col--reverse
+    * Modifier – .c-mediaElement--lte--$name--row
+    * Modifier – .c-mediaElement--lte--$name--row--reverse
+    *
+    * Applies flex direction column on $name
+    */
+    @include media('<='+$name) {
+        .c-mediaElement--lte--#{$name}--col {
+            flex-direction: column;
 
-        & .c-mediaElement-content {
-            margin-bottom: spacing(x3);
+            & .c-mediaElement-content {
+                margin-bottom: $flexMargin;
+            }
+        }
+        .c-mediaElement--lte--#{$name}--col--reverse {
+            flex-direction: column-reverse;
+
+            & .c-mediaElement-content {
+                margin-top: $flexMargin;
+            }
+        }
+        .c-mediaElement--lte--#{$name}--row {
+            flex-direction: row;
+        }
+        .c-mediaElement--lte--#{$name}--row--reverse {
+            flex-direction: row-reverse;
+        }
+    }
+
+    /**
+    * Modifier – .c-mediaElement--lt--$name--col
+    * Modifier – .c-mediaElement--lt--$name--col--reverse
+    * Modifier – .c-mediaElement--lt--$name--row
+    * Modifier – .c-mediaElement--lt--$name--row--reverse
+    *
+    * Applies flex direction column on $name
+    */
+    @include media('<'+$name) {
+        .c-mediaElement--lt--#{$name}--col {
+            flex-direction: column;
+
+            & .c-mediaElement-content {
+                margin-bottom: $flexMargin;
+            }
+        }
+        .c-mediaElement--lt--#{$name}--col--reverse {
+            flex-direction: column-reverse;
+
+            & .c-mediaElement-content {
+                margin-top: $flexMargin;
+            }
+        }
+        .c-mediaElement--lt--#{$name}--row {
+            flex-direction: row;
+        }
+        .c-mediaElement--lt--#{$name}--row--reverse {
+            flex-direction: row-reverse;
         }
     }
 }

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -122,7 +122,7 @@ export default {
          * @returns {*[]}
          */
         flexClasses () {
-            return (new FlexStyles(this.flex)).styles.map(style => this.$style[style]);
+            return (new FlexStyles(this.flex)).classNames.map(style => this.$style[style]);
         }
     }
 };
@@ -153,7 +153,7 @@ $font-sizes: (
     )
 );
 
-$flexMargin: spacing(x3);
+$mediaElement-content-margin: spacing(x3);
 
 .c-mediaElement {
     display: flex;
@@ -164,14 +164,14 @@ $flexMargin: spacing(x3);
     flex-direction: column-reverse;
 
     & .c-mediaElement-content {
-        margin-top: $flexMargin;
+        margin-top: $mediaElement-content-margin;
     }
 }
 .c-mediaElement--col {
     flex-direction: column;
 
     & .c-mediaElement-content {
-        margin-bottom: $flexMargin;
+        margin-bottom: $mediaElement-content-margin;
     }
 }
 .c-mediaElement--row {
@@ -193,24 +193,24 @@ $flexMargin: spacing(x3);
      * Applies flex direction column on $name
      */
     @include media('>='+$name) {
-        .c-mediaElement-col--gte--#{$name} {
+        .c-mediaElement--gte--#{$name}--col {
             flex-direction: column;
 
             & .c-mediaElement-content {
-                margin-bottom: $flexMargin;
+                margin-bottom: $mediaElement-content-margin;
             }
         }
-        .c-mediaElement-col--gte--#{$name}--reverse {
+        .c-mediaElement--gte--#{$name}--col--reverse {
             flex-direction: column-reverse;
 
             & .c-mediaElement-content {
-                margin-top: $flexMargin;
+                margin-top: $mediaElement-content-margin;
             }
         }
-        .c-mediaElement-row--gte--#{$name} {
+        .c-mediaElement--gte--#{$name}--row {
             flex-direction: row;
         }
-        .c-mediaElement-row--gte--#{$name}--reverse {
+        .c-mediaElement--gte--#{$name}--row--reverse {
             flex-direction: row-reverse;
         }
     }
@@ -224,18 +224,18 @@ $flexMargin: spacing(x3);
     * Applies flex direction column on $name
     */
     @include media('>'+$name) {
-        .c-mediaElement--gt-#{$name}--col {
+        .c-mediaElement--gt--#{$name}--col {
             flex-direction: column;
 
             & .c-mediaElement-content {
-                margin-bottom: $flexMargin;
+                margin-bottom: $mediaElement-content-margin;
             }
         }
         .c-mediaElement--gt--#{$name}--col--reverse {
             flex-direction: column-reverse;
 
             & .c-mediaElement-content {
-                margin-top: $flexMargin;
+                margin-top: $mediaElement-content-margin;
             }
         }
         .c-mediaElement--gt--#{$name}--row {
@@ -259,14 +259,14 @@ $flexMargin: spacing(x3);
             flex-direction: column;
 
             & .c-mediaElement-content {
-                margin-bottom: $flexMargin;
+                margin-bottom: $mediaElement-content-margin;
             }
         }
         .c-mediaElement--lte--#{$name}--col--reverse {
             flex-direction: column-reverse;
 
             & .c-mediaElement-content {
-                margin-top: $flexMargin;
+                margin-top: $mediaElement-content-margin;
             }
         }
         .c-mediaElement--lte--#{$name}--row {
@@ -290,14 +290,14 @@ $flexMargin: spacing(x3);
             flex-direction: column;
 
             & .c-mediaElement-content {
-                margin-bottom: $flexMargin;
+                margin-bottom: $mediaElement-content-margin;
             }
         }
         .c-mediaElement--lt--#{$name}--col--reverse {
             flex-direction: column-reverse;
 
             & .c-mediaElement-content {
-                margin-top: $flexMargin;
+                margin-top: $mediaElement-content-margin;
             }
         }
         .c-mediaElement--lt--#{$name}--row {

--- a/packages/components/molecules/f-media-element/src/components/_tests/MediaElement.test.js
+++ b/packages/components/molecules/f-media-element/src/components/_tests/MediaElement.test.js
@@ -1,6 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import MediaElement from '../MediaElement.vue';
-import { ALIGN, FONT_SIZE } from '../../constants';
+import {ALIGN, FONT_SIZE, MODIFIER_OPPOSITES_RULES_MAP, MODIFIER_RULES_MAP} from '../../constants';
 
 const mockTitle = '__TEST_TITLE__';
 const mockText = '__TEST_TEXT__';
@@ -141,6 +141,174 @@ describe('MediaElement.vue', () => {
             // Assert
             expect(style.exists()).toBe(true);
         });
+
+        describe('flex ::', () => {
+            it('should add a default class name when not set', () => {
+                const className = 'c-mediaElement--row';
+                // Arrange
+                const wrapper = shallowMount(MediaElement, {
+                    propsData: {
+                        title: mockTitle,
+                        text: mockText,
+                        imageUrl: mockImageUrl
+                    },
+                    mocks: {
+                        $style: {
+                            [className]: className
+                        }
+                    }
+                });
+
+                // Act
+                const style = wrapper.find(`.${className}`);
+
+                // Assert
+                expect(style.exists()).toBe(true);
+            });
+
+            it('should apply class with the default direction if default.column is true', () => {
+                const className = 'c-mediaElement--col';
+                // Arrange
+                const wrapper = shallowMount(MediaElement, {
+                    propsData: {
+                        title: mockTitle,
+                        text: mockText,
+                        imageUrl: mockImageUrl,
+                        flex: {
+                            default: {
+                                column: true,
+                                reverse: false
+                            }
+                        }
+                    },
+                    mocks: {
+                        $style: {
+                            [className]: className
+                        }
+                    }
+                });
+
+                // Act
+                const style = wrapper.find(`.${className}`);
+
+                // Assert
+                expect(style.exists()).toBe(true);
+            });
+
+            it('should apply class with reverse direction if default.reverse is true', () => {
+                const className = 'c-mediaElement--row--reverse';
+                // Arrange
+                const wrapper = shallowMount(MediaElement, {
+                    propsData: {
+                        title: mockTitle,
+                        text: mockText,
+                        imageUrl: mockImageUrl,
+                        flex: {
+                            default: {
+                                column: false,
+                                reverse: true
+                            }
+                        }
+                    },
+                    mocks: {
+                        $style: {
+                            [className]: className
+                        }
+                    }
+                });
+
+                // Act
+                const style = wrapper.find(`.${className}`);
+
+                // Assert
+                expect(style.exists()).toBe(true);
+            });
+
+            it.each([
+                ['>', 'narrowMid'],
+                ['>=', 'narrowMid'],
+                ['<', 'narrowMid'],
+                ['<=', 'narrowMid']
+            ])('should apply class that applies column and reverse when %s %s screen size', (operator, size) => {
+                const className = `c-mediaElement--${MODIFIER_RULES_MAP[operator]}--${size}--col--reverse`;
+                // Arrange
+                const wrapper = shallowMount(MediaElement, {
+                    propsData: {
+                        title: mockTitle,
+                        text: mockText,
+                        imageUrl: mockImageUrl,
+                        flex: {
+                            default: {
+                                column: false,
+                                reverse: false
+                            },
+                            modifier: {
+                                rule: [
+                                    operator,
+                                    size
+                                ],
+                                column: true,
+                                reverse: true
+                            }
+                        }
+                    },
+                    mocks: {
+                        $style: {
+                            [className]: className
+                        }
+                    }
+                });
+
+                // Act
+                const style = wrapper.find(`.${className}`);
+
+                // Assert
+                expect(style.exists()).toBe(true);
+            });
+
+            it.each([
+                ['>', 'narrowMid'],
+                ['>=', 'narrowMid'],
+                ['<', 'narrowMid'],
+                ['<=', 'narrowMid']
+            ])('should apply class that applies default column and reverse for opposite of %s %s screen size', (operator, size) => {
+                const className = `c-mediaElement--${MODIFIER_OPPOSITES_RULES_MAP[operator]}--${size}--row`;
+                // Arrange
+                const wrapper = shallowMount(MediaElement, {
+                    propsData: {
+                        title: mockTitle,
+                        text: mockText,
+                        imageUrl: mockImageUrl,
+                        flex: {
+                            default: {
+                                column: false,
+                                reverse: false
+                            },
+                            modifier: {
+                                rule: [
+                                    operator,
+                                    size
+                                ],
+                                column: true,
+                                reverse: true
+                            }
+                        }
+                    },
+                    mocks: {
+                        $style: {
+                            [className]: className
+                        }
+                    }
+                });
+
+                // Act
+                const style = wrapper.find(`.${className}`);
+
+                // Assert
+                expect(style.exists()).toBe(true);
+            });
+        });
+
     });
 
     describe('slot', () => {

--- a/packages/components/molecules/f-media-element/src/components/_tests/MediaElement.test.js
+++ b/packages/components/molecules/f-media-element/src/components/_tests/MediaElement.test.js
@@ -56,75 +56,6 @@ describe('MediaElement.vue', () => {
             expect(textWrapper.text()).toEqual(mockText);
         });
 
-        it('should apply stack class when stacked prop is true', () => {
-            // Arrange
-            const wrapper = shallowMount(MediaElement, {
-                propsData: {
-                    title: mockTitle,
-                    text: mockText,
-                    imageUrl: mockImageUrl,
-                    stacked: true
-                },
-                mocks: {
-                    $style: {
-                        'c-mediaElement--stack': 'c-mediaElement--stack'
-                    }
-                }
-            });
-
-            // Act
-            const style = wrapper.find('.c-mediaElement--stack');
-
-            // Assert
-            expect(style.exists()).toBe(true);
-        });
-
-        it('should apply reverse class when reverse prop is true', () => {
-            // Arrange
-            const wrapper = shallowMount(MediaElement, {
-                propsData: {
-                    title: mockTitle,
-                    text: mockText,
-                    imageUrl: mockImageUrl,
-                    reverse: true
-                },
-                mocks: {
-                    $style: {
-                        'c-mediaElement--reverse': 'c-mediaElement--reverse'
-                    }
-                }
-            });
-
-            // Act
-            const style = wrapper.find('.c-mediaElement--reverse');
-
-            // Assert
-            expect(style.exists()).toBe(true);
-        });
-
-        it('should apply stackWhenNarrow class when stackWhenNarrow prop is true', () => {
-            // Arrange
-            const wrapper = shallowMount(MediaElement, {
-                propsData: {
-                    title: mockTitle,
-                    text: mockText,
-                    imageUrl: mockImageUrl,
-                    stackWhenNarrow: true
-                },
-                mocks: {
-                    $style: {
-                        'c-mediaElement--stackWhenNarrow': 'c-mediaElement--stackWhenNarrow'
-                    }
-                }
-            });
-
-            // Act
-            const style = wrapper.find('.c-mediaElement--stackWhenNarrow');
-
-            // Assert
-            expect(style.exists()).toBe(true);
-        });
-
         it.each([
             [ALIGN.LEFT, 'c-mediaElement-content--left'],
             [ALIGN.RIGHT, 'c-mediaElement-content--right'],
@@ -182,12 +113,12 @@ describe('MediaElement.vue', () => {
         });
 
         it.each([
-            [FONT_SIZE.SM, 'c-mediaElement-content--fontSizeSmall'],
-            [FONT_SIZE.MD, 'c-mediaElement-content--fontSizeMedium'],
-            [FONT_SIZE.LG, 'c-mediaElement-content--fontSizeLarge'],
-            [FONT_SIZE.XL, 'c-mediaElement-content--fontSizeXLarge'],
-            [FONT_SIZE.XXL, 'c-mediaElement-content--fontSizeXXLarge'],
-            ['__TEST_DUMMY_VALUE__', 'c-mediaElement-content--fontSizeMedium']
+            [FONT_SIZE.SM, 'c-mediaElement-contentFontSize--sm'],
+            [FONT_SIZE.MD, 'c-mediaElement-contentFontSize--md'],
+            [FONT_SIZE.LG, 'c-mediaElement-contentFontSize--lg'],
+            [FONT_SIZE.XL, 'c-mediaElement-contentFontSize--xl'],
+            [FONT_SIZE.XXL, 'c-mediaElement-contentFontSize--xxl'],
+            ['__TEST_DUMMY_VALUE__', 'c-mediaElement-contentFontSize--md']
         ])('should when textSize prop is %s, set class %s', (textSizeProp, textSizeClass) => {
             // Arrange
             const wrapper = shallowMount(MediaElement, {

--- a/packages/components/molecules/f-media-element/src/constants.js
+++ b/packages/components/molecules/f-media-element/src/constants.js
@@ -11,3 +11,17 @@ export const FONT_SIZE = {
     XL: 'xl',
     XXL: 'xxl'
 };
+
+export const MODIFIER_RULES_MAP = {
+    '>=': 'gte',
+    '>': 'gt',
+    '<': 'lt',
+    '<=': 'lte'
+};
+
+export const MODIFIER_OPPOSITES_RULES_MAP = {
+    '>=': 'lt',
+    '>': 'lte',
+    '<': 'gte',
+    '<=': 'gt'
+};

--- a/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
+++ b/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
@@ -29,7 +29,7 @@ MediaElementComponent.args = {
         },
         modifier: {
             rule: [
-                '>=',
+                '<',
                 'narrowMid'
             ],
             column: true,

--- a/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
+++ b/packages/components/molecules/f-media-element/stories/MediaElement.stories.js
@@ -22,9 +22,20 @@ MediaElementComponent.storyName = 'f-media-element';
 MediaElementComponent.args = {
     title: 'Stampcards',
     text: 'See the stamps you’ve collected and any discounts you’ve earned.',
-    stacked: false,
-    reverse: false,
-    stackWhenNarrow: false,
+    flex: {
+        default: {
+            column: false,
+            reverse: false
+        },
+        modifier: {
+            rule: [
+                '>=',
+                'narrowMid'
+            ],
+            column: true,
+            reverse: true
+        }
+    },
     altText: 'Test alt text',
     imageUrl: 'https://via.placeholder.com/250',
 };

--- a/packages/components/organisms/f-offers/package.json
+++ b/packages/components/organisms/f-offers/package.json
@@ -42,8 +42,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-globalisation": "1.0.0",
-    "@justeat/f-services": "1.11.0"
+    "@justeat/f-services": "1.11.0",
+    "@justeat/f-globalisation": "1.0.0"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0",
@@ -51,19 +51,19 @@
     "@justeat/f-trak": "0.7.1"
   },
   "devDependencies": {
-    "@justeat/f-button": "1.7.0",
-    "@justeat/f-media-element": "0.3.0",
-    "@justeat/f-searchbox": "3.13.0",
-    "@justeat/f-trak": "0.7.1",
-    "@justeat/f-wdio-utils": "0.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
+    "@justeat/f-wdio-utils": "0.2.0",
     "@vue/test-utils": "1.0.3",
-    "faker": "5.5.3",
+    "node-sass-magic-importer": "5.3.2",
     "js-cookie": "2.2.1",
+    "@justeat/f-trak": "0.7.1",
+    "@justeat/f-media-element": "0.3.0",
+    "@justeat/f-button": "1.7.0",
+    "@justeat/f-searchbox": "3.13.0",
     "miragejs": "0.1.41",
-    "node-sass-magic-importer": "5.3.2"
+    "faker": "5.5.3"
   }
 }

--- a/packages/components/organisms/f-offers/package.json
+++ b/packages/components/organisms/f-offers/package.json
@@ -42,8 +42,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.11.0",
-    "@justeat/f-globalisation": "1.0.0"
+    "@justeat/f-globalisation": "1.0.0",
+    "@justeat/f-services": "1.11.0"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0",
@@ -51,19 +51,19 @@
     "@justeat/f-trak": "0.7.1"
   },
   "devDependencies": {
+    "@justeat/f-button": "1.7.0",
+    "@justeat/f-media-element": "0.3.0",
+    "@justeat/f-searchbox": "3.13.0",
+    "@justeat/f-trak": "0.7.1",
+    "@justeat/f-wdio-utils": "0.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
-    "@justeat/f-wdio-utils": "0.2.0",
     "@vue/test-utils": "1.0.3",
-    "node-sass-magic-importer": "5.3.2",
+    "faker": "5.5.3",
     "js-cookie": "2.2.1",
-    "@justeat/f-trak": "0.7.1",
-    "@justeat/f-media-element": "0.3.0",
-    "@justeat/f-button": "1.7.0",
-    "@justeat/f-searchbox": "3.13.0",
     "miragejs": "0.1.41",
-    "faker": "5.5.3"
+    "node-sass-magic-importer": "5.3.2"
   }
 }


### PR DESCRIPTION
This PR adds a new prop called flex, this allows a lot finer control over the layout of the `f-media-element` at multiple screen sizes. I have also updated the styles to have new classes for flex example `c-flex-col-gt`. I have also added modifiers to front like `narrowMid:c-flex-col-gt` for example. Let me know if people would prefer a different approach. 
