### PR TITLE
f-searchbox@4.0.0-beta.34 - Move submit events later in flow.

### DIFF
--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.0.0-beta.34
+------------------------------
+*September 10, 2021*
+
+### Changed
+- Moved `clearAddressValue` later in `submit` function so that address values are not cleared before being set in the location cookie.
+- Moved `onCustomSubmit` later in `submit` function so that the location cookie is set before consuming applications fire the `onSubmit` event.
+
+
 v4.0.0-beta.33
 ------------------------------
 *September 6, 2021*

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-searchbox",
   "description": "Fozzie Searchbox – Just Eat Takeaway Global Searchbox",
-  "version": "4.0.0-beta.33",
+  "version": "4.0.0-beta.34",
   "main": "dist/f-searchbox.umd.min.js",
   "maxBundleSize": "60kB",
   "files": [

--- a/packages/components/molecules/f-searchbox/src/components/Form.vue
+++ b/packages/components/molecules/f-searchbox/src/components/Form.vue
@@ -328,8 +328,6 @@ export default {
 
             if (this.isValid === true) {
                 this.setErrors([]);
-                this.clearAddressValue(this.shouldClearAddressOnValidSubmit);
-                onCustomSubmit(this.onSubmit, this.addressValue, e);
                 this.verifyHasPostcodeChanged();
 
                 if (this.service.isAutocompleteEnabled) {
@@ -356,7 +354,10 @@ export default {
                     processLocationCookie(this.shouldSetCookies, this.addressValue);
                 }
 
+                onCustomSubmit(this.onSubmit, this.addressValue, e);
+
                 this.$emit(SUBMIT_VALID_ADDRESS);
+                this.clearAddressValue(this.shouldClearAddressOnValidSubmit);
             } else {
                 e.preventDefault();
                 this.setErrors(this.isValid);

--- a/packages/components/molecules/f-searchbox/src/components/Form.vue
+++ b/packages/components/molecules/f-searchbox/src/components/Form.vue
@@ -337,6 +337,7 @@ export default {
 
                     // if the address is still missing fields, return here
                     if (!info) {
+                        this.clearAddressValue(this.shouldClearAddressOnValidSubmit);
                         return false;
                     }
 


### PR DESCRIPTION
### Changed
- Moved `clearAddressValue` later in `submit` function so that address values are not cleared before being set in the location cookie.
- Moved `onCustomSubmit` later in `submit` function so that the location cookie is set before consuming applications fire the `onSubmit` event.