### PR TITLE
f-content-cards@4.8.0 📦 Bumps version of f-braze-adapter for new KVPs

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.8.0
+------------------------------
+*July 22, 2021*
+
+### Changed
+- Bumped version of f-braze-adapter to respect `is_visible` and `deduplication_key` KVPs
+- Marked Terms and Conditions card as Deprecated - as we're handling this in the For You component separately
+
+
 v4.7.0
 ------------------------------
 *June 10, 2021*

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "main": "dist/f-content-cards.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [
@@ -54,7 +54,7 @@
     "vue": "2.x"
   },
   "devDependencies": {
-    "@justeat/f-braze-adapter": "3.4.0",
+    "@justeat/f-braze-adapter": "3.5.0",
     "@justeat/f-vue-icons": "1.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
@@ -1,3 +1,4 @@
+<!-- DEPRECATED - we don't need this on the frontend anymore -->
 <template>
     <div
         :data-test-id="dataTestId('shell')"


### PR DESCRIPTION
v4.8.0
------------------------------
*July 22, 2021*

### Changed
- Bumped version of f-braze-adapter to respect `is_visible` and `deduplication_key` KVPs
- Marked Terms and Conditions card as Deprecated - as we're handling this in the For You component separately

---

## Browsers Tested

- [X] Chrome (latest)
- [X] Firefox (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

