### PR TITLE
f-takeawaypay-activation@1.3.0 - Add visual regression tests

### DIFF
--- a/packages/components/organisms/f-takeawaypay-activation/CHANGELOG.md
+++ b/packages/components/organisms/f-takeawaypay-activation/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.3.0
+------------------------------
+*October 05, 2021*
+
+### Added
+- Visual regression tests
 
 v1.2.0
 ------------------------------

--- a/packages/components/organisms/f-takeawaypay-activation/jest.config.js
+++ b/packages/components/organisms/f-takeawaypay-activation/jest.config.js
@@ -34,7 +34,8 @@ module.exports = {
 
     modulePathIgnorePatterns: [
         './test/accessibility/',
-        './test/component/'
+        './test/component/',
+        './test/visual/'
     ],
 
     testURL: 'http://localhost/'

--- a/packages/components/organisms/f-takeawaypay-activation/package.json
+++ b/packages/components/organisms/f-takeawaypay-activation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-takeawaypay-activation",
   "description": "Fozzie TakeawayPay Activation - Handles Takeaway Pay activation for users",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/f-takeawaypay-activation.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [
@@ -36,6 +36,7 @@
     "test": "vue-cli-service test:unit",
     "test-component:chrome": "cross-env-shell JE_ENV=local TEST_TYPE=component wdio ../../../../wdio-chrome.conf.js",
     "test-a11y:chrome": "cross-env-shell JE_ENV=local TEST_TYPE=a11y wdio ../../../../wdio-chrome.conf.js --suite a11y",
+    "test:visual": "cross-env-shell JE_ENV=local PERCY_TOKEN=${PERCY_TOKEN_F_TAKEAWAYPAY_ACTIVATION} TEST_TYPE=visual percy exec -- wdio ../../../../wdio-chrome.conf.js",
     "report:test-component:chome": "cross-env-shell JE_ENV=ci TEST_TYPE=component ALLURE_REPORTER=true wdio ../../../../wdio-chrome.conf.js && yarn:allure:open",
     "allure:open": "yarn allure:clean && allure open",
     "allure:clean": "rimraf ../../../../test/results/allure"
@@ -59,7 +60,7 @@
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
-    "@justeat/f-wdio-utils": "0.1.0",
+    "@justeat/f-wdio-utils": "0.3.0",
     "@vue/test-utils": "1.0.3",
     "node-sass-magic-importer": "5.3.2"
   }

--- a/packages/components/organisms/f-takeawaypay-activation/test-utils/component-objects/f-takeawaypayActivation-selectors.js
+++ b/packages/components/organisms/f-takeawaypay-activation/test-utils/component-objects/f-takeawaypayActivation-selectors.js
@@ -1,1 +1,5 @@
-export const COMPONENT = '[data-test-id="takeawaypay-activation-component"]';
+exports.TAKEAWAYPAYACTIVATION_COMPONENT = '[data-test-id="takeawaypay-activation-component"]';
+exports.LOGGEDIN_COMPONENT = '[data-test-id="activation-logged-in-component"]';
+exports.ERROR_COMPONENT = '[data-test-id="activation-failed-component"]';
+exports.ACTIVATION_SUCCESS_COMPONENT = '[data-test-id="activation-successful-component"]';
+exports.ACTIVATE_TAKEAWAYPAY_BUTTON = '[data-test-id="takeawaypay-activation-activate-button"]';

--- a/packages/components/organisms/f-takeawaypay-activation/test-utils/component-objects/f-takeawaypayActivation.component.js
+++ b/packages/components/organisms/f-takeawaypay-activation/test-utils/component-objects/f-takeawaypayActivation.component.js
@@ -1,24 +1,60 @@
 const Page = require('@justeat/f-wdio-utils/src/page.object');
-const { COMPONENT } = require('./f-takeawaypayActivation-selectors')
+const {
+    TAKEAWAYPAYACTIVATION_COMPONENT,
+    LOGGEDIN_COMPONENT,
+    ERROR_COMPONENT,
+    ACTIVATION_SUCCESS_COMPONENT,
+    ACTIVATE_TAKEAWAYPAY_BUTTON
+} = require('./f-takeawaypayActivation-selectors');
 
 module.exports = class TakeawaypayActivation extends Page {
-
-    get component () { return $(COMPONENT); }
-
-    load() {
-        this.open();
-        this.waitForComponent();
+    constructor() {
+        super('organism', 'takeawaypay-activation-component');
     }
 
-    open () {
-        super.openComponent('organism', 'takeawaypay-activation-component');
+    get component() { return $(TAKEAWAYPAYACTIVATION_COMPONENT); }
+
+    get loggedInComponent() { return $(LOGGEDIN_COMPONENT); }
+
+    get errorComponent() { return $(ERROR_COMPONENT); }
+
+    get activationSuccessComponent() { return $(ACTIVATION_SUCCESS_COMPONENT); }
+
+    get activateTakeawayPayButton() { return $(ACTIVATE_TAKEAWAYPAY_BUTTON); }
+
+    load(type = 'default') {
+        switch (type) {
+            case 'error':
+                super.load(this.errorComponent);
+                break;
+            case 'loggedIn':
+                super.load(this.loggedInComponent);
+                break;
+            case 'default':
+            default:
+                super.load(this.component);
+                break;
+        }
+    }
+
+    withQuery(name, value) {
+        super.withQuery(name, value);
+        return this;
     }
 
     waitForComponent () {
         super.waitForComponent(this.component);
     }
 
+    waitForActivationSuccessComponent() {
+        super.waitForComponent(this.activationSuccessComponent);
+    }
+
     isComponentDisplayed () {
         return this.component.isDisplayed();
+    }
+
+    clickActivateTakeawayPayButton() {
+        return this.activateTakeawayPayButton.click();
     }
 }

--- a/packages/components/organisms/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-authenticated.visual.desktop.spec.js
+++ b/packages/components/organisms/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-authenticated.visual.desktop.spec.js
@@ -1,0 +1,34 @@
+const TakeawayPayComponent = require('../../test-utils/component-objects/f-takeawaypayActivation.component');
+
+let takeawayPayComponent;
+
+describe('f-takeawaypay-activation - Authenticated - Desktop Visual Tests', () => {
+    beforeEach(() => {
+        // Arrange
+        takeawayPayComponent = new TakeawayPayComponent();
+        takeawayPayComponent
+            .withQuery('knob-Authentication', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvZS5ibG9nZ3NAanVzdGVhdHRha2Vhd2F5LmNvbSIsImNyZWF0ZWRfZGF0ZSI6IjIwMjEtMDItMDhUMTA6Mjc6NDkuMTkzMDAwMFoiLCJuYW1lIjoiSm9lIEJsb2dncyIsImdsb2JhbF91c2VyX2lkIjoiVTdOUkFsV0FnNXpPZHNkUmdmN25rVHlvaTkwWEVvPSIsImdpdmVuX25hbWUiOiJKb2UiLCJmYW1pbHlfbmFtZSI6IkJsb2dncyIsImlhdCI6MTYxNTQ2OTUxNn0.VapH6uHnn4lHIkvN_mS9A9IVVWL0YPNE39gDDD-l7SU')
+            .withQuery('knob-Employee Id', '12345')
+            .withQuery('knob-Home URL', '/home')
+            .withQuery('knob-Login URL', '/account/login')
+            .withQuery('knob-Registration URL', '/account/register');
+
+        // Act
+        takeawayPayComponent.load('loggedIn');
+    });
+
+    it('should display user details when the user is logged in.', () => {
+        // Assert
+        browser.percyScreenshot('f-takeawaypay-activation - Authenticated', 'desktop');
+    });
+
+    it('should display a successful message when the activation is successful', () => {
+        // Act
+        takeawayPayComponent.clickActivateTakeawayPayButton();
+        takeawayPayComponent.waitForActivationSuccessComponent();
+        browser.pause(500);
+
+        // Assert
+        browser.percyScreenshot('f-takeawaypay-activation - Successful activation', 'desktop');
+    });
+});

--- a/packages/components/organisms/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-authenticated.visual.mobile.spec.js
+++ b/packages/components/organisms/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-authenticated.visual.mobile.spec.js
@@ -1,0 +1,34 @@
+const TakeawayPayComponent = require('../../test-utils/component-objects/f-takeawaypayActivation.component');
+
+let takeawayPayComponent;
+
+describe('f-takeawaypay-activation - Authenticated - Mobile Visual Tests', () => {
+    beforeEach(() => {
+        // Arrange
+        takeawayPayComponent = new TakeawayPayComponent();
+        takeawayPayComponent
+            .withQuery('knob-Authentication', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvZS5ibG9nZ3NAanVzdGVhdHRha2Vhd2F5LmNvbSIsImNyZWF0ZWRfZGF0ZSI6IjIwMjEtMDItMDhUMTA6Mjc6NDkuMTkzMDAwMFoiLCJuYW1lIjoiSm9lIEJsb2dncyIsImdsb2JhbF91c2VyX2lkIjoiVTdOUkFsV0FnNXpPZHNkUmdmN25rVHlvaTkwWEVvPSIsImdpdmVuX25hbWUiOiJKb2UiLCJmYW1pbHlfbmFtZSI6IkJsb2dncyIsImlhdCI6MTYxNTQ2OTUxNn0.VapH6uHnn4lHIkvN_mS9A9IVVWL0YPNE39gDDD-l7SU')
+            .withQuery('knob-Employee Id', '12345')
+            .withQuery('knob-Home URL', '/home')
+            .withQuery('knob-Login URL', '/account/login')
+            .withQuery('knob-Registration URL', '/account/register');
+
+        // Act
+        takeawayPayComponent.load('loggedIn');
+    });
+
+    it('should display user details when the user is logged in.', () => {
+        // Assert
+        browser.percyScreenshot('f-takeawaypay-activation - Authenticated', 'mobile');
+    });
+
+    it('should display a successful message when the activation is successful', () => {
+        // Act
+        takeawayPayComponent.clickActivateTakeawayPayButton();
+        takeawayPayComponent.waitForActivationSuccessComponent();
+        browser.pause(500);
+
+        // Assert
+        browser.percyScreenshot('f-takeawaypay-activation - Successful activation', 'mobile');
+    });
+});

--- a/packages/components/organisms/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-error.visual.desktop.spec.js
+++ b/packages/components/organisms/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-error.visual.desktop.spec.js
@@ -1,0 +1,24 @@
+const TakeawayPayComponent = require('../../test-utils/component-objects/f-takeawaypayActivation.component');
+
+let takeawayPayComponent;
+
+describe('f-takeawaypay-activation - Error page - Desktop Visual Tests', () => {
+    beforeEach(() => {
+        // Arrange
+        takeawayPayComponent = new TakeawayPayComponent();
+        takeawayPayComponent
+            .withQuery('knob-Activation Status Response', '400')
+            .withQuery('knob-Employee Id', '12345')
+            .withQuery('knob-Home URL', '/home')
+            .withQuery('knob-Login URL', '/account/login')
+            .withQuery('knob-Registration URL', '/account/register');
+
+        // Act
+        takeawayPayComponent.load('error');
+    });
+
+    it('should display the component when there is an error.', () => {
+        // Assert
+        browser.percyScreenshot('f-takeawaypay-activation - Error', 'desktop');
+    });
+});

--- a/packages/components/organisms/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-error.visual.mobile.spec.js
+++ b/packages/components/organisms/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-error.visual.mobile.spec.js
@@ -1,0 +1,24 @@
+const TakeawayPayComponent = require('../../test-utils/component-objects/f-takeawaypayActivation.component');
+
+let takeawayPayComponent;
+
+describe('f-takeawaypay-activation - Error page - Mobile Visual Tests', () => {
+    beforeEach(() => {
+        // Arrange
+        takeawayPayComponent = new TakeawayPayComponent();
+        takeawayPayComponent
+            .withQuery('knob-Activation Status Response', '400')
+            .withQuery('knob-Employee Id', '12345')
+            .withQuery('knob-Home URL', '/home')
+            .withQuery('knob-Login URL', '/account/login')
+            .withQuery('knob-Registration URL', '/account/register');
+
+        // Act
+        takeawayPayComponent.load('error');
+    });
+
+    it('should display the component when there is an error.', () => {
+        // Assert
+        browser.percyScreenshot('f-takeawaypay-activation - Error', 'mobile');
+    });
+});

--- a/packages/components/organisms/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-unauthenticated.visual.desktop.spec.js
+++ b/packages/components/organisms/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-unauthenticated.visual.desktop.spec.js
@@ -1,0 +1,18 @@
+const TakeawayPayComponent = require('../../test-utils/component-objects/f-takeawaypayActivation.component');
+
+let takeawayPayComponent;
+
+describe('f-takeawaypay-activation - Unauthenticated - Desktop Visual Tests', () => {
+    beforeEach(() => {
+        // Arrange
+        takeawayPayComponent = new TakeawayPayComponent();
+
+        // Act
+        takeawayPayComponent.load();
+    });
+
+    it('should display the component when the user is not logged in.', () => {
+        // Assert
+        browser.percyScreenshot('f-takeawaypay-activation - Unauthenticated', 'desktop');
+    });
+});

--- a/packages/components/organisms/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-unauthenticated.visual.mobile.spec.js
+++ b/packages/components/organisms/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-unauthenticated.visual.mobile.spec.js
@@ -1,0 +1,18 @@
+const TakeawayPayComponent = require('../../test-utils/component-objects/f-takeawaypayActivation.component');
+
+let takeawayPayComponent;
+
+describe('f-takeawaypay-activation - Unauthenticated - Mobile Visual Tests', () => {
+    beforeEach(() => {
+        // Arrange
+        takeawayPayComponent = new TakeawayPayComponent();
+
+        // Act
+        takeawayPayComponent.load();
+    });
+
+    it('should display the component when the user is not logged in.', () => {
+        // Assert
+        browser.percyScreenshot('f-takeawaypay-activation - Unauthenticated', 'mobile');
+    });
+});


### PR DESCRIPTION
v1.3.0
------------------------------
*October 05, 2021*

### Added
- Visual regression tests

Coverage (desktop and mobile): 
- Default state (not logged in)
- Logged in
- Activation successful
- Activation failed

## Browsers Tested

- [x ] Chrome (latest)

Note: after speaking with Ben Siggery, we are only testing Chrome for now.