### PR TITLE
f-form-field@1.18.0 - Make test id for text area dynamic based on name attribute

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.18.0
+------------------------------
+*July 22, 2021*
+
+### Changed
+- Made text area data test id dynamic based on name attribute
+
+
 v1.17.0
 ------------------------------
 *July 19, 2021*

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "main": "dist/f-form-field.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -53,7 +53,7 @@
                     $style['c-formField-field--textarea'],
                     { [$style['c-formField--invalid']]: hasError }
                 ]"
-                data-test-id="formfield-textarea"
+                :data-test-id="testId.textarea"
                 v-on="listeners" />
 
             <input
@@ -229,11 +229,11 @@ export default {
 
         testId () {
             const formFieldName = this.$attrs.name;
-
             return {
                 container: formFieldName ? `formfield-${formFieldName}` : 'formfield-container',
                 input: formFieldName ? `formfield-${formFieldName}-input` : 'formfield-input',
-                label: formFieldName ? `formfield-${formFieldName}-label` : 'formfield-label'
+                label: formFieldName ? `formfield-${formFieldName}-label` : 'formfield-label',
+                textarea: formFieldName ? `formfield-${formFieldName}-textarea` : 'formfield-textarea'
             };
         },
 

--- a/packages/components/atoms/f-form-field/src/components/_tests/FormField.test.js
+++ b/packages/components/atoms/f-form-field/src/components/_tests/FormField.test.js
@@ -331,7 +331,7 @@ describe('FormField', () => {
                 expect(wrapper.attributes('data-test-id')).toBe(`formfield-${attrsData.attrs.name}`);
             });
 
-            it('should include attribute `name` in the generated input data-test-id when it is set', () => {
+            it('should include attribute `name` and an `input` suffix` in the generated input data-test-id when it is set', () => {
                 // Arrange
                 const attrsData = {
                     attrs: {
@@ -345,6 +345,24 @@ describe('FormField', () => {
 
                 // Assert
                 expect(formInput.attributes('data-test-id')).toBe(`formfield-${attrsData.attrs.name}-input`);
+            });
+
+            it('should include attribute `name` and a `textarea` suffix in the generated textarea data-test-id when it is set', () => {
+                // Arrange
+                const attrs = {
+                    name: 'email'
+                };
+
+                const propsData = {
+                    inputType: 'textarea'
+                };
+
+                // Act
+                const wrapper = mount(FormField, { attrs, propsData });
+                const formInput = wrapper.find('textarea');
+
+                // Assert
+                expect(formInput.attributes('data-test-id')).toBe(`formfield-${attrs.name}-textarea`);
             });
 
             it('when name is set, it should be included in the generated testId.input data-test-id', () => {


### PR DESCRIPTION
Like we do with the input, I have removed the hardcoding of the test id on the text area and it is now based on the attribute name.