### PR TITLE
f-takeawaypay-activation@2.2.1 - bump the version

### DIFF
--- a/packages/components/organisms/f-takeawaypay-activation/CHANGELOG.md
+++ b/packages/components/organisms/f-takeawaypay-activation/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v2.2.1
+------------------------------
+*October 06, 2021*
+
+Re-publish to clean up the old styles from the compiled package.
+
+
 v2.2.0
 ------------------------------
 *October 06, 2021*

--- a/packages/components/organisms/f-takeawaypay-activation/package.json
+++ b/packages/components/organisms/f-takeawaypay-activation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-takeawaypay-activation",
   "description": "Fozzie TakeawayPay Activation - Handles Takeaway Pay activation for users",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "dist/f-takeawaypay-activation.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [


### PR DESCRIPTION
Re-publish to clean up the old styles from the compiled package.