### PR TITLE
#trivial - bump f-offers max package size

### DIFF
--- a/packages/components/organisms/f-offers/package.json
+++ b/packages/components/organisms/f-offers/package.json
@@ -3,7 +3,7 @@
   "description": "Fozzie Offers - displays offers to the customers",
   "version": "1.1.0",
   "main": "dist/f-offers.umd.min.js",
-  "maxBundleSize": "130kB",
+  "maxBundleSize": "140kB",
   "files": [
     "dist",
     "test-utils"


### PR DESCRIPTION
All PRs are failing because f-offers has gone over its max size.

