### PR TITLE
#trivial Incorporated Page.withQuery into a param for Page.load

### DIFF
--- a/packages/components/atoms/f-button/test-utils/component-objects/f-button.component.js
+++ b/packages/components/atoms/f-button/test-utils/component-objects/f-button.component.js
@@ -13,12 +13,12 @@ module.exports = class Buttons extends Page {
         super.open(url);
     }
 
-    load (type = 'action') {
-        if (type === 'action') {
-            super.load(this.actionComponent);
-        } else {
-            super.load(this.linkComponent);
-        }
+    load (queries) {
+        super.load(this.actionComponent, queries);
+    }
+
+    loadLink (queries) {
+        super.load(this.linkComponent, queries);
     }
 
     /**

--- a/packages/components/atoms/f-button/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-button/test/accessibility/axe-accessibility.spec.js
@@ -2,15 +2,15 @@ const { getAccessibilityTestResults } = require('../../../../../../test/utils/ax
 
 const Button = require('../../test-utils/component-objects/f-button.component');
 
-let button;
+let button = new Button();
 
 describe('Accessibility tests', () => {
     it('a11y - should test f-button action component WCAG compliance', () => {
         // Act
-        button = new Button();
-        button.withQuery('knob-Button Type', 'primary');
-        button.withQuery('knob-Button Size', 'medium');
-        button.load();
+        button.load( {
+            'Button Type': 'primary',
+            'Button Size': 'medium',
+        });
         
         const axeResults = getAccessibilityTestResults('f-button - action');
 
@@ -19,12 +19,11 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-button link component WCAG compliance', () => {
         // Act
-        button = new Button();
-        button.withQuery('knob-Button Type', 'link')
-            .withQuery('knob-href', 'link')
-            .withQuery('knob-Button Size', 'medium');
-
-        button.load("link");
+        button.loadLink({
+            'Button Type': 'link',
+            'href': 'link',
+            'Button Size': 'medium',
+        });
         
         const axeResults = getAccessibilityTestResults('f-button - link');
 

--- a/packages/components/atoms/f-button/test/component/f-button.component.desktop.spec.js
+++ b/packages/components/atoms/f-button/test/component/f-button.component.desktop.spec.js
@@ -1,30 +1,26 @@
 const Button = require('../../test-utils/component-objects/f-button.component');
 
-let button;
+let button = new Button();
 
 describe('f-button component tests', () => {
     it('should display the f-button action component', () => {
-        // Arrange
-        button = new Button();
-        button.withQuery('knob-Button Type', 'primary');
-        button.withQuery('knob-Button Size', 'medium');
-
         // Act
-        button.load();
+        button.load({
+            'Button Type': 'primary',
+            'Button Size': 'medium',
+        });
 
         // Assert
         expect(button.isActionComponentDisplayed()).toBe(true);
     });
 
     it('should display the f-button link component', () => {
-        // Arrange
-        button = new Button();
-        button.withQuery('knob-Button Type', 'link')
-            .withQuery('knob-href', 'link')
-            .withQuery('knob-Button Size', 'medium');
-
         // Act
-        button.load('link');
+        button.loadLink({
+            'Button Type': 'link',
+            'href': 'link',
+            'Button Size': 'medium',
+        });
 
         // Assert
         expect(button.isLinkComponentDisplayed()).toBe(true);

--- a/packages/components/atoms/f-button/test/visual/f-button.visual.desktop.spec.js
+++ b/packages/components/atoms/f-button/test/visual/f-button.visual.desktop.spec.js
@@ -1,56 +1,48 @@
 const Button = require('../../test-utils/component-objects/f-button.component');
 
-let button;
+let button = new Button();
 
 describe('f-button Desktop visual tests', () => {
     describe('primary button', () => {
         it('should display medium size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'primary');
-            button.withQuery('knob-Button Size', 'medium');
-
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'primary',
+                'Button Size': 'medium',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Primary - Medium', 'desktop');
         });
 
         it('should display large size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'primary');
-            button.withQuery('knob-Button Size', 'large');
-
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'primary',
+                'Button Size': 'large',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Primary - Large', 'desktop');
         });
 
         it('should display small size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'primary');
-            button.withQuery('knob-Button Size', 'small');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'primary',
+                'Button Size': 'small',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Primary - Small', 'desktop');
         });
 
         it('should display xsmall size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'primary');
-            button.withQuery('knob-Button Size', 'xsmall');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'primary',
+                'Button Size': 'xsmall',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Primary - XSmall', 'desktop');
@@ -58,28 +50,24 @@ describe('f-button Desktop visual tests', () => {
 
         describe('isLoading', () => {
             it('should display medium size in a loading state', () => {
-                // Arrange
-                button = new Button();
-                button.withQuery('knob-Button Type', 'primary');
-                button.withQuery('knob-Button Size', 'medium');
-                button.withQuery('knob-isLoading', 'true');
-                
                 // Act
-                button.load();
+                button.load({
+                    'Button Type': 'primary',
+                    'Button Size': 'medium',
+                    'isLoading': 'true',
+                });
 
                 // Assert
                 browser.percyScreenshot('f-button - Primary - Medium - Loading', 'desktop');
             });
 
             it('should display large size in a loading state', () => {
-                // Arrange
-                button = new Button();
-                button.withQuery('knob-Button Type', 'primary');
-                button.withQuery('knob-Button Size', 'large');
-                button.withQuery('knob-isLoading', 'true');
-                
                 // Act
-                button.load();
+                button.load({
+                    'Button Type': 'primary',
+                    'Button Size': 'large',
+                    'isLoading': 'true',
+                });
 
                 // Assert
                 browser.percyScreenshot('f-button - Primary - Large - Loading', 'desktop');
@@ -89,52 +77,44 @@ describe('f-button Desktop visual tests', () => {
 
     describe('secondary button', () => {
         it('should display medium size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'secondary');
-            button.withQuery('knob-Button Size', 'medium');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'secondary',
+                'Button Size': 'medium',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Secondary - Medium', 'desktop');
         });
 
         it('should display large size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'secondary');
-            button.withQuery('knob-Button Size', 'large');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'secondary',
+                'Button Size': 'large',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Secondary - Large', 'desktop');
         });
 
         it('should display small size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'secondary');
-            button.withQuery('knob-Button Size', 'small');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'secondary',
+                'Button Size': 'small',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Secondary - Small', 'desktop');
         });
 
         it('should display xsmall size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'secondary');
-            button.withQuery('knob-Button Size', 'xsmall');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'secondary',
+                'Button Size': 'xsmall',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Secondary - XSmall', 'desktop');
@@ -142,28 +122,24 @@ describe('f-button Desktop visual tests', () => {
 
         describe('isLoading', () => {
             it('should display medium size in a loading state', () => {
-                // Arrange
-                button = new Button();
-                button.withQuery('knob-Button Type', 'secondary');
-                button.withQuery('knob-Button Size', 'medium');
-                button.withQuery('knob-isLoading', 'true');
-                
                 // Act
-                button.load();
+                button.load({
+                    'Button Type': 'secondary',
+                    'Button Size': 'medium',
+                    'isLoading': 'true',
+                });
 
                 // Assert
                 browser.percyScreenshot('f-button - Secondary - Medium - Loading', 'desktop');
             });
 
             it('should display large size in a loading state', () => {
-                // Arrange
-                button = new Button();
-                button.withQuery('knob-Button Type', 'secondary');
-                button.withQuery('knob-Button Size', 'large');
-                button.withQuery('knob-isLoading', 'true');
-                
                 // Act
-                button.load();
+                button.load({
+                    'Button Type': 'secondary',
+                    'Button Size': 'large',
+                    'isLoading': 'true',
+                });
 
                 // Assert
                 browser.percyScreenshot('f-button - Secondary - Large - Loading', 'desktop');
@@ -173,52 +149,44 @@ describe('f-button Desktop visual tests', () => {
 
     describe('outline button', () => {
         it('should display medium size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'outline');
-            button.withQuery('knob-Button Size', 'medium');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'outline',
+                'Button Size': 'medium',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Outline - Medium', 'desktop');
         });
 
         it('should display large size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'outline');
-            button.withQuery('knob-Button Size', 'large');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'outline',
+                'Button Size': 'large',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Outline - Large', 'desktop');
         });
 
         it('should display small size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'outline');
-            button.withQuery('knob-Button Size', 'small');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'outline',
+                'Button Size': 'small',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Outline - Small', 'desktop');
         });
 
         it('should display xsmall size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'outline');
-            button.withQuery('knob-Button Size', 'xsmall');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'outline',
+                'Button Size': 'xsmall',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Outline - XSmall', 'desktop');
@@ -226,28 +194,24 @@ describe('f-button Desktop visual tests', () => {
 
         describe('isLoading', () => {
             it('should display medium size in a loading state', () => {
-                // Arrange
-                button = new Button();
-                button.withQuery('knob-Button Type', 'outline');
-                button.withQuery('knob-Button Size', 'medium');
-                button.withQuery('knob-isLoading', 'true');
-                
                 // Act
-                button.load();
+                button.load({
+                    'Button Type': 'outline',
+                    'Button Size': 'medium',
+                    'isLoading': 'true',
+                });
 
                 // Assert
                 browser.percyScreenshot('f-button - Outline - Medium - Loading', 'desktop');
             });
 
             it('should display large size in a loading state', () => {
-                // Arrange
-                button = new Button();
-                button.withQuery('knob-Button Type', 'outline');
-                button.withQuery('knob-Button Size', 'large');
-                button.withQuery('knob-isLoading', 'true');
-                
                 // Act
-                button.load();
+                button.load({
+                    'Button Type': 'outline',
+                    'Button Size': 'large',
+                    'isLoading': 'true',
+                });
 
                 // Assert
                 browser.percyScreenshot('f-button - Outline - Large - Loading', 'desktop');
@@ -257,52 +221,44 @@ describe('f-button Desktop visual tests', () => {
 
     describe('ghost', () => {
         it('should display medium size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'ghost');
-            button.withQuery('knob-Button Size', 'medium');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'ghost',
+                'Button Size': 'medium',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Ghost - Medium', 'desktop');
         });
 
         it('should display large size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'ghost');
-            button.withQuery('knob-Button Size', 'large');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'ghost',
+                'Button Size': 'large',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Ghost - Large', 'desktop');
         });
 
         it('should display small size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'ghost');
-            button.withQuery('knob-Button Size', 'small');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'ghost',
+                'Button Size': 'small',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Ghost - Small', 'desktop');
         });
 
         it('should display xsmall size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'ghost');
-            button.withQuery('knob-Button Size', 'xsmall');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'ghost',
+                'Button Size': 'xsmall',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Ghost - XSmall', 'desktop');
@@ -310,28 +266,24 @@ describe('f-button Desktop visual tests', () => {
 
         describe('isLoading', () => {
             it('should display medium size in a loading state', () => {
-                // Arrange
-                button = new Button();
-                button.withQuery('knob-Button Type', 'ghost');
-                button.withQuery('knob-Button Size', 'medium');
-                button.withQuery('knob-isLoading', 'true');
-                
                 // Act
-                button.load();
+                button.load({
+                    'Button Type': 'ghost',
+                    'Button Size': 'medium',
+                    'isLoading': 'true',
+                });
 
                 // Assert
                 browser.percyScreenshot('f-button - Ghost - Medium - Loading', 'desktop');
             });
 
             it('should display large size in a loading state', () => {
-                // Arrange
-                button = new Button();
-                button.withQuery('knob-Button Type', 'ghost');
-                button.withQuery('knob-Button Size', 'large');
-                button.withQuery('knob-isLoading', 'true');
-                
                 // Act
-                button.load();
+                button.load({
+                    'Button Type': 'ghost',
+                    'Button Size': 'large',
+                    'isLoading': 'true',
+                });
 
                 // Assert
                 browser.percyScreenshot('f-button - Ghost - Large - Loading', 'desktop');
@@ -341,52 +293,44 @@ describe('f-button Desktop visual tests', () => {
 
     describe('link', () => {
         it('should display medium size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'link');
-            button.withQuery('knob-Button Size', 'medium');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'link',
+                'Button Size': 'medium',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Link - Medium', 'desktop');
         });
 
         it('should display large size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'link');
-            button.withQuery('knob-Button Size', 'large');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'link',
+                'Button Size': 'large',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Link - Large', 'desktop');
         });
 
         it('should display small size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'link');
-            button.withQuery('knob-Button Size', 'small');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'link',
+                'Button Size': 'small',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Link - Small', 'desktop');
         });
 
         it('should display xsmall size', () => {
-            // Arrange
-            button = new Button();
-            button.withQuery('knob-Button Type', 'link');
-            button.withQuery('knob-Button Size', 'xsmall');
-            
             // Act
-            button.load();
+            button.load({
+                'Button Type': 'link',
+                'Button Size': 'xsmall',
+            });
 
             // Assert
             browser.percyScreenshot('f-button - Link - XSmall', 'desktop');
@@ -394,28 +338,24 @@ describe('f-button Desktop visual tests', () => {
 
         describe('isLoading', () => {
             it('should display medium size in a loading state', () => {
-                // Arrange
-                button = new Button();
-                button.withQuery('knob-Button Type', 'link');
-                button.withQuery('knob-Button Size', 'medium');
-                button.withQuery('knob-isLoading', 'true');
-                
                 // Act
-                button.load();
+                button.load({
+                    'Button Type': 'link',
+                    'Button Size': 'medium',
+                    'isLoading': 'true',
+                });
 
                 // Assert
                 browser.percyScreenshot('f-button - Link - Medium - Loading', 'desktop');
             });
 
             it('should display large size in a loading state', () => {
-                // Arrange
-                button = new Button();
-                button.withQuery('knob-Button Type', 'link');
-                button.withQuery('knob-Button Size', 'large');
-                button.withQuery('knob-isLoading', 'true');
-                
                 // Act
-                button.load();
+                button.load({
+                    'Button Type': 'link',
+                    'Button Size': 'large',
+                    'isLoading': 'true',
+                });
 
                 // Assert
                 browser.percyScreenshot('f-button - Link - Large - Loading', 'desktop');

--- a/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout.component.js
+++ b/packages/components/organisms/f-checkout/test-utils/component-objects/f-checkout.component.js
@@ -123,21 +123,16 @@ module.exports = class Checkout extends Page {
      * @param {String} checkout.isValid The checkout validation
      */
 
-    load () {
-        super.load(this.component);
+    load (queries) {
+        super.load(this.component, queries);
     }
 
-    loadError() {
-        super.load(this.errorPageComponent);
+    loadError(queries) {
+        super.load(this.errorPageComponent, queries);
     }
 
     open (url) {
         super.open(url);
-    }
-
-    withQuery (name, value) {
-        super.withQuery(name, value);
-        return this;
     }
 
     waitForComponent (component = this.component) {

--- a/packages/components/organisms/f-checkout/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-checkout/test/accessibility/axe-accessibility.spec.js
@@ -4,16 +4,14 @@ const { getAccessibilityTestResults } = require('../../../../../../test/utils/ax
 
 const Checkout = require('../../test-utils/component-objects/f-checkout.component');
 
-let checkout;
+let checkout = new Checkout();
 
 describe('Accessibility tests', () => {
     it('a11y - should test f-checkout component (delivery) WCAG compliance', () => {
-        // Act
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', true);
-
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': true,
+        });
         const axeResults = getAccessibilityTestResults('f-checkout-delivery');
 
         // Assert
@@ -21,12 +19,10 @@ describe('Accessibility tests', () => {
     });
 
     it('a11y - should test f-checkout component (collection) WCAG compliance', () => {
-        // Act
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', true);
-
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': true,
+        });
         const axeResults = getAccessibilityTestResults('f-checkout-collection');
 
         // Assert
@@ -34,12 +30,10 @@ describe('Accessibility tests', () => {
     });
 
     it('a11y - should test f-checkout component (guest) WCAG compliance', () => {
-        // Act
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', false);
-
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': false,
+        });
         const axeResults = getAccessibilityTestResults('f-checkout-guest');
 
         // Assert
@@ -47,12 +41,10 @@ describe('Accessibility tests', () => {
     });
 
     it('a11y - should test f-checkout component (error) WCAG compliance', () => {
-        // Act
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'Invalid URL')
-            .withQuery('&knob-Is User Logged In', false);
-
-        checkout.loadError();
+        checkout.loadError({
+            'Service Type': 'Invalid URL',
+            'Is User Logged In': false,
+        });
         const axeResults = getAccessibilityTestResults('f-checkout-error-page');
 
         // Assert
@@ -71,14 +63,12 @@ describe('Accessibility tests', () => {
         ['dinein', 'time-unavailable']
     ])
     .it('a11y - Authenticated - "%s" - should have a correct tab order in patch checkout error - "%s"', (serviceType, patchError) => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', serviceType)
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Patch Checkout Errors', patchError);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': serviceType,
+            'Is User Logged In': true,
+            'Patch Checkout Errors': patchError,
+        });
         checkout.goToPayment();
 
         const expectedTabOrder = [checkout.errorMessageRetry, checkout.closeMessageModal];
@@ -93,14 +83,12 @@ describe('Accessibility tests', () => {
         ['delivery']
     ])
     .it('a11y - Authenticated - "%s" - should have a correct tab order in duplicate order error', serviceType => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', serviceType)
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Place Order Errors', 'duplicate');
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': serviceType,
+            'Is User Logged In': true,
+            'Place Order Errors': 'duplicate',
+        });
         checkout.goToPayment();
 
         const expectedTabOrder = [checkout.errorMessageRetry, checkout.errorMessageDupOrderGoToHistory, checkout.closeMessageModal];
@@ -116,13 +104,11 @@ describe('Accessibility tests', () => {
         ['collection', 'time-unavailable']
     ])
     .it('a11y - Guest - "%s" - should have a correct tab order in patch checkout error - "%s"', (serviceType, patchError) => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', serviceType)
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Patch Checkout Errors', patchError);
-
-        checkout.load();
+        checkout.load({
+            'Service Type': serviceType,
+            'Is User Logged In': false,
+            'Patch Checkout Errors': patchError,
+        });
 
         // Act
         checkout.setFieldValue('firstName', 'Jerry');
@@ -147,13 +133,11 @@ describe('Accessibility tests', () => {
         ['delivery', 'time-unavailable']
     ])
     .it('a11y - Guest - "%s" - should have a correct tab order in patch checkout error - "%s"', (serviceType, patchError) => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', serviceType)
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Patch Checkout Errors', patchError);
-
-        checkout.load();
+        checkout.load({
+            'Service Type': serviceType,
+            'Is User Logged In': false,
+            'Patch Checkout Errors': patchError,
+        });
 
         // Act
         checkout.setFieldValue('firstName', 'Jerry');
@@ -181,13 +165,11 @@ describe('Accessibility tests', () => {
         ['dinein', 'time-unavailable']
     ])
     .it('a11y - Guest - "%s" - should have a correct tab order in patch checkout error - "%s"', (serviceType, patchError) => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', serviceType)
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Patch Checkout Errors', patchError);
-
-        checkout.load();
+        checkout.load({
+            'Service Type': serviceType,
+            'Is User Logged In': false,
+            'Patch Checkout Errors': patchError,
+        });
 
         // Act
         checkout.setFieldValue('firstName', 'Jerry');
@@ -208,13 +190,11 @@ describe('Accessibility tests', () => {
     });
 
     it('a11y - Guest - Collection - should have a correct tab order in duplicate order error', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Place Order Errors', 'duplicate');
-
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': false,
+            'Place Order Errors': 'duplicate',
+        });
 
         // Act
         checkout.setFieldValue('firstName', 'Jerry');
@@ -234,13 +214,11 @@ describe('Accessibility tests', () => {
     });
 
     it('a11y - Guest - Delivery - should have a correct tab order in duplicate order error', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Place Order Errors', 'duplicate');
-
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': false,
+            'Place Order Errors': 'duplicate',
+        });
 
         // Act
         checkout.setFieldValue('firstName', 'Jerry');
@@ -263,13 +241,11 @@ describe('Accessibility tests', () => {
     });
 
     it('a11y - Guest - Dine In - should have a correct tab order in duplicate order error', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'dinein')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Place Order Errors', 'duplicate');
-
-        checkout.load();
+        checkout.load({
+            'Service Type': 'dinein',
+            'Is User Logged In': false,
+            'Place Order Errors': 'duplicate',
+        });
 
         // Act
         checkout.setFieldValue('firstName', 'Jerry');

--- a/packages/components/organisms/f-checkout/test/component/f-checkout-delivery.component.desktop.spec.js
+++ b/packages/components/organisms/f-checkout/test/component/f-checkout-delivery.component.desktop.spec.js
@@ -1,17 +1,15 @@
 const Checkout = require('../../test-utils/component-objects/f-checkout.component');
 
-
-let checkout;
+let checkout = new Checkout();
 
 describe('f-checkout "delivery" component tests', () => {
     describe('uk tenant', () => {
         beforeEach(() => {
-            checkout = new Checkout();
-            checkout.withQuery('&knob-Service Type', 'delivery')
-                .withQuery('&knob-Is User Logged In', true)
-                .withQuery('&knob-Is ASAP available', true);
-
-            checkout.load();
+            checkout.load({
+                'Service Type': 'delivery',
+                'Is User Logged In': true,
+                'Is ASAP available': true,
+            });
         });
 
         it('should enable a user to submit a postcode with correct characters', () => {
@@ -32,13 +30,12 @@ describe('f-checkout "delivery" component tests', () => {
 
     describe('au tenant', () => {
         beforeEach(() => {
-            checkout = new Checkout();
-            checkout.withQuery('&knob-Service Type', 'delivery')
-                .withQuery('&knob-Is User Logged In', true)
-                .withQuery('&knob-Is ASAP available', true)
-                .withQuery('&knob-Locale', 'en-AU');
-
-            checkout.load();
+            checkout.load({
+                'Service Type': 'delivery',
+                'Is User Logged In': true,
+                'Is ASAP available': true,
+                'Locale': 'en-AU',
+            });
         });
 
         it('should prevent more than 50 characters in state field', () => {

--- a/packages/components/organisms/f-checkout/test/component/f-checkout-dinein.component.desktop.spec.js
+++ b/packages/components/organisms/f-checkout/test/component/f-checkout-dinein.component.desktop.spec.js
@@ -1,14 +1,13 @@
 const Checkout = require('../../test-utils/component-objects/f-checkout.component');
 
-let checkout;
+let checkout = new Checkout();
 
 describe('f-checkout "dinein" component tests', () => {
     beforeEach(() => {
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'dinein')
-            .withQuery('&knob-Is User Logged In', true);
-
-        checkout.load();
+        checkout.load({
+            'Service Type': 'dinein',
+            'Is User Logged In': true,
+        });
     });
 
     it('should prevent a user from entering more than 12 characters in the tableIdentifier field', () => {

--- a/packages/components/organisms/f-checkout/test/component/f-checkout-guest.component.desktop.spec.js
+++ b/packages/components/organisms/f-checkout/test/component/f-checkout-guest.component.desktop.spec.js
@@ -2,16 +2,15 @@ import forEach from 'mocha-each';
 
 const Checkout = require('../../test-utils/component-objects/f-checkout.component');
 
-let checkout;
+let checkout = new Checkout();
 
 describe('f-checkout "guest" component tests - @browserstack', () => {
     beforeEach(() => {
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Is ASAP available', true);
-
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': false,
+            'Is ASAP available': true,
+        });
     });
 
     it('should navigate to correct url when the login link is clicked', () => {

--- a/packages/components/organisms/f-checkout/test/component/f-checkout.component.shared.spec.js
+++ b/packages/components/organisms/f-checkout/test/component/f-checkout.component.shared.spec.js
@@ -2,16 +2,15 @@ import forEach from 'mocha-each';
 
 const Checkout = require('../../test-utils/component-objects/f-checkout.component');
 
-let checkout;
+let checkout = new Checkout();
 
 describe('f-checkout component tests - @browserstack', () => {
     beforeEach(() => {
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true);
-
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+        });
     });
 
     it.skip('should submit the checkout form', () => {
@@ -75,11 +74,13 @@ describe('f-checkout component tests - @browserstack', () => {
     });
 
     it('should close the checkout error when "Retry" is clicked', () => {
-        // Arrange
-        checkout.withQuery('&knob-Patch Checkout Errors', 'restaurant-not-taking-orders');
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Patch Checkout Errors': 'restaurant-not-taking-orders',
+        });
         checkout.goToPayment();
         checkout.clickRetryButton();
         browser.pause(2000);
@@ -90,11 +91,13 @@ describe('f-checkout component tests - @browserstack', () => {
 
     describe('when the "Duplicate Order Warning" modal is displayed', () => {
         beforeEach(() => {
-            // Arrange
-            checkout.withQuery('&knob-Place Order Errors', 'duplicate');
-
             // Act
-            checkout.load();
+            checkout.load({
+                'Service Type': 'delivery',
+                'Is User Logged In': true,
+                'Is ASAP available': true,
+                'Place Order Errors': 'duplicate',
+            });
             checkout.goToPayment();
         });
 

--- a/packages/components/organisms/f-checkout/test/visual/f-checkout-authenticated.visual.desktop.spec.js
+++ b/packages/components/organisms/f-checkout/test/visual/f-checkout-authenticated.visual.desktop.spec.js
@@ -1,16 +1,15 @@
 const Checkout = require('../../test-utils/component-objects/f-checkout.component');
 
-let checkout;
+let checkout = new Checkout();
 
 describe('f-checkout - Collection - Authenticated - Desktop Visual Tests', () => {
     beforeEach(() => {
         // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true);
-
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+        });
     });
 
     it('should display the component base state.', () => {
@@ -28,15 +27,13 @@ describe('f-checkout - Collection - Authenticated - Desktop Visual Tests', () =>
     });
 
     it('should display the "Something went wrong" error.', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Patch Checkout Errors', 'SERVER')
-            .withQuery('&knob-Is ASAP available', true);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': true,
+            'Patch Checkout Errors': 'SERVER',
+            'Is ASAP available': true,
+        });
         checkout.goToPayment();
         browser.pause(500);
 
@@ -45,15 +42,13 @@ describe('f-checkout - Collection - Authenticated - Desktop Visual Tests', () =>
     });
 
     it('should display the "Restaurant not taking orders" modal', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true)
-            .withQuery('&knob-Patch Checkout Errors', 'restaurant-not-taking-orders');
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Patch Checkout Errors': 'restaurant-not-taking-orders',
+        });
         checkout.goToPayment();
 
         // Assert
@@ -76,15 +71,13 @@ describe('f-checkout - Collection - Authenticated - Desktop Visual Tests', () =>
     });
 
     it('should display the "Duplicate Order Warning" modal', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true)
-            .withQuery('&knob-Place Order Errors', 'duplicate');
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Place Order Errors': 'duplicate',
+        });
         checkout.goToPayment();
 
         // Assert
@@ -94,14 +87,12 @@ describe('f-checkout - Collection - Authenticated - Desktop Visual Tests', () =>
 
 describe('f-checkout - Collection - Authenticated - isAsapAvailable: false Desktop Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', false);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': true,
+            'Is ASAP available': false,
+        });
     });
 
     it('should display the pre-order warning.', () => {
@@ -112,14 +103,12 @@ describe('f-checkout - Collection - Authenticated - isAsapAvailable: false Deskt
 
 describe('f-checkout - Delivery - Authenticated - Desktop Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+        });
     });
 
     it('should display the component base state.', () => {
@@ -168,15 +157,13 @@ describe('f-checkout - Delivery - Authenticated - Desktop Visual Tests', () => {
     });
 
     it('should display the "Duplicate Order Warning" modal', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true)
-            .withQuery('&knob-Place Order Errors', 'duplicate');
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Place Order Errors': 'duplicate',
+        });
         checkout.goToPayment();
 
         // Assert
@@ -186,14 +173,12 @@ describe('f-checkout - Delivery - Authenticated - Desktop Visual Tests', () => {
 
 describe('f-checkout - Delivery - Authenticated - isAsapAvailable: false Desktop Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', false);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': true,
+            'Is ASAP available': false,
+        });
     });
 
     it('should display the pre-order warning.', () => {
@@ -204,14 +189,12 @@ describe('f-checkout - Delivery - Authenticated - isAsapAvailable: false Desktop
 
 describe('f-checkout - Dine In - Authenticated - Desktop Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'dinein')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'dinein',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+        });
     });
 
     it('should display the component base state.', () => {
@@ -245,15 +228,13 @@ describe('f-checkout - Dine In - Authenticated - Desktop Visual Tests', () => {
     });
 
     it('should display the "Duplicate Order Warning" modal', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'dinein')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true)
-            .withQuery('&knob-Place Order Errors', 'duplicate');
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'dinein',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Place Order Errors': 'duplicate',
+        });
         checkout.goToPayment();
 
         // Assert

--- a/packages/components/organisms/f-checkout/test/visual/f-checkout-authenticated.visual.mobile.spec.js
+++ b/packages/components/organisms/f-checkout/test/visual/f-checkout-authenticated.visual.mobile.spec.js
@@ -4,14 +4,12 @@ let checkout;
 
 describe('f-checkout - Collection - Authenticated - Mobile Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': true,
+            'Is ASAP available': true
+        });
     });
 
     it('should display the component base state.', () => {
@@ -29,15 +27,13 @@ describe('f-checkout - Collection - Authenticated - Mobile Visual Tests', () => 
     });
 
     it('should display the "Something went wrong" error.', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Patch Checkout Errors', 'SERVER')
-            .withQuery('&knob-Is ASAP available', true);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': true,
+            'Patch Checkout Errors': 'SERVER',
+            'Is ASAP available': true
+        });
         checkout.goToPayment();
 
         // Assert
@@ -45,14 +41,13 @@ describe('f-checkout - Collection - Authenticated - Mobile Visual Tests', () => 
     });
 
     it('should display the "Restaurant not taking orders" modal', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true)
-            .withQuery('&knob-Patch Checkout Errors', 'restaurant-not-taking-orders');
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Patch Checkout Errors': 'restaurant-not-taking-orders'
+        });
         checkout.goToPayment();
 
         // Assert
@@ -60,14 +55,13 @@ describe('f-checkout - Collection - Authenticated - Mobile Visual Tests', () => 
     });
 
     it('should display the "Additional Items Required" modal', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true)
-            .withQuery('&knob-Patch Checkout Errors', 'additional-items-required');
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Patch Checkout Errors': 'additional-items-required'
+        });
         checkout.goToPayment();
 
         // Assert
@@ -90,15 +84,13 @@ describe('f-checkout - Collection - Authenticated - Mobile Visual Tests', () => 
     });
 
     it('should display the "Duplicate Order Warning" modal', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true)
-            .withQuery('&knob-Place Order Errors', 'duplicate');
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Place Order Errors': 'duplicate'
+        });
         checkout.goToPayment();
 
         // Assert
@@ -108,14 +100,12 @@ describe('f-checkout - Collection - Authenticated - Mobile Visual Tests', () => 
 
 describe('f-checkout - Collection - Authenticated - isAsapAvailable: false Mobile Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', false);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': true,
+            'Is ASAP available': false
+        });
     });
 
     it('should display the pre-order warning.', () => {
@@ -126,14 +116,12 @@ describe('f-checkout - Collection - Authenticated - isAsapAvailable: false Mobil
 
 describe('f-checkout - Delivery - Authenticated - Mobile Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': true,
+            'Is ASAP available': true
+        });
     });
 
     it('should display the component base state.', () => {
@@ -182,15 +170,13 @@ describe('f-checkout - Delivery - Authenticated - Mobile Visual Tests', () => {
     });
 
     it('should display the "Duplicate Order Warning" modal', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true)
-            .withQuery('&knob-Place Order Errors', 'duplicate');
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Place Order Errors': 'duplicate'
+        });
         checkout.goToPayment();
 
         // Assert
@@ -198,15 +184,13 @@ describe('f-checkout - Delivery - Authenticated - Mobile Visual Tests', () => {
     });
 
     it('should display the "Restaurant not taking orders" modal', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true)
-            .withQuery('&knob-Patch Checkout Errors', 'restaurant-not-taking-orders');
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Patch Checkout Errors': 'restaurant-not-taking-orders'
+        });
         checkout.goToPayment();
 
         // Assert
@@ -214,15 +198,13 @@ describe('f-checkout - Delivery - Authenticated - Mobile Visual Tests', () => {
     });
 
     it('should display the "Additional Items Required" modal', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true)
-            .withQuery('&knob-Patch Checkout Errors', 'additional-items-required');
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Patch Checkout Errors': 'additional-items-required'
+        });
         checkout.goToPayment();
 
         // Assert
@@ -232,14 +214,12 @@ describe('f-checkout - Delivery - Authenticated - Mobile Visual Tests', () => {
 
 describe('f-checkout - Delivery - Authenticated - isAsapAvailable: false Mobile Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', false);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': true,
+            'Is ASAP available': false
+        });
     });
 
     it('should display the pre-order warning.', () => {
@@ -250,14 +230,12 @@ describe('f-checkout - Delivery - Authenticated - isAsapAvailable: false Mobile 
 
 describe('f-checkout - Dine In - Authenticated - Mobile Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'dinein')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'dinein',
+            'Is User Logged In': true,
+            'Is ASAP available': true
+        });
     });
 
     it('should display the component base state.', () => {
@@ -291,15 +269,13 @@ describe('f-checkout - Dine In - Authenticated - Mobile Visual Tests', () => {
     });
 
     it('should display the "Duplicate Order Warning" modal', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'dinein')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true)
-            .withQuery('&knob-Place Order Errors', 'duplicate');
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'dinein',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Place Order Errors': 'duplicate'
+        });
         checkout.goToPayment();
 
         // Assert

--- a/packages/components/organisms/f-checkout/test/visual/f-checkout-guest.visual.desktop.spec.js
+++ b/packages/components/organisms/f-checkout/test/visual/f-checkout-guest.visual.desktop.spec.js
@@ -4,14 +4,12 @@ let checkout = new Checkout();
 
 describe('f-checkout - Collection - Guest - Desktop Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Is ASAP available', true);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': false,
+            'Is ASAP available': true
+        });
     });
 
     it('should display the component base state.', () => {
@@ -45,8 +43,9 @@ describe('f-checkout - Collection - Guest - Desktop Visual Tests', () => {
 
     it('should display the "Duplicate Order Warning" modal', () => {
         // Arrange
-        checkout.withQuery('&knob-Place Order Errors', 'duplicate');
-        checkout.load();
+        checkout.load({
+            'Place Order Errors': 'duplicate'
+        });
         checkout.setFieldValue('firstName', 'Jerry');
         checkout.setFieldValue('lastName', 'Jazzman');
         checkout.setFieldValue('emailAddress', 'jerry.jazzman@ronniescotts.co.uk');
@@ -72,14 +71,12 @@ describe('f-checkout - Collection - Guest - Desktop Visual Tests', () => {
 
 describe('f-checkout - Collection - Guest - isAsapAvailable: false Desktop Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Is ASAP available', false);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': false,
+            'Is ASAP available': false
+        });
     });
 
     it('should display the pre-order warning.', () => {
@@ -90,14 +87,12 @@ describe('f-checkout - Collection - Guest - isAsapAvailable: false Desktop Visua
 
 describe('f-checkout - Delivery - Guest - Desktop Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Is ASAP available', true);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': false,
+            'Is ASAP available': true
+        });
     });
 
     it('should display the delivery f-checkout component guest base state.', () => {
@@ -132,8 +127,9 @@ describe('f-checkout - Delivery - Guest - Desktop Visual Tests', () => {
 
     it('should display the "Duplicate Order Warning" modal', () => {
         // Arrange
-        checkout.withQuery('&knob-Place Order Errors', 'duplicate');
-        checkout.load();
+        checkout.load({
+            'Place Order Errors': 'duplicate'
+        });
         checkout.setFieldValue('firstName', 'Jerry');
         checkout.setFieldValue('lastName', 'Jazzman');
         const addressInfo = {
@@ -165,14 +161,12 @@ describe('f-checkout - Delivery - Guest - Desktop Visual Tests', () => {
 
 describe('f-checkout - Delivery - Guest - isAsapAvailable: false Desktop Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Is ASAP available', false);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': false,
+            'Is ASAP available': false
+        });
     });
 
     it('should display the pre-order warning.', () => {
@@ -183,14 +177,12 @@ describe('f-checkout - Delivery - Guest - isAsapAvailable: false Desktop Visual 
 
 describe('f-checkout - Dine In - Guest - Desktop Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'dinein')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Is ASAP available', false);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'dinein',
+            'Is User Logged In': false,
+            'Is ASAP available': false
+        });
     });
 
     it('should display the component base state.', () => {
@@ -224,15 +216,13 @@ describe('f-checkout - Dine In - Guest - Desktop Visual Tests', () => {
     });
 
     it('should display the "Duplicate Order Warning" modal', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'dinein')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Is ASAP available', false)
-            .withQuery('&knob-Place Order Errors', 'duplicate');
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'dinein',
+            'Is User Logged In': false,
+            'Is ASAP available': false,
+            'Place Order Errors': 'duplicate'
+        });
         checkout.goToPayment();
 
         // Assert

--- a/packages/components/organisms/f-checkout/test/visual/f-checkout-guest.visual.mobile.spec.js
+++ b/packages/components/organisms/f-checkout/test/visual/f-checkout-guest.visual.mobile.spec.js
@@ -4,14 +4,12 @@ let checkout = new Checkout();
 
 describe('f-checkout - Collection - Guest - Mobile Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Is ASAP available', true);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': false,
+            'Is ASAP available': true
+        });
     });
 
     it('should display the component base state.', () => {
@@ -45,8 +43,9 @@ describe('f-checkout - Collection - Guest - Mobile Visual Tests', () => {
 
     it('should display the "Duplicate Order Warning" modal', () => {
         // Arrange
-        checkout.withQuery('&knob-Place Order Errors', 'duplicate');
-        checkout.load();
+        checkout.load({
+            'Place Order Errors': 'duplicate'
+        });
         checkout.setFieldValue('firstName', 'Jerry');
         checkout.setFieldValue('lastName', 'Jazzman');
         checkout.setFieldValue('emailAddress', 'jerry.jazzman@ronniescotts.co.uk');
@@ -62,14 +61,12 @@ describe('f-checkout - Collection - Guest - Mobile Visual Tests', () => {
 
 describe('f-checkout - Collection - Guest - isAsapAvailable: false Mobile Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'collection')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Is ASAP available', false);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'collection',
+            'Is User Logged In': false,
+            'Is ASAP available': false
+        });
     });
 
     it('should display the pre-order warning.', () => {
@@ -81,14 +78,12 @@ describe('f-checkout - Collection - Guest - isAsapAvailable: false Mobile Visual
 
 describe('f-checkout - Delivery - Guest - Mobile Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Is ASAP available', true);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': false,
+            'Is ASAP available': true
+        });
     });
 
     it('should display the delivery f-checkout component guest base state.', () => {
@@ -123,8 +118,9 @@ describe('f-checkout - Delivery - Guest - Mobile Visual Tests', () => {
 
     it('should display the "Duplicate Order Warning" modal', () => {
         // Arrange
-        checkout.withQuery('&knob-Place Order Errors', 'duplicate');
-        checkout.load();
+        checkout.load({
+            'Place Order Errors': 'duplicate'
+        });
         checkout.setFieldValue('firstName', 'Jerry');
         checkout.setFieldValue('lastName', 'Jazzman');
         const addressInfo = {
@@ -146,14 +142,12 @@ describe('f-checkout - Delivery - Guest - Mobile Visual Tests', () => {
 
 describe('f-checkout - Delivery - Guest - isAsapAvailable: false Mobile Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Is ASAP available', false);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'delivery',
+            'Is User Logged In': false,
+            'Is ASAP available': false
+        });
     });
 
     it('should display the pre-order warning.', () => {
@@ -164,14 +158,12 @@ describe('f-checkout - Delivery - Guest - isAsapAvailable: false Mobile Visual T
 
 describe('f-checkout - Dine In - Guest - Mobile Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'dinein')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Is ASAP available', false);
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'dinein',
+            'Is User Logged In': false,
+            'Is ASAP available': false
+        });
     });
 
     it('should display the component base state.', () => {
@@ -205,15 +197,13 @@ describe('f-checkout - Dine In - Guest - Mobile Visual Tests', () => {
     });
 
     it('should display the "Duplicate Order Warning" modal', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'dinein')
-            .withQuery('&knob-Is User Logged In', false)
-            .withQuery('&knob-Is ASAP available', false)
-            .withQuery('&knob-Place Order Errors', 'duplicate');
-
         // Act
-        checkout.load();
+        checkout.load({
+            'Service Type': 'dinein',
+            'Is User Logged In': false,
+            'Is ASAP available': false,
+            'Place Order Errors': 'duplicate'
+        });
         checkout.goToPayment();
 
         // Assert

--- a/packages/components/organisms/f-checkout/test/visual/f-checkout-invalid.visual.desktop.spec.js
+++ b/packages/components/organisms/f-checkout/test/visual/f-checkout-invalid.visual.desktop.spec.js
@@ -4,12 +4,10 @@ let checkout;
 
 describe('f-checkout - Invalid - Desktop Visual Tests', () => {
     beforeEach(() => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'invalid-url');
-
         // Act
-        checkout.loadError();
+        checkout.loadError({
+            'Service Type': 'invalid-url'
+        });
     });
 
     it('should display the error page component', () => {

--- a/packages/components/organisms/f-checkout/test/visual/f-checkout-invalid.visual.mobile.spec.js
+++ b/packages/components/organisms/f-checkout/test/visual/f-checkout-invalid.visual.mobile.spec.js
@@ -5,30 +5,26 @@ let checkout;
 describe('f-checkout - Invalid - Mobile Visual Tests', () => {
 
     it('should display the "Get Checkout" error page', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true)
-            .withQuery('&knob-Get Checkout Errors', '500')
-
         // Act
-        checkout.loadError();
+        checkout.loadError({
+            'Service Type': 'delivery',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Get Checkout Errors': '500'
+        });
 
         // Assert
         browser.percyScreenshot('f-checkout - Delivery - Authenticated - "Get Checkout" Error Page', 'mobile');
     });
 
     it('should display the "Get Checkout 403" error page', () => {
-        // Arrange
-        checkout = new Checkout();
-        checkout.withQuery('&knob-Service Type', 'delivery')
-            .withQuery('&knob-Is User Logged In', true)
-            .withQuery('&knob-Is ASAP available', true)
-            .withQuery('&knob-Get Checkout Errors', '403')
-
         // Act
-        checkout.loadError();
+        checkout.loadError({
+            'Service Type': 'delivery',
+            'Is User Logged In': true,
+            'Is ASAP available': true,
+            'Get Checkout Errors': '403'
+        });
 
         // Assert
         browser.percyScreenshot('f-checkout - Delivery - Authenticated - "Get Checkout 403" Error Page', 'mobile');

--- a/packages/components/organisms/f-cookie-banner/test-utils/component-objects/f-cookieBanner-legacy.component.js
+++ b/packages/components/organisms/f-cookie-banner/test-utils/component-objects/f-cookieBanner-legacy.component.js
@@ -14,8 +14,8 @@ module.exports = class CookieBanner extends Page {
 
     get closeButton () { return this.component.$('[data-test-id="cookieBanner-close-button"]'); }
 
-    load () {
-        const pageUrl = buildUrl(this.componentType, this.componentName, this.path);
+    load (queries) {
+        const pageUrl = buildUrl(this.componentType, this.componentName, super.composePath(queries));
         this.open(pageUrl);
         browser.deleteAllCookies();
         browser.refresh();

--- a/packages/components/organisms/f-cookie-banner/test-utils/component-objects/f-cookieConsentBanner.component.js
+++ b/packages/components/organisms/f-cookie-banner/test-utils/component-objects/f-cookieConsentBanner.component.js
@@ -18,8 +18,8 @@ module.exports = class CookieBanner extends Page {
 
     get componentContent () { return $('[data-test-id="cookieBannerContent"]'); }
 
-    load () {
-        const pageUrl = buildUrl(this.componentType, this.componentName, this.path);
+    load (queries) {
+        const pageUrl = buildUrl(this.componentType, this.componentName, super.composePath(queries));
         this.open(pageUrl);
         browser.deleteAllCookies();
         browser.refresh();

--- a/packages/components/organisms/f-cookie-banner/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/accessibility/axe-accessibility.spec.js
@@ -12,8 +12,9 @@ describe('Legacy Accessibility tests', () => {
     it('a11y - should test legacy f-cookie-banner component WCAG compliance', () => {
         // Arrange
         const formattedLocale = 'en-AU';
-        legacyCookieBanner.withQuery('&knob-Locale', formattedLocale);
-        legacyCookieBanner.load();
+        legacyCookieBanner.load({
+            'Locale': formattedLocale
+        });
 
         // Act
         const axeResults = getAccessibilityTestResults('f-cookie-banner');
@@ -25,8 +26,9 @@ describe('Legacy Accessibility tests', () => {
     it('a11y - should test new f-cookie-banner component WCAG compliance', () => {
         // Arrange
         const formattedLocale = 'en-GB';
-        cookieConsentBanner.withQuery('&knob-Locale', formattedLocale);
-        cookieConsentBanner.load();
+        cookieConsentBanner.load({
+            'Locale': formattedLocale
+        });
 
         // Act
         const axeResults = getAccessibilityTestResults('f-cookie-banner');

--- a/packages/components/organisms/f-cookie-banner/test/component/f-cookieBanner-legacy.component.desktop.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/component/f-cookieBanner-legacy.component.desktop.spec.js
@@ -2,13 +2,13 @@ import forEach from 'mocha-each';
 
 const CookieBanner = require('../../test-utils/component-objects/f-cookieBanner-legacy.component');
 
-let cookieBanner;
+let cookieBanner = new CookieBanner();
 
 describe('Legacy - f-cookieBanner component tests @browserstack', () => {
     beforeEach(() => {
-        cookieBanner = new CookieBanner();
-        cookieBanner.withQuery('&knob-Locale', 'en-AU');
-        cookieBanner.load();
+        cookieBanner.load({
+            'Locale': 'en-AU'
+        });
     });
 
     it('should set "je-cookie_banner" cookie when dismissed.', () => {
@@ -28,11 +28,7 @@ describe('Legacy - Multi-tenant - f-cookieBanner component tests', () => {
         ['en-NZ', 'nz/info/privacy-policy#cookies_policy']
     ])
         .it('should go to the correct cookie policy page for "%s" - "%s"', (tenant, expectedCookiePolicyUrl) => {
-            // Arrange
-            cookieBanner = new CookieBanner();
-            cookieBanner.withQuery('&knob-Locale', tenant);
-
-            cookieBanner.load();
+            cookieBanner.load({ 'Locale': tenant });
 
             // Act
             cookieBanner.clickCookiePolicyLink();

--- a/packages/components/organisms/f-cookie-banner/test/component/f-cookieBanner-legacy.component.shared.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/component/f-cookieBanner-legacy.component.shared.spec.js
@@ -5,8 +5,7 @@ const cookieBanner = new CookieBanner();
 describe('Legacy - f-cookieBanner component tests - @browserstack', () => {
     it('should display the f-cookieBanner component', () => {
         // Arrange
-        cookieBanner.withQuery('&knob-Locale', 'en-AU');
-        cookieBanner.load();
+        cookieBanner.load({'Locale': 'en-AU'});
 
         // Assert
         expect(cookieBanner.isCookieBannerComponentDisplayed()).toBe(true);

--- a/packages/components/organisms/f-cookie-banner/test/component/f-cookieConsentBanner.component.desktop.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/component/f-cookieConsentBanner.component.desktop.spec.js
@@ -2,13 +2,11 @@ import forEach from 'mocha-each';
 
 const CookieBanner = require('../../test-utils/component-objects/f-cookieConsentBanner.component');
 
-let cookieBanner;
+let cookieBanner = new CookieBanner();
 
 describe('New - f-cookieBanner component tests - @browserstack', () => {
     beforeEach(() => {
-        cookieBanner = new CookieBanner();
-        cookieBanner.withQuery('&knob-Locale', 'en-IE');
-        cookieBanner.load();
+        cookieBanner.load({ 'Locale': 'en-IE' });
     });
 
     forEach(['full', 'necessary'])
@@ -38,10 +36,7 @@ describe('New - Multi-tenant - f-cookieBanner component tests', () => {
     ])
         .it('should go to the correct cookie policy page', (tenant, expectedCookiePolicyUrl) => {
             // Arrange
-            cookieBanner = new CookieBanner();
-            cookieBanner.withQuery('&knob-Locale', tenant);
-
-            cookieBanner.load();
+            cookieBanner.load({ 'Locale': tenant });
 
             // Act
             cookieBanner.clickCookiePolicyLink();

--- a/packages/components/organisms/f-cookie-banner/test/component/f-cookieConsentBanner.component.shared.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/component/f-cookieConsentBanner.component.shared.spec.js
@@ -2,14 +2,11 @@ import forEach from 'mocha-each';
 
 const CookieBanner = require('../../test-utils/component-objects/f-cookieConsentBanner.component');
 
-let cookieBanner;
+let cookieBanner = new CookieBanner();
 
 describe('New - f-cookieBanner component tests - @browserstack', () => {
     beforeEach(() => {
-        cookieBanner = new CookieBanner();
-        cookieBanner.withQuery('&knob-Locale', 'en-IE');
-
-        cookieBanner.load();
+        cookieBanner.load({ 'Locale': 'en-IE' });
     });
 
     it('should display the f-cookieBanner content', () => {
@@ -30,12 +27,8 @@ describe('New - f-cookieBanner component tests - @browserstack', () => {
     // 'dk' and 'no' disabled for now
     forEach(['es-ES', 'en-IE', 'it-IT', 'en-GB'])
         .it('should display the f-cookieBanner component for "%s"', tenant => {
-            // Arrange
-            cookieBanner = new CookieBanner();
-            cookieBanner.withQuery('&knob-Locale', tenant);
-
             // Act
-            cookieBanner.load();
+            cookieBanner.load({ 'Locale': tenant });
 
             // Assert
             expect(cookieBanner.isCookieBannerComponentDisplayed()).toBe(true);

--- a/packages/components/organisms/f-cookie-banner/test/visual/f-cookieConsentBanner.visual.desktop.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/visual/f-cookieConsentBanner.visual.desktop.spec.js
@@ -2,25 +2,18 @@ import forEach from 'mocha-each';
 
 const CookieBanner = require('../../test-utils/component-objects/f-cookieConsentBanner.component');
 
-let cookieBanner;
+let cookieBanner = new CookieBanner();
 
 describe('New - f-cookieBanner Desktop Visual Tests', () => {
     beforeEach(() => {
-        cookieBanner = new CookieBanner();
-        cookieBanner.withQuery('&knob-Locale', 'en-IE');
-
-        cookieBanner.load();
+        cookieBanner.load({ 'Locale': 'en-IE' });
     });
 
     // 'dk' and 'no' disabled for now
     forEach(['es-ES', 'en-IE', 'it-IT'])
     .it('should display the f-cookieBanner component for "%s"', tenant => {
-        // Arrange
-        cookieBanner = new CookieBanner();
-        cookieBanner.withQuery('&knob-Locale', tenant);
-
         // Act
-        cookieBanner.load();
+        cookieBanner.load({ 'Locale': tenant });
 
         // Assert
         browser.percyScreenshot(`f-cookiebanner - CookieConsent - ${tenant}`, 'desktop');

--- a/packages/components/organisms/f-cookie-banner/test/visual/f-cookieConsentBanner.visual.mobile.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/visual/f-cookieConsentBanner.visual.mobile.spec.js
@@ -2,25 +2,18 @@ import forEach from 'mocha-each';
 
 const CookieBanner = require('../../test-utils/component-objects/f-cookieConsentBanner.component');
 
-let cookieBanner;
+let cookieBanner = new CookieBanner();
 
 describe('New - f-cookieBanner Mobile Visual Tests', () => {
     beforeEach(() => {
-        cookieBanner = new CookieBanner();
-        cookieBanner.withQuery('&knob-Locale', 'en-IE');
-
-        cookieBanner.load();
+        cookieBanner.load({ 'Locale': 'en-IE' });
     });
 
     // 'dk' and 'no' disabled for now
     forEach(['es-ES', 'en-IE', 'it-IT'])
     .it('should display the f-cookieBanner component for "%s"', tenant => {
-        // Arrange
-        cookieBanner = new CookieBanner();
-        cookieBanner.withQuery('&knob-Locale', tenant);
-
         // Act
-        cookieBanner.load();
+        cookieBanner.load({ 'Locale': tenant });
 
         // Assert
         browser.percyScreenshot(`f-cookiebanner - CookieConsent - ${tenant}`, 'mobile');

--- a/packages/components/organisms/f-cookie-banner/test/visual/f-cookiebanner-legacy.visual.desktop.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/visual/f-cookiebanner-legacy.visual.desktop.spec.js
@@ -5,9 +5,7 @@ const cookieBanner = new CookieBanner();
 describe('Legacy - f-cookieBanner Desktop Visual Tests', () => {
     it('should display the f-cookieBanner component', () => {
         // Arrange
-        cookieBanner.withQuery('&knob-Locale', 'en-AU');
-        
-        cookieBanner.load();
+        cookieBanner.load({ 'Locale': 'en-AU' });
 
         // Assert
         browser.percyScreenshot('f-cookiebanner - Legacy', 'desktop');

--- a/packages/components/organisms/f-cookie-banner/test/visual/f-cookiebanner-legacy.visual.mobile.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/visual/f-cookiebanner-legacy.visual.mobile.spec.js
@@ -5,9 +5,7 @@ const cookieBanner = new CookieBanner();
 describe('Legacy - f-cookieBanner Mobile Visual Tests', () => {
     it('should display the f-cookieBanner component', () => {
         // Arrange
-        cookieBanner.withQuery('&knob-Locale', 'en-AU');
-        
-        cookieBanner.load();
+        cookieBanner.load({ 'Locale': 'en-AU' });
 
         // Assert
         browser.percyScreenshot('f-cookiebanner - Legacy', 'mobile');

--- a/packages/components/organisms/f-footer/test-utils/component-objects/f-footer.component.js
+++ b/packages/components/organisms/f-footer/test-utils/component-objects/f-footer.component.js
@@ -68,8 +68,8 @@ module.exports = class Footer extends Page {
         this.countryValue = this.countries.filter(element => element.getAttribute('data-test-id').includes(country))[0];
     }
 
-    load () {
-        super.load(this.component);
+    load (queries) {
+        super.load(this.component, queries);
     }
 
     open (url) {

--- a/packages/components/organisms/f-footer/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-footer/test/accessibility/axe-accessibility.spec.js
@@ -3,18 +3,17 @@ import forEach from 'mocha-each';
 const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
 const Footer = require('../../test-utils/component-objects/f-footer.component');
 
-let footer;
+let footer = new Footer();
 
 describe('Accessibility tests', () => {
     forEach(['en-GB', 'en-AU', 'en-IE', 'en-NZ', 'da-DK', 'es-ES', 'it-IT', 'nb-NO'])
         .it('a11y - should test f-footer component WCAG compliance for country code "%s" with default options selected', tenant => {
-            footer = new Footer();
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'false');
-            footer.withQuery('&knob-Show courier links', 'false');
-
             // Act
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'false',
+                'Show courier links': 'false'
+            });
             const axeResults = getAccessibilityTestResults('f-footer');
 
             // Assert
@@ -23,13 +22,12 @@ describe('Accessibility tests', () => {
 
     forEach(['en-GB', 'en-AU', 'en-IE', 'en-NZ'])
         .it('a11y - should test f-footer component WCAG compliance for country code "%s" with extra options selected', tenant => {
-            footer = new Footer();
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'true');
-            footer.withQuery('&knob-Show courier links', 'false');
-
             // Act
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'true',
+                'Show courier links': 'false'
+            });
             const axeResults = getAccessibilityTestResults('f-footer');
 
             // Assert

--- a/packages/components/organisms/f-footer/test/component/f-footer.component.desktop.spec.js
+++ b/packages/components/organisms/f-footer/test/component/f-footer.component.desktop.spec.js
@@ -2,16 +2,15 @@ import forEach from 'mocha-each';
 
 const Footer = require('../../test-utils/component-objects/f-footer.component');
 
-let footer;
+let footer = new Footer();
 
 describe('Desktop - f-footer component tests - @browserstack', () => {
     beforeEach(() => {
-        footer = new Footer();
-        footer.withQuery('&knob-Locale', 'en-GB');
-        footer.withQuery('&knob-Show country selector', 'true');
-        footer.withQuery('&knob-Show courier links', 'false');
-
-        footer.load();
+        footer.load({
+            'Locale': 'en-GB',
+            'Show country selector': 'true',
+            'Show courier links': 'false'
+        });
     });
 
     forEach([['ios', 'apple'], ['android', 'google'], ['huawei', 'appgallery']])
@@ -52,13 +51,12 @@ describe('Desktop - f-footer component tests - @browserstack', () => {
     // Make sure tenant is appended to screenshot for Percy tests
     forEach(['en-GB', 'en-AU', 'en-IE', 'en-NZ', 'da-DK', 'es-ES', 'it-IT', 'nb-NO'])
         .it('should not show courier links and country selector for country code "%s" when options are unselected - @percy', tenant => {
-            // Arrange
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'false');
-            footer.withQuery('&knob-Show courier links', 'false');
-
             // Act
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'false',
+                'Show courier links': 'false'
+            });
 
             // Assert
             expect(footer.areCourierLinksDisplayed()).toBe(false);
@@ -68,14 +66,12 @@ describe('Desktop - f-footer component tests - @browserstack', () => {
     // Make sure tenant is appended to screenshot for Percy tests
     forEach(['en-AU', 'en-IE', 'en-NZ'])
         .it('should show courier links for country code "%s" when option is selected - @percy', tenant => {
-            // Arrange
-            footer = new Footer();
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'false');
-            footer.withQuery('&knob-Show courier links', 'true');
-
             // Act
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'false',
+                'Show courier links': 'true'
+            });
 
             // Assert
             expect(footer.areCourierLinksDisplayed()).toBe(true);
@@ -84,14 +80,12 @@ describe('Desktop - f-footer component tests - @browserstack', () => {
     // Make sure tenant is appended to screenshot for Percy tests
     forEach(['en-GB', 'es-ES', 'it-IT', 'nb-NO'])
         .it('should never show courier links for country code "%s", even when option is selected - @percy', tenant => {
-            // Arrange
-            footer = new Footer();
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'false');
-            footer.withQuery('&knob-Show courier links', 'true');
-
             // Act
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'false',
+                'Show courier links': 'true'
+            });
 
             // Assert
             expect(footer.areCourierLinksDisplayed()).toBe(false);
@@ -100,14 +94,12 @@ describe('Desktop - f-footer component tests - @browserstack', () => {
     // Make sure tenant is appended to screenshot for Percy tests
     forEach(['en-AU', 'en-IE', 'en-NZ', 'da-DK', 'es-ES', 'it-IT', 'nb-NO'])
         .it('should always show country selector for country code "%s" when selected - @percy', tenant => {
-            // Arrange
-            footer = new Footer();
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'true');
-            footer.withQuery('&knob-Show courier links', 'false');
-
             // Act
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'true',
+                'Show courier links': 'false'
+            });
 
             // Assert
             expect(footer.isCountrySelectorDisplayed()).toBe(true);
@@ -116,16 +108,14 @@ describe('Desktop - f-footer component tests - @browserstack', () => {
     // Make sure tenant is appended to screenshot for Percy tests
     forEach(['en-AU', 'en-GB', 'en-NZ', 'en-IE', 'da-DK', 'es-ES', 'it-IT'])
         .it('should display the corresponding icon for the "%s" country code - @percy', tenant => {
-            // Arrange
-            footer = new Footer();
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'true');
-            footer.withQuery('&knob-Show courier links', 'false');
-            const countryIcon = tenant.split('-');
-
             // Act
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'true',
+                'Show courier links': 'false'
+            });
 
+            const countryIcon = tenant.split('-');
             // Assert
             expect(footer.isCurrentCountryIconDisplayed(countryIcon[1].toLowerCase())).toBe(true);
         });
@@ -171,14 +161,12 @@ describe('Desktop - f-footer component tests - @browserstack', () => {
     // Make sure tenant is appended to screenshot for Percy tests
     forEach(['en-GB', 'en-AU', 'en-IE', 'en-NZ', 'da-DK', 'es-ES', 'it-IT', 'nb-NO'])
         .it('should display social icons block for country code "%s" - @percy', tenant => {
-            // Arrange
-            footer = new Footer();
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'false');
-            footer.withQuery('&knob-Show courier links', 'false');
-
             // Act
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'false',
+                'Show courier links': 'false'
+            });
 
             // Assert
             expect(footer.isSocialIconBlockDisplayed()).toBe(true);
@@ -187,14 +175,12 @@ describe('Desktop - f-footer component tests - @browserstack', () => {
     // Make sure tenant is appended to screenshot for Percy tests
     forEach(['en-GB', 'en-AU', 'en-IE', 'en-NZ', 'da-DK', 'es-ES', 'it-IT', 'nb-NO'])
         .it('should display app downloads block for country code "%s" - @percy', tenant => {
-            // Arrange
-            footer = new Footer();
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'false');
-            footer.withQuery('&knob-Show courier links', 'false');
-
             // Act
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'false',
+                'Show courier links': 'false'
+            });
 
             // Assert
             expect(footer.isDownloadIconBlockDisplayed()).toBe(true);
@@ -203,14 +189,12 @@ describe('Desktop - f-footer component tests - @browserstack', () => {
     // Make sure tenant is appended to screenshot for Percy tests
     forEach(['en-GB', 'en-AU', 'en-IE', 'en-NZ', 'da-DK', 'es-ES', 'it-IT', 'nb-NO'])
         .it('should display payment options block for country code "%s" - @percy', tenant => {
-            // Arrange
-            footer = new Footer();
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'false');
-            footer.withQuery('&knob-Show courier links', 'false');
-
             // Act
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'false',
+                'Show courier links': 'false'
+            });
 
             // Assert
             expect(footer.isPaymentIconsBlockDisplayed()).toBe(true);
@@ -219,14 +203,12 @@ describe('Desktop - f-footer component tests - @browserstack', () => {
     // Make sure tenant is appended to screenshot for Percy tests
     forEach(['en-GB', 'en-AU', 'en-IE', 'en-NZ', 'da-DK', 'es-ES', 'it-IT', 'nb-NO'])
         .it('should display the feedback block for country code "%s" - @percy', tenant => {
-            // Arrange
-            footer = new Footer();
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'false');
-            footer.withQuery('&knob-Show courier links', 'false');
-
             // Act
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'false',
+                'Show courier links': 'false'
+            });
 
             // Assert
             expect(footer.isFeedbackBlockDisplayed()).toBe(true);

--- a/packages/components/organisms/f-footer/test/component/f-footer.component.mobile.spec.js
+++ b/packages/components/organisms/f-footer/test/component/f-footer.component.mobile.spec.js
@@ -1,17 +1,15 @@
 const Footer = require('../../test-utils/component-objects/f-footer.component');
 
-let footer;
+let footer = new Footer();
 
 describe('Mobile - f-footer component tests - @percy', () => {
     beforeEach(() => {
-        // Arrange
-        footer = new Footer();
-        footer.withQuery('&knob-Locale', 'en-GB');
-        footer.withQuery('&knob-Show country selector', 'false');
-        footer.withQuery('&knob-Show courier links', 'false');
-
         // Act
-        footer.load();
+        footer.load({
+            'Locale': 'en-GB',
+            'Show country selector': 'false',
+            'Show courier links': 'false'
+        });
     });
 
     it('should not show the items with the drop down boxes when in mobile view', () => {

--- a/packages/components/organisms/f-footer/test/visual/f-footer.visual.desktop.spec.js
+++ b/packages/components/organisms/f-footer/test/visual/f-footer.visual.desktop.spec.js
@@ -11,49 +11,41 @@ describe('f-footer - Desktop Visual Tests', () => {
 
     forEach(['en-GB', 'en-AU', 'en-IE', 'en-NZ', 'es-ES', 'it-IT'])
         .it('should display the base footer for tenant: "%s"', tenant => {
-
-            // Arrange
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'false');
-            footer.withQuery('&knob-Show courier links', 'false');
-
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'false',
+                'Show courier links': 'false'
+            });
             browser.percyScreenshot(`f-footer - Base - ${tenant}`, 'desktop')
         });
 
     forEach(['en-GB', 'en-AU', 'en-IE', 'en-NZ', 'es-ES', 'it-IT'])
         .it('should display the footer with country selector for tenant: "%s"', tenant => {
-
-            // Arrange
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'true');
-            footer.withQuery('&knob-Show courier links', 'false');
-
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'true',
+                'Show courier links': 'false'
+            });
             browser.percyScreenshot(`f-footer - Country Selector - ${tenant}`, 'desktop')
         });
 
     forEach(['en-AU', 'en-NZ'])
         .it('should display the footer with courier links for tenant: "%s"', tenant => {
-
-            // Arrange
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'false');
-            footer.withQuery('&knob-Show courier links', 'true');
-
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'false',
+                'Show courier links': 'true'
+            });
             browser.percyScreenshot(`f-footer - Courier Links - ${tenant}`, 'desktop')
         });
 
     forEach(['en-AU', 'en-NZ'])
         .it('should display the footer with courier links and country selector for tenant: "%s"', tenant => {
-
-            // Arrange
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'true');
-            footer.withQuery('&knob-Show courier links', 'true');
-
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'true',
+                'Show courier links': 'true'
+            });
             browser.percyScreenshot(`f-footer - Courier Links and Country Selector - ${tenant}`, 'desktop')
         });
 });

--- a/packages/components/organisms/f-footer/test/visual/f-footer.visual.mobile.spec.js
+++ b/packages/components/organisms/f-footer/test/visual/f-footer.visual.mobile.spec.js
@@ -11,49 +11,41 @@ describe('f-footer - Mobile Visual Tests', () => {
 
     forEach(['en-GB', 'en-AU', 'en-IE', 'en-NZ', 'es-ES', 'it-IT'])
         .it('should display the base footer for tenant: "%s"', tenant => {
-
-            // Arrange
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'false');
-            footer.withQuery('&knob-Show courier links', 'false');
-
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'false',
+                'Show courier links': 'false'
+            });
             browser.percyScreenshot(`f-footer - Base - ${tenant}`, 'mobile')
         });
 
     forEach(['en-GB', 'en-AU', 'en-IE', 'en-NZ', 'es-ES', 'it-IT'])
         .it('should display the footer with country selector for tenant: "%s"', tenant => {
-
-            // Arrange
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'true');
-            footer.withQuery('&knob-Show courier links', 'false');
-
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'true',
+                'Show courier links': 'false'
+            });
             browser.percyScreenshot(`f-footer - Country Selector - ${tenant}`, 'mobile')
         });
 
     forEach(['en-AU', 'en-NZ'])
         .it('should display the footer with courier links for tenant: "%s"', tenant => {
-
-            // Arrange
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'false');
-            footer.withQuery('&knob-Show courier links', 'true');
-
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'false',
+                'Show courier links': 'true'
+            });
             browser.percyScreenshot(`f-footer - Courier Links - ${tenant}`, 'mobile')
         });
 
     forEach(['en-AU', 'en-NZ'])
         .it('should display the footer with courier links and country selector for tenant: "%s"', tenant => {
-
-            // Arrange
-            footer.withQuery('&knob-Locale', tenant);
-            footer.withQuery('&knob-Show country selector', 'true');
-            footer.withQuery('&knob-Show courier links', 'true');
-
-            footer.load();
+            footer.load({
+                'Locale': tenant,
+                'Show country selector': 'true',
+                'Show courier links': 'true'
+            });
             browser.percyScreenshot(`f-footer - Courier Links and Country Selector - ${tenant}`, 'mobile')
         });
 });

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
@@ -46,8 +46,8 @@ module.exports = class Header extends Page {
         this.countryValue = this.navigation.countrySelector.countries.filter(element => element.getAttribute('data-test-id').includes(country))[0];
     }
 
-    load () {
-        super.load(this.component);
+    load (queries) {
+        super.load(this.component, queries);
     }
 
     open (url) {

--- a/packages/components/organisms/f-header/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-header/test/accessibility/axe-accessibility.spec.js
@@ -9,10 +9,11 @@ describe('Accessibility tests', () => {
     forEach(['en-GB', 'en-AU', 'en-NZ', 'en-IE', 'it-IT', 'es-ES', 'da-DK', 'nb-NO'])
         .it('a11y - should test f-header component WCAG compliance for "%s"', tenant => {
             // Act
-            header.withQuery('&knob-Locale', tenant);
-            header.withQuery('&knob-Show offers link', 'true');
-            header.withQuery('&knob-Show delivery enquiry', 'true');
-            header.load();
+            header.load({
+                'Locale': tenant,
+                'Show offers link': 'true',
+                'Show delivery enquiry': 'true'
+            });
             const axeResults = getAccessibilityTestResults('f-header');
 
             // Assert

--- a/packages/components/organisms/f-header/test/component/f-header.component.desktop.spec.js
+++ b/packages/components/organisms/f-header/test/component/f-header.component.desktop.spec.js
@@ -2,17 +2,16 @@ import forEach from 'mocha-each';
 
 const Header = require('../../test-utils/component-objects/f-header.component');
 
-let header;
+let header = new Header();
 
 describe('Desktop - f-header component tests - @browserstack', () => {
     beforeEach(() => {
-        // Arrange
-        header = new Header();
-        header.withQuery('&knob-Show offers link', 'true');
-        header.withQuery('&knob-Show delivery enquiry', 'true');
-
         // Act
-        header.load();
+        header.load({
+            'Show offers link': 'true',
+            'Show delivery enquiry': 'true'
+        });
+
         browser.maximizeWindow();
     });
 
@@ -25,11 +24,12 @@ describe('Desktop - f-header component tests - @browserstack', () => {
     // Make sure tenant is appended to screenshot for Percy tests
     forEach(['en-AU', 'en-IE', 'en-NZ'])
         .it('should display the below navigation links for country code "%s" - @percy', tenant => {
-            // Arrange
-            header.withQuery('&knob-Locale', tenant);
-
             // Act
-            header.load();
+            header.load({
+                'Locale': tenant,
+                'Show offers link': 'true',
+                'Show delivery enquiry': 'true'
+            });
             ['offersLink', 'userAccount', 'help', 'countrySelector'].forEach(link => {
                 // Assert
                 expect(header.isNavigationLinkDisplayed(link)).toBe(true);
@@ -39,13 +39,12 @@ describe('Desktop - f-header component tests - @browserstack', () => {
 
     forEach(['it-IT', 'es-ES', 'da-DK', 'nb-NO'])
         .it('should display the below navigation links', tenant => {
-            // Arrange
-            header.withQuery('&knob-Locale', tenant);
-            header.withQuery('&knob-Show offers link', 'true');
-            header.withQuery('&knob-Show delivery enquiry', 'true');
-
             // Act
-            header.load();
+            header.load({
+                'Locale': tenant,
+                'Show offers link': 'true',
+                'Show delivery enquiry': 'true'
+            });
             ['userAccount', 'help', 'countrySelector'].forEach(link => {
                 // Assert
                 expect(header.isNavigationLinkDisplayed(link)).toBe(true);
@@ -56,14 +55,13 @@ describe('Desktop - f-header component tests - @browserstack', () => {
     // Make sure tenant is appended to screenshot for Percy tests
     forEach(['it-IT', 'es-ES', 'da-DK', 'nb-NO'])
         .it('should display the below navigation links for country code "%s" - @percy', tenant => {
-            // Arrange
-            header.withQuery('&knob-Locale', tenant);
-            header.withQuery('&knob-Show offers link', 'true');
-            header.withQuery('&knob-Show delivery enquiry', 'true');
-
             ['userAccount', 'help', 'countrySelector'].forEach(link => {
                 // Act
-                header.load();
+                header.load({
+                    'Locale': tenant,
+                    'Show offers link': 'true',
+                    'Show delivery enquiry': 'true'
+                });
 
                 // Assert
                 expect(header.isNavigationLinkDisplayed(link)).toBe(true);
@@ -118,11 +116,14 @@ describe('Desktop - f-header component tests - @browserstack', () => {
         .describe('for country code "%s" - @percy', tenant => {
             it('should display correct selector icon - @percy', () => {
                 // Arrange
-                header.withQuery('&knob-Locale', tenant);
                 const countryIcon = tenant.split('-');
 
                 // Act
-                header.load();
+                header.load({
+                    'Locale': tenant,
+                    'Show offers link': 'true',
+                    'Show delivery enquiry': 'true'
+                });
 
                 // Assert
                 expect(header.isCurrentCountryIconDisplayed(countryIcon[1].toLowerCase())).toBe(true);

--- a/packages/components/organisms/f-header/test/component/f-header.component.mobile.spec.js
+++ b/packages/components/organisms/f-header/test/component/f-header.component.mobile.spec.js
@@ -2,17 +2,15 @@ import forEach from 'mocha-each';
 
 const Header = require('../../test-utils/component-objects/f-header.component');
 
-let header;
+let header = new Header();
 
 describe('Mobile - f-header component tests - @browserstack', () => {
     beforeEach(() => {
-        // Arrange
-        header = new Header();
-        header.withQuery('&knob-Show offers link', 'true');
-        header.withQuery('&knob-Show delivery enquiry', 'true');
-
         // Act
-        header.load();
+        header.load({
+            'Show offers link': 'true',
+            'Show delivery enquiry': 'true'
+        });
         header.openMobileNavigationBar();
 
         if (process.env.JE_ENV !== 'browserstack') {
@@ -42,8 +40,11 @@ describe('Mobile - f-header component tests - @browserstack', () => {
         .describe('closed navigation for country code "%s" - @percy', tenant => {
             beforeEach(() => {
                 // Act
-                header.withQuery('&knob-Locale', tenant);
-                header.load();
+                header.load({
+                    'Locale': tenant,
+                    'Show offers link': 'true',
+                    'Show delivery enquiry': 'true'
+                });
             });
 
             forEach(['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'])
@@ -61,11 +62,12 @@ describe('Mobile - f-header component tests - @browserstack', () => {
     forEach(['en-AU', 'en-IE', 'en-NZ'])
         .describe('open navigation for country code "%s" - @percy', tenant => {
             beforeEach(() => {
-                // Arrange
-                header.withQuery('&knob-Locale', tenant);
-
                 // Act
-                header.load();
+                header.load({
+                    'Locale': tenant,
+                    'Show offers link': 'true',
+                    'Show delivery enquiry': 'true'
+                });
                 header.openMobileNavigationBar();
             });
 
@@ -84,11 +86,12 @@ describe('Mobile - f-header component tests - @browserstack', () => {
     forEach(['it-IT', 'es-ES', 'da-DK', 'nb-NO'])
         .describe('closed navigation for country code "%s" - @percy', tenant => {
             beforeEach(() => {
-                // Arrange
-                header.withQuery('&knob-Locale', tenant);
-
                 // Act
-                header.load();
+                header.load({
+                    'Locale': tenant,
+                    'Show offers link': 'true',
+                    'Show delivery enquiry': 'true'
+                });
             });
 
             forEach(['offersLink', 'delivery', 'userAccount', 'help', 'countrySelector'])
@@ -106,11 +109,12 @@ describe('Mobile - f-header component tests - @browserstack', () => {
     forEach(['it-IT', 'es-ES', 'da-DK', 'nb-NO'])
         .describe.only('open navigation for country code "%s" - @percy', tenant => {
             beforeEach(() => {
-                // Arrange
-                header.withQuery('&knob-Locale', tenant);
-
                 // Act
-                header.load();
+                header.load({
+                    'Locale': tenant,
+                    'Show offers link': 'true',
+                    'Show delivery enquiry': 'true'
+                });
                 header.openMobileNavigationBar();
             });
 

--- a/packages/components/organisms/f-header/test/component/f-header.component.shared.spec.js
+++ b/packages/components/organisms/f-header/test/component/f-header.component.shared.spec.js
@@ -1,16 +1,15 @@
 const Header = require('../../test-utils/component-objects/f-header.component');
 
-let header;
+let header = new Header();
 
 describe('Shared - f-header component tests - @percy', () => {
     beforeEach(() => {
-        header = new Header();
-        header.withQuery('&knob-Locale', 'en-GB');
-        header.withQuery('&knob-Show offers link', 'true');
-        header.withQuery('&knob-Show delivery enquiry', 'true');
-
         // Act
-        header.load();
+        header.load({
+            'Locale': 'en-GB',
+            'Show offers link': 'true',
+            'Show delivery enquiry': 'true'
+        });
     });
 
     it('should display component', () => {

--- a/packages/components/organisms/f-header/test/visual/f-header.visual.desktop.spec.js
+++ b/packages/components/organisms/f-header/test/visual/f-header.visual.desktop.spec.js
@@ -2,7 +2,7 @@ import forEach from 'mocha-each';
 
 const Header = require('../../test-utils/component-objects/f-header.component');
 
-let header;
+let header = new Header();
 
 describe('Shared - f-header component tests', () => {
     forEach([['en-GB', true], ['en-GB', false],
@@ -13,19 +13,19 @@ describe('Shared - f-header component tests', () => {
     ['es-ES', true], ['es-ES', false]
     ])
         .it('should display component', (tenant, isLoggedIn) => {
-            // Arrange
-            header = new Header();
-            header.withQuery('&knob-Locale', tenant);
-            // Both props below should only show for UK
-            header.withQuery('&knob-Show offers link', 'true');
-            header.withQuery('&knob-Show delivery enquiry', 'true');
+            const queries = {
+                'Locale': tenant,
+                // Both props below should only show for UK
+                'Show offers link': 'true',
+                'Show delivery enquiry': 'true'
+            };
 
             if (!isLoggedIn) {
-                header.withQuery('&knob-User info', isLoggedIn);
+                queries['User info'] = isLoggedIn;
             }
 
             // Act
-            header.load();
+            header.load(queries);
 
             // Assert
             browser.percyScreenshot(`f-header - Base state - isLoggedIn: ${isLoggedIn} - ${tenant}`, 'desktop');
@@ -33,24 +33,19 @@ describe('Shared - f-header component tests', () => {
 
     forEach(['white', 'highlight', 'transparent'])
         .it('should display the "%s" header theme', theme => {
-            // Arrange
-            header = new Header();
-            header.withQuery('&knob-Locale', 'en-GB');
-            header.withQuery('&knob-Header theme', theme);
-
             // Act
-            header.load();
+            header.load({
+                'Locale': 'en-GB',
+                'Header theme': theme
+            });
 
             // Assert
             browser.percyScreenshot(`f-header - Theme colours - ${theme}`, 'desktop');
         });
 
     it('should display all avalible countries', () => {
-        header = new Header();
-        header.withQuery('&knob-Locale', 'en-GB');
-
         // Act
-        header.load();
+        header.load({ 'Locale': 'en-GB' });
         header.moveToCountrySelector();
 
         // Assert
@@ -59,23 +54,19 @@ describe('Shared - f-header component tests', () => {
 
     forEach(['Show login/user info link', 'Show help link', 'Show country selector'])
         .it('should not display "%s" ', knobName => {
-            header = new Header();
-            header.withQuery('&knob-Locale', 'en-GB');
-            header.withQuery(`&knob-${knobName}`, 'false');
-
             // Act
-            header.load();
+            header.load({
+                'Locale': 'en-GB',
+                [knobName]: 'false'
+            });
 
             // Assert
             browser.percyScreenshot(`f-header - ${knobName} - False`, 'desktop');
         });
 
     it('should display all user account options', () => {
-        header = new Header();
-        header.withQuery('&knob-Locale', 'en-GB');
-
         // Act
-        header.load();
+        header.load({ 'Locale': 'en-GB' });
         header.moveToUserAccount();
 
         // Assert

--- a/packages/components/organisms/f-header/test/visual/f-header.visual.mobile.spec.js
+++ b/packages/components/organisms/f-header/test/visual/f-header.visual.mobile.spec.js
@@ -2,7 +2,7 @@ import forEach from 'mocha-each';
 
 const Header = require('../../test-utils/component-objects/f-header.component');
 
-let header;
+let header = new Header();
 
 describe('Shared - f-header component tests', () => {
     forEach([['en-GB', true], ['en-GB', false],
@@ -14,18 +14,19 @@ describe('Shared - f-header component tests', () => {
     ])
         .it('should display component', (tenant, isLoggedIn) => {
             // Arrange
-            header = new Header();
-            header.withQuery('&knob-Locale', tenant);
-            // Both props below should only show for UK
-            header.withQuery('&knob-Show offers link', 'true');
-            header.withQuery('&knob-Show delivery enquiry', 'true');
+            const queries = {
+                'Locale': tenant,
+                // Both props below should only show for UK
+                'Show offers link': 'true',
+                'Show delivery enquiry': 'true'
+            };
 
             if (!isLoggedIn) {
-                header.withQuery('&knob-User info', isLoggedIn);
+                queries['User info'] = isLoggedIn;
             }
 
             // Act
-            header.load();
+            header.load(queries);
             header.openMobileNavigationBar();
 
             // Assert
@@ -34,24 +35,19 @@ describe('Shared - f-header component tests', () => {
 
     forEach(['white', 'highlight', 'transparent'])
         .it('should display the "%s" header theme', theme => {
-            // Arrange
-            header = new Header();
-            header.withQuery('&knob-Locale', 'en-GB');
-            header.withQuery('&knob-Header theme', theme);
-
             // Act
-            header.load();
+            header.load({
+                'Locale': 'en-GB',
+                'Header theme': theme
+            });
 
             // Assert
             browser.percyScreenshot(`f-header - Theme colours - ${theme}`, 'mobile');
         });
 
     it('should display all avalible countries', () => {
-        header = new Header();
-        header.withQuery('&knob-Locale', 'en-GB');
-
         // Act
-        header.load();
+        header.load({ 'Locale': 'en-GB' });
         header.openMobileNavigationBar();
         header.openCountrySelector();
 
@@ -61,12 +57,11 @@ describe('Shared - f-header component tests', () => {
 
     forEach(['Show login/user info link', 'Show help link', 'Show country selector'])
         .it('should not display "%s" ', knobName => {
-            header = new Header();
-            header.withQuery('&knob-Locale', 'en-GB');
-            header.withQuery(`&knob-${knobName}`, 'false');
-
             // Act
-            header.load();
+            header.load({
+                'Locale': 'en-GB',
+                [knobName]: 'false'
+            });
             header.openMobileNavigationBar();
 
             // Assert

--- a/packages/services/f-wdio-utils/src/page.object.js
+++ b/packages/services/f-wdio-utils/src/page.object.js
@@ -8,8 +8,8 @@ class Page {
         this.path = '';
     }
 
-    load (component) {
-        const pageUrl = buildUrl(this.componentType, this.componentName, this.path);
+    load (component, queries) {
+        const pageUrl = buildUrl(this.componentType, this.componentName, this.composePath(queries));
         this.open(pageUrl);
         this.waitForComponent(component);
     }
@@ -23,9 +23,12 @@ class Page {
         component.waitForExist();
     }
 
-    withQuery (name, value) {
-        this.path += `&${name}=${value}`;
-        return this;
+    composePath (queries) {
+        if (!queries) { return ""; }
+
+        return "&" + Object.keys(queries)
+        .map(name => `knob-${name}=${queries[name]}`)
+        .join("&");
     }
 
     // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
Simplifies loading a page with the correct config. Removes need for instance data in Page objects.

Old way:
```
button = new Button();
button.withQuery('knob-Button Type', 'primary');
button.withQuery('knob-Button Size', 'medium');
button.load();
```
New way:
```
button.load({
    'Button Type': 'primary',
    'Button Size': 'medium',
});
```