### PR TITLE
fozzie-components@4.3.2 - Only apply wip label to newly opened/reopened PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,16 +1,18 @@
-name: "Pull Request Labeler"
-on:
-- pull_request_target
+name: Pull Request Labeler
+on: pull_request_target
+# By default, pull_request_target runs when the activity type is opened, synchronize, or reopened
+# https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target
 
 jobs:
   wip:
+    if: '${{ github.event.action != 'synchronize' }}' # Only apply the label for newly opened/reopened PRs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/labeler@v3
       with:
         configuration-path: '.github/wip-labeler.yml'
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: '${{ secrets.GITHUB_TOKEN }}'
 
   categorise:
     runs-on: ubuntu-latest
@@ -19,6 +21,6 @@ jobs:
     - uses: actions/labeler@v3
       with:
         configuration-path: '.github/component-labeler.yml'
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: '${{ secrets.GITHUB_TOKEN }}'
         # Category labels will be removed if they no longer apply
         sync-labels: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.3.2
+------------------------------
+*October 6, 2021*
+
+### Updated
+- Only apply `wip` label to newly opened/reopened PRs.
+
+
 v4.3.1
 ------------------------------
 *October 6, 2021*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build\"",


### PR DESCRIPTION
### Updated
- Only apply `wip` label to newly opened/reopened PRs.