### PR TITLE
f-checkout@v0.172.0 - Update to new version of Mega Modal that outputs min js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,6 +267,7 @@ jobs:
     environment:
       # required to prevent ENOMEM errors
       LERNA_ARGS: --concurrency 1
+      NODE_OPTIONS: --max_old_space_size=4096
     steps: # a collection of executable commands
       - checkout # special step to check out source code to working directory
       - detect_root_change

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -12,7 +12,7 @@ v0.11.1
 - Serve minified JS instead of common JS.
 
 ### Changed
- - Updated version of `f-button`.
+- Updated version of `f-button`.
 
 v0.11.0
 ------------------------------

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -8,6 +8,9 @@ v0.11.1
 ------------------------------
 *August 13, 2021*
 
+### Added
+- Webpack config for chunk splitting bundles
+
 ### Fixed
 - Serve minified JS instead of common JS.
 

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -11,6 +11,8 @@ v0.11.1
 ### Fixed
 - Serve minified JS instead of common JS.
 
+### Changed
+ - Updated version of `f-button`.
 
 v0.11.0
 ------------------------------

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -4,12 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (to be added to next release)
+v0.11.1
 ------------------------------
-*July 26, 2021*
+*August 13, 2021*
 
-### Changed
-- Updated version of `f-button`.
+### Fixed
+- Serve minified JS instead of common JS.
 
 
 v0.11.0

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -22,7 +22,6 @@ v0.11.0
 - Updated version of `f-button`.
 - Close button now uses type `ghostTertiary`.
 
-
 v0.10.0
 ------------------------------
 *May 25, 2021*

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
   "version": "0.11.0",
-  "main": "dist/f-mega-modal.common.js",
+  "main": "dist/f-mega-modal.umd.min.js",
   "maxBundleSize": "6kB",
   "files": [
     "dist"

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "dist/f-mega-modal.umd.min.js",
   "maxBundleSize": "6kB",
   "files": [

--- a/packages/components/molecules/f-mega-modal/vue.config.js
+++ b/packages/components/molecules/f-mega-modal/vue.config.js
@@ -9,7 +9,7 @@ module.exports = {
         optimization: {
             splitChunks: {
                 cacheGroups: {
-                    node_vendors: {
+                    nodeVendors: {
                         test: /[\\/]node_modules[\\/]/,
                         chunks: 'all',
                         priority: 1

--- a/packages/components/molecules/f-mega-modal/vue.config.js
+++ b/packages/components/molecules/f-mega-modal/vue.config.js
@@ -5,6 +5,19 @@ const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    configureWebpack: {
+        optimization: {
+            splitChunks: {
+                cacheGroups: {
+                    node_vendors: {
+                        test: /[\\/]node_modules[\\/]/,
+                        chunks: 'all',
+                        priority: 1
+                    }
+                }
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -4,12 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (to be added to next release)
+v4.0.0-beta.32
 ------------------------------
-*July 26, 2021*
+*August 13, 2021*
 
 ### Changed
 - Updated version of `f-button`.
+- Updated version of `f-mega-modal`.
 
 
 v4.0.0-beta.31

--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -8,6 +8,9 @@ v4.0.0-beta.32
 ------------------------------
 *August 13, 2021*
 
+### Added
+- Webpack config for chunk splitting bundles
+
 ### Changed
 - Updated version of `f-button`.
 - Updated version of `f-mega-modal`.

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-searchbox",
   "description": "Fozzie Searchbox – Just Eat Takeaway Global Searchbox",
-  "version": "4.0.0-beta.31",
+  "version": "4.0.0-beta.32",
   "main": "dist/f-searchbox.umd.min.js",
   "maxBundleSize": "60kB",
   "files": [
@@ -29,7 +29,7 @@
   ],
   "scripts": {
     "prepublishOnly": "yarn lint && yarn test && yarn build",
-    "build": "vue-cli-service build --target lib --name f-searchbox ./src/index.js",
+    "build": "vue-cli-service build --report --target lib --name f-searchbox ./src/index.js",
     "demo": "vue serve --port 8080 ./src/demo/index.js",
     "lint": "vue-cli-service lint",
     "lint:fix": "yarn lint --fix",
@@ -62,7 +62,7 @@
     "@justeat/f-button": "1.10.1",
     "@justeat/f-error-message": "0.3.1",
     "@justeat/f-globalisation": "0.2.0",
-    "@justeat/f-mega-modal": "0.3.0",
+    "@justeat/f-mega-modal": "0.11.1",
     "@justeat/f-vue-icons": "1.13.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -29,7 +29,7 @@
   ],
   "scripts": {
     "prepublishOnly": "yarn lint && yarn test && yarn build",
-    "build": "vue-cli-service build --report --target lib --name f-searchbox ./src/index.js",
+    "build": "vue-cli-service build --target lib --name f-searchbox ./src/index.js",
     "demo": "vue serve --port 8080 ./src/demo/index.js",
     "lint": "vue-cli-service lint",
     "lint:fix": "yarn lint --fix",

--- a/packages/components/molecules/f-searchbox/vue.config.js
+++ b/packages/components/molecules/f-searchbox/vue.config.js
@@ -9,7 +9,7 @@ module.exports = {
         optimization: {
             splitChunks: {
 				cacheGroups: {
-					node_vendors: {
+					nodeVendors: {
 						test: /[\\/]node_modules[\\/]/,
 						chunks: "all",
 						priority: 1

--- a/packages/components/molecules/f-searchbox/vue.config.js
+++ b/packages/components/molecules/f-searchbox/vue.config.js
@@ -5,18 +5,19 @@ const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
-    configureWebpack : {
+    parallel: !process.env.CIRCLECI,
+    configureWebpack: {
         optimization: {
             splitChunks: {
-				cacheGroups: {
-					nodeVendors: {
-						test: /[\\/]node_modules[\\/]/,
-						chunks: "all",
-						priority: 1
-					}
-				}
+                cacheGroups: {
+                    nodeVendors: {
+                        test: /[\\/]node_modules[\\/]/,
+                        chunks: 'all',
+                        priority: 1
+                    }
+                }
             }
-          }
+        }
     },
     chainWebpack: config => {
         config.module

--- a/packages/components/molecules/f-searchbox/vue.config.js
+++ b/packages/components/molecules/f-searchbox/vue.config.js
@@ -5,6 +5,19 @@ const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    configureWebpack : {
+        optimization: {
+            splitChunks: {
+				cacheGroups: {
+					node_vendors: {
+						test: /[\\/]node_modules[\\/]/,
+						chunks: "all",
+						priority: 1
+					}
+				}
+            }
+          }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -8,6 +8,9 @@ v0.172.0
 ------------------------------
 *August 13, 2021*
 
+### Added
+- Webpack config for chunk splitting bundles
+
 ### Changed
 - Version of f-mega-modal package to reduce checkout bundle size.
 

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.172.0
+v0.173.0
 ------------------------------
 *August 13, 2021*
 
@@ -13,6 +13,14 @@ v0.172.0
 
 ### Changed
 - Version of f-mega-modal package to reduce checkout bundle size.
+
+
+v0.172.0
+------------------------------
+*August 102, 2021*
+
+### Added
+- Error Message to Age Verification page.
 
 
 v0.171.0

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.172.0
+------------------------------
+*August 13, 2021*
+
+### Changed
+- Version of f-mega-modal package to reduce checkout bundle size.
+
 
 v0.171.0
 ------------------------------

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -67,7 +67,7 @@
     "@justeat/f-card": "1.3.0",
     "@justeat/f-error-message": "0.3.1",
     "@justeat/f-form-field": "2.0.0",
-    "@justeat/f-mega-modal": "0.9.0",
+    "@justeat/f-mega-modal": "0.11.0",
     "@justeat/f-wdio-utils": "0.3.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.171.0",
+  "version": "0.172.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [
@@ -67,7 +67,7 @@
     "@justeat/f-card": "1.3.0",
     "@justeat/f-error-message": "0.3.1",
     "@justeat/f-form-field": "2.0.0",
-    "@justeat/f-mega-modal": "0.11.0",
+    "@justeat/f-mega-modal": "0.11.1",
     "@justeat/f-wdio-utils": "0.3.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.172.0",
+  "version": "0.173.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [

--- a/packages/components/organisms/f-checkout/vue.config.js
+++ b/packages/components/organisms/f-checkout/vue.config.js
@@ -9,7 +9,7 @@ module.exports = {
         optimization: {
             splitChunks: {
 				cacheGroups: {
-					node_vendors: {
+					nodeVendors: {
 						test: /[\\/]node_modules[\\/]/,
 						chunks: "all",
 						priority: 1

--- a/packages/components/organisms/f-checkout/vue.config.js
+++ b/packages/components/organisms/f-checkout/vue.config.js
@@ -6,18 +6,18 @@ const sassOptions = require('../../../../config/sassOptions')(rootDir);
 // vue.config.js
 module.exports = {
     parallel: !process.env.CIRCLECI,
-    configureWebpack : {
+    configureWebpack: {
         optimization: {
             splitChunks: {
-				cacheGroups: {
-					nodeVendors: {
-						test: /[\\/]node_modules[\\/]/,
-						chunks: "all",
-						priority: 1
-					}
-				}
+                cacheGroups: {
+                    nodeVendors: {
+                        test: /[\\/]node_modules[\\/]/,
+                        chunks: 'all',
+                        priority: 1
+                    }
+                }
             }
-          }
+        }
     },
     chainWebpack: config => {
         config.module

--- a/packages/components/organisms/f-checkout/vue.config.js
+++ b/packages/components/organisms/f-checkout/vue.config.js
@@ -5,6 +5,19 @@ const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    configureWebpack : {
+        optimization: {
+            splitChunks: {
+				cacheGroups: {
+					node_vendors: {
+						test: /[\\/]node_modules[\\/]/,
+						chunks: "all",
+						priority: 1
+					}
+				}
+            }
+          }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/organisms/f-checkout/vue.config.js
+++ b/packages/components/organisms/f-checkout/vue.config.js
@@ -5,6 +5,7 @@ const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    parallel: !process.env.CIRCLECI,
     configureWebpack : {
         optimization: {
             splitChunks: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,6 +2231,14 @@
   dependencies:
     vue-i18n "8.0.0"
 
+"@justeat/f-http@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-http/-/f-http-0.8.0.tgz#46a99a274d3611186d387a26920de02d5f1a05d7"
+  integrity sha512-wWDbLYXdc4bOUkMpATC9ZEB3g8x85GeajH6x4Xeo22r/GM1bG8k+1/SimbeoGQirA8acYSpkKywawGbgMuExmQ==
+  dependencies:
+    axios "0.21.1"
+    axios-mock-adapter "1.19.0"
+
 "@justeat/f-icons@3.5.1":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-3.5.1.tgz#a8211d31c3310f5403cee2a72de899a53bcf3d20"
@@ -2252,11 +2260,6 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.7.0.tgz#e7f4aedfbaa614386f7fe5a180111e884c7db694"
   integrity sha512-IGknAfUH9vExdkY8hg/tcK1iAHFzA1DusKiKMHFOf3obQ/cAMA2hK7I9JCSCGjBUrcBYhpY3WdlLxu9hInJREw==
-
-"@justeat/f-mega-modal@0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.9.0.tgz#834750c3ca4f66aeabd5b689628ccb5ed2d14db2"
-  integrity sha512-1OZay+2ZpelgdYvlVPV5cveZHY9Cls6yH9aQkGAYxXLzIEgmC8GfiQqtlwvLR0BQSNXr/K83asa0RUays3PE+w==
 
 "@justeat/f-popover@0.2.1":
   version "0.2.1"
@@ -2389,6 +2392,13 @@
   integrity sha512-jeWACUUp0LfQbKO+BS8KiMIQ/RlaLNuinIHwrmDAxHfxCj2RoElS/Z426cVzGWkIuvs20RiaNFMF31pasHq4QQ==
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
+
+"@justeat/f-wdio-utils@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.1.0.tgz#e8a62dd2d03c2cf14ce1fa7d50540c2171b8fc38"
+  integrity sha512-m2WfTJWR5Yako3hKEZ7SL3zDvZQA7VQ9hbUBnk02lxMYSKSqeHmLPICaLGtPXCIDBEuESFk2kscHSQc3GBxxmg==
+  dependencies:
+    "@justeat/f-services" "1.7.0"
 
 "@justeat/fozzie@5.0.0-beta.10":
   version "5.0.0-beta.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2251,11 +2251,6 @@
   dependencies:
     window-or-global "^1.0.1"
 
-"@justeat/f-mega-modal@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.3.0.tgz#58a88476ee204264988640b3cd47ac5d295bde4a"
-  integrity sha512-Cr6CDlrZAHoM3ZUJ2sOMLYAVYz+cka5R6THi24va3mhI8kgOSA4ZVzvx607QskTyasIX4xNfrju0HKity1Lq9w==
-
 "@justeat/f-mega-modal@0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-0.7.0.tgz#e7f4aedfbaa614386f7fe5a180111e884c7db694"


### PR DESCRIPTION
This PR is a test to see if the reduced bundle size of f-checkout improves memory usage and stops builds failing
