### PR TITLE
f-braze-adapter@v4.0.0-beta.3

### DIFF
--- a/packages/services/f-braze-adapter/CHANGELOG.md
+++ b/packages/services/f-braze-adapter/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.0.0-beta.3
+------------------------------
+*July 20, 2021*
+
+### Changed
+- Changed how braze adapter is initialised, it is no longer async
+- Increased Braze sdk to the latest version
+- Modified tests to account for changes
+- Made Braze SDK a peer dependency
+
+
 v4.0.0-beta.2
 ------------------------------
 *July 19, 2021*

--- a/packages/services/f-braze-adapter/babel.config.js
+++ b/packages/services/f-braze-adapter/babel.config.js
@@ -3,7 +3,8 @@ module.exports = api => {
     const isTest = api.env('test');
     const presets = [];
     const plugins = [
-        '@babel/plugin-proposal-optional-chaining'
+        '@babel/plugin-proposal-optional-chaining',
+        '@babel/plugin-proposal-class-properties' // https://babeljs.io/docs/en/babel-plugin-syntax-class-properties
     ];
 
     if (isTest) {

--- a/packages/services/f-braze-adapter/package.json
+++ b/packages/services/f-braze-adapter/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@justeat/f-braze-adapter",
   "description": "Fozzie Metadata Service",
-  "version": "4.0.0-beta.2",
-  "main": "src/index.js",
+  "version": "4.0.0-beta.3",
+  "main": "dist/f-braze-adapter.umd.js",
   "files": [
-    "src"
+    "dist"
   ],
   "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/services/f-braze-adapter",
   "contributors": [
@@ -25,7 +25,8 @@
     "fozzie"
   ],
   "scripts": {
-    "prepublishOnly": "yarn lint:fix && yarn test",
+    "prepublishOnly": "yarn lint:fix && yarn test && yarn build",
+    "build": "vite build",
     "lint": "vue-cli-service lint --no-fix",
     "lint:fix": "yarn lint --fix",
     "test": "vue-cli-service test:unit",
@@ -35,7 +36,6 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "appboy-web-sdk": "2.5.2",
     "date-fns": "2.16.1",
     "lodash.findindex": "4.6.0",
     "lodash.orderby": "4.6.0",
@@ -43,15 +43,18 @@
     "lodash.uniq": "4.5.0"
   },
   "devDependencies": {
+    "@braze/web-sdk": "3.3.0",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
     "core-js": "3.6.5",
     "jest-extended": "0.11.5",
     "mockdate": "3.0.2",
-    "js-cookie": "2.2.1"
+    "js-cookie": "2.2.1",
+    "vite": "2.4.2"
   },
   "peerDependencies": {
-    "js-cookie": ">=2.2.1"
+    "js-cookie": ">=2.2.1",
+    "@braze/web-sdk": "3.3.0"
   }
 }

--- a/packages/services/f-braze-adapter/package.json
+++ b/packages/services/f-braze-adapter/package.json
@@ -3,6 +3,7 @@
   "description": "Fozzie Metadata Service",
   "version": "4.0.0-beta.3",
   "main": "dist/f-braze-adapter.umd.js",
+  "module": "dist/f-braze-adapter.es.js",
   "files": [
     "dist"
   ],
@@ -43,7 +44,7 @@
     "lodash.uniq": "4.5.0"
   },
   "devDependencies": {
-    "@braze/web-sdk": "^3.3.0",
+    "@braze/web-sdk": ">=3.3.0",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
@@ -55,6 +56,6 @@
   },
   "peerDependencies": {
     "js-cookie": ">=2.2.1",
-    "@braze/web-sdk": "^3.3.0"
+    "@braze/web-sdk": ">=3.3.0"
   }
 }

--- a/packages/services/f-braze-adapter/package.json
+++ b/packages/services/f-braze-adapter/package.json
@@ -44,7 +44,7 @@
     "lodash.uniq": "4.5.0"
   },
   "devDependencies": {
-    "@braze/web-sdk": ">=3.3.0",
+    "@braze/web-sdk": "^3.3.0",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",

--- a/packages/services/f-braze-adapter/package.json
+++ b/packages/services/f-braze-adapter/package.json
@@ -43,7 +43,7 @@
     "lodash.uniq": "4.5.0"
   },
   "devDependencies": {
-    "@braze/web-sdk": "3.3.0",
+    "@braze/web-sdk": "^3.3.0",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
@@ -55,6 +55,6 @@
   },
   "peerDependencies": {
     "js-cookie": ">=2.2.1",
-    "@braze/web-sdk": "3.3.0"
+    "@braze/web-sdk": "^3.3.0"
   }
 }

--- a/packages/services/f-braze-adapter/src/BrazeAdapter.js
+++ b/packages/services/f-braze-adapter/src/BrazeAdapter.js
@@ -1,21 +1,7 @@
 import GetConsumerRegistry from './services/BrazeConsumerRegistry';
 
 export default class BrazeAdapter {
-    /**
-     * Initializes the braze adapter and returns instance of the braze adapter class
-     * @param apiKey
-     * @param userId
-     * @param enableLogging
-     * @param sessionTimeout
-     * @param enabledCardTypes
-     * @param brands
-     * @param callbacks
-     * @param interceptInAppMessages
-     * @param interceptInAppMessageClickEvents
-     * @param customFilters
-     * @returns {Promise<BrazeAdapter>}
-     */
-    static async initialise ({
+    constructor ({
         apiKey,
         userId,
         enableLogging,
@@ -25,44 +11,10 @@ export default class BrazeAdapter {
         callbacks,
         interceptInAppMessages,
         interceptInAppMessageClickEvents,
-        customFilters
-    }) {
-        const registry = await GetConsumerRegistry({
-            apiKey,
-            userId,
-            enableLogging,
-            sessionTimeout
-        });
-
-        return new BrazeAdapter({
-            enabledCardTypes,
-            brands,
-            callbacks,
-            interceptInAppMessages,
-            interceptInAppMessageClickEvents,
-            customFilters,
-            registry
-        });
-    }
-
-    get dispatcher () {
-        return this._consumerRegistry.dispatcher;
-    }
-
-    constructor ({
-        enabledCardTypes,
-        brands,
-        callbacks,
-        interceptInAppMessages,
-        interceptInAppMessageClickEvents,
         customFilters,
-        loggerCallbacks,
-        registry
+        loggerCallbacks
     }) {
-        // create / get the registry
-        this._consumerRegistry = registry;
-        // register the consumer
-        this._consumer = this._consumerRegistry.register({
+        const consumerOptions = {
             enabledCardTypes,
             brands,
             callbacks,
@@ -70,7 +22,20 @@ export default class BrazeAdapter {
             interceptInAppMessageClickEvents,
             customFilters,
             loggerCallbacks
+        };
+
+        this._consumerRegistry = GetConsumerRegistry({
+            apiKey,
+            userId,
+            enableLogging,
+            sessionTimeout
         });
+
+        this._consumer = this._consumerRegistry.register(consumerOptions);
+    }
+
+    get dispatcher () {
+        return this._consumerRegistry.dispatcher;
     }
 
     /**

--- a/packages/services/f-braze-adapter/src/index.js
+++ b/packages/services/f-braze-adapter/src/index.js
@@ -1,4 +1,4 @@
 import BrazeAdapter from './BrazeAdapter';
 
-export default BrazeAdapter.initialise;
+export default BrazeAdapter;
 

--- a/packages/services/f-braze-adapter/src/services/BrazeConsumerRegistry.js
+++ b/packages/services/f-braze-adapter/src/services/BrazeConsumerRegistry.js
@@ -23,23 +23,22 @@ class BrazeConsumerRegistry {
      * @return {BrazeConsumerRegistry}
      * @constructor
      */
-    static async GetConsumerRegistry ({
+    static GetConsumerRegistry ({
         sessionTimeout = sessionTimeoutInSeconds,
         apiKey,
         userId,
         enableLogging
     }) {
         if (!registryInstance) {
-            const dispatcher = new BrazeDispatcher(sessionTimeout);
+            const dispatcher = new BrazeDispatcher({
+                sessionTimeout,
+                apiKey,
+                userId,
+                enableLogging
+            });
 
             registryInstance = new BrazeConsumerRegistry(dispatcher);
         }
-
-        await registryInstance.dispatcher.configure({
-            apiKey,
-            userId,
-            enableLogging
-        });
 
         return registryInstance;
     }
@@ -52,9 +51,9 @@ class BrazeConsumerRegistry {
         this.consumers = [];
 
         // subscribe to event stream for braze cards and messages
-        dispatcherEventStream.subscribe(CONTENT_CARDS_EVENT_NAME, this.applyContentCardCallbacks);
-        dispatcherEventStream.subscribe(IN_APP_MESSAGE_EVENT_NAME, this.applyInAppMessageCallbacks);
-        dispatcherEventStream.subscribe(IN_APP_MESSAGE_EVENT_CLICKS_NAME, this.applyInAppMessageClickEventsCallbacks);
+        dispatcherEventStream.subscribe(CONTENT_CARDS_EVENT_NAME, cards => this.applyContentCardCallbacks(cards));
+        dispatcherEventStream.subscribe(IN_APP_MESSAGE_EVENT_NAME, message => this.applyInAppMessageCallbacks(message));
+        dispatcherEventStream.subscribe(IN_APP_MESSAGE_EVENT_CLICKS_NAME, message => this.applyInAppMessageClickEventsCallbacks(message));
         dispatcherEventStream.subscribe(LOGGER, log => this.applyLoggerCallbacks(...log));
 
         this._dispatcher = dispatcher;

--- a/packages/services/f-braze-adapter/src/services/_tests/BrazeDispatcher.node.test.js
+++ b/packages/services/f-braze-adapter/src/services/_tests/BrazeDispatcher.node.test.js
@@ -1,10 +1,10 @@
 /**
  * @jest-environment node
  */
-import appboy from 'appboy-web-sdk';
+import appboy from '@braze/web-sdk';
 import BrazeDispatcher from '../BrazeDispatcher';
 
-jest.mock('appboy-web-sdk', () => ({
+jest.mock('@braze/web-sdk', () => ({
     initialize: jest.fn()
 }));
 jest.mock('../utils/isAppboyInitialised');
@@ -22,8 +22,8 @@ describe('BrazeDispatcher › node', () => {
         expect.assertions(2);
 
         try {
-            const Dispatcher = new BrazeDispatcher(0);
-            await Dispatcher.configure({
+            // eslint-disable-next-line no-unused-vars
+            const Dispatcher = new BrazeDispatcher({
                 userId,
                 apiKey
             });

--- a/packages/services/f-braze-adapter/src/services/utils/_tests/isAppboyInitialised.test.js
+++ b/packages/services/f-braze-adapter/src/services/utils/_tests/isAppboyInitialised.test.js
@@ -1,40 +1,32 @@
+import appboy from '@braze/web-sdk';
 import isAppboyInitialised from '../isAppboyInitialised';
 
-const id = '__ID__';
-const getUserId = jest.fn();
-const appboy = {
-    getUser: () => ({
-        getUserId
-    })
-};
+jest.mock('@braze/web-sdk');
 
 describe('f-braze-adapter › isAppboyInitialised', () => {
     afterEach(() => {
         jest.resetAllMocks();
     });
 
-    it('should return false when appboy is undefined', async () => {
-        const isAppboyInitialisedReturn = await isAppboyInitialised();
-        expect(isAppboyInitialisedReturn).toBe(false);
-    });
-
-    it('should return false when getUser is undefined', async () => {
+    it('should return false when appboy is not initialised', () => {
         // Arrange
-        getUserId.mockImplementation(hasUserId => hasUserId(null));
+        appboy.getUser.mockImplementation(() => {
+            throw new Error('Appboy must be initialized before calling methods.');
+        });
 
         // Act
-        const isAppboyInitialisedReturn = await isAppboyInitialised(appboy);
+        const isAppboyInitialisedReturn = isAppboyInitialised();
 
         // Assert
         expect(isAppboyInitialisedReturn).toBe(false);
     });
 
-    it('should return true when getUserId returns a truthy value', async () => {
+    it('should return true when getUser does not throw exception', () => {
         // Arrange
-        getUserId.mockImplementation(hasUserId => hasUserId(id));
+        appboy.getUser.mockImplementation(() => jest.fn());
 
         // Act
-        const isAppboyInitialisedReturn = await isAppboyInitialised(appboy);
+        const isAppboyInitialisedReturn = isAppboyInitialised();
 
         // Assert
         expect(isAppboyInitialisedReturn).toBe(true);

--- a/packages/services/f-braze-adapter/src/services/utils/isAppboyInitialised.js
+++ b/packages/services/f-braze-adapter/src/services/utils/isAppboyInitialised.js
@@ -1,12 +1,18 @@
+import appboy from '@braze/web-sdk';
 /**
  * Checks if a previous version of appboy has been initialised
- * @param appboy - Appboy SDK instance
- * @param {function} appboy.getUser - Appboy SDK getUser callback
- * @returns {promise<boolean>} - has appboy been initialised
+ * @returns {boolean} - has appboy been initialised
  */
-const isAppboyInitialised = appboy => new Promise(resolve => {
-    if (!appboy) return resolve(false);
-    return appboy.getUser().getUserId(id => resolve(!!id));
-});
+const isAppboyInitialised = () => {
+    try {
+        appboy.getUser();
+    } catch (e) {
+        if (e.message === 'Appboy must be initialized before calling methods.') {
+            return false;
+        }
+    }
+    // will return true if above does not throw exception
+    return true;
+};
 
 export default isAppboyInitialised;

--- a/packages/services/f-braze-adapter/src/tests/BrazeAdapter.test.js
+++ b/packages/services/f-braze-adapter/src/tests/BrazeAdapter.test.js
@@ -41,27 +41,28 @@ describe('BrazeAdapter', () => {
             GetConsumerRegistry.mockReset();
         });
 
-        it('should create an instance of the BrazeAdapter', async () => {
+        it('should create an instance of the BrazeAdapter', () => {
             // Arrange
             GetConsumerRegistry.mockImplementation(() => ({
                 register: jest.fn()
             }));
 
             // Act
-            const brazeAdapter = await BrazeAdapter.initialise(mockConfig);
+            const brazeAdapter = new BrazeAdapter(mockConfig);
 
             // Assert
             expect(brazeAdapter).toBeInstanceOf(BrazeAdapter);
         });
 
-        it('should call the GetConsumerRegistry function', async () => {
+        it('should call the GetConsumerRegistry function', () => {
             // Arrange
             GetConsumerRegistry.mockImplementation(() => ({
                 register: jest.fn()
             }));
 
             // Act
-            await BrazeAdapter.initialise(mockConfig);
+            // eslint-disable-next-line no-unused-vars
+            const adapter = new BrazeAdapter(mockConfig);
 
             // Assert
             expect(GetConsumerRegistry).toHaveBeenCalledTimes(1);
@@ -70,36 +71,47 @@ describe('BrazeAdapter', () => {
         it('should handle errors in instantiating the consumer registry', async () => {
             // Arrange
             const error = new Error('Test error');
-            GetConsumerRegistry.mockImplementation(() => new Promise((resolve, reject) => {
-                reject(error);
-            }));
+            GetConsumerRegistry.mockImplementation(() => {
+                throw error;
+            });
+
+            function mockFunction () {
+                // eslint-disable-next-line no-unused-vars
+                const adapter = new BrazeAdapter(mockConfig);
+            }
 
             // Assert
-            expect(BrazeAdapter.initialise(mockConfig)).rejects.toEqual(error);
+            expect(mockFunction).toThrowError(error);
         });
 
         it('should handle errors in registering a consumer', async () => {
             // Arrange
+            const error = new Error('Test error');
             GetConsumerRegistry.mockImplementation(() => ({
                 register: () => {
-                    throw new Error('Test error');
+                    throw error;
                 }
             }));
 
+            function mockFunction () {
+                // eslint-disable-next-line no-unused-vars
+                const adapter = new BrazeAdapter(mockConfig);
+            }
+
             // Assert
-            expect(BrazeAdapter.initialise(mockConfig)).rejects.toThrowError('Test error');
+            expect(mockFunction).toThrowError(error);
         });
 
-        it('should NOT be a singleton class', async () => {
+        it('should NOT be a singleton class', () => {
             // Arrange
             GetConsumerRegistry.mockImplementation(() => ({
                 register: jest.fn()
             }));
 
             // Act
-            const brazeAdapter = await BrazeAdapter.initialise(mockConfig);
+            const brazeAdapter = new BrazeAdapter(mockConfig);
 
-            const brazeAdapter2 = await BrazeAdapter.initialise(mockConfig);
+            const brazeAdapter2 = new BrazeAdapter(mockConfig);
 
             // Assert
             expect(brazeAdapter).not.toEqual(brazeAdapter2);
@@ -113,7 +125,7 @@ describe('BrazeAdapter', () => {
 
         let brazeAdapter;
 
-        beforeEach(async () => {
+        beforeEach(() => {
             // Arrange
             GetConsumerRegistry.mockImplementation(() => ({
                 consumers: [],
@@ -126,7 +138,7 @@ describe('BrazeAdapter', () => {
                 unregister: jest.fn()
             }));
 
-            brazeAdapter = await BrazeAdapter.initialise(mockConfig);
+            brazeAdapter = new BrazeAdapter(mockConfig);
         });
 
         it('should pushShapedEventToDataLayer via dispatcher', () => {

--- a/packages/services/f-braze-adapter/vite.config.js
+++ b/packages/services/f-braze-adapter/vite.config.js
@@ -1,0 +1,24 @@
+// vite.config.js
+const path = require('path');
+
+module.exports = {
+    build: {
+        target: 'es2015',
+        lib: {
+            entry: path.resolve(__dirname, 'src/index.js'),
+            name: 'f-braze-adapter'
+        },
+        rollupOptions: {
+            // make sure to externalize deps that shouldn't be bundled
+            // into your library
+            external: ['@braze/web-sdk'],
+            output: {
+                // Provide global variables to use in the UMD build
+                // for externalized deps
+                globals: {
+                    '@braze/web-sdk': 'appboy'
+                }
+            }
+        }
+    }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,6 +1355,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@braze/web-sdk@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@braze/web-sdk/-/web-sdk-3.3.0.tgz#d5c6cf322ad2b8d7e7556834690cf7757f2b9434"
+  integrity sha512-mjor7k9g6wGF+q67k9r0NSjW7FGgYuRrsLTZzbEhK3u2uwqry4ngeuYmxZosJFqH19T+j7ZSvjkYb99+NYURLA==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -2186,6 +2191,18 @@
   dependencies:
     eslint-config-airbnb-base "14.1.0"
     eslint-plugin-vue "6.2.2"
+
+"@justeat/f-braze-adapter@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-braze-adapter/-/f-braze-adapter-3.4.0.tgz#bac8be899ccadac7573f0a8673bfa0694885348b"
+  integrity sha512-iJPs/izz9Ko42gZda4kGrDnH8IXRJhzdBzDRnUiBg3lGijURGx6xFsbbyagQgxEY70Uw/SdpStsF5SvpswQJNw==
+  dependencies:
+    appboy-web-sdk "2.5.2"
+    date-fns "2.16.1"
+    lodash.findindex "4.6.0"
+    lodash.orderby "4.6.0"
+    lodash.startswith "4.2.1"
+    lodash.uniq "4.5.0"
 
 "@justeat/f-button@0.4.1":
   version "0.4.1"
@@ -10679,6 +10696,11 @@ es6-shim@^0.35.5:
   version "0.35.6"
   resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.6.tgz#d10578301a83af2de58b9eadb7c2c9945f7388a0"
   integrity sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA==
+
+esbuild@^0.12.8:
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.12.15.tgz#9d99cf39aeb2188265c5983e983e236829f08af0"
+  integrity sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==
 
 esbuild@^0.9.3:
   version "0.9.7"
@@ -20127,7 +20149,7 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^8.1.10, postcss@^8.2.1:
+postcss@^8.1.10, postcss@^8.2.1, postcss@^8.3.5:
   version "8.3.5"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.5.tgz#982216b113412bc20a86289e91eb994952a5b709"
   integrity sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==
@@ -24790,6 +24812,18 @@ vite@2.1.2:
     rollup "^2.38.5"
   optionalDependencies:
     fsevents "~2.3.1"
+
+vite@2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.4.2.tgz#07d00615775c808530bc9f65641062b349b67929"
+  integrity sha512-2MifxD2I9fjyDmmEzbULOo3kOUoqX90A58cT6mECxoVQlMYFuijZsPQBuA14mqSwvV3ydUsqnq+BRWXyO9Qa+w==
+  dependencies:
+    esbuild "^0.12.8"
+    postcss "^8.3.5"
+    resolve "^1.20.0"
+    rollup "^2.38.5"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 vlq@^0.2.2:
   version "0.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,7 +1355,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@braze/web-sdk@3.3.0":
+"@braze/web-sdk@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@braze/web-sdk/-/web-sdk-3.3.0.tgz#d5c6cf322ad2b8d7e7556834690cf7757f2b9434"
   integrity sha512-mjor7k9g6wGF+q67k9r0NSjW7FGgYuRrsLTZzbEhK3u2uwqry4ngeuYmxZosJFqH19T+j7ZSvjkYb99+NYURLA==


### PR DESCRIPTION
Changing braze adapter to no longer be a dynamic import as it prevents it being used inside another component within this library, instead the `@braze/sdk` is listed as a peer dependency and dev dependency. I am also using vite to bundle the package as it also now needs to be bundled to be used within the offers component within this library. Vite was chosen as it was being used by `f-services`. Also changed is the braze SDK version I have now upgraded this to the latest version. 

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
