### PR TITLE
f-takeawaypay-activation@1.1.0 - Updated branding for UK

### DIFF
--- a/packages/components/organisms/f-takeawaypay-activation/CHANGELOG.md
+++ b/packages/components/organisms/f-takeawaypay-activation/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.1.0
+------------------------------
+*September 15, 2021*
+
+### Changed
+- Updated branding for UK
+
 
 v1.0.0
 ------------------------------

--- a/packages/components/organisms/f-takeawaypay-activation/package.json
+++ b/packages/components/organisms/f-takeawaypay-activation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-takeawaypay-activation",
   "description": "Fozzie TakeawayPay Activation - Handles Takeaway Pay activation for users",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/f-takeawaypay-activation.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-takeawaypay-activation/src/components/_tests/__snapshots__/ActivationFailed.test.js.snap
+++ b/packages/components/organisms/f-takeawaypay-activation/src/components/_tests/__snapshots__/ActivationFailed.test.js.snap
@@ -4,10 +4,10 @@ exports[`ActivationFailed should be rendered correctly 1`] = `
 <div data-test-id="activation-failed-component" locale="en-GB">
   <bag-sad-bg-icon-stub></bag-sad-bg-icon-stub>
   <h1>
-    We can't activate Takeaway Pay on your account right now, sorry.
+    We can't activate Just Eat Pay on your account right now, sorry.
   </h1>
   <p>
-    Try again or get in touch with your Takeaway Pay administrator for help.
+    Try again or get in touch with your Just Eat Pay administrator for help.
   </p>
 </div>
 `;

--- a/packages/components/organisms/f-takeawaypay-activation/src/components/_tests/__snapshots__/ActivationLoggedIn.test.js.snap
+++ b/packages/components/organisms/f-takeawaypay-activation/src/components/_tests/__snapshots__/ActivationLoggedIn.test.js.snap
@@ -4,16 +4,16 @@ exports[`ActivationLoggedIn should be rendered correctly 1`] = `
 <div data-test-id="activation-logged-in-component">
   <bag-run-bg-icon-stub></bag-run-bg-icon-stub>
   <h1>
-    Welcome back, Joe. Let's activate Takeaway Pay on your account.
+    Welcome back, Joe. Let's activate Just Eat Pay on your account.
   </h1>
   <p>
-    Takeaway Pay will be activated for <span>test@mail.com</span></p>
+    Just Eat Pay will be activated for <span>test@mail.com</span></p>
   <p>
     Not you? Choose a different account or sign up.
   </p>
   <div>
     <f-button-stub buttontype="primary" buttonsize="large" isfullwidth="true" actiontype="button" data-test-id="takeawaypay-activation-activate-button">
-      Activate Takeaway Pay
+      Activate Just Eat Pay
     </f-button-stub>
     <f-button-stub buttontype="outline" buttonsize="large" isfullwidth="true" actiontype="button" href="/login" data-test-id="takeawaypay-activation-loggedin-login-link">
       Use a different account
@@ -74,15 +74,15 @@ exports[`ActivationLoggedIn should be rendered correctly while activation is in 
     </g>
   </svg>
   <h1>
-    Welcome back, Joe. Let's activate Takeaway Pay on your account.
+    Welcome back, Joe. Let's activate Just Eat Pay on your account.
   </h1>
   <p>
-    Takeaway Pay will be activated for <span>test@mail.com</span></p>
+    Just Eat Pay will be activated for <span>test@mail.com</span></p>
   <p>
     Not you? Choose a different account or sign up.
   </p>
   <div><button type="button" data-test-id="takeawaypay-activation-activate-button" aria-live="polite" aria-busy="true" disabled="disabled" class="Button_o-btn_1KX8u Button_o-btn--primary_NRuBe Button_o-btn--sizeLarge_3A8Ov Button_o-btn--fullWidth_1xkfh Button_o-btn--loading_2up-7"><span data-test-id="action-button-spinner" class="Button_c-spinner_16ib0"></span><span class="Button_o-button-content_3Ow1e Button_o-btn-content--hidden_1592m"><!---->
-            Activate Takeaway Pay
+            Activate Just Eat Pay
         <!----></span></button>
     <!---->
     <!---->

--- a/packages/components/organisms/f-takeawaypay-activation/src/components/_tests/__snapshots__/ActivationNotLoggedIn.test.js.snap
+++ b/packages/components/organisms/f-takeawaypay-activation/src/components/_tests/__snapshots__/ActivationNotLoggedIn.test.js.snap
@@ -4,7 +4,7 @@ exports[`ActivationNotLoggedIn should be rendered correctly 1`] = `
 <div data-test-id="activation-not-logged-in-component" locale="en-GB">
   <bag-run-bg-icon-stub></bag-run-bg-icon-stub>
   <h1>
-    Let's get you started with Takeaway Pay.
+    Let's get you started with Just Eat Pay.
   </h1>
   <p>
     Do you already have a Just Eat account?

--- a/packages/components/organisms/f-takeawaypay-activation/src/components/_tests/__snapshots__/ActivationSuccessful.test.js.snap
+++ b/packages/components/organisms/f-takeawaypay-activation/src/components/_tests/__snapshots__/ActivationSuccessful.test.js.snap
@@ -7,7 +7,7 @@ exports[`ActivationSuccessful should be rendered correctly 1`] = `
     All systems go.
   </h1>
   <p>
-    Takeaway Pay is now activated on your account.
+    Just Eat Pay is now activated on your account.
   </p>
   <div>
     <f-button-stub buttontype="primary" buttonsize="large" isfullwidth="true" actiontype="button" href="/home" data-test-id="takeawaypay-activation-home-link">

--- a/packages/components/organisms/f-takeawaypay-activation/src/tenants/en-GB.js
+++ b/packages/components/organisms/f-takeawaypay-activation/src/tenants/en-GB.js
@@ -2,18 +2,18 @@ const messages = {
     locale: 'en-GB',
 
     messages: {
-        titleActivationAvailable: 'Welcome back, {consumerGivenName}. Let\'s activate Takeaway Pay on your account.',
-        titleActivationNotLoggedIn: 'Let\'s get you started with Takeaway Pay.',
+        titleActivationAvailable: 'Welcome back, {consumerGivenName}. Let\'s activate Just Eat Pay on your account.',
+        titleActivationNotLoggedIn: 'Let\'s get you started with Just Eat Pay.',
         titleActivationSuccessful: 'All systems go.',
-        titleActivationFailed: ' We can\'t activate Takeaway Pay on your account right now, sorry.',
-        descriptionActivationAvailable1: 'Takeaway Pay will be activated for',
+        titleActivationFailed: ' We can\'t activate Just Eat Pay on your account right now, sorry.',
+        descriptionActivationAvailable1: 'Just Eat Pay will be activated for',
         descriptionActivationAvailable2: 'Not you? Choose a different account or sign up.',
         descriptionActivationNotLoggedIn: 'Do you already have a Just Eat account?',
-        descriptionActivationFailed: 'Try again or get in touch with your Takeaway Pay administrator for help.',
-        descriptionActivationSuccessful: 'Takeaway Pay is now activated on your account.'
+        descriptionActivationFailed: 'Try again or get in touch with your Just Eat Pay administrator for help.',
+        descriptionActivationSuccessful: 'Just Eat Pay is now activated on your account.'
     },
     actions: {
-        activateTakeawayPay: 'Activate Takeaway Pay',
+        activateTakeawayPay: 'Activate Just Eat Pay',
         startOrdering: 'Start ordering',
         createAccount: 'Create a new account',
         loginToAccount1: 'Use a different account',


### PR DESCRIPTION
"Takeaway Pay" => "Just Eat Pay" updates

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
