### PR TITLE
fozzie-components@4.2.0 - icing phase 2 (part 1 of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v4.2.0
+------------------------------
+*October 5, 2021*
+
+### Changed
+- `fozzie` package version bump to 6.0.0-beta.5 to include new colour theme and radius vars.
+
+
 v4.1.0
 ------------------------------
 *October 04, 2021*
 
 ### Updated
 - Circle CI cached components to include new f-restaurant-card component
-
-v4.1.0
-------------------------------
-*September 29, 2021*
-
-### Changed
-- `fozzie` package version bump to 6.0.0-beta.5 to include new colour theme and radius vars.
 
 
 v4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ v4.1.0
 ### Updated
 - Circle CI cached components to include new f-restaurant-card component
 
+v4.1.0
+------------------------------
+*September 22, 2021*
+
+### Changed
+- `fozzie` package version bump to 6.0.0-beta.3 to include new colour theme and radius vars.
+
+
 v4.0.0
 ------------------------------
 *September 15, 2021*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ v4.1.0
 
 v4.1.0
 ------------------------------
-*September 22, 2021*
+*September 29, 2021*
 
 ### Changed
-- `fozzie` package version bump to 6.0.0-beta.3 to include new colour theme and radius vars.
+- `fozzie` package version bump to 6.0.0-beta.5 to include new colour theme and radius vars.
 
 
 v4.0.0

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-env": "7.14.9",
     "@justeat/browserslist-config-fozzie": "1.2.0",
     "@justeat/eslint-config-fozzie": "3.4.1",
-    "@justeat/fozzie": "6.0.0-beta.4",
+    "@justeat/fozzie": "6.0.0-beta.5",
     "@justeat/stylelint-config-fozzie": "2.2.0",
     "@percy/cli": "1.0.0-beta.52",
     "@percy/webdriverio": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-env": "7.14.9",
     "@justeat/browserslist-config-fozzie": "1.2.0",
     "@justeat/eslint-config-fozzie": "3.4.1",
-    "@justeat/fozzie": "6.0.0-beta.3",
+    "@justeat/fozzie": "6.0.0-beta.4",
     "@justeat/stylelint-config-fozzie": "2.2.0",
     "@percy/cli": "1.0.0-beta.52",
     "@percy/webdriverio": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build\"",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-env": "7.14.9",
     "@justeat/browserslist-config-fozzie": "1.2.0",
     "@justeat/eslint-config-fozzie": "3.4.1",
-    "@justeat/fozzie": "6.0.0-beta.1",
+    "@justeat/fozzie": "6.0.0-beta.3",
     "@justeat/stylelint-config-fozzie": "2.2.0",
     "@percy/cli": "1.0.0-beta.52",
     "@percy/webdriverio": "2.0.0",

--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.0.0
+------------------------------
+*September 22, 2021*
+
+### Changed
+- New colour scheme and border radius in line with Icing Phase 2.
+
+### Removed
+- Font-family beclaration from the button styles as we have one font for the whole site and there is no need in declaring it on button level.
+
+
 v2.0.0
 ------------------------------
 *September 15, 2021*

--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v3.0.0
 ------------------------------
-*September 22, 2021*
+*September 29, 2021*
 
 ### Changed
 - New colour scheme and border radius in line with Icing Phase 2.

--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -12,7 +12,7 @@ v3.0.0
 - New colour scheme and border radius in line with Icing Phase 2.
 
 ### Removed
-- Font-family beclaration from the button styles as we have one font for the whole site and there is no need in declaring it on button level.
+- Font-family declaration from the button styles as we have one font for the whole site and there is no need in declaring it on button level.
 
 
 v2.0.0

--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -6,13 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v3.0.0
 ------------------------------
-*September 29, 2021*
+*October 04, 2021*
 
 ### Changed
 - New colour scheme and border radius in line with Icing Phase 2.
 
 ### Removed
 - Font-family declaration from the button styles as we have one font for the whole site and there is no need in declaring it on button level.
+
+### Added
+- `inverse` and `ghostInverse` props for icon buttons
 
 
 v2.0.0

--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v3.0.0
 ------------------------------
-*October 04, 2021*
+*October 5, 2021*
 
 ### Changed
 - New colour scheme and border radius in line with Icing Phase 2.

--- a/packages/components/atoms/f-button/README.md
+++ b/packages/components/atoms/f-button/README.md
@@ -82,7 +82,7 @@ The props that can be defined are as follows:
 | Prop          | Type              | Required   | Default  | Description |
 | :---          | :---:             | :---:      | :---:    | :---        |
 | `actionType`  | `String`          | No         | `button` | Sets the action button type.<br>Options: `button`, `submit`, `reset`. |
-| `buttonType`  | `String`          | No         | `primary`| Sets the modifier theme for styling.<br>n.b. Only certain `buttonType` values are allowed in combination with the `isIcon` prop.<br>Options (when `isIcon: false`): `primary`, `secondary`, `outline`, `ghost`, `link`.<br>Options (when `isIcon: true`): `primary`, `secondary`, `ghost`, `ghostTertiary`|
+| `buttonType`  | `String`          | No         | `primary`| Sets the modifier theme for styling.<br>n.b. Only certain `buttonType` values are allowed in combination with the `isIcon` prop.<br>Options (when `isIcon: false`): `primary`, `secondary`, `outline`, `ghost`, `link`.<br>Options (when `isIcon: true`): `primary`, `secondary`, `ghost`, `ghostTertiary`, `inverse`, `ghostInverse`|
 | `buttonSize`  | `String`          | No         | `medium` | Sets the button size.<br>Options: `large`, `medium`, `small`, `xsmall`. |
 | `isFullWidth` | `Boolean`         | No         | `false`  | Controls whether or not to apply `fullWidth` modifier class |
 | `isIcon`      | `Boolean`         | No         | `false`  | When true, changes the button style to be displayed as an Icon Button (Icon, with no text). |

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "main": "dist/f-button.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -187,22 +187,22 @@ export default {
 </script>
 
 <style lang="scss" module>
-$btn-default-borderRadius              : $border-radius;
-$btn-default-font-family               : $font-family-base;
-$btn-default-font-size                 : 'body-l';
+
+$btn-default-borderRadius              : $radius-rounded-e;
+$btn-default-font-size                 : 'heading-s';
 $btn-default-weight                    : $font-weight-bold;
-$btn-default-padding                   : 12px spacing(x3);
+$btn-default-padding                   : 10px spacing(x3);
 $btn-default-outline-color             : $color-focus;
 $btn-default-loading-opacity           : 0.35;
 $btn-default-iconHeight                : 18px;
 $btn-default-iconSpacing               : 3px;
 $btn-default-iconSideSpacing           : $btn-default-iconSpacing + spacing();
 
-$btn-primary-bgColor                   : $color-interactive-primary;
-$btn-primary-bgColor--hover            : darken($color-interactive-primary, $color-hover-01);
-$btn-primary-bgColor--active           : darken($color-interactive-primary, $color-active-01);
-$btn-primary-textColor                 : $color-content-interactive-primary;
-$btn-primary-loading-color             : $color-content-interactive-primary;
+$btn-primary-bgColor                   : $color-interactive-brand;
+$btn-primary-bgColor--hover            : darken($color-interactive-brand, $color-hover-01);
+$btn-primary-bgColor--active           : darken($color-interactive-brand, $color-active-01);
+$btn-primary-textColor                 : $color-content-interactive-light;
+$btn-primary-loading-color             : $color-content-interactive-light;
 $btn-primary-loading-colorOpaque       : rgba($btn-primary-loading-color, $btn-default-loading-opacity);
 
 $btn-secondary-bgColor                 : $color-interactive-secondary;
@@ -240,11 +240,11 @@ $btn-link-loading-colorOpaque          : rgba($btn-link-loading-color, $btn-defa
 $btn-disabled-bgColor                  : $color-disabled-01;
 $btn-disabled-textColor                : $color-content-disabled;
 
-$btn-sizeLarge-font-size               : 'heading-s';
 $btn-sizeLarge-padding                 : 14px spacing(x3);
-$btn-sizeLarge-loading-color           : $color-content-interactive-primary;
+$btn-sizeLarge-loading-color           : $color-content-interactive-light;
 $btn-sizeLarge-loading-colorOpaque     : rgba($btn-sizeLarge-loading-color, $btn-default-loading-opacity);
 
+$btn-sizeSmall-font-size               : 'body-l';
 $btn-sizeSmall-padding                 : spacing() spacing(x2);
 $btn-sizeSmall-iconHeight              : 15px;
 $btn-sizeSmall-iconSpacing             : 2.5px;
@@ -278,7 +278,6 @@ $btn-icon-sizeXSmall-iconSize          : 18px;
     position: relative;
     display: inline-block;
     vertical-align: middle;
-    font-family: $btn-default-font-family;
     @include font-size($btn-default-font-size);
     cursor: pointer;
     padding: $btn-default-padding;
@@ -288,7 +287,7 @@ $btn-icon-sizeXSmall-iconSize          : 18px;
     border-radius: $btn-default-borderRadius;
     border: 1px solid transparent;
     user-select: none;
-    color: $color-grey-50;
+    color: $btn-secondary-textColor;
     text-decoration: none;
 
     // Hide focus styles if they're not needed, for example, when an element receives focus via the mouse.
@@ -358,7 +357,7 @@ $btn-icon-sizeXSmall-iconSize          : 18px;
  */
 
 .o-btn--primary,
-.o-btn--icon.o-btn--primary.o-btn--sizeLarge {
+.o-btn--icon.o-btn--primary {
     background-color: $btn-primary-bgColor;
 
     &,
@@ -387,6 +386,34 @@ $btn-icon-sizeXSmall-iconSize          : 18px;
     .o-btn-icon svg use,
     .o-btn-icon svg path {
         fill: $btn-primary-textColor;
+    }
+
+    &.o-btn--sizeSmall,
+    &.o-btn--sizeXSmall {
+        background-color: $color-interactive-primary;
+
+        &:hover {
+            background-color: lighten($color-interactive-primary, $color-hover-02);
+        }
+        &:active,
+        &.o-btn--loading {
+            background-color: lighten($color-interactive-primary, $color-active-02);
+        }
+    }
+}
+
+.o-btn--icon.o-btn--primary {
+    &.o-btn--sizeSmall,
+    &.o-btn--sizeXSmall {
+        background-color: $btn-primary-bgColor;
+
+        &:hover {
+            background-color: $btn-primary-bgColor--hover;
+        }
+        &:active,
+        &.o-btn--loading {
+            background-color: $btn-primary-bgColor--active;
+        }
     }
 }
 
@@ -666,24 +693,11 @@ $btn-icon-sizeXSmall-iconSize          : 18px;
  */
 
 .o-btn--sizeLarge {
-    @include font-size($btn-sizeLarge-font-size);
     padding: $btn-sizeLarge-padding;
-
-    &.o-btn--primary {
-        background-color: $color-interactive-brand;
-
-        &:hover {
-            background-color: darken($color-interactive-brand, $color-hover-01);
-        }
-        &:active, &.o-btn--loading {
-            background-color: darken($color-interactive-brand, $color-active-01);
-        }
-
-        @include spinnerColor($btn-sizeLarge-loading-color, $btn-sizeLarge-loading-colorOpaque);
-    }
 }
 
 .o-btn--sizeSmall {
+    @include font-size($btn-sizeSmall-font-size);
     padding: $btn-sizeSmall-padding;
 
     .o-btn-icon {

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -303,7 +303,7 @@ $btn-icon-sizeXSmall-iconSize          : 18px;
 
     &:hover,
     &:active {
-        &:not(.o-btnLink) {
+        &:not(.o-btn--link) {
             outline: 0; // no need as already has a focus/active state
         }
     }
@@ -426,6 +426,12 @@ $btn-icon-sizeXSmall-iconSize          : 18px;
 .o-btn--secondary {
     background-color: $btn-secondary-bgColor;
     color: $btn-secondary-textColor;
+
+    &:hover,
+    &:active,
+    &:focus {
+        color: $btn-secondary-textColor;
+    }
 
     &:hover {
         background-color: $btn-secondary-bgColor--hover;
@@ -563,13 +569,13 @@ $btn-icon-sizeXSmall-iconSize          : 18px;
 
     &:hover {
         cursor: pointer;
-        color: darken($color-content-link, $color-hover-01);
+        color: lighten($color-content-link, $color-hover-02);
         background-color: transparent;
         text-decoration: underline;
     }
     &:active,
     &:focus {
-        color: darken($color-content-link, $color-active-01);
+        color: lighten($color-content-link, $color-active-02);
         background-color: transparent;
     }
 

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -256,14 +256,13 @@ $btn-sizeXSmall-iconHeight             : 12px;
 $btn-sizeXSmall-iconSpacing            : 2px;
 $btn-sizeXSmall-iconSideSpacing        : $btn-sizeXSmall-iconSpacing + spacing();
 
-$btn-icon-sizeLarge-buttonSize         : 56px; // button--icon is a sircle so width and height can use one var
+$btn-icon-iconSize                     : 18px; // at the moment all the icon buttons except large have the same icon size
+$btn-icon-sizeLarge-buttonSize         : 56px; // icon button is a circle so width and height can use one var
 $btn-icon-sizeLarge-iconSize           : 21px;
 $btn-icon-sizeMedium-buttonSize        : 48px;
-$btn-icon-sizeMedium-iconSize          : 21px;
 $btn-icon-sizeSmall-buttonSize         : 40px;
-$btn-icon-sizeSmall-iconSize           : 18px;
 $btn-icon-sizeXSmall-buttonSize        : 32px;
-$btn-icon-sizeXSmall-iconSize          : 18px;
+
 
 @include loadingIndicator('medium');
 
@@ -613,15 +612,9 @@ $btn-icon-sizeXSmall-iconSize          : 18px;
         }
     }
 
-    &.o-btn--outline {
-        path {
-            fill: $btn-outline-textColor;
-        }
-    }
-
     &.o-btn--ghost {
         path {
-            fill: $btn-ghost-textColor;
+            fill: $color-content-interactive-brand;
         }
     }
 
@@ -631,23 +624,22 @@ $btn-icon-sizeXSmall-iconSize          : 18px;
         }
     }
 
-    &.o-btn--link {
-        path {
-            fill: $color-content-link;
-        }
+    &.o-btn--ghost,
+    &.o-btn--ghostTertiary {
+        background-color: $color-interactive-inverse; // for icon button to have a white background when it is located on top of images/dark surfaces
 
         &:hover {
-            path {
-                fill: darken($color-content-link, $color-hover-01);
-            }
+            background-color: $btn-ghost-bgColor--hover;
         }
 
-        &:active,
-        &:focus {
-            path {
-                fill: darken($color-content-link, $color-active-01);
-            }
+        &:active {
+            background-color: $btn-ghost-bgColor--active;
         }
+    }
+
+    svg {
+        width: $btn-icon-iconSize;
+        height: $btn-icon-iconSize;
     }
 }
 
@@ -665,31 +657,16 @@ $btn-icon-sizeXSmall-iconSize          : 18px;
     width: $btn-icon-sizeMedium-buttonSize;
     height: $btn-icon-sizeMedium-buttonSize;
     padding: 0;
-
-    svg {
-        width: $btn-icon-sizeMedium-iconSize;
-        height: $btn-icon-sizeMedium-iconSize;
-    }
 }
 .o-btn--icon.o-btn--sizeSmall {
     width: $btn-icon-sizeSmall-buttonSize;
     height: $btn-icon-sizeSmall-buttonSize;
     padding: 0;
-
-    svg {
-        width: $btn-icon-sizeSmall-iconSize;
-        height: $btn-icon-sizeSmall-iconSize;
-    }
 }
 .o-btn--icon.o-btn--sizeXSmall {
     width: $btn-icon-sizeXSmall-buttonSize;
     height: $btn-icon-sizeXSmall-buttonSize;
     padding: 0;
-
-    svg {
-        width: $btn-icon-sizeXSmall-iconSize;
-        height: $btn-icon-sizeXSmall-iconSize;
-    }
 }
 
 /**

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -612,7 +612,8 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
         }
     }
 
-    &.o-btn--ghost {
+    &.o-btn--ghost,
+    &.o-btn--inverse {
         path {
             fill: $color-content-interactive-brand;
         }
@@ -624,8 +625,7 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
         }
     }
 
-    &.o-btn--ghost,
-    &.o-btn--ghostTertiary {
+    &.o-btn--inverse {
         background-color: $color-interactive-inverse; // for icon button to have a white background when it is located on top of images/dark surfaces
 
         &:hover {
@@ -634,6 +634,22 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
 
         &:active {
             background-color: $btn-ghost-bgColor--active;
+        }
+    }
+
+    &.o-btn--ghostInverse {
+        path {
+            fill: $color-content-inverse;
+        }
+
+        background-color: $btn-ghost-bgColor;
+
+        &:hover {
+            background-color: lighten($color-black, $color-hover-02);
+        }
+
+        &:active {
+            background-color: lighten($color-black, $color-active-02);
         }
     }
 

--- a/packages/components/atoms/f-button/src/constants.js
+++ b/packages/components/atoms/f-button/src/constants.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/prefer-default-export
 export const VALID_BUTTON_TYPES = {
-    iconButton: ['primary', 'secondary', 'ghost', 'ghostTertiary'],
+    iconButton: ['primary', 'secondary', 'ghost', 'ghostTertiary', 'inverse', 'ghostInverse'],
     button: ['primary', 'secondary', 'outline', 'ghost', 'link']
 };
 

--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v3.0.0
 ------------------------------
-*September 22, 2021*
+*September 29, 2021*
 
 ### Changed
 - New border radius in line with Icing Phase 2.

--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.0.0
+------------------------------
+*September 22, 2021*
+
+### Changed
+- New border radius in line with Icing Phase 2.
+
+### Removed
+- `isRounded` prop as now all the cards should be rounded.
+
+
 v2.0.0
 ------------------------------
 *September 16, 2021*

--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v3.0.0
 ------------------------------
-*September 29, 2021*
+*October 5, 2021*
 
 ### Changed
 - New border radius in line with Icing Phase 2.

--- a/packages/components/atoms/f-card/README.md
+++ b/packages/components/atoms/f-card/README.md
@@ -71,7 +71,6 @@ The props that can be defined are as follows:
 | `cardHeadingTag`          | `String`   |  No        | `'h1'`  | Sets the tag for the card component's heading.<br><br>Allowed values are `h1`, `h2`, `h3`, `h4`, `h5` and `h6` |
 | `hasOutline`              | `Boolean`  |  No        | `false` | When set to `true`, an outline is applied to the card component.  |
 | `isPageContentWrapper`    | `Boolean`  |  No        | `false` | When set to `true`, applies styles to make the card act like a page content wrapper.<br><br>The card will be full width on narrow devices, and then a fixed width above a certain breakpoint width (about 480px), when the card will be centred on the page. |
-| `isRounded`               | `Boolean`  |  No        | `false` | When set to `true`, rounded corners are applied to the card component. |
 | `hasFullWidthFooter` | `Boolean` | No | `false` | When set to `true`, named slot `full-width-bottom-element` can be passed to render full width content at the bottom of the card without card paddings. |
 
 ### CSS Classes

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card",
   "description": "Fozzie Card Component – Used for providing wrapper card styling to an element (or group of elements)",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "main": "dist/f-card.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -3,7 +3,6 @@
         data-test-id="card-component"
         :class="[
             $style['c-card'], {
-                [$style['c-card--rounded']]: isRounded,
                 [$style['c-card--outline']]: hasOutline,
                 [$style['c-card--pageContentWrapper']]: isPageContentWrapper
             }]">
@@ -56,10 +55,6 @@ export default {
             type: Boolean,
             default: false
         },
-        isRounded: {
-            type: Boolean,
-            default: false
-        },
         hasFullWidthFooter: {
             type: Boolean,
             default: false
@@ -71,26 +66,22 @@ export default {
 <style lang="scss" module>
 
 $card-bgColor                             : $color-container-default;
-$card-borderColor                         : $color-border-strong;
-$card-borderRadius                        : $border-radius;
+$card-borderColor                         : $color-border-default;
+$card-borderRadius                        : $radius-rounded-c;
 $card-padding                             : spacing(x2);
-
 $card--pageContentWrapper-width           : 472px; // so that it falls on our 8px spacing grid
 
 .c-card {
     background-color: $card-bgColor;
     display: block;
+    border-radius: $card-borderRadius;
 }
     .c-card-innerSpacing {
         padding: $card-padding;
     }
 
-    .c-card--rounded {
-        border-radius: $card-borderRadius;
-    }
-
     .c-card--outline {
-        border: solid 1px $card-borderColor;
+        border: 1px solid $card-borderColor;
     }
 
     // .c-card--pageContentWrapper Modifier

--- a/packages/components/atoms/f-card/src/components/_tests/Card.test.js
+++ b/packages/components/atoms/f-card/src/components/_tests/Card.test.js
@@ -66,7 +66,6 @@ describe('Card', () => {
 
     describe('props', () => {
         describe.each([
-            ['isRounded', 'c-card--rounded'],
             ['hasOutline', 'c-card--outline'],
             ['isPageContentWrapper', 'c-card--pageContentWrapper']
         ])('%s', (propKey, cssClass) => {

--- a/packages/components/atoms/f-card/stories/card.stories.js
+++ b/packages/components/atoms/f-card/stories/card.stories.js
@@ -23,7 +23,6 @@ export const CardComponent = (args, { argTypes }) => ({
             :card-heading="cardHeading"
             :card-heading-position="cardHeadingPosition"
             :card-heading-tag="cardHeadingTag"
-            :is-rounded="isRounded"
             :has-outline="hasOutline"
             :is-page-content-wrapper="isPageContentWrapper"
             :has-full-width-footer="hasFullWidthFooter">
@@ -38,7 +37,6 @@ CardComponent.args = {
     cardHeading: 'My Card Heading',
     cardHeadingPosition: 'left',
     cardHeadingTag: 'h1',
-    isRounded: false,
     hasOutline: false,
     isPageContentWrapper: false,
     hasFullWidthFooter: false

--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v4.0.0
 ------------------------------
-*September 22, 2021*
+*September 29, 2021*
 
 ### Changed
 - New border radius in line with Icing Phase 2.

--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.0.0
+------------------------------
+*September 22, 2021*
+
+### Changed
+- New border radius in line with Icing Phase 2.
+
+
 v3.0.0
 ------------------------------
 *September 15, 2021*

--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v4.0.0
 ------------------------------
-*September 29, 2021*
+*October 5, 2021*
 
 ### Changed
 - New border radius in line with Icing Phase 2.

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/f-form-field.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/atoms/f-form-field/src/assets/scss/common.scss
+++ b/packages/components/atoms/f-form-field/src/assets/scss/common.scss
@@ -18,7 +18,7 @@ $form-input-secondaryTextColour         : $color-content-subdued;
 
 $form-input-borderWidth                 : 1px;
 $form-input-borderColour                : $color-border-default;
-$form-input-borderRadius                : $border-radius;
+$form-input-borderRadius                : $radius-rounded-c;
 $form-input-borderColour--invalid       : $color-support-error;
 
 $form-input-focus--boxShadow            : 0 0 0 2px $color-focus;

--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0
+------------------------------
+*September 22, 2021*
+
+### Changed
+- New colour scheme in line with Icing Phase 2.
+
+### Added
+- `o-link--distinct` prop to change default link colour (dark grey) to blue.
+
+
 v1.0.0
 ------------------------------
 *September 16, 2021*

--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v2.0.0
 ------------------------------
-*September 22, 2021*
+*September 29, 2021*
 
 ### Changed
 - New colour scheme in line with Icing Phase 2.

--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v2.0.0
 ------------------------------
-*September 29, 2021*
+*October 5, 2021*
 
 ### Changed
 - New colour scheme in line with Icing Phase 2.

--- a/packages/components/atoms/f-link/README.md
+++ b/packages/components/atoms/f-link/README.md
@@ -76,6 +76,7 @@ The props that can be defined are as follows (if any):
 | `hasTextDecoration` | `Boolean` | `true` | Adds underline to link text. |
 | `isFullWidth` | `Boolean` | `false` | Link set as full width. |
 | `noLineBreak` | `Boolean` | `false` | Removes white space. |
+| `isDistinct` | `Boolean` | `false` | Changes default link colour (dark grey) to blue. |
 
 ## Development
 

--- a/packages/components/atoms/f-link/package.json
+++ b/packages/components/atoms/f-link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-link",
   "description": "Fozzie Link - Fozzie link component",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "dist/f-link.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -6,7 +6,8 @@
                     [$style['o-link--bold']]: isBold,
                     [$style['o-link--noDecoration']]: !hasTextDecoration,
                     [$style['o-link--full']]: isFullWidth,
-                    [$style['o-link--noBreak']]: noLineBreak
+                    [$style['o-link--noBreak']]: noLineBreak,
+                    [$style['o-link--distinct']]: isDistinct
                 }]"
             data-test-id="link-component"
             :aria-describedby="descriptionId"
@@ -53,6 +54,11 @@ export default {
         },
 
         noLineBreak: {
+            type: Boolean,
+            default: false
+        },
+
+        isDistinct: {
             type: Boolean,
             default: false
         }
@@ -134,5 +140,18 @@ export default {
 
 .o-link--noBreak {
     white-space: nowrap;
+}
+
+.o-link--distinct {
+    color: $color-content-link-distinct;
+
+    &:hover,
+    &:focus {
+        color: darken($color-content-link-distinct, $color-hover-01);
+    }
+
+    &:active {
+        color: darken($color-content-link-distinct, $color-active-01);
+    }
 }
 </style>

--- a/packages/components/atoms/f-link/stories/Link.stories.js
+++ b/packages/components/atoms/f-link/stories/Link.stories.js
@@ -1,6 +1,4 @@
-import {
-    withKnobs, text, boolean, select
-} from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
 import VLink from '../src/components/Link.vue';
 
@@ -14,7 +12,7 @@ export const VLinkComponent = () => ({
     data () {
         return {
             dataTestId: 'link-component'
-        }
+        };
     },
     props: {
         isExternalSite: {
@@ -39,11 +37,14 @@ export const VLinkComponent = () => ({
 
         noLineBreak: {
             default: boolean('noLineBreak', false)
+        },
+        isDistinct: {
+            default: boolean('isDistinct', false)
         }
     },
 
     computed: {
-        target() {
+        target () {
             return this.opensInNewLocation ? '_blank' : null;
         }
     },
@@ -56,7 +57,8 @@ export const VLinkComponent = () => ({
                     :is-full-width="isFullWidth"
                     :no-line-break="noLineBreak"
                     :is-external-site="isExternalSite"
-                    :target="target">
+                    :target="target"
+                    :isDistinct="isDistinct">
                     <span>This is a Link</span>
                 </v-link>`
 });

--- a/packages/components/atoms/f-popover/CHANGELOG.md
+++ b/packages/components/atoms/f-popover/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0
+------------------------------
+*September 22, 2021*
+
+### Changed
+- New border radius in line with Icing Phase 2.
+
+
 v1.0.0
 ------------------------------
 *September 16, 2021*

--- a/packages/components/atoms/f-popover/CHANGELOG.md
+++ b/packages/components/atoms/f-popover/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v2.0.0
 ------------------------------
-*September 22, 2021*
+*September 29, 2021*
 
 ### Changed
 - New border radius in line with Icing Phase 2.

--- a/packages/components/atoms/f-popover/CHANGELOG.md
+++ b/packages/components/atoms/f-popover/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v2.0.0
 ------------------------------
-*September 29, 2021*
+*October 5, 2021*
 
 ### Changed
 - New border radius in line with Icing Phase 2.

--- a/packages/components/atoms/f-popover/package.json
+++ b/packages/components/atoms/f-popover/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-popover",
   "description": "Fozzie Popover - renders recieved content as a popover",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "dist/f-popover.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-popover/src/components/Popover.vue
+++ b/packages/components/atoms/f-popover/src/components/Popover.vue
@@ -27,7 +27,7 @@ $tooltip-width                 : 10px;
         box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.03),
                     0 1px 10px 1px rgba(0, 0, 0, 0.07),
                     0 2px 4px -1px rgba(0, 0, 0, 0.06);
-        border-radius: $border-radius;
+        border-radius: $radius-rounded-c;
         padding: 0 $popover-padding;
         width: auto;
 

--- a/packages/components/molecules/f-user-message/CHANGELOG.md
+++ b/packages/components/molecules/f-user-message/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v3.0.0
 ------------------------------
-*September 22, 2021*
+*September 29, 2021*
 
 ### Changed
 - Background colour token in line with Icing Phase 2.

--- a/packages/components/molecules/f-user-message/CHANGELOG.md
+++ b/packages/components/molecules/f-user-message/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.0.0
+------------------------------
+*September 22, 2021*
+
+### Changed
+- Background colour token in line with Icing Phase 2.
+
+
 v2.0.0
 ------------------------------
 *September 15, 2021*

--- a/packages/components/molecules/f-user-message/CHANGELOG.md
+++ b/packages/components/molecules/f-user-message/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v3.0.0
 ------------------------------
-*September 29, 2021*
+*October 5, 2021*
 
 ### Changed
 - Background colour token in line with Icing Phase 2.

--- a/packages/components/molecules/f-user-message/package.json
+++ b/packages/components/molecules/f-user-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-user-message",
   "description": "Fozzie User Message – Globalised User Message Component",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "main": "dist/f-user-message.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/molecules/f-user-message/src/components/UserMessage.vue
+++ b/packages/components/molecules/f-user-message/src/components/UserMessage.vue
@@ -66,7 +66,7 @@ export default {
 <style lang="scss" module>
 .c-userMessage {
     color: $color-content-light;
-    background-color: $color-support-brand;
+    background-color: $color-support-brand-01;
     max-width: 100%;
 }
 

--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v6.0.0
+------------------------------
+*September 23, 2021*
+
+### Changed
+- `$color-content-brand-strong` pie value to `$color-content-default` in line with icing phase 2.
+- New colour scheme from `pie-design-tokens` in line with icing phase 2.
+
 v5.0.0
 ------------------------------
 *September 15, 2021*

--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v6.0.0
 ------------------------------
-*September 23, 2021*
+*September 29, 2021*
 
 ### Changed
 - `$color-content-brand-strong` pie value to `$color-content-default` in line with icing phase 2.

--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -6,11 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v6.0.0
 ------------------------------
-*September 29, 2021*
+*October 5, 2021*
 
 ### Changed
 - `$color-content-brand-strong` pie value to `$color-content-default` in line with icing phase 2.
 - New colour scheme from `pie-design-tokens` in line with icing phase 2.
+
 
 v5.0.0
 ------------------------------

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "main": "dist/f-content-cards.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [

--- a/packages/components/organisms/f-content-cards/src/assets/scss/_card-styles.scss
+++ b/packages/components/organisms/f-content-cards/src/assets/scss/_card-styles.scss
@@ -31,5 +31,5 @@
   background-size: cover;
   background-color: $color-container-subtle;
   background-position: center;
-  border-radius: $border-radius $border-radius 0 0;
+  border-radius: $radius-rounded-c $radius-rounded-c 0 0;
 }

--- a/packages/components/organisms/f-content-cards/src/assets/scss/common.scss
+++ b/packages/components/organisms/f-content-cards/src/assets/scss/common.scss
@@ -4,6 +4,3 @@
 $theme: 'jet' !default;
 
 @import  '~@justeat/fozzie/src/scss/fozzie';
-
-// defined separately from the $border-radius variable in order to match the radius for UI elements in OrderWeb
-$post-order-card-radius: 8px;

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -171,7 +171,7 @@ export default {
             .c-contentCard-info {
                 padding-top: spacing(x10) + spacing(x6);
                 padding-bottom: spacing(x2);
-                border-radius: $border-radius;
+                border-radius: $radius-rounded-c;
             }
 
             .c-contentCard-bgImg {
@@ -233,7 +233,7 @@ export default {
         background-color: $color-container-default;
         padding: spacing(x2);
         box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-        border-radius: 0 0 $border-radius $border-radius;
+        border-radius: 0 0 $radius-rounded-c $radius-rounded-c;
     }
 
     .c-contentCard-footer {
@@ -271,7 +271,7 @@ export default {
             @include media ('<mid') {
                 border: 1px solid $color-border-strong;
                 padding: spacing(x3);
-                border-radius: 0 0 $post-order-card-radius $post-order-card-radius;
+                border-radius: 0 0 $radius-rounded-c $radius-rounded-c;
             }
         }
 
@@ -296,10 +296,10 @@ export default {
 
         .c-contentCard-bgImg {
             overflow: hidden;
-            border-radius: $post-order-card-radius;
+            border-radius: $radius-rounded-c;
 
             @include media ('<mid') {
-                border-radius: $post-order-card-radius $post-order-card-radius 0 0;
+                border-radius: $radius-rounded-c $radius-rounded-c 0 0;
             }
         }
 
@@ -330,7 +330,7 @@ export default {
             @include media('<mid') {
                 position: relative;
                 padding: spacing(x2) spacing(x2) spacing(x2) spacing(x9);
-                border-radius: $post-order-card-radius;
+                border-radius: $radius-rounded-c;
             }
         }
     }

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/FirstTimeCustomerCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/FirstTimeCustomerCard.vue
@@ -58,7 +58,7 @@ $banner-bgColour-legacy : #cd381f;
     background: $banner-bgColour;
     padding: 0 spacing();
     margin: spacing(x2) 0 spacing() 0;
-    border-radius: $border-radius;
+    border-radius: $radius-rounded-c;
 }
 
 .c-restaurantCard-banner-content {

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
@@ -105,7 +105,7 @@ export default {
 <style lang="scss" module>
     .c-postOrderCard {
         border: 1px solid $color-border-strong;
-        border-radius: $post-order-card-radius;
+        border-radius: $radius-rounded-c;
         padding: spacing(x3);
         max-width: 100%;
         flex: 1 1 0%; // do not remove unit its intentional for IE11

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/PromotionCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/PromotionCard.vue
@@ -97,7 +97,7 @@ export default {
         vertical-align: middle;
 
         padding: spacing() 1.2em;
-        border-radius: $border-radius;
+        border-radius: $radius-rounded-c;
         font-weight: $font-weight-bold;
         font-family: $font-family-base;
         @include font-size('body-l');

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/SkeletonLoader.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/SkeletonLoader.vue
@@ -46,7 +46,7 @@ export default {
     }
 
     .c-skeletonLoader-card {
-        border-radius: $border-radius;
+        border-radius: $radius-rounded-c;
         display: flex;
         flex-direction: column;
         flex: 0 0 40%;

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
@@ -287,7 +287,7 @@ $stampCard-responsive-tabletViewBreakpoint: '<=mid';
     display: flex;
     flex-direction: column;
     padding: spacing(x2);
-    border-radius: $border-radius;
+    border-radius: $radius-rounded-c;
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.03),
     0 3px 1px -2px rgba(0, 0, 0, 0.07),
     0 1px 5px 0 rgba(0, 0, 0, 0.06);
@@ -319,7 +319,7 @@ $stampCard-responsive-tabletViewBreakpoint: '<=mid';
     margin-bottom: spacing();
     width: $stampCard-iconSize-landscape;
     height: $stampCard-iconSize-landscape;
-    border-radius: $border-radius;
+    border-radius: $radius-rounded-c;
 
     @include media($stampCard-responsive-mobileViewBreakpoint) {
         width: $stampCard-iconSize-portrait;

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCardPromotionCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCardPromotionCard.vue
@@ -96,7 +96,7 @@ $stampCard-promo-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.03),
 
     @include media('>narrowMid') {
         max-width: 344px;
-        border-radius: 2px;
+        border-radius: $radius-rounded-c;
         box-shadow: $stampCard-promo-shadow;
     }
 
@@ -116,7 +116,7 @@ $stampCard-promo-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.03),
 .c-stampCardPromotion1-img {
     display: block;
     width: 100%;
-    border-radius: $border-radius $border-radius 0 0;
+    border-radius: $radius-rounded-c $radius-rounded-c 0 0;
 }
 
 .c-stampCardPromotion1-icon {
@@ -124,7 +124,7 @@ $stampCard-promo-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.03),
     top: spacing(x2);
     left: spacing(x2);
     margin: 0;
-    border-radius: $border-radius;
+    border-radius: $radius-rounded-c;
     border: 0.5px solid $color-border-default;
 
     @include media('>narrowMid') {
@@ -143,7 +143,7 @@ $stampCard-promo-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.03),
     margin-top: - spacing(x3);
     margin-left: spacing(x2);
     margin-right: spacing(x2) - 1px;
-    border-radius: $border-radius;
+    border-radius: $radius-rounded-c;
     box-shadow: $stampCard-promo-shadow;
 
     @include media ('>narrowMid') {

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
@@ -160,7 +160,7 @@ export default {
         display: block;
         width: 100%;
         box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-        border-radius: 4px;
+        border-radius: $radius-rounded-c;
         padding: spacing(x2) calc(35% + #{spacing()}) spacing(x2) spacing(x2);
         max-width: 800px; //to replicate max-width of searchbox
         margin: auto;

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/voucherCard/VoucherCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/voucherCard/VoucherCard.vue
@@ -204,7 +204,7 @@ export default {
     }
 
     .c-contentCard-voucher-copy-copied {
-        color: $color-content-brand-strong;
+        color: $color-content-default;
     }
 
     .c-contentCard-voucher-copy-transition-out {
@@ -220,7 +220,7 @@ export default {
     }
 
     .c-contentCard-voucher-code-cooldown-tick {
-        fill: $color-content-brand-strong;
+        fill: $color-content-default;
         width: spacing(x2);
         height: spacing(x2);
         padding: 0;

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v7.0.0
 ------------------------------
-*September 23, 2021*
+*September 29, 2021*
 
 ### Changed
 - `$color-support-brand` pie value to `$color-support-brand-01` in line with icing phase 2.

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v7.0.0
+------------------------------
+*September 23, 2021*
+
+### Changed
+- `$color-support-brand` pie value to `$color-support-brand-01` in line with icing phase 2.
+- New colour scheme from `pie-design-tokens` in line with icing phase 2.
+Note: This version doesn't contain all the style changes for icing phase 2. More changes will come in the later version.
+
+
 v6.0.0
 ------------------------------
 *September 16, 2021*

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v7.0.0
 ------------------------------
-*September 29, 2021*
+*October 5, 2021*
 
 ### Changed
 - `$color-support-brand` pie value to `$color-support-brand-01` in line with icing phase 2.

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -10,8 +10,8 @@ v7.0.0
 
 ### Changed
 - `$color-support-brand` pie value to `$color-support-brand-01` in line with icing phase 2.
-- New colour scheme from `pie-design-tokens` in line with icing phase 2.
-Note: This version doesn't contain all the style changes for icing phase 2. More changes will come in the later version.
+- New colour scheme and border-radius from `pie-design-tokens` in line with icing phase 2.
+- Updated version of `f-button` and `f-popover`.
 
 
 v6.0.0

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -53,8 +53,8 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.12.13",
-    "@justeat/f-button": "2.0.0",
-    "@justeat/f-popover": "1.0.0",
+    "@justeat/f-button": "3.0.0",
+    "@justeat/f-popover": "2.0.0",
     "@justeat/f-vue-icons": "2.4.0",
     "@justeat/f-wdio-utils": "0.3.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -237,7 +237,7 @@ html:global(.is-navInView) {
     }
 
     .c-header--highlightBg {
-        background-color: $color-support-brand;
+        background-color: $color-support-brand-01;
         min-height: 88px;
     }
 

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -296,20 +296,6 @@ html:global(.is-navInView) {
         }
     }
 
-    .c-header-buttonCount {
-        top: 0;
-        right: 0;
-        min-width: 16px;
-        padding: 1px 3px 0;
-        text-align: center;
-        border-radius: 8px;
-        position: absolute;
-        @include font-size(caption, false);
-        color: $header-buttonCount-color;
-        background: $header-buttonCount-bg;
-        border: 1px solid $header-buttonCount-borderColor;
-    }
-
     .c-header-button--primary {
         display: block;
         width: 40px;

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -207,6 +207,10 @@ html:global(.is-navInView) {
             top: 0;
         }
     }
+
+    @include media('>mid') {
+        border-radius: 0 0 $radius-rounded-d $radius-rounded-d;
+    }
 }
 
     // Adds a border to the header to separate it from the

--- a/yarn.lock
+++ b/yarn.lock
@@ -2343,10 +2343,10 @@
   dependencies:
     "@justeat/f-services" "1.7.0"
 
-"@justeat/fozzie@6.0.0-beta.3":
-  version "6.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-6.0.0-beta.3.tgz#3dd766bbc541682c9017fbd7a4174fce576bf820"
-  integrity sha512-7jAAAhsGYaNICwogjyju69SWpWNUkuCnRrTI9qreF9y0itlyJO9cVx8e1UmUbENxT/agk3uDxZZd4WsYIe6JPA==
+"@justeat/fozzie@6.0.0-beta.4":
+  version "6.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-6.0.0-beta.4.tgz#ed5a81051196657fabad71fa0b870dea9f3740b5"
+  integrity sha512-uHxgHFfooHpV3R4q2yVypLbIYXpiP0nwyrRMPAqAhxoyTK7tRT7zdulcC0L7ZKGGl60rsdIIjx2a6StyQG+vHQ==
   dependencies:
     "@justeat/f-dom" "1.1.0"
     "@justeat/f-logger" "0.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2343,10 +2343,10 @@
   dependencies:
     "@justeat/f-services" "1.7.0"
 
-"@justeat/fozzie@6.0.0-beta.4":
-  version "6.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-6.0.0-beta.4.tgz#ed5a81051196657fabad71fa0b870dea9f3740b5"
-  integrity sha512-uHxgHFfooHpV3R4q2yVypLbIYXpiP0nwyrRMPAqAhxoyTK7tRT7zdulcC0L7ZKGGl60rsdIIjx2a6StyQG+vHQ==
+"@justeat/fozzie@6.0.0-beta.5":
+  version "6.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-6.0.0-beta.5.tgz#a2a357f96cd3e8a9076a9d0e4d58f687a4184398"
+  integrity sha512-YUBCnFGRDXb9DILjo8Ui8YdAZQ95ml25mGcYJQ1lNzlK29xcfnaJzQwSv1U5sfbKfhHZeyHGHRpN3071tREhFA==
   dependencies:
     "@justeat/f-dom" "1.1.0"
     "@justeat/f-logger" "0.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2123,6 +2123,18 @@
     eslint-config-airbnb-base "14.1.0"
     eslint-plugin-vue "6.2.2"
 
+"@justeat/f-button@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-2.0.0.tgz#437c7f37eed9b62536ddaab704d4d3536f9a881f"
+  integrity sha512-lCPiIp5+DhP/gKj6fYmZscui/Ajn3CLGBbg59nJlaSQ+OM6+cUr0VZ0b2EdI1mYCL03HZO0aNseGB5B7yYNYBw==
+
+"@justeat/f-card@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-card/-/f-card-2.0.0.tgz#616a88e149f23643639af33c9aa995d64e671d7a"
+  integrity sha512-H4KXZ4Mk+tLrwOjFjuH2ztNLIBoncAimYCBkAPLI9ISpH4EXLk/H6gmFED4mYkEkFmD1qyLEE4oM45M4KQMWcQ==
+  dependencies:
+    "@justeat/f-services" "0.13.0"
+
 "@justeat/f-content-cards@6.0.0-beta.2":
   version "6.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-6.0.0-beta.2.tgz#1b77d0d33ad0b8b41d26d78029c848e8444d20b5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2146,6 +2146,14 @@
   dependencies:
     qwery "4.0.0"
 
+"@justeat/f-form-field@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-3.0.0.tgz#0e629cfeb13b42e441c14a9d6ff01c4313af7e79"
+  integrity sha512-5+po42XYPhpLB2n3LsMEIBmkq5l4tLqfElRuqkgvCfg6S+xKzT8jGqb++VFrdhyNKFnVEyDW6CP2A4qrCIQ7mA==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+    "@justeat/f-vue-icons" "2.5.0"
+
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-0.2.0.tgz#90ec559642c165b6325669c506c417abe09fa5dd"
@@ -2166,12 +2174,26 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-3.9.0.tgz#9b57f82cdbd98e15c12f2e24ea25c78d3ff2260c"
   integrity sha512-5mE57SuZ2DErEK/K7bfmxhMpB5+vGnCs/Py8ltVTUJh7C8SYRDcIAFgagcJvDLA6NzA2grtSlgNTksIXdKH34g==
 
+"@justeat/f-link@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-link/-/f-link-1.0.0.tgz#9044cd51473b839826f0cda3f3fb98219ca31352"
+  integrity sha512-Eer68h4NScqJKZz7t77z3TUgb6rDgFjQo+PDEz5wuC2WkkqZYMt0fJtxlfhNuj7nEpnN2aPPs2FCf+hCQcNfrw==
+  dependencies:
+    "@justeat/f-services" "1.7.0"
+
 "@justeat/f-logger@0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-logger/-/f-logger-0.8.1.tgz#10aef6a3d97b75e1ded2367fa0b69972661f76e6"
   integrity sha512-owV/JWeve1Bc4HrSu2zFIgXjuAqAD5PYflw2iAMFk7SVbl2gGvewUgKszf61ZOg9qjADdxmCkW5sZPQkRzHmbQ==
   dependencies:
     window-or-global "^1.0.1"
+
+"@justeat/f-popover@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-popover/-/f-popover-1.0.0.tgz#f4e0c31dece638a5ed4fdecb38d1dea536e79731"
+  integrity sha512-5MQRHwAApRnCdmc86OAgFDBhoNmjYZ2gAB2hZDkK1sSEiS7dxIDTvs+rINTggx9ilsTBwPOBAxpsMZm0OkllIw==
+  dependencies:
+    "@justeat/f-services" "1.7.0"
 
 "@justeat/f-searchbox@5.1.0":
   version "5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2321,22 +2321,22 @@
   dependencies:
     "@justeat/f-services" "1.7.0"
 
-"@justeat/fozzie@6.0.0-beta.1":
-  version "6.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-6.0.0-beta.1.tgz#f9ae0ba3bed371770c993fbf297d68e16067a012"
-  integrity sha512-/tTyMrRZcg8fUxIHmlPo1UjFtlVYb+N4AolpLXIpsCmyQblJBkhx9sNCTipQEmJdYACQex4OL5RSdxq0pGewNw==
+"@justeat/fozzie@6.0.0-beta.3":
+  version "6.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-6.0.0-beta.3.tgz#3dd766bbc541682c9017fbd7a4174fce576bf820"
+  integrity sha512-7jAAAhsGYaNICwogjyju69SWpWNUkuCnRrTI9qreF9y0itlyJO9cVx8e1UmUbENxT/agk3uDxZZd4WsYIe6JPA==
   dependencies:
     "@justeat/f-dom" "1.1.0"
     "@justeat/f-logger" "0.8.1"
     "@justeat/f-utils" "2.0.0"
-    "@justeat/pie-design-tokens" "1.0.0-beta.0"
+    "@justeat/pie-design-tokens" "1.1.0"
     fontfaceobserver "2.1.0"
     include-media "1.4.10"
 
-"@justeat/pie-design-tokens@1.0.0-beta.0":
-  version "1.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-1.0.0-beta.0.tgz#272457e7f806ac931800935cd54b10801c45a589"
-  integrity sha512-egiGduhwftk8O9KSnTnK5rN3cP/FY1TurdvFiC12C3mkXEImEZnpLTbf/sZ/StV95m4E69y45jiaPB87FXzSVw==
+"@justeat/pie-design-tokens@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-1.1.0.tgz#d93ad0411cd0457522d8bd466de521382682e05d"
+  integrity sha512-YtiJ7Uq+JZgYAJAFYr0e0an+p8RRk9MimAtqNnk2MFI5au7eNMFt3lTugwfoRgk4jKQfNg2RwTZe0tuuzzc8nw==
   dependencies:
     jsonc-parser "2.2.0"
     lodash.merge "4.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2200,13 +2200,6 @@
   dependencies:
     window-or-global "^1.0.1"
 
-"@justeat/f-popover@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-popover/-/f-popover-1.0.0.tgz#f4e0c31dece638a5ed4fdecb38d1dea536e79731"
-  integrity sha512-5MQRHwAApRnCdmc86OAgFDBhoNmjYZ2gAB2hZDkK1sSEiS7dxIDTvs+rINTggx9ilsTBwPOBAxpsMZm0OkllIw==
-  dependencies:
-    "@justeat/f-services" "1.7.0"
-
 "@justeat/f-searchbox@5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-searchbox/-/f-searchbox-5.1.0.tgz#11d2242bab6c5bef5783392055a0b5f1c58e9adc"


### PR DESCRIPTION
First part of the changes for Icing Part 1 (all the atoms + f-content-cards and f-header changes)

## fozzie-components@4.1.0

### Changed
- `fozzie` package version bump to 6.0.0-beta.5 to include new colour theme and radius vars.

## f-button@3.0.0

### Changed
- New colour scheme and border radius in line with Icing Phase 2.

### Removed
- Font-family declaration from the button styles as we have one font for the whole site and there is no need in declaring it on button level.

## f-card@3.0.0

### Changed
- New border radius in line with Icing Phase 2.

### Removed
- `isRounded` prop as now all the cards should be rounded.

## f-form-field@4.0.0

### Changed
- New border radius in line with Icing Phase 2.

## f-link@2.0.0

### Changed
- New colour scheme in line with Icing Phase 2.

### Added
- `o-link--distinct` prop to change default link colour (dark grey) to blue.

## f-popover@2.0.0

### Changed
- New border radius in line with Icing Phase 2.

## f-user-message@3.0.0

### Changed
- Background colour token in line with Icing Phase 2.

## f-header@7.0.0

### Changed
- `$color-support-brand` pie value to `$color-support-brand-01` in line with icing phase 2.
- New colour scheme and border-radius from `pie-design-tokens` in line with icing phase 2.
- Updated version of `f-button` and `f-popover`.

## f-content-cards@6.0.0

### Changed
- `$color-content-brand-strong` pie value to `$color-content-default` in line with icing phase 2.
- New colour scheme from `pie-design-tokens` in line with icing phase 2.


