### PR TITLE
f-analytics@v0.16.0 - Remove redundant fields

### DIFF
--- a/packages/services/f-analytics/CHANGELOG.md
+++ b/packages/services/f-analytics/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.16.0
+------------------------------
+*September 24, 2021*
+
+### Changed
+- Removed the redundant properties from  pushPlatformData() & pushPageData().
+
+
 v0.15.0
 ------------------------------
 *September 21, 2021*

--- a/packages/services/f-analytics/CHANGELOG.md
+++ b/packages/services/f-analytics/CHANGELOG.md
@@ -9,7 +9,7 @@ v0.16.0
 *September 24, 2021*
 
 ### Changed
-- Removed the redundant properties from  pushPlatformData() & pushPageData().
+- Removed the redundant fields from  pushPlatformData() & pushPageData().
 
 
 v0.15.0

--- a/packages/services/f-analytics/README.md
+++ b/packages/services/f-analytics/README.md
@@ -122,7 +122,7 @@ You can see the GTM tags and any GA data by inspecting the `header` of the page 
 
           ...
 
-          mounted () {
+          beforeMount () {
               this.$gtm.pushPlatformData();
           },
 
@@ -175,11 +175,10 @@ You can see the GTM tags and any GA data by inspecting the `header` of the page 
     - ### **`pushPageData()`**<br>
       Evaluates and gather data for the `pageData` GA model and pushes it to the `dataLayer`<br>
       #### **Syntax**.
-      > this.`$gtm`.**pushPageData**(_{ pageName: `accounts sign-up`, requestId: `021c24d2-86ef-...`, customFields: { custom1: 'one' } }_);
+      > this.`$gtm`.**pushPageData**(_{ pageName: `accounts sign-up`, customFields: { custom1: 'one' } }_);
       #### **Parameters**.
       > (**object**) {<br>
       >> - (**string**) `pageName`
-      >> - (**string**) `requestId` (_optional_)
       >> - (**number**) `httpStatusCode` (_optional_)(_only override this if you wish to change the default 200, i.e you may be displaying a custom static 404 page and want to record the value 404 instead of 200 or you may be displaying a successful account creation page and want to record the value 201 rather than 200_)
       >> - (**object**) `customFields` (_optional_) (_You may want to overwrite/add fields and this parameter allows you to indicate an object of fields/values that if already present will overwrite and if not then will be append to the model_)
 

--- a/packages/services/f-analytics/package.json
+++ b/packages/services/f-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-analytics",
   "description": "Fozzie Analytics - A utility that encapsulates the GTM / Google Analytics functionality",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "maxBundleSize": "200kB",
   "main": "dist/f-analytics.umd.js",
   "module": "dist/f-analytics.es.js",

--- a/packages/services/f-analytics/src/constants.js
+++ b/packages/services/f-analytics/src/constants.js
@@ -2,37 +2,31 @@ const COUNTRY_INFO = {
     'en-GB': {
         language: 'en',
         country: 'uk',
-        brand: 'justeat',
         currency: 'gbp'
     },
     'en-IE': {
         language: 'en',
         country: 'ie',
-        brand: 'justeat',
         currency: 'eur'
     },
     'it-IT': {
         language: 'it',
         country: 'it',
-        brand: 'justeat',
         currency: 'eur'
     },
     'es-ES': {
         language: 'es',
         country: 'es',
-        brand: 'justeat',
         currency: 'eur'
     },
     'en-AU': {
         language: 'en',
         country: 'au',
-        brand: 'menulog',
         currency: 'aud'
     },
     'en-NZ': {
         language: 'en',
         country: 'nz',
-        brand: 'menulog',
         currency: 'nzd'
     }
 };

--- a/packages/services/f-analytics/src/plugins/_tests/analytics.plugin.test.js
+++ b/packages/services/f-analytics/src/plugins/_tests/analytics.plugin.test.js
@@ -88,7 +88,7 @@ describe('Analytics Plugin ::', () => {
         it('should inject the global object', () => {
             // Arrange
             const modifiedOptions = { ...options, globalVarName: 'jazz' };
-            const expected = new AnalyticService(defaultStore, context.req, modifiedOptions);
+            const expected = new AnalyticService(defaultStore, modifiedOptions);
 
             // Act
             AnalyticsPlugin(context, injectSpy, modifiedOptions);

--- a/packages/services/f-analytics/src/plugins/analytics.plugin.js
+++ b/packages/services/f-analytics/src/plugins/analytics.plugin.js
@@ -63,7 +63,7 @@ export default ({ store, req }, inject, _options) => {
 
     prepareServerSideValues(store, req, options);
 
-    const service = new AnalyticService(store, req, options);
+    const service = new AnalyticService(store, options);
 
     inject(options.globalVarName, service);
 

--- a/packages/services/f-analytics/src/services/_tests/analytics.service.test.js
+++ b/packages/services/f-analytics/src/services/_tests/analytics.service.test.js
@@ -83,7 +83,7 @@ describe('Analytic Service ::', () => {
     });
 
     describe('When calling pushPlatformData', () => {
-        // 1 == locale, 2 == country, 3 == currency, 4 == language
+        // 1 = locale, 2 = country, 3 = currency, 4 == language
         const cases = [
             ['en-GB', 'uk', 'gbp', 'en'],
             ['en-IE', 'ie', 'eur', 'en'],
@@ -304,7 +304,7 @@ describe('Analytic Service ::', () => {
             expect(windowsPushSpy).not.toHaveBeenCalled();
         });
 
-        // 1 == window width, 2 == window height, 3 == expected orientation value
+        // 1 = window width, 2 = window height, 3 = expected orientation value
         const cases = [
             [1281, 1282, 'Portrait'],
             [1281, 1280, 'Landscape'],

--- a/packages/services/f-analytics/src/services/_tests/analytics.service.test.js
+++ b/packages/services/f-analytics/src/services/_tests/analytics.service.test.js
@@ -16,7 +16,6 @@ describe('Analytic Service ::', () => {
     let store;
     let storeDispatchSpy;
     let service;
-    let req;
     let windowCopy;
     let windowSpy;
     let windowsPushSpy;
@@ -25,7 +24,6 @@ describe('Analytic Service ::', () => {
     const mockWindow = ({ winWidth = 667, winHeight = 375 } = {}) => {
         windowsPushSpy = jest.fn();
         windowCopy = { ...window };
-        jest.spyOn(windowCopy.navigator, 'userAgent', 'get').mockReturnValue('test-agent-string');
         const innerWidthSpy = jest.fn().mockReturnValue(winWidth);
         const innerHeightSpy = jest.fn().mockReturnValue(winHeight);
         windowSpy = jest.spyOn(global, 'window', 'get');
@@ -53,7 +51,7 @@ describe('Analytic Service ::', () => {
         // Arrange - window state
         mockWindow();
         // Arrange - sut
-        service = new AnalyticService(store, req, options);
+        service = new AnalyticService(store, options);
     });
 
     afterEach(() => {
@@ -62,7 +60,7 @@ describe('Analytic Service ::', () => {
 
     it('should instantiate a new instance', () => {
         // Act
-        const instance = () => new AnalyticService(store, req, options);
+        const instance = () => new AnalyticService(store, options);
 
         // Assert
         expect(instance).not.toThrowError();
@@ -87,30 +85,28 @@ describe('Analytic Service ::', () => {
     describe('When calling pushPlatformData', () => {
         // 1 == locale, 2 == branding, 3 == country, 4 == currency, 5 == language
         const cases = [
-            ['en-GB', 'justeat', 'uk', 'gbp', 'en'],
-            ['en-IE', 'justeat', 'ie', 'eur', 'en'],
-            ['it-IT', 'justeat', 'it', 'eur', 'it'],
-            ['es-ES', 'justeat', 'es', 'eur', 'es'],
-            ['en-AU', 'menulog', 'au', 'aud', 'en'],
-            ['en-NZ', 'menulog', 'nz', 'nzd', 'en']
+            ['en-GB', 'uk', 'gbp', 'en'],
+            ['en-IE', 'ie', 'eur', 'en'],
+            ['it-IT', 'it', 'eur', 'it'],
+            ['es-ES', 'es', 'eur', 'es'],
+            ['en-AU', 'au', 'aud', 'en'],
+            ['en-NZ', 'nz', 'nzd', 'en']
         ];
         test.each(cases)(
             'should dispatch the correct `plaformData` to the store given %p as the locale',
-            (localeArg, brandingExpected, countryExpected, currencyExpected, languageExpected) => {
+            (localeArg, countryExpected, currencyExpected, languageExpected) => {
                 // Arrange
                 const expectedPlatformData = {
                     ...defaultState.platformData,
                     appType: 'web',
                     applicationId: 7,
-                    branding: brandingExpected,
                     country: countryExpected,
                     currency: currencyExpected,
                     language: languageExpected,
-                    name: options.featureName,
-                    userAgent: navigator.userAgent
+                    name: options.featureName
                 };
                 options.locale = localeArg;
-                service = new AnalyticService(store, req, options);
+                service = new AnalyticService(store, options);
 
                 // Act
                 service.pushPlatformData();
@@ -130,13 +126,11 @@ describe('Analytic Service ::', () => {
                 ...defaultState.platformData,
                 appType: 'web',
                 applicationId: 7,
-                branding: 'justeat',
                 country: 'uk',
                 currency: 'gbp',
                 environment: 'localhost',
                 language: 'en',
-                name: 'new-feature-name',
-                userAgent: navigator.userAgent
+                name: 'new-feature-name'
             };
 
             // Act
@@ -153,13 +147,11 @@ describe('Analytic Service ::', () => {
                 ...defaultState.platformData,
                 appType: 'web',
                 applicationId: 7,
-                branding: 'menulog',
                 country: 'au',
                 currency: 'aud',
                 environment: 'localhost',
                 language: 'en',
-                name: options.featureName,
-                userAgent: navigator.userAgent
+                name: options.featureName
             };
 
             // Act
@@ -176,13 +168,11 @@ describe('Analytic Service ::', () => {
                 ...defaultState.platformData,
                 appType: 'web',
                 applicationId: 7,
-                branding: 'justeat',
                 country: 'uk',
                 currency: 'gbp',
                 environment: 'localhost',
                 language: 'en',
-                name: 'new-feature-name',
-                userAgent: navigator.userAgent
+                name: 'new-feature-name'
             };
 
             // Act
@@ -316,20 +306,20 @@ describe('Analytic Service ::', () => {
 
         // 1 == window width, 2 == window height, 3 == expected display value, 4 == expected orientation value
         const cases = [
-            [1281, 1282, 'full-size', 'Portrait'],
-            [1281, 1280, 'full-size', 'Landscape'],
-            [1280, 1025, 'huge', 'Landscape'],
-            [1026, 1025, 'huge', 'Landscape'],
-            [1025, 768, 'wide', 'Landscape'],
-            [769, 768, 'wide', 'Landscape'],
-            [768, 414, 'mid', 'Landscape'],
-            [415, 414, 'mid', 'Landscape'],
-            [414, 413, 'narrow', 'Landscape'],
-            [414, 415, 'narrow', 'Portrait']
+            [1281, 1282, 'Portrait'],
+            [1281, 1280, 'Landscape'],
+            [1280, 1025, 'Landscape'],
+            [1026, 1025, 'Landscape'],
+            [1025, 768, 'Landscape'],
+            [769, 768, 'Landscape'],
+            [768, 414, 'Landscape'],
+            [415, 414, 'Landscape'],
+            [414, 413, 'Landscape'],
+            [414, 415, 'Portrait']
         ];
         test.each(cases)(
             'should set the correct pageData given window width is %p and window height is %p',
-            (winWidth, winHeight, displayExpected, orientationExpected) => {
+            (winWidth, winHeight, orientationExpected) => {
                 // Arrange
                 mockWindow({ winWidth, winHeight });
 
@@ -340,29 +330,11 @@ describe('Analytic Service ::', () => {
                 expect(windowsPushSpy).toHaveBeenCalledWith(expect.objectContaining({
                     pageData: expect.objectContaining({
                         name: 'jazz',
-                        orientation: orientationExpected,
-                        display: displayExpected
+                        orientation: orientationExpected
                     })
                 }));
             }
         );
-
-        it('should set requestId value when provided', () => {
-            // Arrange
-            const expected = {
-                requestId: '6cbe6509-9122-4e66-a90a-cc483c34282e'
-            };
-
-            // Act
-            service.pushPageData({ requestId: expected.requestId });
-
-            // Assert
-            expect(windowsPushSpy).toHaveBeenCalledWith(expect.objectContaining({
-                pageData: expect.objectContaining({
-                    requestId: expected.requestId
-                })
-            }));
-        });
 
         it('should override the httpStatusCode when provided', () => {
             // Arrange

--- a/packages/services/f-analytics/src/services/_tests/analytics.service.test.js
+++ b/packages/services/f-analytics/src/services/_tests/analytics.service.test.js
@@ -83,7 +83,7 @@ describe('Analytic Service ::', () => {
     });
 
     describe('When calling pushPlatformData', () => {
-        // 1 == locale, 2 == branding, 3 == country, 4 == currency, 5 == language
+        // 1 == locale, 2 == country, 3 == currency, 4 == language
         const cases = [
             ['en-GB', 'uk', 'gbp', 'en'],
             ['en-IE', 'ie', 'eur', 'en'],
@@ -304,7 +304,7 @@ describe('Analytic Service ::', () => {
             expect(windowsPushSpy).not.toHaveBeenCalled();
         });
 
-        // 1 == window width, 2 == window height, 3 == expected display value, 4 == expected orientation value
+        // 1 == window width, 2 == window height, 3 == expected orientation value
         const cases = [
             [1281, 1282, 'Portrait'],
             [1281, 1280, 'Landscape'],

--- a/packages/services/f-analytics/src/services/analytics.mapper.js
+++ b/packages/services/f-analytics/src/services/analytics.mapper.js
@@ -10,27 +10,6 @@ import {
 } from '../constants';
 
 /**
- * Returns the current display width name (if clientside).
- *
- * @return {string} The display width name
- */
-const getDisplaySize = () => {
-    if (typeof (window) !== 'undefined') {
-        const width = window.innerWidth;
-
-        // Use fozzie for breakpoints?
-        if (width > 1280) return 'full-size';
-        else if (width > 1025) return 'huge';
-        else if (width > 768) return 'wide';
-        else if (width > 414) return 'mid';
-
-        return 'narrow';
-    }
-
-    return undefined;
-};
-
-/**
  * Returns the current orientation name (if clientside).
  *
  * @return {string} The orientation name
@@ -72,24 +51,6 @@ const mapAnonymousUserId = req => {
 };
 
 /**
- * Maps the user agent string (if present) to the PlatformData 'userAgent' field
- * Note: if executed clientside then the value will be read from the `window.navigator`
- * otherside it is read from the 'user-agent' header.
- *
- * @param {object} req - The `request` context
- * @return {string} userAgentString
- */
-const mapUserAgent = req => {
-    let userAgentString;
-    if (typeof (window) !== 'undefined' && window.navigator) {
-        userAgentString = window.navigator.userAgent;
-    } else if (req && req.headers) {
-        userAgentString = req.headers['user-agent'];
-    }
-    return userAgentString;
-};
-
-/**
  * Maps various environment variables (if present); that are only available when executed
  * serverside, to the PlatformData.
  * Also maps the user percentage experiment value (if present) to the PlatformData; again
@@ -123,21 +84,17 @@ export const mapServerSidePlatformData = ({ platformData, req } = {}) => {
  * @param {object} platformData - A reference to the current PlatformData instance
  * @param {string} featureName - The name of the feature
  * @param {string} locale - The current locale
- * @param {object} req - The `request` context
  * @return {object} new platformData object
  */
 export const mapPlatformData = ({
-    platformData, featureName, locale, req
+    platformData, featureName, locale
 } = {}) => {
-    const userAgent = mapUserAgent(req);
     const mappedPlatformData = {
         ...platformData,
-        name: featureName,
-        userAgent
+        name: featureName
     };
     mappedPlatformData.appType = DEFAULT_APP_TYPE;
     mappedPlatformData.applicationId = DEFAULT_APP_ID;
-    mappedPlatformData.branding = COUNTRY_INFO[locale].brand;
     mappedPlatformData.country = COUNTRY_INFO[locale].country;
     mappedPlatformData.language = COUNTRY_INFO[locale].language;
     mappedPlatformData.currency = COUNTRY_INFO[locale].currency;
@@ -188,7 +145,6 @@ export const mapUserData = ({ userData, authToken, req } = {}) => {
  *
  * @param {object} pageData - A reference to the current PageData instance
  * @param {string} pageName - The name of the page
- * @param {string} requestId - The current request Id
  * @param {number} httpStatusCode - The httpStatusCode (only supplied when 200 needs to be overriden)
  * @param {object} req - The `request` context
  * @return {object} new pageData object
@@ -196,21 +152,17 @@ export const mapUserData = ({ userData, authToken, req } = {}) => {
 export const mapPageData = ({
     pageData,
     pageName,
-    requestId,
     httpStatusCode,
     req
 } = {}) => {
     const conversationId = getCookie('x-je-conversation', req);
-    const displaySize = getDisplaySize();
     const orientation = getOrientation();
 
     const mappedPageData = {
         ...pageData,
         name: pageName || pageData.pageName,
         conversationId: conversationId || pageData.conversationId,
-        requestId: requestId || pageData.requestId,
         httpStatusCode: httpStatusCode || pageData.httpStatusCode,
-        display: displaySize || pageData.display,
         orientation: orientation || pageData.orientation
     };
 

--- a/packages/services/f-analytics/src/services/analytics.service.js
+++ b/packages/services/f-analytics/src/services/analytics.service.js
@@ -7,9 +7,8 @@ import {
 const isDataLayerPresent = () => typeof (window) !== 'undefined' && window.dataLayer;
 
 export default class AnalyticService {
-    constructor (store, req, options) {
+    constructor (store, options) {
         this.store = store;
-        this.req = req;
         this.options = options;
     }
 
@@ -25,8 +24,7 @@ export default class AnalyticService {
         platformData = mapPlatformData({
             platformData,
             featureName: featureName || this.options.featureName,
-            locale: locale || this.options.locale,
-            req: this.req
+            locale: locale || this.options.locale
         });
 
         this.store.dispatch(`${this.options.namespace}/updatePlatformData`, platformData);
@@ -61,7 +59,6 @@ export default class AnalyticService {
     pushPageData ({
         pageName,
         conversationId,
-        requestId,
         httpStatusCode,
         customFields
     } = {}) {
@@ -71,7 +68,6 @@ export default class AnalyticService {
             pageData,
             pageName,
             conversationId,
-            requestId,
             httpStatusCode,
             req: this.req
         });

--- a/packages/services/f-analytics/src/store/_tests/analytics.module.test.js
+++ b/packages/services/f-analytics/src/store/_tests/analytics.module.test.js
@@ -86,8 +86,6 @@ describe('Analytics Module ::', () => {
                     name: 'test-name',
                     appType: 'test-appType',
                     applicationId: 9,
-                    userAgent: 'test-userAgent',
-                    branding: 'test-branding',
                     country: 'zu',
                     language: 'ze',
                     currency: 'zud'

--- a/packages/services/f-analytics/src/store/analytics.module.js
+++ b/packages/services/f-analytics/src/store/analytics.module.js
@@ -13,8 +13,6 @@ export default {
             name: undefined,
             appType: undefined,
             applicationId: undefined,
-            userAgent: undefined,
-            branding: undefined,
             country: undefined,
             language: undefined,
             jeUserPercentage: undefined,
@@ -35,9 +33,7 @@ export default {
             name: undefined,
             httpStatusCode: 200,
             conversationId: undefined,
-            requestId: undefined,
-            orientation: undefined,
-            display: undefined
+            orientation: undefined
         },
         events: []
     }),

--- a/packages/services/f-analytics/src/tests/helpers/setup.js
+++ b/packages/services/f-analytics/src/tests/helpers/setup.js
@@ -8,8 +8,6 @@ const defaultState = {
         name: undefined,
         appType: undefined,
         applicationId: undefined,
-        userAgent: undefined,
-        branding: undefined,
         country: undefined,
         language: undefined,
         jeUserPercentage: undefined,
@@ -30,9 +28,7 @@ const defaultState = {
         name: undefined,
         httpStatusCode: 200,
         conversationId: undefined,
-        requestId: undefined,
-        orientation: undefined,
-        display: undefined
+        orientation: undefined
     },
     events: []
 };
@@ -43,8 +39,6 @@ const modifiedState = {
         name: 'test-name',
         appType: 'test-appType',
         applicationId: 9,
-        userAgent: 'test-userAgent',
-        branding: 'test-branding',
         country: 'zu',
         language: 'ze',
         jeUserPercentage: 88,
@@ -65,9 +59,7 @@ const modifiedState = {
         name: 'test-name',
         httpStatusCode: 200,
         conversationId: '460cc3a8-83f7-4e80-bb46-c8a69967f249',
-        requestId: '6cbe6509-9122-4e66-a90a-cc483c34282e',
-        orientation: 'Landscape',
-        display: 'wide'
+        orientation: 'Landscape'
     }
 };
 


### PR DESCRIPTION
### Changed
- Removed the redundant properties from `pushPlatformData()` & `pushPageData()`.