### PR TITLE
f-cookie-banner@0.23.0  - Adding dk-DK to the list of locales in the banner's static version.

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.23.0
+------------------------------
+*August 19, 2021*
+
+### Added
+- `dk-DK` to the list of locales in the banner's static version.
+
+
 v0.22.0
 ------------------------------
 *August 18, 2021*

--- a/packages/components/organisms/f-cookie-banner/f-cookie-banner-static/gulpfile.js
+++ b/packages/components/organisms/f-cookie-banner/f-cookie-banner-static/gulpfile.js
@@ -6,7 +6,7 @@ const del = require('del');
 const { exec } = require('child_process');
 const replace = require('gulp-replace');
 
-const LOCALES = ['en-GB', 'es-ES', 'it-IT', 'en-IE', 'en-AU', 'en-NZ'];
+const LOCALES = ['en-GB', 'es-ES', 'it-IT', 'en-IE', 'en-AU', 'en-NZ', 'dk-DK'];
 
 const PATHS = {
     vueSrcFolder: './src',

--- a/packages/components/organisms/f-cookie-banner/f-cookie-banner-static/src/App.vue
+++ b/packages/components/organisms/f-cookie-banner/f-cookie-banner-static/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-    <cookie-banner locale='en-NZ' />
+    <cookie-banner locale='dk-DK' />
 </template>
 
 <script>

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "30kB",
   "files": [


### PR DESCRIPTION
v0.23.0
------------------------------
*August 19, 2021*

### Added
- `dk-DK` to the list of locales in the banner's static version.