### PR TITLE
f-cookie-banner@0.24.0 - Fix cookie position.

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.24.0
+------------------------------
+*August 27, 2021*
+
+### Fixed
+- Moved `isBodyHeightLessThanWindowHeight` to computed so it can re-calculate cookie position.
+
 
 v0.23.0
 ------------------------------

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "30kB",
   "files": [

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -149,7 +149,7 @@ export default {
         const copy = localeConfig.messages;
         const consentCookieName = 'je-cookieConsent';
         const legacyConsentCookieName = 'je-banner_cookie';
-        const reopenLinkToBottom = this.isBodyHeightLessThanWindowHeight();
+        const reopenLinkToBottom = this.isBodyHeightLessThanWindowHeight;
 
         return {
             config: { ...localeConfig },
@@ -170,6 +170,17 @@ export default {
          */
         legacyBanner () {
             return this.shouldShowLegacyBanner === null ? this.config.displayLegacy : this.shouldShowLegacyBanner;
+        },
+
+        /**
+         * Check to see if we need to absolute position reopen link.
+         * * @returns {Boolean}
+         */
+        isBodyHeightLessThanWindowHeight () {
+            if (typeof window === 'object') {
+                return window.innerHeight - document.body.offsetHeight > 0;
+            }
+            return false;
         }
     },
 
@@ -337,16 +348,6 @@ export default {
                     break;
                 }
             }
-        },
-
-        /**
-         * Check to see if we need to absolute position reopen link
-         */
-        isBodyHeightLessThanWindowHeight () {
-            if (typeof window === 'object') {
-                return window.innerHeight - document.body.offsetHeight > 0;
-            }
-            return false;
         }
     }
 };


### PR DESCRIPTION
Moved method to computed so the banner can be repositioned when the consuming app loads.

###Before:
![Screenshot 2021-08-27 at 09 36 16](https://user-images.githubusercontent.com/2299779/131098550-ed87cd30-9a95-47c5-af82-9b01283a9537.png)

### After:
![Screenshot 2021-08-27 at 09 36 27](https://user-images.githubusercontent.com/2299779/131098577-5b04ac70-5cec-463e-aefc-4b1efbef2d23.png)

## Browsers Tested

- [x] Chrome (latest)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
