### PR TITLE
f-form-field@2.1.0 - Add support for `disabled` and `selected` dropdown option attributes

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.1.0
+------------------------------
+*August 17, 2021*
+
+### Added
+- Support for `disabled` and `selected` attributes for dropdown options.
+
+
 v2.0.0
 ------------------------------
 *August 5, 2021*

--- a/packages/components/atoms/f-form-field/README.md
+++ b/packages/components/atoms/f-form-field/README.md
@@ -70,7 +70,7 @@ The props that can be defined are as follows (if any):
 | Prop  | Type  | Default | Description |
 | ----- | ----- | ------- | ----------- |
 | `assistiveText` | `String` | `''` | Text to assist the user that will display underneath the input field. |
-| `dropdownOptions` | `Array` | `null` | The options to be displayed in the dropdown. Each option can contain the following properties:<br /> `text` (required) - The text to be displayed.<br />`value` (required) - The underlying value for the option.<br />`disabled` (optional) - Can be used to prevent an option from being selected.<br />`selected` (optional) - May be used together with `disabled` to create a placeholder, although this will be ignored by `v-model` (see Vue docs on Form Input Bindings). |
+| `dropdownOptions` | `Array` | `null` | The options to be displayed in the dropdown. Each option can contain the following properties:<br /> `text` (required) - The text to be displayed.<br />`value` (required) - The underlying value for the option.<br />`disabled` (optional) - Can be used to prevent an option from being selected.<br />`selected` (optional) - This will be ignored by `v-model` (see Vue docs on Form Input Bindings), but it may be used together with `disabled` to create a placeholder. |
 | `fieldSize` | `String` | `medium` | The size of the form field. <br>Options: `small`, `medium`, `large` |
 | `hasError` | `Boolean` | `false` | When `true` border colour changes to red. |
 | `inputType` | `String` | `text` | The type of input needed. <br>Options: `text`, `email`, `password`, `radio`, `checkbox`, `dropdown`, `number`, `tel`, `textarea`  |

--- a/packages/components/atoms/f-form-field/README.md
+++ b/packages/components/atoms/f-form-field/README.md
@@ -70,7 +70,7 @@ The props that can be defined are as follows (if any):
 | Prop  | Type  | Default | Description |
 | ----- | ----- | ------- | ----------- |
 | `assistiveText` | `String` | `''` | Text to assist the user that will display underneath the input field. |
-| `dropdownOptions` | `Array` | `null` | The options to be displayed in the dropdown. |
+| `dropdownOptions` | `Array` | `null` | The options to be displayed in the dropdown. Each option can contain the following properties:<br /> `text` (required) - The text to be displayed.<br />`value` (required) - The underlying value for the option.<br />`disabled` (optional) - Can be used to prevent an option from being selected.<br />`selected` (optional) - May be used together with `disabled` to create a placeholder, although this will be ignored by `v-model` (see Vue docs on Form Input Bindings). |
 | `fieldSize` | `String` | `medium` | The size of the form field. <br>Options: `small`, `medium`, `large` |
 | `hasError` | `Boolean` | `false` | When `true` border colour changes to red. |
 | `inputType` | `String` | `text` | The type of input needed. <br>Options: `text`, `email`, `password`, `radio`, `checkbox`, `dropdown`, `number`, `tel`, `textarea`  |

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "dist/f-form-field.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
@@ -18,6 +18,8 @@
             <option
                 v-for="(option, index) in dropdownOptions"
                 :key="index"
+                :disabled="option.disabled"
+                :selected="option.selected"
                 :data-test-id="`${testId.option}-${index}`"
                 :value="option.value">{{ option.text }}</option>
         </select>

--- a/packages/components/atoms/f-form-field/src/components/_tests/FormDropdown.test.js
+++ b/packages/components/atoms/f-form-field/src/components/_tests/FormDropdown.test.js
@@ -7,7 +7,7 @@ describe('FormDropdown', () => {
         { text: 'text 1', value: 'value 1' },
         { text: 'text 2', value: 'value 2' },
         { text: 'text 3', value: 'value 3' },
-        { text: 'text 4', value: 'value 4' }
+        { disabled: true, text: 'text 4', value: 'value 4' }
     ];
 
     const attributes = {
@@ -45,6 +45,24 @@ describe('FormDropdown', () => {
 
                 // Assert
                 expect(option.exists()).toBe(false);
+            });
+
+            it('should apply `disabled` attribute if passed in', () => {
+                // Arrange & Act
+                const wrapper = shallowMount(FormDropdown, { propsData });
+                const option = wrapper.find('[data-test-id="formfield-dropdown-option-4"]');
+
+                // Assert
+                expect(option.attributes().disabled).toBe('disabled');
+            });
+
+            it('should not apply disabled attribute if not passed in', () => {
+                // Arrange & Act
+                const wrapper = shallowMount(FormDropdown, { propsData });
+                const option = wrapper.find('[data-test-id="formfield-dropdown-option-1"]');
+
+                // Assert
+                expect(option.attributes().disabled).toBeUndefined();
             });
         });
 

--- a/packages/components/atoms/f-form-field/stories/FormField.stories.js
+++ b/packages/components/atoms/f-form-field/stories/FormField.stories.js
@@ -41,8 +41,20 @@ export const FormFieldComponent = () => ({
         },
         dropdownOptions: {
             default: object('Dropdown Options', [
-                { text: 'As soon as possible', value: '2021-01-01T01:00:00.000Z' },
-                { text: 'Today in 5 minutes', value: '2021-01-01T01:05:00.000Z' }
+                {
+                    disabled: true,
+                    selected: true,
+                    text: 'Disabled option',
+                    value: ''
+                },
+                {
+                    text: 'As soon as possible',
+                    value: '2021-01-01T01:00:00.000Z'
+                },
+                {
+                    text: 'Today in 5 minutes',
+                    value: '2021-01-01T01:05:00.000Z'
+                }
             ])
         },
         isGrouped: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2239,10 +2239,10 @@
     axios "0.21.1"
     axios-mock-adapter "1.19.0"
 
-"@justeat/f-icons@3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-3.5.1.tgz#a8211d31c3310f5403cee2a72de899a53bcf3d20"
-  integrity sha512-Erb2sYftVUYt+aF1nsFr1ZyKFZiEakTmHk6No3OWxRCWP0rfkT3NYkZ4vn3bIjcVFK0s9igZSZ5ZOeFUIt5xeg==
+"@justeat/f-icons@3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-3.7.0.tgz#7d0912995cb46f50d72aa80b880b719156cc21f5"
+  integrity sha512-JeUN84qJwIfDGHAgbaqBJ3ecZNVTzAxC1s9Ew375W2EKo5EWxe9fFonPKqDmQhimObS67NqbCHgGA3O1PeJHPg==
 
 "@justeat/f-logger@0.8.1":
   version "0.8.1"
@@ -2395,6 +2395,13 @@
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-2.4.0.tgz#aad0aa3563ff726043da9d29e8456435176ae913"
   integrity sha512-jeWACUUp0LfQbKO+BS8KiMIQ/RlaLNuinIHwrmDAxHfxCj2RoElS/Z426cVzGWkIuvs20RiaNFMF31pasHq4QQ==
+  dependencies:
+    babel-helper-vue-jsx-merge-props "2.0.3"
+
+"@justeat/f-vue-icons@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-2.5.0.tgz#769e2ff3725599cf17fdb5a618968f9f814d7179"
+  integrity sha512-eli7NQKc5M8o232QOG6BX6jl1zjs3kJwc1xjWpoN0u17iIWqa9xCsLwqLKWEPXUeZ91xRXYhr8bEccWzMANNUQ==
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
 


### PR DESCRIPTION
### Added
- Support for `disabled` and `selected` attributes for dropdown options.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Firefox
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
