### PR TITLE
f-loyalty@v0.9.0 - terms component

### DIFF
--- a/packages/components/organisms/f-loyalty/CHANGELOG.md
+++ b/packages/components/organisms/f-loyalty/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.9.0
 ------------------------------
-*October 04, 2021*
+*October 07, 2021*
 
 ### Added
 - Terms component

--- a/packages/components/organisms/f-loyalty/CHANGELOG.md
+++ b/packages/components/organisms/f-loyalty/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.8.0
 ------------------------------
+*October 04, 2021*
+
+### Added
+- Terms component
+- Unit tests for the component
+
+
+v0.8.0
+------------------------------
 *October 07, 2021*
 
 ### Added

--- a/packages/components/organisms/f-loyalty/CHANGELOG.md
+++ b/packages/components/organisms/f-loyalty/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v0.8.0
+v0.9.0
 ------------------------------
 *October 04, 2021*
 

--- a/packages/components/organisms/f-loyalty/package.json
+++ b/packages/components/organisms/f-loyalty/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-loyalty",
   "description": "Fozzie Loyalty - provides a way for customers to collect loyalty stamps for restaurants",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "dist/f-loyalty.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [

--- a/packages/components/organisms/f-loyalty/src/components/Terms.vue
+++ b/packages/components/organisms/f-loyalty/src/components/Terms.vue
@@ -1,0 +1,36 @@
+<template functional>
+    <div :class="$style['c-loyalty-terms']">
+        <a
+            :class="$style['c-loyalty-terms-link']"
+            data-test-id="terms-and-conditions"
+            :href="parent.$t('termsUrl')">
+            {{ parent.$t("termsText") }}
+        </a>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'StampCardsTerms'
+};
+</script>
+
+<style lang="scss" module>
+.c-loyalty-terms {
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    align-items: center;
+}
+
+.c-loyalty-terms-link {
+    margin: spacing(x3) 0;
+    text-align: center;
+    font-weight: $font-bodyStrong-s-weight;
+    text-decoration: none;
+
+    &:hover {
+         text-decoration: underline;
+    }
+}
+</style>

--- a/packages/components/organisms/f-loyalty/src/components/Terms.vue
+++ b/packages/components/organisms/f-loyalty/src/components/Terms.vue
@@ -3,17 +3,11 @@
         <a
             :class="$style['c-loyalty-terms-link']"
             data-test-id="terms-and-conditions"
-            :href="parent.$t('termsUrl')">
-            {{ parent.$t("termsText") }}
+            :href="props.termsUrl">
+            {{ props.termsText }}
         </a>
     </div>
 </template>
-
-<script>
-export default {
-    name: 'StampCardsTerms'
-};
-</script>
 
 <style lang="scss" module>
 .c-loyalty-terms {

--- a/packages/components/organisms/f-loyalty/src/components/_tests/Terms.test.js
+++ b/packages/components/organisms/f-loyalty/src/components/_tests/Terms.test.js
@@ -1,0 +1,71 @@
+import { createLocalVue, mount } from '@vue/test-utils';
+import VueI18n from 'vue-i18n';
+import Terms from '../Terms.vue';
+import i18nMocker from './helper';
+import tenantConfigs from '../../tenants';
+
+const localVue = createLocalVue();
+localVue.use(VueI18n);
+
+let messages,
+    wrapper;
+
+beforeEach(() => {
+    jest.resetAllMocks();
+
+    messages = {
+        'en-GB': tenantConfigs['en-GB'].messages,
+        'en-AU': tenantConfigs['en-AU'].messages
+    };
+});
+
+describe('Terms.vue', () => {
+    // Arrange
+    const component = {
+        name: 'mockWrapper',
+        components: {
+            Terms
+        },
+        template: '<div><terms /></div>'
+    };
+
+    const i18n = {
+        locale: 'en-AU',
+        fallbackLocale: 'en-AU',
+        messages
+    };
+
+    beforeEach(() => {
+        // Arrange
+        wrapper = mount(component, {
+            localVue,
+            i18n,
+            mocks: {
+                $t: key => i18nMocker(key, i18n.locale)
+            }
+        });
+    });
+
+    it.each([
+        'en-GB',
+        'en-AU'
+    ])('should render the terms url in the href attribute', key => {
+        // Act
+        const link = wrapper.find('[data-test-id="terms-and-conditions"]');
+
+        // Assert
+        expect(link.text()).toEqual(messages[key].termsText);
+    });
+
+    it.each([
+        'en-GB',
+        'en-AU'
+    ])('should render the correct text for the link', key => {
+        // Act
+        const link = wrapper.find('[data-test-id="terms-and-conditions"]');
+        const href = link.attributes('href');
+
+        // Assert
+        expect(href).toEqual(messages[key].termsUrl);
+    });
+});

--- a/packages/components/organisms/f-loyalty/src/components/_tests/Terms.test.js
+++ b/packages/components/organisms/f-loyalty/src/components/_tests/Terms.test.js
@@ -26,7 +26,10 @@ describe('Terms.vue', () => {
         components: {
             Terms
         },
-        template: '<div><terms /></div>'
+        template: `
+            <div>
+                <terms :terms-url="$t('termsUrl')" :terms-text="$t('termsText')" />
+            </div>`
     };
 
     const i18n = {
@@ -49,7 +52,7 @@ describe('Terms.vue', () => {
     it.each([
         'en-GB',
         'en-AU'
-    ])('should render the terms url in the href attribute', key => {
+    ])('should render the correct text for the link', key => {
         // Act
         const link = wrapper.find('[data-test-id="terms-and-conditions"]');
 
@@ -60,7 +63,7 @@ describe('Terms.vue', () => {
     it.each([
         'en-GB',
         'en-AU'
-    ])('should render the correct text for the link', key => {
+    ])('should render the terms url in the href attribute', key => {
         // Act
         const link = wrapper.find('[data-test-id="terms-and-conditions"]');
         const href = link.attributes('href');


### PR DESCRIPTION
PR adds the terms component ready for use in the main results page. I have added unit tests to support the new component.