### PR TITLE
f-checkout@v0.167.0 - Add max length.

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.167.0
+------------------------------
+*August 05, 2021*
+
+### Added
+- `max-length` property to guest email field.
+- `max-length` to component tests.
+
+
 v0.165.0
 ------------------------------
 *July 26, 2021*

--- a/packages/components/organisms/f-checkout/src/components/Guest.vue
+++ b/packages/components/organisms/f-checkout/src/components/Guest.vue
@@ -46,6 +46,7 @@
             :value="customer.email"
             name="guest-email"
             input-type="email"
+            maxlength="50"
             :label-text="$t('guest.email')"
             :has-error="!isEmailValid"
             aria-describedby="email-error"

--- a/packages/components/organisms/f-checkout/test/component/f-checkout-guest.component.desktop.spec.js
+++ b/packages/components/organisms/f-checkout/test/component/f-checkout-guest.component.desktop.spec.js
@@ -33,7 +33,8 @@ describe('f-checkout "guest" component tests - @browserstack', () => {
 
     forEach([
         [100, 'firstName'],
-        [100, 'lastName']
+        [100, 'lastName'],
+        [50, 'email']
     ])
         .it('should prevent a user from entering more than "%s" characters in the "%s" field', (maxlength, field) => {
             // Arrange

--- a/packages/components/organisms/f-checkout/test/component/f-checkout-guest.component.desktop.spec.js
+++ b/packages/components/organisms/f-checkout/test/component/f-checkout-guest.component.desktop.spec.js
@@ -34,7 +34,7 @@ describe('f-checkout "guest" component tests - @browserstack', () => {
     forEach([
         [100, 'firstName'],
         [100, 'lastName'],
-        [50, 'email']
+        [50, 'emailAddress']
     ])
         .it('should prevent a user from entering more than "%s" characters in the "%s" field', (maxlength, field) => {
             // Arrange


### PR DESCRIPTION
Set max length to 50 due to API limit.

## UI Review Checks

- [x] Unit tests have been [created|updated]

## Browsers Tested

- [x] Chrome (latest)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
