### PR TITLE
#trivial - update readme for testing single components

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ OR
 ```bash
 # Run Component tests for individual f-* package
 # Note: Ensure Storybook is not running when running the following commands
+cd ./fozzie-components
+yarn storybook:build
+yarn storybook:serve-static
+
+# And in another window
 cd ./fozzie-components/packages/f-*user-message*
 yarn test-component:chrome
 ```


### PR DESCRIPTION
Updates the readme testing section on how to test a single component. The previous version was misleading, as it instructed the reader to ensure Storybook was not running when running the test command.

Readme now clearly instructs the reader to start Storybook before running the command.
