### PR TITLE
f-takeawaypay-activation@2.5.0 - Added vertical spacing between buttons

### DIFF
--- a/packages/components/organisms/f-takeawaypay-activation/CHANGELOG.md
+++ b/packages/components/organisms/f-takeawaypay-activation/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.5.0
+------------------------------
+*October 13, 2021*
+
+### Changed
+- Added more space between action buttons
+
 v2.4.0
 ------------------------------
 *October 11, 2021*

--- a/packages/components/organisms/f-takeawaypay-activation/package.json
+++ b/packages/components/organisms/f-takeawaypay-activation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-takeawaypay-activation",
   "description": "Fozzie TakeawayPay Activation - Handles Takeaway Pay activation for users",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "main": "dist/f-takeawaypay-activation.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-takeawaypay-activation/src/assets/scss/_takeaway-pay-activation.scss
+++ b/packages/components/organisms/f-takeawaypay-activation/src/assets/scss/_takeaway-pay-activation.scss
@@ -18,4 +18,9 @@
 
 .c-takeawaypayActivation-actions {
     padding-top: spacing(x3);
+
+    a,
+    button {
+        margin-bottom: spacing(x2);
+    }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30234676/136986516-45b5bf6b-0ac4-4311-8402-ea72e43b24f9.png)
