### PR TITLE
f-checkout@v0.160.0 - Remove page data and push event

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.160.0
+------------------------------
+*July 15, 2021*
+
+### Removed
+- `pageData` from `trackInitialLoad` in the analytics module.
+
+### Added
+- `CheckoutMounted` event.
+
+
 v0.159.0
 ------------------------------
 *July 12, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.159.0",
+  "version": "0.160.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -508,6 +508,7 @@ export default {
 
         await this.initialise();
         this.trackInitialLoad();
+        this.$emit(EventNames.CheckoutMounted);
     },
 
     methods: {

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -1157,6 +1157,14 @@ describe('Checkout', () => {
             // Assert
             expect(trackInitialLoadSpy).toHaveBeenCalled();
         });
+
+        it('should emit `CheckoutMounted` event', async () => {
+            // Act
+            await wrapper.vm.initialise();
+
+            // Assert
+            expect(wrapper.emitted(EventNames.CheckoutMounted).length).toBe(1);
+        });
     });
 
     describe('methods ::', () => {

--- a/packages/components/organisms/f-checkout/src/event-names.js
+++ b/packages/components/organisms/f-checkout/src/event-names.js
@@ -18,6 +18,7 @@ const CheckoutUpdateSuccess = 'checkout-update-success';
 const CheckoutUpdateFailure = 'checkout-update-failure';
 const CheckoutCustomerGetSuccess = 'checkout-customer-get-success';
 const CheckoutCustomerGetFailure = 'checkout-customer-get-failure';
+const CheckoutMounted = 'checkout-mounted';
 
 export default {
     CheckoutSuccess,
@@ -39,5 +40,6 @@ export default {
     CheckoutUpdateSuccess,
     CheckoutUpdateFailure,
     CheckoutCustomerGetSuccess,
-    CheckoutCustomerGetFailure
+    CheckoutCustomerGetFailure,
+    CheckoutMounted
 };

--- a/packages/components/organisms/f-checkout/src/store/checkoutAnalytics.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkoutAnalytics.module.js
@@ -52,8 +52,6 @@ export default {
                 return;
             }
 
-            const pageName = rootState[VUEX_CHECKOUT_MODULE].isLoggedIn ? 'Overview' : 'Guest';
-
             window.dataLayer.push({
                 checkout: {
                     step: 1
@@ -62,10 +60,6 @@ export default {
                 restaurant: {
                     id: rootState[VUEX_CHECKOUT_MODULE].restaurant.id,
                     seoName: rootState[VUEX_CHECKOUT_MODULE].restaurant.seoName
-                },
-                pageData: {
-                    name: `Checkout 1 ${pageName}`,
-                    group: 'Checkout'
                 },
                 menu: {
                     type: rootState[VUEX_CHECKOUT_MODULE].serviceType

--- a/packages/components/organisms/f-checkout/src/store/tests/checkoutAnalytics.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkoutAnalytics.module.test.js
@@ -189,10 +189,6 @@ describe('CheckoutAnalyticsModule', () => {
                         id: rootState[VUEX_CHECKOUT_MODULE].restaurant.id,
                         seoName: rootState[VUEX_CHECKOUT_MODULE].restaurant.seoName
                     },
-                    pageData: {
-                        name: 'Checkout 1 Guest',
-                        group: 'Checkout'
-                    },
                     menu: {
                         type: rootState[VUEX_CHECKOUT_MODULE].serviceType
                     }
@@ -205,38 +201,6 @@ describe('CheckoutAnalyticsModule', () => {
 
                 // Assert
                 expect(window.dataLayer[0]).toEqual(expectedEvent);
-            });
-
-            describe('when user `isLoggedIn` is true', () => {
-                it('should set `name` to `Checkout 1 Overview`', () => {
-                    // Arrange
-                    const expectedName = 'Checkout 1 Overview';
-
-                    rootState[VUEX_CHECKOUT_MODULE].isLoggedIn = true;
-                    expectedEvent.pageData.name = expectedName;
-
-                    // Act
-                    trackInitialLoad({ rootState, dispatch });
-
-                    // Assert
-                    expect(window.dataLayer[0]).toEqual(expectedEvent);
-                });
-            });
-
-            describe('when user `isLoggedIn` is false', () => {
-                it('should set `name` to `Checkout 1 Guest`', () => {
-                    // Arrange
-                    const expectedName = 'Checkout 1 Guest';
-
-                    rootState[VUEX_CHECKOUT_MODULE].isLoggedIn = false;
-                    expectedEvent.pageData.name = expectedName;
-
-                    // Act
-                    trackInitialLoad({ rootState, dispatch });
-
-                    // Assert
-                    expect(window.dataLayer[0]).toEqual(expectedEvent);
-                });
             });
 
             it('should dispatch `trackFormInteraction` with `start` action', () => {


### PR DESCRIPTION
### Removed
- `pageData` from `trackInitialLoad` in the analytics module.

### Added
- `CheckoutMounted` event.