### PR TITLE
f-analytics@v0.15.0 - Preserve state when registering module server & client side

### DIFF
--- a/packages/services/f-analytics/CHANGELOG.md
+++ b/packages/services/f-analytics/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.15.0
+------------------------------
+*September 21, 2021*
+
+### Changed
+- Always attempt to register the store but always preserve state.
+- You can supply the `groupName` when calling pushPageData() rather than is defaulting to `featureName`.
+
+
 v0.14.0
 ------------------------------
 *September 10, 2021*

--- a/packages/services/f-analytics/CHANGELOG.md
+++ b/packages/services/f-analytics/CHANGELOG.md
@@ -9,8 +9,8 @@ v0.15.0
 *September 21, 2021*
 
 ### Changed
-- Always attempt to register the store but always preserve state.
-- You can supply the `groupName` when calling pushPageData() rather than is defaulting to `featureName`.
+- Always attempt to register the store but always preserve state, if present.
+- Removed the redundant `groupName` prop from pushPageData().
 
 
 v0.14.0

--- a/packages/services/f-analytics/README.md
+++ b/packages/services/f-analytics/README.md
@@ -175,11 +175,10 @@ You can see the GTM tags and any GA data by inspecting the `header` of the page 
     - ### **`pushPageData()`**<br>
       Evaluates and gather data for the `pageData` GA model and pushes it to the `dataLayer`<br>
       #### **Syntax**.
-      > this.`$gtm`.**pushPageData**(_{ pageName: `sign-up`, groupName: `accounts`, requestId: `021c24d2-86ef-...`, customFields: { custom1: 'one' } }_);
+      > this.`$gtm`.**pushPageData**(_{ pageName: `accounts sign-up`, requestId: `021c24d2-86ef-...`, customFields: { custom1: 'one' } }_);
       #### **Parameters**.
       > (**object**) {<br>
       >> - (**string**) `pageName`
-      >> - (**string**) `groupName`
       >> - (**string**) `requestId` (_optional_)
       >> - (**number**) `httpStatusCode` (_optional_)(_only override this if you wish to change the default 200, i.e you may be displaying a custom static 404 page and want to record the value 404 instead of 200 or you may be displaying a successful account creation page and want to record the value 201 rather than 200_)
       >> - (**object**) `customFields` (_optional_) (_You may want to overwrite/add fields and this parameter allows you to indicate an object of fields/values that if already present will overwrite and if not then will be append to the model_)

--- a/packages/services/f-analytics/README.md
+++ b/packages/services/f-analytics/README.md
@@ -175,10 +175,11 @@ You can see the GTM tags and any GA data by inspecting the `header` of the page 
     - ### **`pushPageData()`**<br>
       Evaluates and gather data for the `pageData` GA model and pushes it to the `dataLayer`<br>
       #### **Syntax**.
-      > this.`$gtm`.**pushPageData**(_{ pageName: `checkout`, requestId: `021c24d2-86ef-...`, customFields: { custom1: 'one', group: 'diff-grp-name' } }_);
+      > this.`$gtm`.**pushPageData**(_{ pageName: `sign-up`, groupName: `accounts`, requestId: `021c24d2-86ef-...`, customFields: { custom1: 'one' } }_);
       #### **Parameters**.
       > (**object**) {<br>
       >> - (**string**) `pageName`
+      >> - (**string**) `groupName`
       >> - (**string**) `requestId` (_optional_)
       >> - (**number**) `httpStatusCode` (_optional_)(_only override this if you wish to change the default 200, i.e you may be displaying a custom static 404 page and want to record the value 404 instead of 200 or you may be displaying a successful account creation page and want to record the value 201 rather than 200_)
       >> - (**object**) `customFields` (_optional_) (_You may want to overwrite/add fields and this parameter allows you to indicate an object of fields/values that if already present will overwrite and if not then will be append to the model_)
@@ -262,7 +263,7 @@ You can see the GTM tags and any GA data by inspecting the `header` of the page 
   | :--- | :--- | :--- | :--- | :--- |
   | namespace| 'some_unique-namespace' | Optional | `f-analytics` | This is used to ensure uniqueness with regards to internal objects, e.g. the internal Vuex Store used by this service, do not change unless you have an issue and need to use this namespace locally |
   | globalVarName| 'gtm' | Optional | `gtm` | This is used to access the global service/methods, do not change unless you have an issue and need to use this name locally |
-  | featureName| 'coreweb-registration' | Required | | This is used to identify analytics sent by your feature |
+  | featureName| 'coreweb' | Required | | This is used to identify analytics sent by your feature |
   | locale| 'en-GB' | Optional | `en-GB` | This is used to calcualate various platform data values |
   | id| 'GTM-X1234Z' | | | This is used know what GA account to push analytics to |
   | auth| 'authKey' | Optional | | Please speak to your Analytics team for more information about this option |

--- a/packages/services/f-analytics/package.json
+++ b/packages/services/f-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-analytics",
   "description": "Fozzie Analytics - A utility that encapsulates the GTM / Google Analytics functionality",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "maxBundleSize": "200kB",
   "main": "dist/f-analytics.umd.js",
   "module": "dist/f-analytics.es.js",

--- a/packages/services/f-analytics/src/plugins/_tests/analytics.plugin.test.js
+++ b/packages/services/f-analytics/src/plugins/_tests/analytics.plugin.test.js
@@ -27,6 +27,7 @@ describe('Analytics Plugin ::', () => {
         let injectSpy;
         let defaultStore;
         let state;
+        let registerStoreModuleSpy;
 
         beforeEach(() => {
             // Arrange - store
@@ -39,6 +40,8 @@ describe('Analytics Plugin ::', () => {
                 dispatch: storeDispatchSpy,
                 hasModule: storeModuleSpy
             };
+            registerStoreModuleSpy = jest.fn();
+            defaultStore.registerModule = registerStoreModuleSpy;
             // Arrange - context
             context = { store: defaultStore, req: jest.fn() };
             injectSpy = jest.fn(() => {});
@@ -55,7 +58,6 @@ describe('Analytics Plugin ::', () => {
             AnalyticsPlugin(context, injectSpy, null);
 
             // Assert that all the default options where used
-            expect(storeModuleSpy).toHaveBeenCalledWith(defaultOptions.namespace);
             expect(document.head.innerHTML).toContain(`${defaultOptions.id}`);
             expect(document.head.innerHTML).not.toContain(`${defaultOptions.auth}`);
             expect(document.head.innerHTML).not.toContain(`${defaultOptions.preview}`);
@@ -76,7 +78,6 @@ describe('Analytics Plugin ::', () => {
             AnalyticsPlugin(context, injectSpy, partialOptions);
 
             // Assert
-            expect(storeModuleSpy).toHaveBeenCalledWith(partialOptions.namespace);
             expect(document.head.innerHTML).toContain(`${partialOptions.id}`);
             expect(document.head.innerHTML).toContain(`${partialOptions.auth}`);
             expect(document.head.innerHTML).toContain(`${partialOptions.preview}`);
@@ -137,7 +138,7 @@ describe('Analytics Plugin ::', () => {
             }));
         });
 
-        it('should register the module if not already registered', () => {
+        it('should register the module', () => {
             // Arrange - store
             registerStoreModuleSpy = jest.fn(() => true);
             context = {
@@ -155,44 +156,26 @@ describe('Analytics Plugin ::', () => {
             AnalyticsPlugin(context, jest.fn(), options);
 
             // Assert
-            expect(registerStoreModuleSpy).toHaveBeenCalledWith(options.namespace, expect.anything());
-        });
-
-        it('should not register the module if already registered', () => {
-            // Arrange - store
-            registerStoreModuleSpy = jest.fn(() => true);
-            context = {
-                store: {
-                    state,
-                    dispatch: jest.fn(),
-                    hasModule: jest.fn(() => true),
-                    registerModule: registerStoreModuleSpy
-                },
-                req: jest.fn(),
-                res: jest.fn()
-            };
-
-            // Act
-            AnalyticsPlugin(context, jest.fn(), options);
-
-            // Assert
-            expect(registerStoreModuleSpy).not.toHaveBeenCalled();
+            expect(registerStoreModuleSpy).toHaveBeenCalledWith(options.namespace, expect.anything(), { preserveState: true });
         });
     });
 
     describe('When preparing the page with GTM Tags', () => {
         let context;
         let state;
+        let registerStoreModuleSpy;
 
         beforeEach(() => {
             // Arrange - store
+            registerStoreModuleSpy = jest.fn();
             state = [`${options.namespace}`];
             state[`${options.namespace}`] = { ...defaultState };
             context = {
                 store: {
                     state,
                     dispatch: jest.fn(),
-                    hasModule: jest.fn(() => true)
+                    hasModule: jest.fn(() => true),
+                    registerModule: registerStoreModuleSpy
                 },
                 req: jest.fn(),
                 res: jest.fn()
@@ -262,6 +245,7 @@ describe('Analytics Plugin ::', () => {
         let store;
         let req;
         let get;
+        let registerStoreModuleSpy;
 
         beforeEach(() => {
             // Arrange - store
@@ -273,6 +257,8 @@ describe('Analytics Plugin ::', () => {
                 dispatch: storeDispatchSpy,
                 hasModule: jest.fn(() => true)
             };
+            registerStoreModuleSpy = jest.fn();
+            store.registerModule = registerStoreModuleSpy;
             // Arrange - cookies
             get = jest.fn();
             when(get).calledWith('je-user_percentage').mockReturnValue('35');

--- a/packages/services/f-analytics/src/plugins/analytics.plugin.js
+++ b/packages/services/f-analytics/src/plugins/analytics.plugin.js
@@ -14,12 +14,6 @@ const prepareServerSideValues = (store, req, options) => {
     }
 };
 
-const registerStoreModule = (store, options) => {
-    if (!store.hasModule(options.namespace)) {
-        store.registerModule(options.namespace, analyticsModule);
-    }
-};
-
 const preparePageTags = options => {
     // Only add tags if clientside and if not already added
     if (typeof (window) !== 'undefined' && !window.dataLayer) {
@@ -65,7 +59,7 @@ export default ({ store, req }, inject, _options) => {
 
     preparePageTags(options);
 
-    registerStoreModule(store, options);
+    store.registerModule(options.namespace, analyticsModule, { preserveState: true });
 
     prepareServerSideValues(store, req, options);
 

--- a/packages/services/f-analytics/src/plugins/analytics.plugin.js
+++ b/packages/services/f-analytics/src/plugins/analytics.plugin.js
@@ -59,7 +59,7 @@ export default ({ store, req }, inject, _options) => {
 
     preparePageTags(options);
 
-    store.registerModule(options.namespace, analyticsModule, { preserveState: true });
+    store.registerModule(options.namespace, analyticsModule, { preserveState: !!store.state[`${options.namespace}`] });
 
     prepareServerSideValues(store, req, options);
 

--- a/packages/services/f-analytics/src/services/_tests/analytics.service.test.js
+++ b/packages/services/f-analytics/src/services/_tests/analytics.service.test.js
@@ -334,13 +334,12 @@ describe('Analytic Service ::', () => {
                 mockWindow({ winWidth, winHeight });
 
                 // Act
-                service.pushPageData({ pageName: 'jazz', groupName: 'man' });
+                service.pushPageData({ pageName: 'jazz' });
 
                 // Assert
                 expect(windowsPushSpy).toHaveBeenCalledWith(expect.objectContaining({
                     pageData: expect.objectContaining({
                         name: 'jazz',
-                        group: 'man',
                         orientation: orientationExpected,
                         display: displayExpected
                     })

--- a/packages/services/f-analytics/src/services/_tests/analytics.service.test.js
+++ b/packages/services/f-analytics/src/services/_tests/analytics.service.test.js
@@ -334,11 +334,13 @@ describe('Analytic Service ::', () => {
                 mockWindow({ winWidth, winHeight });
 
                 // Act
-                service.pushPageData();
+                service.pushPageData({ pageName: 'jazz', groupName: 'man' });
 
                 // Assert
                 expect(windowsPushSpy).toHaveBeenCalledWith(expect.objectContaining({
                     pageData: expect.objectContaining({
+                        name: 'jazz',
+                        group: 'man',
                         orientation: orientationExpected,
                         display: displayExpected
                     })

--- a/packages/services/f-analytics/src/services/analytics.mapper.js
+++ b/packages/services/f-analytics/src/services/analytics.mapper.js
@@ -185,7 +185,7 @@ export const mapUserData = ({ userData, authToken, req } = {}) => {
  * Maps various static/computed variables to the PageData.
  *
  * @param {object} pageData - A reference to the current PageData instance
- * @param {string} featureName - The name of the feature
+ * @param {string} groupName - The name of the group
  * @param {string} pageName - The name of the page
  * @param {string} requestId - The current request Id
  * @param {number} httpStatusCode - The httpStatusCode (only supplied when 200 needs to be overriden)
@@ -194,7 +194,7 @@ export const mapUserData = ({ userData, authToken, req } = {}) => {
  */
 export const mapPageData = ({
     pageData,
-    featureName,
+    groupName,
     pageName,
     requestId,
     httpStatusCode,
@@ -206,7 +206,7 @@ export const mapPageData = ({
 
     const mappedPageData = {
         ...pageData,
-        group: featureName,
+        group: groupName || pageData.groupName,
         name: pageName || pageData.pageName,
         conversationId: conversationId || pageData.conversationId,
         requestId: requestId || pageData.requestId,

--- a/packages/services/f-analytics/src/services/analytics.mapper.js
+++ b/packages/services/f-analytics/src/services/analytics.mapper.js
@@ -94,7 +94,8 @@ const mapUserAgent = req => {
  * serverside, to the PlatformData.
  * Also maps the user percentage experiment value (if present) to the PlatformData; again
  * only available serverside due to it's protection.
- * Note: this is stored until the rest of the PlatformData is collated and sent clientside.
+ * Note 1: this is stored until the rest of the PlatformData is collated and sent clientside.
+ * Note 2: dot notation on the env vars does not bundle well so using valid alternative [] approach.
  *
  * @param {object} platformData - A reference to the current PlatformData instance
  * @param {object} req - The `request` context
@@ -103,13 +104,14 @@ const mapUserAgent = req => {
 export const mapServerSidePlatformData = ({ platformData, req } = {}) => {
     const userPercent = getCookie('je-user_percentage', req);
 
+    /* eslint-disable dot-notation */
     const mappedData = {
         ...platformData,
         jeUserPercentage: userPercent || platformData.jeUserPercentage,
-        environment: process.env.justEatEnvironment || platformData.environment,
-        version: process.env.FEATURE_VERSION || platformData.version,
-        instancePosition: process.env.INSTANCE_POSITION || platformData.instancePosition,
-        isPilot: process.env.IS_PILOT || platformData.isPilot
+        environment: process.env['justEatEnvironment'] || platformData.environment,
+        version: process.env['FEATURE_VERSION'] || platformData.version,
+        instancePosition: process.env['INSTANCE_POSITION'] || platformData.instancePosition,
+        isPilot: process.env['IS_PILOT'] || platformData.isPilot
     };
 
     return mappedData;
@@ -185,7 +187,6 @@ export const mapUserData = ({ userData, authToken, req } = {}) => {
  * Maps various static/computed variables to the PageData.
  *
  * @param {object} pageData - A reference to the current PageData instance
- * @param {string} groupName - The name of the group
  * @param {string} pageName - The name of the page
  * @param {string} requestId - The current request Id
  * @param {number} httpStatusCode - The httpStatusCode (only supplied when 200 needs to be overriden)
@@ -194,7 +195,6 @@ export const mapUserData = ({ userData, authToken, req } = {}) => {
  */
 export const mapPageData = ({
     pageData,
-    groupName,
     pageName,
     requestId,
     httpStatusCode,
@@ -206,7 +206,6 @@ export const mapPageData = ({
 
     const mappedPageData = {
         ...pageData,
-        group: groupName || pageData.groupName,
         name: pageName || pageData.pageName,
         conversationId: conversationId || pageData.conversationId,
         requestId: requestId || pageData.requestId,

--- a/packages/services/f-analytics/src/services/analytics.service.js
+++ b/packages/services/f-analytics/src/services/analytics.service.js
@@ -60,7 +60,6 @@ export default class AnalyticService {
 
     pushPageData ({
         pageName,
-        groupName,
         conversationId,
         requestId,
         httpStatusCode,
@@ -70,7 +69,6 @@ export default class AnalyticService {
 
         pageData = mapPageData({
             pageData,
-            groupName,
             pageName,
             conversationId,
             requestId,

--- a/packages/services/f-analytics/src/services/analytics.service.js
+++ b/packages/services/f-analytics/src/services/analytics.service.js
@@ -60,6 +60,7 @@ export default class AnalyticService {
 
     pushPageData ({
         pageName,
+        groupName,
         conversationId,
         requestId,
         httpStatusCode,
@@ -69,7 +70,7 @@ export default class AnalyticService {
 
         pageData = mapPageData({
             pageData,
-            featureName: this.options.featureName,
+            groupName,
             pageName,
             conversationId,
             requestId,

--- a/packages/services/f-analytics/src/store/analytics.module.js
+++ b/packages/services/f-analytics/src/store/analytics.module.js
@@ -32,7 +32,6 @@ export default {
             signupDate: undefined
         },
         pageData: {
-            group: undefined,
             name: undefined,
             httpStatusCode: 200,
             conversationId: undefined,

--- a/packages/services/f-analytics/src/tests/helpers/setup.js
+++ b/packages/services/f-analytics/src/tests/helpers/setup.js
@@ -27,7 +27,6 @@ const defaultState = {
         signupDate: undefined
     },
     pageData: {
-        group: undefined,
         name: undefined,
         httpStatusCode: 200,
         conversationId: undefined,
@@ -64,7 +63,6 @@ const modifiedState = {
     },
     pageData: {
         name: 'test-name',
-        group: 'test-group',
         httpStatusCode: 200,
         conversationId: '460cc3a8-83f7-4e80-bb46-c8a69967f249',
         requestId: '6cbe6509-9122-4e66-a90a-cc483c34282e',


### PR DESCRIPTION
### Changed
- Always attempt to register the store but always preserve state, if present.
- Removed the redundant `groupName` prop from pushPageData().