### PR TITLE
f-searchbox@v4.0.0-beta.31 – Updating f-button dependency

### DIFF
--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.0.0-beta.31
+------------------------------
+*July 14, 2021*
+
+### Changed
+- Updated version of `f-button` and buttonType changed to `ghost`.
+
+
 v4.0.0-beta.30
 ------------------------------
 *May 26, 2021*
@@ -206,7 +214,7 @@ v4.0.0-beta.13
 *January 05, 2021*
 
 ### Fixed
-- DK & NO field options - provides component with custom attributes, 
+- DK & NO field options - provides component with custom attributes,
 supplied via tenant config `addressField`.
 - DK & NO uses the `where` form value now.
 - Google test from failing silently in CI.

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-searchbox",
   "description": "Fozzie Searchbox – Just Eat Takeaway Global Searchbox",
-  "version": "4.0.0-beta.30",
+  "version": "4.0.0-beta.31",
   "main": "dist/f-searchbox.umd.min.js",
   "maxBundleSize": "60kB",
   "files": [
@@ -36,7 +36,7 @@
     "lint:style": "vue-cli-service lint:style",
     "test": "vue-cli-service test:unit",
     "test-component:browserstack": "cross-env-shell JE_ENV=browserstack TEST_TYPE=component wdio ../../../../wdio-browserstack.conf.js --mochaOpts.grep '@browserstack'",
-    "test-component:chrome": "cross-env-shell JE_ENV=local TEST_TYPE=component wdio ../../../../wdio-chrome.conf.js", 
+    "test-component:chrome": "cross-env-shell JE_ENV=local TEST_TYPE=component wdio ../../../../wdio-chrome.conf.js",
     "test-a11y:chrome": "cross-env-shell JE_ENV=local TEST_TYPE=a11y wdio ../../../../wdio-chrome.conf.js --suite a11y"
   },
   "scriptsInfo": {
@@ -59,7 +59,7 @@
     "vuex": "3.5.1"
   },
   "devDependencies": {
-    "@justeat/f-button": "0.7.0",
+    "@justeat/f-button": "1.9.0",
     "@justeat/f-error-message": "0.3.1",
     "@justeat/f-globalisation": "0.2.0",
     "@justeat/f-mega-modal": "0.3.0",

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchField.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchField.vue
@@ -34,6 +34,8 @@
 
             <clear-button
                 v-if="shouldDisplayClearButton"
+                is-icon
+                button-type="ghost"
                 :class="$style['c-search-btn-clear']"
                 data-test-id="search-btn-clear"
                 @click="onClearAddress">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2199,11 +2199,6 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-0.4.1.tgz#6b735093286422f579bd41cee93400a4d32d1b2d"
   integrity sha512-SL7eTooEY3gZ0DdpPJvsN9W9EZElgxkSEpjYPfiPBHbkGt31Yfnb8OmDmC6MAtlK3Nq5GM5KaZ7bXybljSlPeA==
 
-"@justeat/f-button@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-0.7.0.tgz#cb4afe9e8773385e5ad84b50f51de90a8020ce69"
-  integrity sha512-Wkhuks8mcjUixpssKX68h7o8ICMQTuKa/BF52SV+MUR0pVw7XuiB8DvTv7GSnpbwec5Fp49IjRWJ9T3wrkXUsw==
-
 "@justeat/f-button@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-1.1.0.tgz#204a5477a081e999ed4e5416772758233b1fb8a7"


### PR DESCRIPTION
### Changed
- Updated version of `f-button` and buttonType changed to `ghost`.

---

## Browsers Tested

- [x] Chrome (latest)
