### PR TITLE
f-alert@v0.7.0 – Updating f-button dependency

### DIFF
--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.7.0
+------------------------------
+*July 14, 2021*
+
+### Changed
+- Updated version of `f-button`.
+- Close button now uses type `ghostTertiary`.
+
+
 v0.6.1
 ------------------------------
 *June 09, 2021*

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-alert",
   "description": "Fozzie Alert – Fozzie Alert Component",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "main": "dist/f-alert.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [
@@ -52,7 +52,7 @@
     "@vue/test-utils": "1.0.3",
     "@justeat/f-wdio-utils": "0.2.0",
     "node-sass-magic-importer": "5.3.2",
-    "@justeat/f-button": "0.4.1",
+    "@justeat/f-button": "1.9.0",
     "@justeat/f-vue-icons": "1.13.0"
   }
 }

--- a/packages/components/molecules/f-alert/src/components/Alert.vue
+++ b/packages/components/molecules/f-alert/src/components/Alert.vue
@@ -21,9 +21,10 @@
             <f-button
                 v-if="isDismissible"
                 type="button"
+                is-icon
                 :class="[$style['c-alert-dismiss']]"
-                button-type="icon"
                 button-size="xsmall"
+                button-type="ghostTertiary"
                 data-test-id="alert-dismiss"
                 @click.native="dismiss">
                 <cross-icon
@@ -179,7 +180,7 @@ $alert-borderRadius: $border-radius;
         .c-alert-dismiss-icon {
             height: 16px;
 
-            * {
+            path {
                 fill: $color-content-subdued;
             }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2187,6 +2187,13 @@
     eslint-config-airbnb-base "14.1.0"
     eslint-plugin-vue "6.2.2"
 
+"@justeat/f-alert@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@justeat/f-alert/-/f-alert-0.6.1.tgz#b9360a12dad46ddd1024d40095ca7b32f1256f07"
+  integrity sha512-sYTy+fFmL7Aa+kGEQhmVyZPkrEFm0azhTg0QtbFpHfJGNFIN8wu7hMUCaALKoKD479g/GHWw6ODFOJaKeSyiVg==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+
 "@justeat/f-button@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-0.4.1.tgz#6b735093286422f579bd41cee93400a4d32d1b2d"


### PR DESCRIPTION
### Changed
- Updated version of `f-button`.
- Close button now uses type `ghostTertiary`.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [updated]

## Browsers Tested

- [x] Chrome (latest)
