### PR TITLE
#trivial - generate source maps in common services

### DIFF
--- a/packages/services/f-analytics/CHANGELOG.md
+++ b/packages/services/f-analytics/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.11.0
+------------------------------
+*September 01, 2021*
+
+### Changed
+- Generate and output source maps
+
 v0.10.0
 ------------------------------
 *August 19, 2021*

--- a/packages/services/f-analytics/package.json
+++ b/packages/services/f-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-analytics",
   "description": "Fozzie Analytics - A utility that encapsulates the GTM / Google Analytics functionality",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "maxBundleSize": "200kB",
   "main": "dist/f-analytics.umd.js",
   "module": "dist/f-analytics.es.js",

--- a/packages/services/f-analytics/vite.config.js
+++ b/packages/services/f-analytics/vite.config.js
@@ -6,6 +6,7 @@ export default {
         lib: {
             entry: path.resolve(__dirname, 'src/index.js'),
             name: 'f-analytics'
-        }
+        },
+        sourcemap: true
     }
 };

--- a/packages/services/f-http/CHANGELOG.md
+++ b/packages/services/f-http/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.9.0
+------------------------------
+*September 01, 2021*
+
+### Changed
+- Generate and output source maps
+
+
 v0.8.1
 ------------------------------
 *August 11, 2021*

--- a/packages/services/f-http/package.json
+++ b/packages/services/f-http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-http",
   "description": "Javascript HTTP client for interacting with restful services",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "main": "dist/f-http.umd.js",
   "module": "dist/f-http.es.js",
   "source": "src/index.js",

--- a/packages/services/f-http/vite.config.js
+++ b/packages/services/f-http/vite.config.js
@@ -6,6 +6,7 @@ export default {
         lib: {
             entry: path.resolve(__dirname, 'src/index.js'),
             name: 'f-http'
-        }
+        },
+        sourcemap: true
     }
 };

--- a/packages/services/f-statistics/CHANGELOG.md
+++ b/packages/services/f-statistics/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.3.0
+------------------------------
+*September 01, 2021*
+
+### Changed
+- Generate and output source maps
+
 v0.2.0
 ------------------------------
 *August 09, 2021*

--- a/packages/services/f-statistics/package.json
+++ b/packages/services/f-statistics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-statistics",
   "description": "Javascript client for transporting statistics",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "maxBundleSize": "100kB",
   "main": "dist/f-statistics.umd.js",
   "module": "dist/f-statistics.es.js",

--- a/packages/services/f-statistics/vite.config.js
+++ b/packages/services/f-statistics/vite.config.js
@@ -6,6 +6,7 @@ export default {
         lib: {
             entry: path.resolve(__dirname, 'src/index.js'),
             name: 'f-statistics'
-        }
+        },
+        sourcemap: true
     }
 };


### PR DESCRIPTION
This PR updates a few basic services used by coreweb to generate source maps; the hope is that sentry will be able to pinpoint any errors within these services as it should detect and publish them

Example - 
![image](https://user-images.githubusercontent.com/10741583/131689336-1bcb3c14-d736-4da8-88a9-e3a491a2631e.png)
