### PR TITLE
f-cookie-banner@3.3.0 - Adding a `domain` prop

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.3.0
+------------------------------
+*October 13, 2021*
+
+### Added
+- `domain` prop to allow the consumer to specify which hosts can receive this component's cookie.
+
+
 v3.2.1
 ------------------------------
 *October 08, 2021*

--- a/packages/components/organisms/f-cookie-banner/README.md
+++ b/packages/components/organisms/f-cookie-banner/README.md
@@ -170,6 +170,7 @@ The props that can be defined are as follows:
 | `shouldUseGreyBackground` | `Boolean` | `true` | Use grey background for the reopen link. |
 | `shouldAbsolutePositionReopenLink` | `Boolean` | `true` | Adds a ResizeObserver and absolutely positions the re-open link to the bottom when the content is smaller than the window |
 | `nameSuffix` | `String` | `''` | Add a suffix to the cookie name. This allows the cookie banner to create a cookie with a different name to be able to handle multiple sub-domains. |
+| `domain` | `String` | `null` | Specifies which hosts can receive a cookie. If unspecified, the attribute defaults to the same host that set the cookie, excluding subdomains. If it is specified, then subdomains are always included. Therefore, passing the prop is less restrictive than omitting it. For example, if you specify `just-eat.co.uk`, the cookie will be used in any subdomain of `just-eat.co.uk` |
 
 #### ***Important***
 

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "30kB",
   "files": [

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -147,6 +147,11 @@ export default {
         nameSuffix: {
             type: String,
             default: ''
+        },
+
+        domain: {
+            type: String,
+            default: null
         }
     },
 
@@ -346,7 +351,8 @@ export default {
         setCookieBannerCookie (cookieValue) {
             CookieHelper.set(this.consentCookieName, cookieValue, {
                 path: '/',
-                expires: this.cookieExpiry
+                expires: this.cookieExpiry,
+                domain: this.domain
             });
         },
 
@@ -356,7 +362,8 @@ export default {
         setLegacyCookieBannerCookie () {
             CookieHelper.set(LEGACY_CONSENT_COOKIE_NAME, '130315', {
                 path: '/',
-                expires: this.cookieExpiry
+                expires: this.cookieExpiry,
+                domain: this.domain
             });
         },
 

--- a/packages/components/organisms/f-cookie-banner/src/components/_tests/CookieBanner.test.js
+++ b/packages/components/organisms/f-cookie-banner/src/components/_tests/CookieBanner.test.js
@@ -291,7 +291,9 @@ describe('CookieBanner', () => {
         describe('setCookieBannerCookie', () => {
             it('should set the cookie consent banner cookie', () => {
                 // Arrange
-                const propsData = {};
+                const propsData = {
+                    domain: 'example.com'
+                };
 
                 const wrapper = shallowMount(CookieBanner, {
                     localVue,
@@ -308,7 +310,8 @@ describe('CookieBanner', () => {
                 const payloadValue = 'foo';
                 const payloadObj = {
                     path: '/',
-                    expires: 90
+                    expires: 90,
+                    domain: propsData.domain
                 };
 
                 // Act
@@ -322,7 +325,9 @@ describe('CookieBanner', () => {
         describe('setLegacyCookieBannerCookie', () => {
             it('should set the legacy cookie banner cookie', () => {
                 // Arrange
-                const propsData = {};
+                const propsData = {
+                    domain: 'example.com'
+                };
 
                 const wrapper = shallowMount(CookieBanner, {
                     localVue,
@@ -334,7 +339,8 @@ describe('CookieBanner', () => {
                 const payloadValue = '130315';
                 const payloadObj = {
                     path: '/',
-                    expires: 90
+                    expires: 90,
+                    domain: propsData.domain
                 };
 
                 // Act


### PR DESCRIPTION
v3.3.0
------------------------------
*October 13, 2021*

### Added
- `domain` prop to allow the consumer to specify which hosts can receive this component's cookie.