### PR TITLE
f-consumer-oidc@1.3.0 - Fix dist references.

### DIFF
--- a/packages/services/f-consumer-oidc/CHANGELOG.md
+++ b/packages/services/f-consumer-oidc/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.3.0
+------------------------------
+* September 8, 2021*
+
+### Fixed
+- `dist` references to resolve import error in consuming application.
+
+
 v1.2.0
 ------------------------------
 * September 3, 2021*

--- a/packages/services/f-consumer-oidc/package.json
+++ b/packages/services/f-consumer-oidc/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@justeat/f-consumer-oidc",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Authentication helper to communicate with open apis",
-  "main": "dist/f-consumer-oidc.js",
+  "main": "dist/f-consumer-oidc.umd.js",
+  "module": "dist/f-consumer-oidc.es.js",
   "maxBundleSize": "5kB",
   "files": [
     "dist"


### PR DESCRIPTION
Resolves import errors.

`error  Unable to resolve path to module '@justeat/f-consumer-oidc'  import/no-unresolved`