### PR TITLE
f-loyalty@v0.8.0 - Adding no cards error state

### DIFF
--- a/packages/components/organisms/f-loyalty/CHANGELOG.md
+++ b/packages/components/organisms/f-loyalty/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.8.0
 ------------------------------
-*September 30, 2021*
+*October 07, 2021*
 
 ### Added
 - No card's error state

--- a/packages/components/organisms/f-loyalty/CHANGELOG.md
+++ b/packages/components/organisms/f-loyalty/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.7.0
 ------------------------------
+*September 30, 2021*
+
+### Added
+- No card's error state
+
+
+v0.7.0
+------------------------------
 *October 5, 2021*
 
 ### Changed

--- a/packages/components/organisms/f-loyalty/CHANGELOG.md
+++ b/packages/components/organisms/f-loyalty/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.7.0
+v0.8.0
 ------------------------------
 *September 30, 2021*
 

--- a/packages/components/organisms/f-loyalty/package.json
+++ b/packages/components/organisms/f-loyalty/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-loyalty",
   "description": "Fozzie Loyalty - provides a way for customers to collect loyalty stamps for restaurants",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "dist/f-loyalty.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [

--- a/packages/components/organisms/f-loyalty/src/components/NoCardsErrorState.vue
+++ b/packages/components/organisms/f-loyalty/src/components/NoCardsErrorState.vue
@@ -2,7 +2,7 @@
     <div :class="$style['c-noCardsError']">
         <img
             :class="$style['c-noCardsError-icon']"
-            :src="`stampcards-empty-${$t('stampCards.percentage')}.svg`"
+            :src="`stampcards-empty-${$t('percentage')}.svg`"
             alt="">
         <h3 :class="$style['c-noCardsError-title']">
             {{ $t('stamps.errorNoCards.title') }}

--- a/packages/components/organisms/f-loyalty/src/components/NoCardsErrorState.vue
+++ b/packages/components/organisms/f-loyalty/src/components/NoCardsErrorState.vue
@@ -1,0 +1,78 @@
+<template>
+    <div :class="$style['c-noCardsError']">
+        <img
+            :class="$style['c-noCardsError-icon']"
+            :src="`stampcards-empty-${$t('stampCards.percentage')}.svg`"
+            alt="">
+        <h3 :class="$style['c-noCardsError-title']">
+            {{ $t('stamps.errorNoCards.title') }}
+        </h3>
+        <p
+            :class="$style['c-noCardsError-subTitle']">
+            {{ $t('stamps.errorNoCards.subTitle') }}
+        </p>
+    </div>
+</template>
+
+<script>
+
+export default {
+    name: 'NoCardsErrorState',
+
+    props: {
+        engagementLabel: {
+            type: String,
+            required: true
+        }
+    },
+
+    mounted () {
+        // eslint-disable-next-line no-unused-expressions
+        window?.trak?.event({
+            category: 'engagement',
+            action: 'view_stampcards',
+            label: this.engagementLabel
+        });
+    }
+};
+</script>
+
+<style lang="scss" module>
+
+$stampCard-responsive-mobileViewBreakpoint: '<=narrowMid';
+$stampCard-responsive-notMobileViewBreakpoint: '>narrowMid';
+$stampCard-iconSize: 96px;
+
+.c-noCardsError {
+    width: 100%;
+    padding-top: spacing(x0.5);
+    min-height: $stampCard-iconSize + spacing(x0.5); // Icon size plus padding
+
+    @include media($stampCard-responsive-notMobileViewBreakpoint) {
+        margin-left: spacing();
+        margin-right: spacing();
+    }
+}
+
+.c-noCardsError-icon {
+    float: left;
+    margin-right: spacing();
+    width: $stampCard-iconSize;
+    height: $stampCard-iconSize;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.c-noCardsError-title {
+    @include media($stampCard-responsive-mobileViewBreakpoint) {
+        @include font-size(heading-s, true, narrow);
+    }
+}
+
+.c-noCardsError-title,
+.c-noCardsError-subTitle {
+    margin-left: spacing();
+    margin-right: spacing();
+}
+</style>

--- a/packages/components/organisms/f-loyalty/src/tenants/en-AU.js
+++ b/packages/components/organisms/f-loyalty/src/tenants/en-AU.js
@@ -18,6 +18,12 @@ const messages = {
             title: 'How it works'
         }
     },
+    stamps: {
+        errorNoCards: {
+            title: 'When you order from a participating restaurant, your stamps will be shown here.',
+            subTitle: 'Expecting to see your stamps? Try refreshing this screen by going back to the home screen then coming back here.'
+        }
+    },
     unauthenticated: {
         loginTitle: 'Log in to get started',
         loginButtonText: 'Log in'
@@ -28,7 +34,7 @@ const messages = {
         exampleSection: {
             title: 'For example',
             orders: 'Your Orders',
-            percentage: '10% from each order',
+            percentage: '15% from each order',
             total: 'Total discount for 6th order',
             accessibilityText: 'If you place 5 orders totalling $230, you would earn a discount worth $34.50 for your sixth order.'
         },

--- a/packages/components/organisms/f-loyalty/src/tenants/en-GB.js
+++ b/packages/components/organisms/f-loyalty/src/tenants/en-GB.js
@@ -18,6 +18,12 @@ const messages = {
             title: 'How it works'
         }
     },
+    stamps: {
+        errorNoCards: {
+            title: 'When you order from a participating restaurant, your stamps will be shown here.',
+            subTitle: 'Expecting to see your stamps? Try refreshing this screen by going back to the home screen then coming back here.'
+        }
+    },
     unauthenticated: {
         loginTitle: 'Log in to get started',
         loginButtonText: 'Log in'

--- a/packages/components/organisms/f-loyalty/src/tenants/en-IE.js
+++ b/packages/components/organisms/f-loyalty/src/tenants/en-IE.js
@@ -18,6 +18,12 @@ const messages = {
             title: 'How it works'
         }
     },
+    stamps: {
+        errorNoCards: {
+            title: 'When you order from a participating restaurant, your stamps will be shown here.',
+            subTitle: 'Expecting to see your stamps? Try refreshing this screen by going back to the home screen then coming back here.'
+        }
+    },
     unauthenticated: {
         loginTitle: 'Log in to get started',
         loginButtonText: 'Log in'

--- a/packages/components/organisms/f-loyalty/src/tenants/en-NZ.js
+++ b/packages/components/organisms/f-loyalty/src/tenants/en-NZ.js
@@ -1,4 +1,67 @@
-export default {
+const messages = {
     locale: 'en-NZ',
-    text: 'I am a VLoyalty Component (NZ)'
+    percentage: '15',
+    currency: 'dollar',
+    currencySymbol: '$',
+    termsUrl: '/info/terms-and-conditions#ii.just-eat-voucher-terms-conditions',
+    termsText: 'See Terms & Conditions',
+    header: {
+        title: 'StampCards',
+        text: 'See the stamps you’ve collected and any discounts you’ve earned.',
+        alt: 'Collect your stamps image'
+    },
+    tabs: {
+        stamps: {
+            title: 'Your StampCards'
+        },
+        howItWorks: {
+            title: 'How it works'
+        }
+    },
+    stamps: {
+        errorNoCards: {
+            title: 'When you order from a participating restaurant, your stamps will be shown here.',
+            subTitle: 'Expecting to see your stamps? Try refreshing this screen by going back to the home screen then coming back here.'
+        }
+    },
+    unauthenticated: {
+        loginTitle: 'Log in to get started',
+        loginButtonText: 'Log in'
+    },
+    howItWorks: {
+        title: 'Save on your favourite flavours',
+        text: 'Get rewarded for your loyalty. Start collecting stamps from your favourite restaurants and unlock a tasty little discount on the way…',
+        exampleSection: {
+            title: 'For example',
+            orders: 'Your Orders',
+            percentage: '15% from each order',
+            total: 'Total discount for 6th order',
+            accessibilityText: 'If you place 5 orders totalling $230, you would earn a discount worth $34.50 for your sixth order.'
+        },
+        media: {
+            title: 'How does it work?',
+            cards: {
+                order: {
+                    title: 'Order',
+                    text: 'Collect a stamp every time you order from a participating restaurant.'
+                },
+                earn: {
+                    title: 'Earn',
+                    text: 'Each stamp is worth 10% of your order’s value (exc. fees and charges) and will be saved on its own StampCard.'
+                },
+                collect: {
+                    title: 'Collect',
+                    text: 'Once you’ve collected five stamps from the same restaurant you’ll unlock a discount for your sixth order.'
+                },
+                reward: {
+                    title: 'Get rewarded',
+                    text: 'Your discount is the total of your five saved stamps and will be automatically applied when you place your sixth order.'
+                }
+            }
+        }
+    }
+};
+
+export default {
+    messages
 };

--- a/packages/components/organisms/f-offers/src/components/NoOffersFound.vue
+++ b/packages/components/organisms/f-offers/src/components/NoOffersFound.vue
@@ -5,7 +5,7 @@
         <media-element
             :title="$t('noOffersFound.title')"
             :text="$t('noOffersFound.subtitle')"
-            image-url="https://d30v2pzvrfyzpo.cloudfront.net/a/hw/img/decoration/oi_no-results-image.svg"
+            image-url="https://just-eat-prod-eu-res.cloudinary.com/image/upload/v1630068495/Experiments/Homeweb-Coreweb/oi_no-results-image.svg"
             :image-align="imageAlign"
             :text-size="textSize"
             :flex="flexLayout"

--- a/packages/components/organisms/f-offers/src/components/NoOffersFound.vue
+++ b/packages/components/organisms/f-offers/src/components/NoOffersFound.vue
@@ -5,7 +5,7 @@
         <media-element
             :title="$t('noOffersFound.title')"
             :text="$t('noOffersFound.subtitle')"
-            image-url="https://just-eat-prod-eu-res.cloudinary.com/image/upload/v1630068495/Experiments/Homeweb-Coreweb/oi_no-results-image.svg"
+            image-url="https://d30v2pzvrfyzpo.cloudfront.net/a/hw/img/decoration/oi_no-results-image.svg"
             :image-align="imageAlign"
             :text-size="textSize"
             :flex="flexLayout"


### PR DESCRIPTION
This PR migrates the no cards error state from HomeWeb. It has been modified to support the css modules and use the new cloudinary link.  Also Added is related translations (Note NO international atm).