### PR TITLE
f-checkout@2.4.1 - Use correct case for order placement keys

### DIFF
--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 v2.4.1
+------------------------------
 *October 13, 2021*
 
 ### Changed
@@ -11,6 +12,7 @@ v2.4.1
 
 
 v2.4.0
+------------------------------
 *October 12, 2021*
 
 ### Added
@@ -18,6 +20,7 @@ v2.4.0
 
 
 v2.3.0
+------------------------------
 *October 11, 2021*
 
 ### Removed

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.4.1
+*October 13, 2021*
+
+### Changed
+- Place order note key to the correct case `NoteForRestaurant`
+
+
 v2.4.0
 *October 12, 2021*
 

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "120kB",
   "files": [

--- a/packages/components/organisms/f-checkout/src/components/Checkout.vue
+++ b/packages/components/organisms/f-checkout/src/components/Checkout.vue
@@ -730,7 +730,7 @@ export default {
                 const data = {
                     basketId: this.basket.id,
                     customerNotes: {
-                        noteForRestaurant: this.userNote
+                        NoteForRestaurant: this.userNote
                     },
                     referralState: this.getReferralState()
                 };

--- a/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
+++ b/packages/components/organisms/f-checkout/src/components/_tests/Checkout.test.js
@@ -3970,7 +3970,7 @@ describe('Checkout', () => {
                     data: {
                         basketId,
                         customerNotes: {
-                            noteForRestaurant: defaultCheckoutState.userNote
+                            NoteForRestaurant: defaultCheckoutState.userNote
                         },
                         referralState: 'MockReferralState'
                     },

--- a/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/organisms/f-checkout/src/store/tests/checkout.module.test.js
@@ -775,7 +775,7 @@ describe('CheckoutModule', () => {
                 payload.data = {
                     basketId,
                     customerNotes: {
-                        noteForRestaurant: userNote
+                        NoteForRestaurant: userNote
                     },
                     referralState: 'ReferredByWeb'
                 };


### PR DESCRIPTION
Small change to the key for restaurant notes being sent to the order placement API. 