### PR TITLE
f-content-cards@v5.0.0-beta.1 - Adding in the new braze Adapter and making braze sdk peer dependency

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v5.0.0-beta.1
+------------------------------
+*July 26, 2021*
+
+### Changed
+- Updated content cards to use beta 4 of braze adapter
+- Updated tests to account for change in braze adapter
+
+
 v4.8.0
 ------------------------------
 *July 22, 2021*

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -52,10 +52,10 @@
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
     "vue": "2.x",
-    "@braze/web-sdk": "3.3.0"
+    "@braze/web-sdk": ">=3.3.0"
   },
   "devDependencies": {
-    "@braze/web-sdk": "3.3.0",
+    "@braze/web-sdk": "^3.3.0",
     "@justeat/f-braze-adapter": "4.0.0-beta.3",
     "@justeat/f-vue-icons": "1.2.0",
     "@justeat/f-wdio-utils": "0.2.0",

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "4.8.0",
+  "version": "5.0.0-beta.1",
   "main": "dist/f-content-cards.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [
@@ -51,17 +51,19 @@
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
-    "vue": "2.x"
+    "vue": "2.x",
+    "@braze/web-sdk": "3.3.0"
   },
   "devDependencies": {
-    "@justeat/f-braze-adapter": "3.5.0",
+    "@braze/web-sdk": "3.3.0",
+    "@justeat/f-braze-adapter": "4.0.0-beta.3",
     "@justeat/f-vue-icons": "1.2.0",
+    "@justeat/f-wdio-utils": "0.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
     "@vue/test-utils": "1.0.3",
-    "@justeat/f-wdio-utils": "0.2.0",
     "color": "3.1.3",
     "copy-to-clipboard": "3.3.1",
     "crypto-js": "4.0.0",

--- a/packages/components/organisms/f-content-cards/src/components/ContentCards.js
+++ b/packages/components/organisms/f-content-cards/src/components/ContentCards.js
@@ -1,4 +1,4 @@
-import initialiseMetadataDispatcher from '@justeat/f-braze-adapter';
+import BrazeAdapter from '@justeat/f-braze-adapter';
 import { globalisationServices } from '@justeat/f-services';
 import tenantConfigs from '../tenants';
 import {
@@ -132,7 +132,7 @@ export default {
             this.$emit(GET_CARD_COUNT, current.length);
 
             if (current.length && (current.length !== previous.length)) {
-                this.metadataDispatcher.logCardImpressions(this.cards.map(({ id }) => id));
+                this.brazeAdapter.logCardImpressions(this.cards.map(({ id }) => id));
             }
             if ((current.length > 0) && (previous.length === 0)) {
                 this.state = STATE_DEFAULT;
@@ -208,41 +208,39 @@ export default {
          * @return {Promise<void>}
          **/
         setupMetadata (apiKey, userId, enableLogging = false) {
-            return initialiseMetadataDispatcher({
-                apiKey,
-                userId,
-                enableLogging,
-                enabledCardTypes: [
-                    'Header_Card',
-                    'Promotion_Card_1',
-                    'Promotion_Card_2',
-                    'Recommendation_Card_1',
-                    'Restaurant_FTC_Offer_Card',
-                    'Voucher_Card_1',
-                    'Terms_And_Conditions_Card',
-                    'Terms_And_Conditions_Card_2',
-                    'Anniversary_Card_1',
-                    'Post_Order_Card_1',
-                    'Home_Promotion_Card_1',
-                    'Home_Promotion_Card_2',
-                    'Stamp_Card_1',
-                    'StampCard_Promotion_Card_1'
-                ],
-                brands: this.brands,
-                callbacks: {
-                    handleContentCards: this.metadataContentCards
-                },
-                loggerCallbacks: {
-                    logger: this.handleLogging(this.$logger)
-                }
-            })
-                .then(dispatcher => {
-                    this.metadataDispatcher = dispatcher;
-                })
-                .catch(error => {
-                    this.state = STATE_ERROR;
-                    this.$emit(ON_ERROR, error);
+            try {
+                this.brazeAdapter = new BrazeAdapter({
+                    apiKey,
+                    userId,
+                    enableLogging,
+                    enabledCardTypes: [
+                        'Header_Card',
+                        'Promotion_Card_1',
+                        'Promotion_Card_2',
+                        'Recommendation_Card_1',
+                        'Restaurant_FTC_Offer_Card',
+                        'Voucher_Card_1',
+                        'Terms_And_Conditions_Card',
+                        'Terms_And_Conditions_Card_2',
+                        'Anniversary_Card_1',
+                        'Post_Order_Card_1',
+                        'Home_Promotion_Card_1',
+                        'Home_Promotion_Card_2',
+                        'Stamp_Card_1',
+                        'StampCard_Promotion_Card_1'
+                    ],
+                    brands: this.brands,
+                    callbacks: {
+                        handleContentCards: this.metadataContentCards
+                    },
+                    loggerCallbacks: {
+                        logger: this.handleLogging(this.$logger)
+                    }
                 });
+            } catch (e) {
+                this.state = STATE_ERROR;
+                this.$emit(ON_ERROR, e);
+            }
         },
         /**
          * Common method for handling card ingestion to component. Card list length of 0 (after filtering) is considered
@@ -300,7 +298,7 @@ export default {
             switch (card.source) {
                 case CARDSOURCE_METADATA:
                     this.trackMetadataCardClick(card);
-                    this.metadataDispatcher.logCardClick(card.id);
+                    this.brazeAdapter.logCardClick(card.id);
                     break;
                 case CARDSOURCE_CUSTOM:
                     this.trackCustomCardClick(card);
@@ -333,7 +331,7 @@ export default {
          */
         trackMetadataCardClick (card) {
             const event = createMetadataCardEvent('click', card);
-            this.metadataDispatcher.pushShapedEventToDataLayer(this.pushToDataLayer, event);
+            this.brazeAdapter.pushShapedEventToDataLayer(this.pushToDataLayer, event);
         },
 
         /**
@@ -351,7 +349,7 @@ export default {
          */
         trackMetadataCardVisibility (card) {
             const event = createMetadataCardEvent('view', card);
-            this.metadataDispatcher.pushShapedEventToDataLayer(this.pushToDataLayer, event);
+            this.brazeAdapter.pushShapedEventToDataLayer(this.pushToDataLayer, event);
         },
 
         /**

--- a/packages/components/organisms/f-content-cards/src/components/ContentCards.js
+++ b/packages/components/organisms/f-content-cards/src/components/ContentCards.js
@@ -160,8 +160,8 @@ export default {
             }
         }
     },
-    async mounted () {
-        await this.setupMetadata(this.apiKey, this.userId);
+    mounted () {
+        this.setupMetadata(this.apiKey, this.userId);
     },
     /**
      * Sets up dependencies required by descendant components
@@ -205,7 +205,7 @@ export default {
          * @param {String} apiKey
          * @param {String} userId
          * @param {Boolean} enableLogging
-         * @return {Promise<void>}
+         * @return {void}
          **/
         setupMetadata (apiKey, userId, enableLogging = false) {
             try {

--- a/packages/components/organisms/f-content-cards/vue.config.js
+++ b/packages/components/organisms/f-content-cards/vue.config.js
@@ -6,6 +6,7 @@ const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    configureWebpack: { externals: ['@braze/web-sdk'] },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,6 +1407,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@braze/web-sdk@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@braze/web-sdk/-/web-sdk-3.3.0.tgz#d5c6cf322ad2b8d7e7556834690cf7757f2b9434"
+  integrity sha512-mjor7k9g6wGF+q67k9r0NSjW7FGgYuRrsLTZzbEhK3u2uwqry4ngeuYmxZosJFqH19T+j7ZSvjkYb99+NYURLA==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -2226,6 +2231,17 @@
   integrity sha512-sYTy+fFmL7Aa+kGEQhmVyZPkrEFm0azhTg0QtbFpHfJGNFIN8wu7hMUCaALKoKD479g/GHWw6ODFOJaKeSyiVg==
   dependencies:
     "@justeat/f-services" "1.0.0"
+
+"@justeat/f-braze-adapter@4.0.0-beta.3":
+  version "4.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@justeat/f-braze-adapter/-/f-braze-adapter-4.0.0-beta.3.tgz#af1dada6792b4afae8b8816f07fb3783ea7ea414"
+  integrity sha512-KvozKMihLb3L3tC+8TCqbbpCYgdxvsB/zwLdyt3cxG9fE0tNG2o2hcli6T1IScYS7MF5UEnpENwRtbq0cjDr4A==
+  dependencies:
+    date-fns "2.16.1"
+    lodash.findindex "4.6.0"
+    lodash.orderby "4.6.0"
+    lodash.startswith "4.2.1"
+    lodash.uniq "4.5.0"
 
 "@justeat/f-button@1.9.0":
   version "1.9.0"


### PR DESCRIPTION
Adding in the brazeAdapter v4.0.0-beta.3, making changes to the main ContentCards.js file to adjust to utilise the new braze adapter. Updated unit tests to account for the change in instantiation of the new braze adapter. Added @braze/sdk as a peer dependency and dev dependency. Also updated the vue.config.js to exclude the @braze/sdk from being bundled in final package (being included in dev dependency it requires this). 

- [x] Unit tests have been [created|updated]
