### PR TITLE
fozzie-components@3.43.0 - More granular package size limits for bundlewatch #globalconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.43.0
+------------------------------
+*July 1, 2021*
+
+### Changed
+
+
 v3.42.7
 ------------------------------
 *June 30, 2021*
 
-## Fix
+### Fixed
 - Fix to enable optional chaining in storybook
 
 
@@ -16,7 +23,7 @@ v3.42.6
 ------------------------------
 *June 29, 2021*
 
-## Fix
+### Fixed
 - Fix Storybook deploy CI build.
 
 
@@ -24,7 +31,7 @@ v3.42.5
 ------------------------------
 *June 24, 2021*
 
-## Fix
+### Fixed
 - Fix to output the changes varirable so that it works on CircleCI.
 
 
@@ -32,7 +39,7 @@ v3.42.4
 ------------------------------
 *June 24, 2021*
 
-## Fixed
+### Fixed
 - Trying a different fix for the package comparison. Checks if variable is defined rather than a numeric comparison.
 
 
@@ -40,7 +47,7 @@ v3.42.3
 ------------------------------
 *June 24, 2021*
 
-## Fixed
+### Fixed
 - Storybook deploy should reference yarn (to call lerna indirectly).
 
 
@@ -48,7 +55,7 @@ v3.42.2
 ------------------------------
 *June 24, 2021*
 
-## Fixed
+### Fixed
 - Numeric comparison fixed in CircleCI bash script
 
 
@@ -56,7 +63,7 @@ v3.42.1
 ------------------------------
 *June 24, 2021*
 
-## Fixed
+### Fixed
 - Added a couple of exclusions to the root entries that don't trigger a full build.
 
 
@@ -64,10 +71,10 @@ v3.42.0
 ------------------------------
 *June 23, 2021*
 
-## Changed
+### Changed
 - Optimises the build so that only packages that have been amended run in the build and are tested via Storybook.
 
-## Fixed
+### Fixed
 - DangerJS now correctly reports when Storybook needs a version bump and CHANGELOG entry.
 
 
@@ -75,7 +82,7 @@ v3.41.0
 ------------------------------
 *June 18, 2021*
 
-## Fixed
+### Fixed
 - Storybook deployer moved to the storybook package (so that it deploys the `index.html` to the root of `gh-pages` correctly).
 
 
@@ -83,7 +90,7 @@ v3.40.0
 ------------------------------
 *June 17, 2021*
 
-## Changed
+### Changed
 - Updated `@percy/cli` dependency.
 
 
@@ -91,7 +98,7 @@ v3.39.0
 ------------------------------
 *June 9, 2021*
 
-## Changed
+### Changed
 - Updated Percy tests to use Lerna
 
 
@@ -99,7 +106,7 @@ v3.38.0
 ------------------------------
 *June 7, 2021*
 
-## Changed
+### Changed
 - `fozzie` version.
 
 
@@ -107,7 +114,7 @@ v3.37.0
 ------------------------------
 *May 28, 2021*
 
-## Added
+### Added
 - CircleCI config for running `build`, `lint` & `unit testing` steps individually locally.
 - Documentation into storybook guides as to how to run these tests through CircleCI CLI locally and what each task is setup to do.
 
@@ -116,14 +123,15 @@ v3.36.0
 ------------------------------
 *May 27, 2021*
 
-## Added
+### Added
 - `URL Builder` to all components for testing different knobs against storybook
+
 
 v3.35.0
 ------------------------------
 *May 27, 2021*
 
-## Changed
+### Changed
 - Force Percy to run in parallel
 
 
@@ -163,10 +171,10 @@ v3.31.0
 ------------------------------
 *May 4, 2021*
 
-## Changed
+### Changed
 - Replaced `console.logs` in component tests with error handling `%s` string title
 
-## Removed
+### Removed
 - Unused READMEs inside `test/component` and `test-utils/component-object` folders
 - Extra intermediate `spec` folder in generator for future components (see below entry)
 
@@ -175,11 +183,11 @@ v3.30.0
 ------------------------------
 *April 30, 2021*
 
-## Added
+### Added
 - Error handling added for `forEach` component tests
 - General linting changes and test-cleanup
 
-## Removed
+### Removed
 - Unneeded extra intermediate `spec` folder in `test/spec/component`
 
 
@@ -187,13 +195,13 @@ v3.29.1
 ------------------------------
 *April 29, 2021*
 
-## Added
+### Added
 - CircleCI config for local testing
 - Documentation into storybook guides as to how to install CircleCI local with Docker
 
 *April 16, 2021*
 
-## Added
+### Added
 - `husky` to enable pre-commit lint / test checks
 
 
@@ -201,7 +209,7 @@ v3.28.0
 ------------------------------
 *April 14, 2021*
 
-## Added
+### Added
 - Test tagging mechanism for chrome / browserstack
 
 
@@ -209,7 +217,7 @@ v3.27.0
 ------------------------------
 *April 13, 2021*
 
-## Added
+### Added
 - Test tagging mechanism for chrome / browserstack
 
 
@@ -217,24 +225,26 @@ v3.26.0
 ------------------------------
 *March 29, 2021*
 
-## Added
+### Added
 - A11y markup added for screen-reader support to f-registration.
+
 
 v3.25.0
 ------------------------------
 *March 24, 2021*
 
-## Added
+### Added
 - launch.json to provide ability to run / debug individual WDIO test specs against chrome / browserstack / Jest tests
 
-## Removed
+### Removed
 - jest-allure2 package
+
 
 v3.24.1
 ------------------------------
 *March 23, 2021*
 
-## Added
+### Added
 - `f-wdio-utils` package to all component folders
 - `f-wdio-utils` package to generator
 
@@ -246,7 +256,7 @@ v3.24.0
 ------------------------------
 *March 22, 2021*
 
-## Changed
+### Changed
 - Refactored `jest-allure2` and `allure-reporter`
 - Added script `report:test-component:chrome` into package.json for automating component test report
 - Updated generator to reflect changes
@@ -256,7 +266,7 @@ v3.23.0
 ------------------------------
 *March 18, 2021*
 
-## Changed
+### Changed
 - Updated node `config.yml` to support chromedriver 89.0.0
 
 
@@ -264,7 +274,7 @@ v3.22.0
 ------------------------------
 *March 12, 2021*
 
-## Changed
+### Changed
 - `wdio-browserstack.conf.js` to support new Browserstack configs.
 
 
@@ -282,6 +292,7 @@ v3.20.0
 
 ### Changed
 - Accessibility / Alure folder structure
+
 
 v3.19.0
 ------------------------------
@@ -369,6 +380,7 @@ v3.12.0
 - Accessibility automated tests info to documentation
 - More info to getting started guide
 
+
 v3.11.0
 ------------------------------
 *February 5, 2021*
@@ -398,7 +410,7 @@ v3.9.0
 ------------------------------
 *February 4, 2021*
 
-### Changes
+### Changed
 - Updated `package.json` with `chromedriver` version to `88.0.0`.
 - Updated CircleCI `config.yml` to support updated `chromedriver` version.
 
@@ -426,7 +438,7 @@ v3.7.1
 ------------------------------
 *February 3, 2021*
 
-### Changes
+### Changed
 - Update Axe Helper
 
 
@@ -434,7 +446,7 @@ v3.7.0
 ------------------------------
 *January 29, 2021*
 
-### Changes
+### Changed
 - Bundle watch maxSize value to `100kb` & target files `umd.min.js, .min & .es.js`.
 
 
@@ -450,7 +462,7 @@ v3.6.0
 ------------------------------
 *January 18, 2021*
 
-### Changes
+### Changed
 - Unit test directories updated so that they are named `_tests/` to match our previously agreed frontend guidelines.
 
 
@@ -458,7 +470,7 @@ v3.5.0
 ------------------------------
 *January 12, 2021*
 
-### Changes
+### Changed
 - CircleCI config to run jobs in parallel
 
 
@@ -527,6 +539,7 @@ v2.25.0
 
 ### Added
 - Documentation for font optimisation and subsetting.
+
 
 v2.24.0
 ------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v3.43.0
 *July 1, 2021*
 
 ### Changed
+- Decrease maximum allowed package size for atoms and molecules.
 
 
 v3.42.7

--- a/bundlewatch.config.js
+++ b/bundlewatch.config.js
@@ -3,12 +3,18 @@
 const { readdirSync } = require('fs');
 
 const packageFolders = [
-    'packages/components/atoms',
-    'packages/components/molecules',
-    'packages/components/organisms',
-    'packages/services',
-    'packages/tools'
+    { name: 'packages/components/atoms', maxSize: '15kB' },
+    { name: 'packages/components/molecules', maxSize: '60kB' },
+    { name: 'packages/components/organisms', maxSize: '100kB' },
+    { name: 'packages/services', maxSize: '100kB' },
+    { name: 'packages/tools', maxSize: '100kB' }
 ];
+
+const getMaxSizeForPackage = packageName => {
+    const folder = packageFolders.find(f => packageName.startsWith(f.name));
+    console.log('package:', packageName, 'maxSize:', folder.maxSize);
+    return (folder && folder.maxSize) ? folder.maxSize : '100kB';
+};
 
 const excludedPackages = [
     'packages/services/f-braze-adapter',
@@ -23,22 +29,21 @@ const excludedPackages = [
  * @param {String} source – Path string to check the contents of.
  * @returns {Array} – A set of subfolder paths to each package found
  */
-const getDirectories = source =>
-    readdirSync(source, { withFileTypes: true })
+const getDirectories = source => readdirSync(source, { withFileTypes: true })
         .filter(dirent => dirent.isDirectory())
         .map(dirent => `${source}/${dirent.name}`);
 
 let packageNames = [];
 
 packageFolders.forEach(folder => {
-    packageNames = packageNames.concat(getDirectories(folder));
+    packageNames = packageNames.concat(getDirectories(folder.name));
 });
 
-const filteredPackages = packageNames.filter(package => !excludedPackages.includes(package));
+const filteredPackages = packageNames.filter(packageName => !excludedPackages.includes(packageName));
 
-const files = filteredPackages.map(package => ({
-    path: `${package}/dist/*+(.min|.min.umd|.es).js`,
-    maxSize: '100kB'
+const files = filteredPackages.map(packageName => ({
+    path: `${packageName}/dist/*+(.min|.min.umd|.es).js`,
+    maxSize: getMaxSizeForPackage(packageName)
 }));
 
 module.exports = {

--- a/bundlewatch.config.js
+++ b/bundlewatch.config.js
@@ -12,7 +12,6 @@ const packageFolders = [
 
 const getMaxSizeForPackage = packageName => {
     const folder = packageFolders.find(f => packageName.startsWith(f.name));
-    console.log('package:', packageName, 'maxSize:', folder.maxSize);
     return (folder && folder.maxSize) ? folder.maxSize : '100kB';
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "3.42.7",
+  "version": "3.43.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",

--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -3,6 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
 v4.27.0
 ------------------------------
 *June 17, 2021*
@@ -24,7 +25,7 @@ v4.25.0
 *June 9, 2021*
 
 ### Added
-- Added a link “Just Eat for Business” to the bottom of the “Get to know us” column for the UK. 
+- Added a link “Just Eat for Business” to the bottom of the “Get to know us” column for the UK.
 
 
 v4.24.1
@@ -132,7 +133,7 @@ v4.15.0
 ------------------------------
 *March 30, 2021*
 
-## Fixed
+### Fixed
 - Confianza computed styles.
 
 
@@ -140,7 +141,7 @@ v4.14.0
 ------------------------------
 *March 25, 2021*
 
-## Changed
+### Changed
 - 'Footer' to use CSS modules.
 
 
@@ -148,10 +149,10 @@ v4.13.0
 ------------------------------
 *March 25, 2021*
 
-## Added
+### Added
 - 'headings.scss' and 'lists.scss' to assets.
 
-## Changed
+### Changed
 - Components to use shared scss assets.
 - Add test-ids to `IconList`.
 - Tests to cover changes
@@ -161,7 +162,7 @@ v4.12.0
 ------------------------------
 *March 18, 2021*
 
-## Added
+### Added
 - Courier links and country selector component tests for tenants: 'ie', 'nz', 'dk', 'es', 'it', 'no',
 - Canada(FR) to dropdown country selector list
 - Accessibility tests for the above tenants
@@ -171,14 +172,15 @@ v4.11.0
 ------------------------------
 *March 15, 2021*
 
-## Changed
+### Changed
 - Updated links to match SiteCore
+
 
 v4.10.0
 ------------------------------
 *March 12, 2021*
 
-## Added
+### Added
 - Browserstack test config in `package.json`
 
 ### Changed
@@ -189,7 +191,7 @@ v4.9.1
 ------------------------------
 *March 3, 2021*
 
-## Fixed
+### Fixed
 - Mobile Link lists collapse on scroll
 
 ### Added
@@ -200,7 +202,7 @@ v4.9.0
 ------------------------------
 *March 2, 2021*
 
-## Added
+### Added
 - Codice Etico (Ethical Code) link added for Italy
 
 ### Changed

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -145,7 +145,7 @@ v4.10.0
 ------------------------------
 *March 12, 2021*
 
-## Added
+### Added
 - Browserstack test config in `package.json`
 
 ### Changed

--- a/packages/components/organisms/f-registration/CHANGELOG.md
+++ b/packages/components/organisms/f-registration/CHANGELOG.md
@@ -66,7 +66,7 @@ v0.53.0
 ------------------------------
 *May 11, 2021*
 
-### Changes
+### Changed
 - Switched from Axios and Axios Mock Adapter to f-http
 
 
@@ -85,7 +85,7 @@ v0.51.0
 ------------------------------
 *April 15, 2021*
 
-### Changes
+### Changed
 - Error messages retrieved from i18n files.
 
 
@@ -118,53 +118,38 @@ v0.49.1
 ### Added
 - `f-wdio-utils` npm package to package.json
 
+
 v0.49.0
 ------------------------------
 *March 19, 2021*
 
-## Added
+### Added
 - Add translations for 'en-AU' and 'en-NZ'
+
 
 v0.48.0
 ------------------------------
 *March 18, 2021*
 
-## Removed
+### Removed
 - Remove 'en-GB' as the default value for `props.locale.default`
+
 
 v0.47.0
 ------------------------------
 *March 12, 2021*
 
-## Added
+### Added
 - Browserstack test config in `package.json`
+- Axios mocks for Storybook
+- 'email in use' component test
+- `f-wdio-utils` npm package to `f-registration-component`
+- `selector.js` file for referencing attributes
 
 ### Changed
 - Restructured component tests to support Browserstack
-
-*March 8, 2021*
-
-### Added
-- Axios mocks for Storybook
-- 'email in use' component test
-
-*February 4, 2021*
-
-### Added
-- `f-wdio-utils` npm package to `f-registration-component`
-
-*February 4, 2021*
-
-### Changed
 - component feature tests
 - component object into a class that imports `page.object`
-
-### Added
-- `selector.js` file for referencing attributes
-
-*January 12, 2021*
-
-### Changed
 - Update axios version for security advisory.
 - Use latest version of `f-form-field`.
   - Updated tests to handle new `data-test-id` attributes.
@@ -301,14 +286,10 @@ v0.39.0
 
 ### Changed
 - Added f-error-message for inline registration page errors
-
-*October 28, 2020*
+- 'jet' theme instead of 'je'
 
 ### Added
 - Stylelint added to lint styling on build.
-
-### Changed
-- 'jet' theme instead of 'je'
 
 ### Removed
 - System test mocks

--- a/packages/tools/f-vue-icons/CHANGELOG.md
+++ b/packages/tools/f-vue-icons/CHANGELOG.md
@@ -72,7 +72,7 @@ v2.0.0
 - Chevron split icon.
 - Moped icon.
 
-## Changed
+### Changed
 - Updated npm dependencies.
 - Updated alert icon.
 - Updated celebrate bag icon.

--- a/packages/tools/generator-component/CHANGELOG.md
+++ b/packages/tools/generator-component/CHANGELOG.md
@@ -109,7 +109,7 @@ v1.8.0
 ------------------------------
 *November 26, 2020*
 
-## Added
+### Added
 - Stub CSS files in jest.
 
 


### PR DESCRIPTION
### Changed
- Decrease maximum allowed package size for atoms and molecules.

### Fixed
- Changelog formatting across the monorepo