### PR TITLE
f-checkout@0.162.0 - Ensure coordinates are fetched when address in local storage is changed

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.161.0
+------------------------------
+*July 19, 2021*
+
+### Fixed
+- Ensure coordinates are always retrieved from local storage or fetched from API.
+
+
 v0.160.0
 ------------------------------
 *July 15, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.161.0",
+  "version": "0.162.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.160.0",
+  "version": "0.161.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [

--- a/packages/components/organisms/f-checkout/src/store/checkout.module.js
+++ b/packages/components/organisms/f-checkout/src/store/checkout.module.js
@@ -394,7 +394,7 @@ export default {
                 const storedAddress = addressService.getAddressFromLocalStorage(false);
 
                 if (addressService.doesAddressInStorageAndFormMatch(storedAddress, state.address)) {
-                    addressCoords = [storedAddress.Field2, storedAddress.Field1];
+                    addressCoords = storedAddress.Field1 && storedAddress.Field2 ? [storedAddress.Field2, storedAddress.Field1] : null;
                     commit(UPDATE_GEO_LOCATION, addressCoords);
                 } else {
                     const addressDetails = state.address;

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -1118,7 +1118,7 @@ describe('CheckoutModule', () => {
                         }
                     };
 
-                    window.localStorage.setItem('je-full-address-details', JSON.stringify({...storedAddress, Field1: null, Field2: null }));
+                    window.localStorage.setItem('je-full-address-details', JSON.stringify({ ...storedAddress, Field1: null, Field2: null }));
 
                     // Act
                     await getGeoLocation({ ...context, state: newState }, payload);

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -1106,6 +1106,27 @@ describe('CheckoutModule', () => {
                     expect(commit).toHaveBeenCalledWith(UPDATE_GEO_LOCATION, geoLocationDetails.geometry.coordinates);
                 });
 
+                it(`should get the geo location details from the backend and call ${UPDATE_GEO_LOCATION} mutation if local storage has no stored coordinates`, async () => {
+                    // Arrange
+                    const newState = {
+                        ...state,
+                        address: {
+                            line1: 'Flat 101',
+                            line2: 'Made Up House',
+                            locality: 'London',
+                            postcode: 'NW2 3PE'
+                        }
+                    };
+
+                    window.localStorage.setItem('je-full-address-details', JSON.stringify({...storedAddress, Field1: null, Field2: null }));
+
+                    // Act
+                    await getGeoLocation({ ...context, state: newState }, payload);
+
+                    // Assert
+                    expect(commit).toHaveBeenCalledWith(UPDATE_GEO_LOCATION, geoLocationDetails.geometry.coordinates);
+                });
+
                 describe('When the address in localStorage does not match the address `state`', () => {
                     it('should update localStorage to the changed address', async () => {
                         // Arrange


### PR DESCRIPTION
### Fixed
- Ensure coordinates are always retrieved from local storage or fetched from API.
  