### PR TITLE
f-cookie-banner@1.0.0-beta.2 - extra bold title

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.0.0-beta.2
+------------------------------
+*September 9, 2021*
+
+### Removed
+- `font-weight` override of the banner title
+
+
 v1.0.0-beta.1
 ------------------------------
 *September 6, 2021*

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "30kB",
   "files": [

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -381,7 +381,6 @@ export default {
 
     .c-cookieBanner-title {
         @include font-size(heading-m);
-        font-weight: $font-weight-bold;
         margin: spacing() 0;
         padding: 0;
         color: $color-content-default;


### PR DESCRIPTION
### Removed
- `font-weight` override of the banner title