### PR TITLE
f-button@v1.11.0 - Allow for conditional nested slot content.

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -4,6 +4,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.11.0
+------------------------------
+*August 24, 2021*
+
+### Added
+- `hasNestedContent` computed property that checks whether button content should be nested inside span tags.
+- Secondary default slot to be used when content is not nested.
+- Unit tests for `hasNestedContent` computed property.
+
+### Changed
+- Wrap nested content only when necessary.
+- Use Vue object syntax to add optional classes.
+
+
 v1.10.1
 ------------------------------
 *July 23, 2021*

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "main": "dist/f-button.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -3,11 +3,12 @@
         :is="componentType"
         :class="[
             $style['o-btn'],
-            (isIcon ? $style['o-btn--icon'] : ''),
             $style[`o-btn--${buttonType}`],
-            $style[`o-btn--size${buttonSizeClassname}`],
-            (isFullWidth ? $style['o-btn--fullWidth'] : ''),
-            (isLoading ? $style['o-btn--loading'] : '')
+            $style[`o-btn--size${buttonSizeClassname}`], {
+                [$style['o-btn--icon']]: isIcon,
+                [$style['o-btn--fullWidth']]: isFullWidth,
+                [$style['o-btn--loading']]: isLoading
+            }
         ]"
         :action-type="buttonActionType"
         :data-test-id="`${componentType}-component`"
@@ -15,32 +16,38 @@
         :aria-live="getAriaLive"
         :aria-busy="isLoading"
         v-on="!isLoading && $listeners">
-        <span
-            v-if="isLoading"
-            :class="$style['c-spinner']"
-            :data-test-id="`${componentType}-spinner`" />
-
-        <span
-            :class="[$style['o-button-content'], {
-                [$style['o-btn-content--hidden']]: isLoading
-            }]">
+        <template v-if="hasNestedContent">
+            <span
+                v-if="isLoading"
+                :class="$style['c-spinner']"
+                :data-test-id="`${componentType}-spinner`" />
 
             <span
-                v-if="hasLeadingIcon"
-                :class="[$style['o-btn-icon'], $style['o-btn-icon--leading']]"
-                data-test-id="button-leading-icon">
-                <slot name='leading-icon' />
-            </span>
+                :class="[$style['o-button-content'], {
+                    [$style['o-btn-content--hidden']]: isLoading
+                }]">
 
+                <span
+                    v-if="hasLeadingIcon"
+                    :class="[$style['o-btn-icon'], $style['o-btn-icon--leading']]"
+                    data-test-id="button-leading-icon">
+                    <slot name='leading-icon' />
+                </span>
+
+                <slot />
+
+                <span
+                    v-if="hasTrailingIcon"
+                    :class="[$style['o-btn-icon'], $style['o-btn-icon--trailing']]"
+                    data-test-id="button-trailing-icon">
+                    <slot name='trailing-icon' />
+                </span>
+            </span>
+        </template>
+
+        <template v-else>
             <slot />
-
-            <span
-                v-if="hasTrailingIcon"
-                :class="[$style['o-btn-icon'], $style['o-btn-icon--trailing']]"
-                data-test-id="button-trailing-icon">
-                <slot name='trailing-icon' />
-            </span>
-        </span>
+        </template>
     </component>
 </template>
 
@@ -138,6 +145,12 @@ export default {
 
         hasLeadingIcon () {
             return this.hasIcon && this.hasIcon === 'leading';
+        },
+
+        hasNestedContent () {
+            return this.isLoading
+                || this.hasLeadingIcon
+                || this.hasTrailingIcon;
         }
     },
     watch: {

--- a/packages/components/atoms/f-button/src/components/_tests/Button.test.js
+++ b/packages/components/atoms/f-button/src/components/_tests/Button.test.js
@@ -485,5 +485,38 @@ describe('Button', () => {
                 });
             });
         });
+
+        describe('hasNestedContent :: ', () => {
+            it.each([
+                [false, false, false, false],
+                [true, true, false, false],
+                [true, true, true, false],
+                [true, true, true, true],
+                [true, false, true, false],
+                [true, false, false, true],
+                [true, true, false, true],
+                [true, false, true, true]
+            ])('should return %s when `isLoading` is %s and `hasLeadingIcon` is %s and `hasTrailingIcon` is %s ', (
+                expected,
+                isLoading,
+                hasLeadingIcon,
+                hasTrailingIcon
+            ) => {
+                // Arrange
+                const propsData = {
+                    isLoading
+                };
+                const computed = {
+                    hasLeadingIcon: () => hasLeadingIcon,
+                    hasTrailingIcon: () => hasTrailingIcon
+                };
+
+                // Act
+                const wrapper = shallowMount(FButton, { propsData, computed });
+
+                // Assert
+                expect(wrapper.vm.hasNestedContent).toBe(expected);
+            });
+        });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2120,6 +2120,11 @@
   dependencies:
     "@justeat/f-services" "1.0.0"
 
+"@justeat/f-button@1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-1.10.1.tgz#2e441cd5ea6b3235d5bc9b01f9ee567ca38a9d24"
+  integrity sha512-YffprAYs/vUG5Pgy2avSzKacXHXDwlP+yLUCz+rxhCYcaKUiXcKC/22FgwB7iwFbz6uYND4G2MQYo8w24CurvQ==
+
 "@justeat/f-button@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-1.9.0.tgz#ff7f5dc0ccae943d80ba9affad29c89b11e18156"


### PR DESCRIPTION
### Added
- `hasNestedContent` computed property that checks whether button content should be nested inside span tags.
- Secondary default slot to be used when content is not nested.
- Unit tests for `hasNestedContent` computed property.

### Changed
- Wrap nested content only when necessary.
- Use Vue object syntax to add optional classes.