### PR TITLE
f-checkout@0.176.0 - Trim postcode on patch checkout call

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.175.0
+v0.176.0
 *August 25, 2021*
 
 ### Changed

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.175.0
+*August 25, 2021*
+
+### Changed
+- Map checkout update request now trims whitespace from postcode
+
+
 v0.174.0
 *August 25, 2021*
 

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.174.0",
+  "version": "0.175.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [
@@ -50,7 +50,7 @@
   ],
   "dependencies": {
     "@justeat/f-globalisation": "1.0.0",
-    "@justeat/f-services": "1.11.0",
+    "@justeat/f-services": "1.13.0",
     "axios": "0.21.1",
     "jwt-decode": "3.1.2",
     "vue-scrollto": "2.20.0",

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.175.0",
+  "version": "0.176.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [

--- a/packages/components/organisms/f-checkout/src/services/mapper.js
+++ b/packages/components/organisms/f-checkout/src/services/mapper.js
@@ -43,7 +43,7 @@ const mapUpdateCheckoutRequest = ({
                             ...(address.line2 ? [address.line2] : [])
                         ],
                         locality: address.locality || null,
-                        postalCode: address.postcode || null
+                        postalCode: address.postcode?.trim() || null
                     }
                 } : {}),
                 geolocation

--- a/packages/components/organisms/f-checkout/src/services/tests/mapper.test.js
+++ b/packages/components/organisms/f-checkout/src/services/tests/mapper.test.js
@@ -88,6 +88,27 @@ describe('checkout mapper', () => {
         ]);
     });
 
+    it('should map the address correctly and remove any unnecessary whitespace from postcode', () => {
+        // Act
+        const requestBody = mapUpdateCheckoutRequest({
+            ...defaultParams,
+            address: {
+                ...address,
+                postcode: ' BS1 1AA '
+            }
+        });
+
+        const locationRequest = requestBody[1].value.location;
+
+        // Assert
+        expect(locationRequest.address.postalCode).toBe(address.postcode);
+        expect(locationRequest.address.locality).toBe(address.locality);
+        expect(locationRequest.address.lines).toStrictEqual([
+            address.line1,
+            address.line2
+        ]);
+    });
+
     it('should map time correctly', () => {
         // Arrange
         const time = {

--- a/packages/components/organisms/f-checkout/test/component/f-checkout-delivery.component.desktop.spec.js
+++ b/packages/components/organisms/f-checkout/test/component/f-checkout-delivery.component.desktop.spec.js
@@ -24,6 +24,7 @@ describe('f-checkout "delivery" component tests', () => {
         };
 
         // Act
+        checkout.clearBlurField('addressPostcode');
         checkout.populateCheckoutForm(addressInfo);
         checkout.goToPayment();
 


### PR DESCRIPTION
This PR is reliant on this PR https://github.com/justeat/fozzie-components/pull/1220 as it will bump the version for f-services and the new postcode validation.  So build will fail until that PR is merged and published.