### PR TITLE
f-contact-preferences@0.2.0 - Initial component layout and styling

### DIFF
--- a/packages/components/organisms/f-contact-preferences/CHANGELOG.md
+++ b/packages/components/organisms/f-contact-preferences/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.2.0
+------------------------------
+*October 12, 2021*
+
+### Added
+- Initial component layout and styling
+
+
 v0.1.0
 ------------------------------
 *October 11, 2021*

--- a/packages/components/organisms/f-contact-preferences/package.json
+++ b/packages/components/organisms/f-contact-preferences/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@justeat/f-contact-preferences",
   "description": "Fozzie Contact Preferences - Fozzie user contact preferences form component",
-  "version": "0.1.0",
-  "main": "dist/f-contact-preferences.umd.min.js", 
+  "version": "0.2.0",
+  "main": "dist/f-contact-preferences.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [
-    "dist" 
+    "dist"
   ],
   "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/components/organisms/f-contact-preferences",
   "contributors": [
@@ -43,6 +43,8 @@
     "@justeat/browserslist-config-fozzie": ">=1.2.0"
   },
   "devDependencies": {
+    "@justeat/f-button": "3.0.0",
+    "@justeat/f-card": "3.0.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",

--- a/packages/components/organisms/f-contact-preferences/src/components/ContactPreferences.vue
+++ b/packages/components/organisms/f-contact-preferences/src/components/ContactPreferences.vue
@@ -1,18 +1,81 @@
 <template>
-    <div
-        :class="$style['c-contactPreferences']"
-        data-test-id="contactPreferences">
-        {{ copy.text }}
-    </div>
+    <card-component
+        :card-heading="copy.heading"
+        is-page-content-wrapper
+        has-outline>
+        <h2 :class="$style['c-contactPreferences-subtitle']">
+            {{ copy.orderUpdates.subtitle }}
+        </h2>
+
+        <form submit.prevent="onFormSubmit">
+            <fieldset>
+                <label>
+                    <input
+                        type="checkbox"
+                        checked
+                        disabled>
+                    <span :class="$style['c-label-text--disabled']">
+                        {{ copy.orderUpdates.textMessage }}<br>
+                        ({{ copy.orderUpdates.textMessageDescription }})
+                    </span>
+                </label>
+
+                <label>
+                    <input
+                        type="checkbox"
+                        checked
+                        disabled>
+                    <span :class="$style['c-label-text--disabled']">
+                        {{ copy.orderUpdates.email }}<br>
+                        ({{ copy.orderUpdates.emailDescription }})
+                    </span>
+                </label>
+            </fieldset>
+
+            <h2 :class="$style['c-contactPreferences-subtitle']">
+                {{ copy.newsAndOffers.subtitle }}
+            </h2>
+
+            <fieldset>
+                <label>
+                    <input type="checkbox">
+                    <span>
+                        {{ copy.newsAndOffers.textMessage }}
+                    </span>
+                </label>
+
+                <label>
+                    <input type="checkbox">
+                    <span>
+                        {{ copy.newsAndOffers.email }}
+                    </span>
+                </label>
+            </fieldset>
+
+            <f-button
+                button-type="primary"
+                is-full-width>
+                {{ copy.saveChangesButton }}
+            </f-button>
+        </form>
+    </card-component>
 </template>
 
 <script>
+import FButton from '@justeat/f-button';
+import '@justeat/f-button/dist/f-button.css';
+import CardComponent from '@justeat/f-card';
+import '@justeat/f-card/dist/f-card.css';
+
 import { globalisationServices } from '@justeat/f-services';
 import tenantConfigs from '../tenants';
 
 export default {
     name: 'ContactPreferences',
-    components: {},
+    components: {
+        CardComponent,
+        FButton
+    },
     props: {
         locale: {
             type: String,
@@ -26,21 +89,27 @@ export default {
         return {
             copy: { ...localeConfig }
         };
+    },
+    methods: {
+        onFormSubmit () {}
     }
 };
 </script>
 
 <style lang="scss" module>
-
-.c-contactPreferences {
+fieldset {
     display: flex;
-    justify-content: center;
-    min-height: 80vh;
-    width: 80vw;
-    margin: auto;
-    border: 1px solid $color-red;
-    font-family: $font-family-base;
-    @include font-size(heading-m);
+    flex-flow: column;
+    border: none;
+    padding: 0;
+    margin: spacing(x2) 0;
 }
 
+.c-label-text--disabled {
+    color: $color-content-disabled;
+}
+
+.c-contactPreferences-subtitle {
+    @include font-size(heading-s);
+}
 </style>

--- a/packages/components/organisms/f-contact-preferences/src/components/ContactPreferences.vue
+++ b/packages/components/organisms/f-contact-preferences/src/components/ContactPreferences.vue
@@ -7,14 +7,14 @@
             {{ copy.orderUpdates.subtitle }}
         </h2>
 
-        <form submit.prevent="onFormSubmit">
-            <fieldset>
+        <form @submit.prevent="onFormSubmit">
+            <fieldset :class="$style['c-contactPreferences-fieldset']">
                 <label>
                     <input
                         type="checkbox"
                         checked
                         disabled>
-                    <span :class="$style['c-label-text--disabled']">
+                    <span :class="$style['c-contactPreferences-labelText--disabled']">
                         {{ copy.orderUpdates.textMessage }}<br>
                         ({{ copy.orderUpdates.textMessageDescription }})
                     </span>
@@ -25,7 +25,7 @@
                         type="checkbox"
                         checked
                         disabled>
-                    <span :class="$style['c-label-text--disabled']">
+                    <span :class="$style['c-contactPreferences-labelText--disabled']">
                         {{ copy.orderUpdates.email }}<br>
                         ({{ copy.orderUpdates.emailDescription }})
                     </span>
@@ -36,7 +36,7 @@
                 {{ copy.newsAndOffers.subtitle }}
             </h2>
 
-            <fieldset>
+            <fieldset :class="$style['c-contactPreferences-fieldset']">
                 <label>
                     <input type="checkbox">
                     <span>
@@ -97,7 +97,7 @@ export default {
 </script>
 
 <style lang="scss" module>
-fieldset {
+.c-contactPreferences-fieldset {
     display: flex;
     flex-flow: column;
     border: none;
@@ -105,7 +105,7 @@ fieldset {
     margin: spacing(x2) 0;
 }
 
-.c-label-text--disabled {
+.c-contactPreferences-labelText--disabled {
     color: $color-content-disabled;
 }
 

--- a/packages/components/organisms/f-contact-preferences/src/tenants/en-GB.js
+++ b/packages/components/organisms/f-contact-preferences/src/tenants/en-GB.js
@@ -1,4 +1,17 @@
 export default {
+    heading: 'Contact Preferences',
     locale: 'en-GB',
-    text: 'I am a ContactPreferences Component (GB)'
+    newsAndOffers: {
+        email: 'Email',
+        subtitle: 'Get news and offers by',
+        textMessage: 'Text message'
+    },
+    orderUpdates: {
+        email: 'Email',
+        emailDescription: 'Order receipts are emailed to you',
+        subtitle: 'Get order updates by',
+        textMessage: 'Text message',
+        textMessageDescription: 'For important updates only'
+    },
+    saveChangesButton: 'Save changes'
 };


### PR DESCRIPTION
### Added
- Initial component layout and styling

Still to-do (in later PRs):
- Testing
- Getting initial data from API
- Pushing updates to API

---

![20211012T144238](https://user-images.githubusercontent.com/26894168/136967429-32aa017f-fb08-48ab-831e-dc42e058963b.png)

