### PR TITLE
f-mega-modal@v0.11.0 – Updating f-button dependency

### DIFF
--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.11.0
+------------------------------
+*July 14, 2021*
+
+### Changed
+- Updated version of `f-button`.
+- Close button now uses type `ghostTertiary`.
+
+
 v0.10.0
 ------------------------------
 *May 25, 2021*

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "main": "dist/f-mega-modal.common.js",
-  "maxBundleSize": "5kB",
+  "maxBundleSize": "6kB",
   "files": [
     "dist"
   ],
@@ -43,14 +43,14 @@
     "body-scroll-lock": "3.x"
   },
   "devDependencies": {
-    "@justeat/f-button": "1.1.0",
+    "@justeat/f-button": "1.9.0",
     "@justeat/f-vue-icons": "2.4.0",
+    "@justeat/f-wdio-utils": "0.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
     "@vue/test-utils": "1.0.3",
-    "@justeat/f-wdio-utils": "0.2.0",
     "body-scroll-lock": "3.0.3",
     "node-sass-magic-importer": "5.3.2"
   }

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -34,7 +34,7 @@
                         :class="[$style['c-megaModal-closeBtn'], {
                             [$style['c-megaModal-closeBtn--fixed']]: isCloseFixed || isFullHeight
                         }]"
-                        button-type="secondary"
+                        button-type="ghostTertiary"
                         button-size="xsmall"
                         data-test-id="close-modal"
                         @click.native="close">
@@ -398,10 +398,6 @@ export default {
 
     .c-megaModal-closeBtn--fixed {
         position: fixed;
-    }
-
-    .c-megaModal-closeIcon * {
-        fill: $color-content-link;
     }
 }
 


### PR DESCRIPTION
### Changed
- Updated version of `f-button`.
- Close button now uses type `ghostTertiary`.

---

## UI Review Checks

- [x] README and/or UI Documentation has been updated

## Browsers Tested

- [x] Chrome (latest)
