### PR TITLE
#globalconfig f-button and f-form-field package version bump to apply new font

### DIFF
--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -4,12 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (to be added to next release)
+v1.0.0-beta.0
 ------------------------------
-*July 26, 2021*
+*September 1, 2021*
 
 ### Changed
-- Updated version of `f-button`.
+- Updated version of `f-button` (JETSans Update)
 
 
 v0.7.0

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-alert",
   "description": "Fozzie Alert – Fozzie Alert Component",
-  "version": "0.7.0",
+  "version": "1.0.0-beta.0",
   "main": "dist/f-alert.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [
@@ -52,7 +52,7 @@
     "@vue/test-utils": "1.0.3",
     "@justeat/f-wdio-utils": "0.3.0",
     "node-sass-magic-importer": "5.3.2",
-    "@justeat/f-button": "1.10.1",
+    "@justeat/f-button": "2.0.0-beta.0",
     "@justeat/f-vue-icons": "1.13.0"
   }
 }

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.0.0-beta.0
+------------------------------
+*September 1, 2021*
+
+### Changed
+- Updated version of `f-button` (JETSans Update)
+
+
 v0.12.0
 ------------------------------
 *August 18, 2021*

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "0.12.0",
+  "version": "1.0.0-beta.0",
   "main": "dist/f-mega-modal.common.js",
   "maxBundleSize": "6kB",
   "files": [
@@ -43,7 +43,7 @@
     "body-scroll-lock": "3.x"
   },
   "devDependencies": {
-    "@justeat/f-button": "1.10.1",
+    "@justeat/f-button": "2.0.0-beta.0",
     "@justeat/f-vue-icons": "2.4.0",
     "@justeat/f-wdio-utils": "0.3.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",

--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -4,12 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (to be added to next release)
+v1.0.0-beta.0
 ------------------------------
-*July 26, 2021*
+*September 1, 2021*
 
 ### Changed
-- Updated version of `f-button`.
+- Updated version of `f-button` (JETSans Update)
 
 
 v4.0.0-beta.31

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-searchbox",
   "description": "Fozzie Searchbox – Just Eat Takeaway Global Searchbox",
-  "version": "4.0.0-beta.31",
+  "version": "4.0.0-beta.32",
   "main": "dist/f-searchbox.umd.min.js",
   "maxBundleSize": "60kB",
   "files": [
@@ -59,7 +59,7 @@
     "vuex": "3.5.1"
   },
   "devDependencies": {
-    "@justeat/f-button": "1.10.1",
+    "@justeat/f-button": "2.0.0-beta.0",
     "@justeat/f-error-message": "0.3.1",
     "@justeat/f-globalisation": "0.2.0",
     "@justeat/f-mega-modal": "0.3.0",

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.0.0-beta.0
+------------------------------
+*September 1, 2021*
+
+### Updated
+- New font JETSansDigital
+- `f-button` to v2.0.0-beta.0 which use the new font
+- `f-form-field` to v3.0.0-beta.0 which use the new font
+
+
 v0.176.0
 ------------------------------
 *August 25, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "0.176.0",
+  "version": "1.0.0-beta.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [
@@ -63,10 +63,10 @@
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.12.13",
     "@justeat/f-alert": "0.6.1",
-    "@justeat/f-button": "1.10.1",
+    "@justeat/f-button": "2.0.0-beta.0",
     "@justeat/f-card": "1.3.0",
     "@justeat/f-error-message": "0.6.0",
-    "@justeat/f-form-field": "2.0.0",
+    "@justeat/f-form-field": "3.0.0-beta.0",
     "@justeat/f-mega-modal": "0.9.0",
     "@justeat/f-wdio-utils": "0.3.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,9 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-Latest (to be added to next version)
+v1.0.0-beta.0
 ------------------------------
 *September 1, 2021*
+
+### Changed
+- Updated version of `f-button` (JETSans Update)
 
 ### Added
 - Tests to cover version changes in v0.24.0.
@@ -17,6 +20,14 @@ v0.24.0
 
 ### Fixed
 - Moved `isBodyHeightLessThanWindowHeight` to computed so it can re-calculate cookie position.
+
+
+Latest (to be added to next release)
+------------------------------
+*August 26, 2021*
+
+### Changed
+- Updated version of `f-button`.
 
 
 v0.23.0

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.24.0",
+  "version": "1.0.0-beta.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "30kB",
   "files": [
@@ -54,7 +54,7 @@
     "js-cookie": "2.2.1"
   },
   "devDependencies": {
-    "@justeat/f-button": "1.10.1",
+    "@justeat/f-button": "2.0.0-beta.0",
     "@justeat/f-mega-modal": "0.7.0",
     "@justeat/f-vue-icons": "2.3.0",
     "@justeat/f-wdio-utils": "0.3.0",

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,15 +4,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v5.0.0-beta.1
+------------------------------
+*September 1, 2021*
+
+### Changed
+- `f-button` to v2.0.0-beta.0 which use the new font
+
+
 v5.0.0-beta.0
 ------------------------------
 *August 26, 2021*
 
-### Updated
-- New font JETSansDigital
-
 ### Changed
-- Updated version of `f-button`.
+- New font JETSansDigital
 
 
 v4.19.1

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.12.13",
-    "@justeat/f-button": "1.10.1",
+    "@justeat/f-button": "2.0.0-beta.0",
     "@justeat/f-popover": "0.2.1",
     "@justeat/f-vue-icons": "2.4.0",
     "@justeat/f-wdio-utils": "0.3.0",

--- a/packages/components/organisms/f-loyalty/CHANGELOG.md
+++ b/packages/components/organisms/f-loyalty/CHANGELOG.md
@@ -13,6 +13,14 @@ v0.4.0
 - Unit tests for how it works page
 
 
+Latest (to be added to next release)
+------------------------------
+*August 26, 2021*
+
+### Removed
+- Unused f-button and f-card dependencies
+
+
 v0.3.0
 ------------------------------
 *July 29, 2021*

--- a/packages/components/organisms/f-loyalty/package.json
+++ b/packages/components/organisms/f-loyalty/package.json
@@ -58,8 +58,6 @@
     "@justeat/f-wdio-utils": "0.3.0",
     "@vue/test-utils": "1.0.3",
     "node-sass-magic-importer": "5.3.2",
-    "@justeat/f-button": "1.9.0",
-    "@justeat/f-card": "1.3.0",
     "@justeat/f-trak": "0.7.1",
     "@justeat/f-media-element": "1.0.0",
     "@justeat/f-breadcrumbs": "0.3.0",

--- a/packages/components/organisms/f-offers/CHANGELOG.md
+++ b/packages/components/organisms/f-offers/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.0.0-beta.0
+------------------------------
+*August 26, 2021*
+
+### Updated
+- New font JETSansDigital
+- `f-button` to v2.0.0-beta.0 which use the new font
+
+
 v0.8.0
 ------------------------------
 *August 11, 2021*

--- a/packages/components/organisms/f-offers/package.json
+++ b/packages/components/organisms/f-offers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-offers",
   "description": "Fozzie Offers - displays offers to the customers",
-  "version": "0.8.0",
+  "version": "1.0.0-beta.0",
   "main": "dist/f-offers.umd.min.js",
   "maxBundleSize": "130kB",
   "files": [
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@braze/web-sdk": "3.3.0",
-    "@justeat/f-button": "1.9.0",
+    "@justeat/f-button": "2.0.0-beta.0",
     "@justeat/f-content-cards": "5.0.0-beta.1",
     "@justeat/f-media-element": "1.0.0",
     "@justeat/f-searchbox": "4.0.0",

--- a/packages/components/organisms/f-registration/CHANGELOG.md
+++ b/packages/components/organisms/f-registration/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.0.0-beta.0
+------------------------------
+*September 1, 2021*
+
+### Updated
+- New font JETSansDigital
+- `f-button` to v2.0.0-beta.0 which use the new font
+- `f-form-field` to v3.0.0-beta.0 which use the new font
+
+
 v0.63.0
 ------------------------------
 *August 31, 2021*

--- a/packages/components/organisms/f-registration/package.json
+++ b/packages/components/organisms/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "0.63.0",
+  "version": "1.0.0-beta.0",
   "main": "dist/f-registration.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [
@@ -54,10 +54,10 @@
     "@justeat/browserslist-config-fozzie": ">=1.1.1"
   },
   "devDependencies": {
-    "@justeat/f-button": "1.10.1",
+    "@justeat/f-button": "2.0.0-beta.0",
     "@justeat/f-card": "1.3.0",
     "@justeat/f-error-message": "0.5.0",
-    "@justeat/f-form-field": "2.1.0",
+    "@justeat/f-form-field": "3.0.0-beta.0",
     "@justeat/f-http": "0.8.0",
     "@justeat/f-link": "0.4.0",
     "@justeat/f-vue-icons": "2.7.0",

--- a/packages/components/organisms/f-takeawaypay-activation/CHANGELOG.md
+++ b/packages/components/organisms/f-takeawaypay-activation/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.0.0-beta.1
+------------------------------
+*September 1, 2021*
+
+### Updated
+- `f-button` to v2.0.0-beta.0 which use the new font
+
+
 v1.0.0-beta.0
 ------------------------------
 *August 26, 2021*

--- a/packages/components/organisms/f-takeawaypay-activation/package.json
+++ b/packages/components/organisms/f-takeawaypay-activation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-takeawaypay-activation",
   "description": "Fozzie TakeawayPay Activation - Handles Takeaway Pay activation for users",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "main": "dist/f-takeawaypay-activation.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@justeat/f-globalisation": "1.0.0",
-    "@justeat/f-button": "1.10.1",
+    "@justeat/f-button": "2.0.0-beta.0",
     "@justeat/f-card": "1.3.0",
     "@justeat/f-vue-icons": "2.6.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2125,16 +2125,6 @@
   dependencies:
     "@justeat/f-services" "1.0.0"
 
-"@justeat/f-button@1.10.1":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-1.10.1.tgz#2e441cd5ea6b3235d5bc9b01f9ee567ca38a9d24"
-  integrity sha512-YffprAYs/vUG5Pgy2avSzKacXHXDwlP+yLUCz+rxhCYcaKUiXcKC/22FgwB7iwFbz6uYND4G2MQYo8w24CurvQ==
-
-"@justeat/f-button@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-1.9.0.tgz#ff7f5dc0ccae943d80ba9affad29c89b11e18156"
-  integrity sha512-HJqDqiTEJ/vuo5PAhvcm7Cn0WRZS8EfOxbdpQ+wswXVzvZTwr9nd3xL30HMfP6p8yb/YlpjsaAU6StILoGqOLA==
-
 "@justeat/f-content-cards@5.0.0-beta.1":
   version "5.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-5.0.0-beta.1.tgz#4b89212580dd9fa63c8a2e0dfbe5fd144f7ace3d"
@@ -2171,14 +2161,6 @@
   integrity sha512-PXSomaAuJwvcqwFOoO9JHgXEBv6hMz5h7PQ2a4ABHIrDtu3efOBbybJulhdiGCYRvfLlWQdEWKfVYhrGIbETpw==
   dependencies:
     "@justeat/f-vue-icons" "1.10.0"
-
-"@justeat/f-form-field@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-2.0.0.tgz#fe40f657002e4bef2bfae1aefc02ece4882bff2c"
-  integrity sha512-998BfTlHBAkh8ZCdbuPkb9KNZItwXnKf25kn0nFmgtJKQJQzXHdB1vrWdCjkv4scTCDh+s/a05Q1YR5pYzgCag==
-  dependencies:
-    "@justeat/f-services" "1.0.0"
-    "@justeat/f-vue-icons" "2.5.0"
 
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
Bump the version of `f-button` and `f-form-field` packages in the components to use the new font.

In packages which use only icon button without text, there is no package version bump, in all others version bumped to the next major beta version. I updated f-button in all the packages that use it to be able to test the changes in storybook without styles overriding each other.