### PR TITLE
f-cookie-banner@3.2.1 - Non vue default prop & readme updates

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.2.1
+------------------------------
+*October 08, 2021*
+
+### Changed
+- Non Vue version default `shouldAbsolutePositionReopenLink` prop to false in base template. Add object property check when accessing re-open link height.
+
 
 v3.2.0
 ------------------------------

--- a/packages/components/organisms/f-cookie-banner/README.md
+++ b/packages/components/organisms/f-cookie-banner/README.md
@@ -145,8 +145,8 @@ In the code example below we add the `nameSuffix` prop:
 <template>
     <cookie-banner
         locale='da-DK'
-        should-absolute-position-reopen-link="false"
-        nameSuffix="myName"
+        should-absolute-position-reopen-link='false'
+        nameSuffix='myName'
     />
 </template>
 ```

--- a/packages/components/organisms/f-cookie-banner/README.md
+++ b/packages/components/organisms/f-cookie-banner/README.md
@@ -71,7 +71,9 @@ Static files are generated for each locale and added to `dist/static` folder. Th
 
 #### HTML Tag Implementation
 
-Files can be accessed directly via CDN using [unkpg.com](https://unpkg.com/browse/@justeat/f-cookie-banner/dist/static/). By omitting the version/tag unpkg will serve the latest version automatically.
+Files can be accessed directly via CDN using [unkpg.com](https://unpkg.com/browse/@justeat/f-cookie-banner/dist/static/).
+
+***By omitting the version/tag unpkg will serve the latest version automatically, you may wish to fix the version served in your application***
 
 Using the CDN the cookie banner can be added to any web page using basic tags. The page must contain a placeholder element with the id attribute `cookie-banner` for example `<div id="cookie-banner"></div>`
 
@@ -131,6 +133,26 @@ Finally, use the generated bundle in your HTML page
 </html>
 ```
 
+#### Non Vue Custom Props
+
+The Non Vue version is compiled using the Vue CLI [pre-render plugin](https://github.com/SolarLiner/vue-cli-plugin-prerender-spa) this means that prop values are essentially hardcoded at compilation. You can configure your own custom version by simply adding the required props to the base template file used by the pre-renderer.
+
+Props should be added to the [App.vue](https://github.com/justeat/fozzie-components/blob/master/packages/components/organisms/f-cookie-banner/f-cookie-banner-static/src/App.vue) Remember the `locale` prop will be replaced by the `build:static-files` task.
+
+In the code example below we add the `nameSuffix` prop:
+
+```html
+<template>
+    <cookie-banner
+        locale='da-DK'
+        should-absolute-position-reopen-link="false"
+        nameSuffix="myName"
+    />
+</template>
+```
+
+Next run `yarn build` followed by `yarn build:static-files`. The generated files will be added to the root `dist/static` folder.
+
 ## Configuration
 
 ### Props
@@ -146,11 +168,14 @@ The props that can be defined are as follows:
 | `shouldShowLegacyBanner` | `Boolean` | `false` | Use the legacy "passive" banner markup (UK only). |
 | `cookieExpiry` | `Number` | `90` | Expiry time (days) of cookies written to the browser. |
 | `shouldUseGreyBackground` | `Boolean` | `true` | Use grey background for the reopen link. |
+| `shouldAbsolutePositionReopenLink` | `Boolean` | `true` | Adds a ResizeObserver and absolutely positions the re-open link to the bottom when the content is smaller than the window |
 | `nameSuffix` | `String` | `''` | Add a suffix to the cookie name. This allows the cookie banner to create a cookie with a different name to be able to handle multiple sub-domains. |
 
-**Important: please, be mindful of the amount of cookies your app will be generating when using the `nameSuffix` prop above. If you have questions, please, contact the code owners.**
+#### ***Important***
 
-NOTE: the Non Vue version uses default props that cannot currently be changed. A seperate version is generated for each locale.
+- Please, be mindful of the amount of cookies your app will be generating when using the `nameSuffix` prop above. If you have questions, please, contact the code owners.
+
+- The Non Vue version uses default prop values with the exception of `shouldAbsolutePositionReopenLink` which is set to false to avoid any conflicts with consuming applications. A seperate version is generated for each locale. It is possible to generate a custom build and use your own prop values, see on Vue Custom Props above.
 
 ### CSS Classes
 

--- a/packages/components/organisms/f-cookie-banner/f-cookie-banner-static/src/App.vue
+++ b/packages/components/organisms/f-cookie-banner/f-cookie-banner-static/src/App.vue
@@ -1,7 +1,7 @@
 <template>
     <cookie-banner
         locale='da-DK'
-        should-absolute-position-reopen-link="false" />
+        should-absolute-position-reopen-link='false' />
 </template>
 
 <script>

--- a/packages/components/organisms/f-cookie-banner/f-cookie-banner-static/src/App.vue
+++ b/packages/components/organisms/f-cookie-banner/f-cookie-banner-static/src/App.vue
@@ -1,5 +1,7 @@
 <template>
-    <cookie-banner locale='da-DK' />
+    <cookie-banner
+        locale='da-DK'
+        should-absolute-position-reopen-link="false" />
 </template>
 
 <script>

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "30kB",
   "files": [

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -220,7 +220,7 @@ export default {
          */
         updateIsBodyHeightLessThanWindowHeight () {
             if (typeof window === 'object' && this.shouldHideBanner) {
-                const reopenElementHeight = this.$refs.reopenCookieBannerLink.$el.clientHeight || 0;
+                const reopenElementHeight = this.$refs?.reopenCookieBannerLink?.$el?.clientHeight || 0;
                 this.isBodyHeightLessThanWindowHeight =
                 (window.innerHeight - reopenElementHeight) - document.body.offsetHeight > 0;
             }


### PR DESCRIPTION
### Changed
- Non Vue version default `shouldAbsolutePositionReopenLink` prop to false in base template. Add object property check when accessing re-open link height.