### PR TITLE
f-checkout@v0.165.0: Pass errorCode from UpdateCheckout to the log

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.165.0
+------------------------------
+*July 22, 2021*
+
+### Added
+- Added `x-je-feature` to header config in `services/orderPlacementApi`
+
 v0.164.0
 ------------------------------
 *July 22, 2021*

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.165.0
 ------------------------------
-*July 22, 2021*
+*July 26, 2021*
 
 ### Added
 - Added `x-je-feature` to header config in `services/orderPlacementApi`

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -8,7 +8,7 @@ v0.165.0
 *July 26, 2021*
 
 ### Added
-- Added `x-je-feature` to header config in `services/orderPlacementApi`
+- `errorCode` property for failed UpdateCheckout is passed to the log
 
 v0.164.0
 ------------------------------

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.164.0",
+  "version": "0.165.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -409,8 +409,7 @@ export default {
         * `state.AuthToken`, then retrieve the phone number from customer api
         * This can happen for newly created guest */
         shouldLoadCustomer () {
-            return this.isLoggedIn &&
-                !this.customer.mobileNumber;
+            return this.isLoggedIn && !this.customer.mobileNumber;
         },
 
         shouldShowCheckoutForm () {

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -2110,6 +2110,124 @@ describe('Checkout', () => {
                         result.rejects.toThrow(UpdateCheckoutError);
                         result.rejects.toThrow(errorMessage);
                     });
+
+                    it('should throw an `UpdateCheckoutError` error with the `errorCode` of the error', async () => {
+                        // Arrange
+                        const errorMessage = 'An error';
+                        const error = {
+                            message: errorMessage,
+                            response: {
+                                data: {
+                                    statusCode: 400,
+                                    errors: [{
+                                        description: 'From should be in ISO 8601 Zulu format.',
+                                        errorCode: 'FULFILMENT_TIME_INVALID'
+                                    }]
+                                }
+                            }
+                        };
+
+                        wrapper = mount(VueCheckout, {
+                            store: createStore(
+                                defaultCheckoutState,
+                                {
+                                    ...defaultCheckoutActions,
+                                    updateCheckout: jest.fn(async () => Promise.reject(error))
+                                }
+                            ),
+                            i18n,
+                            localVue,
+                            propsData,
+                            mocks: {
+                                $logger,
+                                $cookies
+                            }
+                        });
+
+                        // Act & Assert
+                        const result = await expect(wrapper.vm.handleUpdateCheckout());
+
+                        result.rejects.toHaveProperty('errorCode', 'FULFILMENT_TIME_INVALID');
+                    });
+
+                    it('should throw an `UpdateCheckoutError` error with comma separated `errorCode` of the error for multiple errors', async () => {
+                        // Arrange
+                        const errorMessage = 'An error';
+                        const error = {
+                            message: errorMessage,
+                            response: {
+                                data: {
+                                    statusCode: 400,
+                                    errors: [
+                                        {
+                                            description: 'The tenant is invalid',
+                                            errorCode: 'TENANT_INVALID'
+                                        },
+                                        {
+                                            description: 'From should be in ISO 8601 Zulu format.',
+                                            errorCode: 'FULFILMENT_TIME_INVALID'
+                                        }]
+                                }
+                            }
+                        };
+
+                        wrapper = mount(VueCheckout, {
+                            store: createStore(
+                                defaultCheckoutState,
+                                {
+                                    ...defaultCheckoutActions,
+                                    updateCheckout: jest.fn(async () => Promise.reject(error))
+                                }
+                            ),
+                            i18n,
+                            localVue,
+                            propsData,
+                            mocks: {
+                                $logger,
+                                $cookies
+                            }
+                        });
+
+                        // Act & Assert
+                        const result = await expect(wrapper.vm.handleUpdateCheckout());
+
+                        result.rejects.toHaveProperty('errorCode', 'TENANT_INVALID,FULFILMENT_TIME_INVALID');
+                    });
+
+                    it('should throw an `UpdateCheckoutError` error with empty `errorCode` if errors array is missing', async () => {
+                        // Arrange
+                        const errorMessage = 'An error';
+                        const error = {
+                            message: errorMessage,
+                            response: {
+                                data: {
+                                    statusCode: 400
+                                }
+                            }
+                        };
+
+                        wrapper = mount(VueCheckout, {
+                            store: createStore(
+                                defaultCheckoutState,
+                                {
+                                    ...defaultCheckoutActions,
+                                    updateCheckout: jest.fn(async () => Promise.reject(error))
+                                }
+                            ),
+                            i18n,
+                            localVue,
+                            propsData,
+                            mocks: {
+                                $logger,
+                                $cookies
+                            }
+                        });
+
+                        // Act & Assert
+                        const result = await expect(wrapper.vm.handleUpdateCheckout());
+
+                        result.rejects.toHaveProperty('errorCode', '');
+                    });
                 });
 
                 describe('AND there is no response object (e.g. timeout)', () => {

--- a/packages/components/organisms/f-checkout/src/exceptions/exceptions.js
+++ b/packages/components/organisms/f-checkout/src/exceptions/exceptions.js
@@ -3,6 +3,14 @@ import EventNames from '../event-names';
 import checkoutIssues from '../checkout-issues';
 import { CHECKOUT_ERROR_FORM_TYPE } from '../constants';
 
+const formatUpdateCheckoutErrorCode = error => {
+    const errorList = error?.response?.data?.errors ?? [];
+    const errorCodes = errorList.map(el => el.errorCode);
+    const result = errorCodes.join(',');
+
+    return result;
+};
+
 class CreateGuestUserError extends Error {
     constructor (message) {
         super(message);
@@ -19,6 +27,7 @@ class UpdateCheckoutError extends Error {
         this.messageKey = 'errorMessages.genericServerError';
         this.eventToEmit = EventNames.CheckoutUpdateFailure;
         this.logMessage = 'Checkout Update Failure';
+        this.errorCode = formatUpdateCheckoutErrorCode(error);
         this.shouldShowInDialog = false;
         this.traceId = error.response && error.response.data ? error.response.data.traceId : null;
     }


### PR DESCRIPTION
This PR adds errorCode property to log output so that we can identify underlying problems from UpdateCheckout when it fails by looking at logs

---

## UI Review Checks

No UI changes

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
