### PR TITLE
f-cookie-banner@0.25.0 - Changing dk-DK to da-DK.

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,12 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-Latest (to be added to next version)
+v0.25.0
 ------------------------------
-*September 1, 2021*
+*September 8, 2021*
 
 ### Added
 - Tests to cover version changes in v0.24.0.
+
+### Changed
+- `dk-DK` to `da-DK`. 
 
 
 v0.24.0

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.25.0
 ------------------------------
-*September 8, 2021*
+*September 9, 2021*
 
 ### Added
 - Tests to cover version changes in v0.24.0.

--- a/packages/components/organisms/f-cookie-banner/f-cookie-banner-static/gulpfile.js
+++ b/packages/components/organisms/f-cookie-banner/f-cookie-banner-static/gulpfile.js
@@ -6,7 +6,7 @@ const del = require('del');
 const { exec } = require('child_process');
 const replace = require('gulp-replace');
 
-const LOCALES = ['en-GB', 'es-ES', 'it-IT', 'en-IE', 'en-AU', 'en-NZ', 'dk-DK'];
+const LOCALES = ['en-GB', 'es-ES', 'it-IT', 'en-IE', 'en-AU', 'en-NZ', 'da-DK'];
 
 const PATHS = {
     vueSrcFolder: './src',

--- a/packages/components/organisms/f-cookie-banner/f-cookie-banner-static/src/App.vue
+++ b/packages/components/organisms/f-cookie-banner/f-cookie-banner-static/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-    <cookie-banner locale='dk-DK' />
+    <cookie-banner locale='da-DK' />
 </template>
 
 <script>

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "30kB",
   "files": [


### PR DESCRIPTION
v0.25.0
------------------------------
*September 9, 2021*

### Added
- Tests to cover version changes in v0.24.0.

### Changed
- `dk-DK` to `da-DK`. 