### PR TITLE
f-button@1.10.1 vertical alignment fix for icon button

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.10.1
+------------------------------
+*July 23, 2021*
+
+### Removed
+- Extra wrapper around button text to fix `isIcon` button vertical alignment.
+
+
 v1.10.0
 ------------------------------
 *July 20, 2021*

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "main": "dist/f-button.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -19,8 +19,11 @@
             v-if="isLoading"
             :class="$style['c-spinner']"
             :data-test-id="`${componentType}-spinner`" />
+
         <span
-            :class="$style['o-button-content']">
+            :class="[$style['o-button-content'], {
+                [$style['o-btn-content--hidden']]: isLoading
+            }]">
 
             <span
                 v-if="hasLeadingIcon"
@@ -29,12 +32,7 @@
                 <slot name='leading-icon' />
             </span>
 
-            <span
-                :class="[$style['o-btn-text'], {
-                    [$style['o-btn-text--hidden']]: isLoading
-                }]">
-                <slot />
-            </span>
+            <slot />
 
             <span
                 v-if="hasTrailingIcon"
@@ -312,8 +310,8 @@ $btn-icon-sizeXSmall-iconSize          : 18px;
         align-items: center;
     }
 
-    // Visually hide button text (used for loading states)
-    .o-btn-text--hidden {
+    // Visually hide button content (used for loading states)
+    .o-btn-content--hidden {
         visibility: hidden;
     }
 

--- a/packages/components/organisms/f-loyalty/CHANGELOG.md
+++ b/packages/components/organisms/f-loyalty/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (to be added to next release)
+------------------------------
+*July 23, 2021*
+
+### Removed
+- Unused f-button and f-card component dev dependencies
+
+
 v0.2.0
 ------------------------------
 *July 20, 2021*

--- a/packages/components/organisms/f-loyalty/package.json
+++ b/packages/components/organisms/f-loyalty/package.json
@@ -58,8 +58,6 @@
     "@justeat/f-wdio-utils": "0.2.0",
     "@vue/test-utils": "1.0.3",
     "node-sass-magic-importer": "5.3.2",
-    "@justeat/f-button": "1.7.0",
-    "@justeat/f-card": "1.3.0",
     "@justeat/f-trak": "0.7.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2227,16 +2227,6 @@
   dependencies:
     "@justeat/f-services" "1.0.0"
 
-"@justeat/f-button@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-1.7.0.tgz#aa6aec60198623f95f59ab34b508362271976b2e"
-  integrity sha512-tICH7QOafDpUC/p9Lz015K/1UTSjak75BSLLvirA1LuL6CDkzweiqsYK9xm98LksdgwYL5qou2HAeYUDhGfTgQ==
-
-"@justeat/f-button@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-1.7.0.tgz#aa6aec60198623f95f59ab34b508362271976b2e"
-  integrity sha512-tICH7QOafDpUC/p9Lz015K/1UTSjak75BSLLvirA1LuL6CDkzweiqsYK9xm98LksdgwYL5qou2HAeYUDhGfTgQ==
-
 "@justeat/f-button@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-1.9.0.tgz#ff7f5dc0ccae943d80ba9affad29c89b11e18156"


### PR DESCRIPTION
## f-button@1.10.1:
### Removed
- Extra wrapper around button text to fix `isIcon` button vertical alignment.

## f-loyalty `#trivial`:
### Removed
- Unused f-button and f-card component dev dependencies