### PR TITLE
f-checkout@1.5.0 - Only call geocoding endpoint when service type is delivery

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.5.0
+------------------------------
+*September 30, 2021*
+
+### Changed
+- Only call Geolocation endpoint when the service type is delivery
+
+
 v1.4.0
 ------------------------------
 *September 29, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -886,25 +886,27 @@ export default {
          *
          */
         async lookupGeoLocation () {
-            try {
-                const locationData = {
-                    addressLines: Object.values(this.address).filter(addressLine => !!addressLine)
-                };
+            if (this.serviceType === CHECKOUT_METHOD_DELIVERY) {
+                try {
+                    const locationData = {
+                        addressLines: Object.values(this.address).filter(addressLine => !!addressLine)
+                    };
 
-                if (locationData.addressLines.length) {
-                    await this.getGeoLocation({
-                        url: this.getGeoLocationUrl,
-                        postData: locationData,
-                        timeout: this.checkoutTimeout
+                    if (locationData.addressLines.length) {
+                        await this.getGeoLocation({
+                            url: this.getGeoLocationUrl,
+                            postData: locationData,
+                            timeout: this.checkoutTimeout
+                        });
+                    }
+                } catch (error) {
+                    this.logInvoker({
+                        message: 'Geo Location Lookup Failed',
+                        data: this.eventData,
+                        logMethod: this.$logger.logWarn,
+                        error
                     });
                 }
-            } catch (error) {
-                this.logInvoker({
-                    message: 'Geo Location Lookup Failed',
-                    data: this.eventData,
-                    logMethod: this.$logger.logWarn,
-                    error
-                });
             }
         },
 

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -2741,6 +2741,26 @@ describe('Checkout', () => {
                     // Assert
                     expect(getGeoLocationSpy).toHaveBeenCalledWith(expected);
                 });
+
+                it('should not call `getGeoLocation` if the service type is not delivery', async () => {
+                    // Arrange
+                    wrapper = mount(VueCheckout, {
+                        store: createStore({ ...defaultCheckoutState, serviceType: CHECKOUT_METHOD_COLLECTION }),
+                        i18n,
+                        localVue,
+                        propsData,
+                        mocks: {
+                            $logger,
+                            $cookies
+                        }
+                    });
+
+                    // Act
+                    await wrapper.vm.lookupGeoLocation();
+
+                    // Assert
+                    expect(getGeoLocationSpy).toHaveBeenCalledTimes(0);
+                });
             });
 
             describe('when `getGeoLocation` request fails', () => {


### PR DESCRIPTION
In Checkout, we've noticed some calls to the geocoding endpoint when the service type is not delivery, which of course is unnecessary. This may be because of the address in local storage, or something else but it's best that we just prevent the call being made based on the service type. 

