### PR TITLE
f-loyalty@v0.5.0

### DIFF
--- a/packages/components/organisms/f-loyalty/CHANGELOG.md
+++ b/packages/components/organisms/f-loyalty/CHANGELOG.md
@@ -4,14 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.5.0
+v0.6.0
 ------------------------------
-*September 08, 2021*
+*September 22, 2021*
 
 ### Added
 - Unauthenticated state for when user is not logged in.
 - Unit tests for the page
-
 
 
 v0.5.0

--- a/packages/components/organisms/f-loyalty/CHANGELOG.md
+++ b/packages/components/organisms/f-loyalty/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.5.0
 ------------------------------
+*September 08, 2021*
+
+### Added
+- Unauthenticated state for when user is not logged in.
+- Unit tests for the page
+
+
+
+v0.5.0
+------------------------------
 *September 16, 2021*
 
 ### Changed

--- a/packages/components/organisms/f-loyalty/package.json
+++ b/packages/components/organisms/f-loyalty/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-loyalty",
   "description": "Fozzie Loyalty - provides a way for customers to collect loyalty stamps for restaurants",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "dist/f-loyalty.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [

--- a/packages/components/organisms/f-loyalty/src/components/Loyalty.vue
+++ b/packages/components/organisms/f-loyalty/src/components/Loyalty.vue
@@ -13,7 +13,7 @@
                         :title="$t('tabs.stamps.title')"
                         :selected="!showHowItWorks"
                     >
-                        loyalty
+                        <unauthenticated data-test-id="StampCards-StampCardsTab-UnauthContent" />
                     </tab>
                     <tab
                         name="how-it-works"
@@ -43,6 +43,7 @@ import loyalty from '../store/loyalty.module';
 import { ACTION_INITIALISE_LOYALTY, VUEX_MODULE_NAMESPACE_LOYALTY } from '../store/types';
 import LoyaltyHeader from './Header.vue';
 import HowItWorks from './HowItWorks.vue';
+import Unauthenticated from './Unauthenticated.vue';
 
 
 export default {
@@ -50,6 +51,7 @@ export default {
 
     components: {
         LoyaltyHeader,
+        Unauthenticated,
         HowItWorks,
         Tabs,
         Tab

--- a/packages/components/organisms/f-loyalty/src/components/Unauthenticated.vue
+++ b/packages/components/organisms/f-loyalty/src/components/Unauthenticated.vue
@@ -1,0 +1,102 @@
+<template>
+    <div :class="$style['c-loyalty-unauthenticated']">
+        <f-card
+            :class="$style['c-loyalty-unauthenticated-wrapper']"
+            has-outline>
+            <img
+                :class="$style['c-loyalty-unauthenticated-img']"
+                :src="`https://just-eat-prod-eu-res.cloudinary.com/image/upload/v1630068495/Experiments/Homeweb-Coreweb/stampcards-complex-object-login-promo-full-colour-${$t('percentage')}.svg `"
+                alt="">
+            <h3
+                data-test-id="unauthenticated-title"
+                :class="$style['c-loyalty-unauthenticated-title']">
+                {{ $t('unauthenticated.loginTitle') }}
+            </h3>
+            <f-button
+                data-test-id="unauthenticated-button"
+                href="/account/login?returnurl=%2Foffers%2Fstamp-cards"
+                is-full-width>
+                {{ $t('unauthenticated.loginButtonText') }}
+            </f-button>
+        </f-card>
+        <div :class="$style['c-loyalty-terms']">
+            <a
+                :class="$style['c-loyalty-terms-link']"
+                data-test-id="unauthenticated-terms-and-conditions"
+                :href="$t('termsUrl')">
+                {{ $t('termsText') }}
+            </a>
+        </div>
+    </div>
+</template>
+
+<script>
+import FCard from '@justeat/f-card';
+import FButton from '@justeat/f-button';
+
+export default {
+    name: 'Unauthenticated',
+
+    components: {
+        FCard,
+        FButton
+    },
+
+    mounted () {
+        // eslint-disable-next-line no-unused-expressions
+        window?.trak?.event({
+            category: 'engagement',
+            action: 'view_stampcards',
+            label: 'logged_out'
+        });
+    }
+};
+</script>
+
+<style lang="scss" module>
+$stampCards-unauthenticated-width: 392px;
+$stampCards-unauthenticated-img-dimension: 200px;
+
+.c-loyalty-unauthenticated {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: spacing(x4);
+
+    @include media('<=narrowMid') {
+        padding: spacing(x2);
+    }
+
+    @include media('<=tiny') {
+        padding: spacing();
+    }
+
+}
+
+.c-loyalty-unauthenticated-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: spacing(x3);
+    width: 100%;
+    max-width: $stampCards-unauthenticated-width;
+    padding: spacing(x5);
+
+    @include media('<=tiny') {
+        padding: spacing(x2);
+    }
+
+}
+
+.c-loyalty-unauthenticated-img {
+    width: $stampCards-unauthenticated-img-dimension;
+    height: $stampCards-unauthenticated-img-dimension;
+}
+
+.c-loyalty-unauthenticated-title {
+    @include font-size(heading-s);
+    margin-bottom: spacing(x3);
+}
+</style>

--- a/packages/components/organisms/f-loyalty/src/components/_tests/Unauthenticated.test.js
+++ b/packages/components/organisms/f-loyalty/src/components/_tests/Unauthenticated.test.js
@@ -1,0 +1,98 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import VueI18n from 'vue-i18n';
+import Vuex from 'vuex';
+import Unauthenticated from '../Unauthenticated.vue';
+import tenantConfigs from '../../tenants';
+import i18nMocker from './helper';
+
+const localVue = createLocalVue();
+localVue.use(VueI18n);
+localVue.use(Vuex);
+
+const LOGIN_URL = '/account/login?returnurl=%2Foffers%2Fstamp-cards';
+
+const mockLocale = 'en-GB';
+
+const i18n = {
+    locale: 'en-GB',
+    messages: {
+        'en-GB': tenantConfigs['en-GB'].messages
+    }
+};
+
+let store,
+    wrapper;
+
+beforeEach(() => {
+    jest.resetAllMocks();
+    window.trak = {
+        event: jest.fn()
+    };
+
+    store = new Vuex.Store({
+        state: {
+            isAppsUserAgent: false
+        }
+    });
+
+    // Arrange
+    wrapper = shallowMount(Unauthenticated, {
+        store,
+        localVue,
+        i18n,
+        mocks: {
+            $t: t => i18nMocker(t, mockLocale)
+        }
+    });
+});
+
+describe('UnauthenticatedLayout.vue', () => {
+    it('should display a card with title "Login to get started"', () => {
+        // Act
+        const title = wrapper.find('[data-test-id="unauthenticated-title"]');
+
+        // Assert
+        expect(title.text()).toBe(tenantConfigs[mockLocale].messages.unauthenticated.loginTitle);
+    });
+
+    it('should contain a href attribute for linking to the login page', () => {
+        // Act
+        const logInButton = wrapper.find('[data-test-id="unauthenticated-button"]');
+
+        // Assert
+        expect(logInButton.attributes('href')).toBe(LOGIN_URL);
+    });
+
+    it('should contain display the correct text for login button', () => {
+        // Act
+        const logInButton = wrapper.find('[data-test-id="unauthenticated-button"]');
+
+        // Assert
+        expect(logInButton.text()).toBe(tenantConfigs[mockLocale].messages.unauthenticated.loginButtonText);
+    });
+
+    it('should contain a href attribute for linking to the terms and conditions page', () => {
+        // Act
+        const termsLink = wrapper.find('[data-test-id="unauthenticated-terms-and-conditions"]');
+
+        // Assert
+        expect(termsLink.attributes('href')).toBe(tenantConfigs[mockLocale].messages.termsUrl);
+    });
+
+    it('should contain display the correct text for terms button', () => {
+        // Act
+        const termsLink = wrapper.find('[data-test-id="unauthenticated-terms-and-conditions"]');
+
+        // Assert
+        expect(termsLink.text()).toBe(tenantConfigs[mockLocale].messages.termsText);
+    });
+
+    it('should publish an engagement event on mount', () => {
+        // Assert
+        expect(window.trak.event).toHaveBeenCalledWith({
+            category: 'engagement',
+            action: 'view_stampcards',
+            label: 'logged_out'
+        });
+    });
+});

--- a/packages/components/organisms/f-loyalty/src/tenants/en-AU.js
+++ b/packages/components/organisms/f-loyalty/src/tenants/en-AU.js
@@ -18,6 +18,10 @@ const messages = {
             title: 'How it works'
         }
     },
+    unauthenticated: {
+        loginTitle: 'Log in to get started',
+        loginButtonText: 'Log in'
+    },
     howItWorks: {
         title: 'Save on your favourite flavours',
         text: 'Get rewarded for your loyalty. Start collecting stamps from your favourite restaurants and unlock a tasty little discount on the way…',

--- a/packages/components/organisms/f-loyalty/src/tenants/en-GB.js
+++ b/packages/components/organisms/f-loyalty/src/tenants/en-GB.js
@@ -18,6 +18,10 @@ const messages = {
             title: 'How it works'
         }
     },
+    unauthenticated: {
+        loginTitle: 'Log in to get started',
+        loginButtonText: 'Log in'
+    },
     howItWorks: {
         title: 'Save on your favourite flavours',
         text: 'Get rewarded for your loyalty. Start collecting stamps from your favourite restaurants and unlock a tasty little discount on the way…',

--- a/packages/components/organisms/f-loyalty/src/tenants/en-IE.js
+++ b/packages/components/organisms/f-loyalty/src/tenants/en-IE.js
@@ -1,4 +1,61 @@
-export default {
+const messages = {
     locale: 'en-IE',
-    text: 'I am a VLoyalty Component (IE)'
+    percentage: '10',
+    currency: 'euro',
+    currencySymbol: '',
+    termsUrl: '/info/terms-and-conditions#ii.just-eat-voucher-terms-conditions',
+    termsText: 'See Terms & Conditions',
+    header: {
+        title: 'StampCards',
+        text: 'See the stamps you’ve collected and any discounts you’ve earned.',
+        alt: 'Collect your stamps image'
+    },
+    tabs: {
+        stamps: {
+            title: 'Your StampCards'
+        },
+        howItWorks: {
+            title: 'How it works'
+        }
+    },
+    unauthenticated: {
+        loginTitle: 'Log in to get started',
+        loginButtonText: 'Log in'
+    },
+    howItWorks: {
+        title: 'Save on your favourite flavours',
+        text: 'Get rewarded for your loyalty. Start collecting stamps from your favourite restaurants and unlock a tasty little discount on the way…',
+        exampleSection: {
+            title: 'For example',
+            orders: 'Your Orders',
+            percentage: '10% from each order',
+            total: 'Total discount for 6th order',
+            accessibilityText: 'If you place 5 orders totalling $230, you would earn a discount worth $34.50 for your sixth order.'
+        },
+        media: {
+            title: 'How does it work?',
+            cards: {
+                order: {
+                    title: 'Order',
+                    text: 'Collect a stamp every time you order from a participating restaurant.'
+                },
+                earn: {
+                    title: 'Earn',
+                    text: 'Each stamp is worth 10% of your order’s value (exc. fees and charges) and will be saved on its own StampCard.'
+                },
+                collect: {
+                    title: 'Collect',
+                    text: 'Once you’ve collected five stamps from the same restaurant you’ll unlock a discount for your sixth order.'
+                },
+                reward: {
+                    title: 'Get rewarded',
+                    text: 'Your discount is the total of your five saved stamps and will be automatically applied when you place your sixth order.'
+                }
+            }
+        }
+    }
+};
+
+export default {
+    messages
 };


### PR DESCRIPTION
PR Adds the unauthenticated state for the loyalty main tab. I have added in migrated unit tests as part of its migration from HomeWeb.  

<img width="1163" alt="Screenshot 2021-09-08 at 14 42 43" src="https://user-images.githubusercontent.com/15876339/132520928-0f1bc18b-35b1-48c7-baf7-abcc8e87e0ba.png">
<img width="353" alt="Screenshot 2021-09-08 at 14 43 31" src="https://user-images.githubusercontent.com/15876339/132520930-871e0d10-d731-4444-b3e2-a0f10cb95816.png">


- [x] Unit tests have been [created|updated]

## Browsers Tested

- [x] Chrome (latest)
