### PR TITLE
f-cookie-banner@3.3.1 - small style tweaks #trivial

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.0.2
+------------------------------
+*October 13, 2021*
+
+### Changed
+- Margin between few full width buttons increased from 8px to 16px.
+
+
 v3.0.1
 ------------------------------
 *October 5, 2021*

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "dist/f-button.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -790,7 +790,7 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
     // Vertically space out multiple fullWidth buttons
     // same as .o-btn--fullWidth + .o-btn--fullWidth
     & + & {
-        margin-top: spacing();
+        margin-top: spacing(x2);
     }
 }
 

--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (to be added to next release)
+------------------------------
+*October 13, 2021*
+
+### Changed
+- Updated version of `f-button`.
+
+
 v3.0.0
 ------------------------------
 *October 5, 2021*

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -52,7 +52,7 @@
     "@vue/test-utils": "1.0.3",
     "@justeat/f-wdio-utils": "0.3.0",
     "node-sass-magic-importer": "5.3.2",
-    "@justeat/f-button": "3.0.0",
+    "@justeat/f-button": "3.0.2",
     "@justeat/f-vue-icons": "1.13.0"
   }
 }

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (to be added to next release)
+------------------------------
+*October 13, 2021*
+
+### Changed
+- Updated version of `f-button`.
+
+
 v3.0.0
 ------------------------------
 *October 5, 2021*

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -43,7 +43,7 @@
     "body-scroll-lock": "3.x"
   },
   "devDependencies": {
-    "@justeat/f-button": "3.0.0",
+    "@justeat/f-button": "3.0.2",
     "@justeat/f-vue-icons": "2.4.0",
     "@justeat/f-wdio-utils": "0.3.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",

--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (to be added to next release)
+------------------------------
+*October 13, 2021*
+
+### Changed
+- Updated version of `f-button`.
+
+
 v4.0.0-beta.36
 ------------------------------
 *October 5, 2021*

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -59,7 +59,7 @@
     "vuex": "3.5.1"
   },
   "devDependencies": {
-    "@justeat/f-button": "3.0.0",
+    "@justeat/f-button": "3.0.2",
     "@justeat/f-error-message": "1.0.0",
     "@justeat/f-globalisation": "0.2.0",
     "@justeat/f-mega-modal": "3.0.0",

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,9 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v2.5.0
-*October 12, 2021*
+Latest (to be added to next release)
 ------------------------------
+*October 13, 2021*
+
+### Changed
+- Updated version of `f-button`.
+
+
+v2.5.0
+------------------------------
+*October 12, 2021*
+
 ### Removed
 - Redirect to login if the user is logged out and guest checkout is disabled
 

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.12.13",
     "@justeat/f-alert": "3.0.0",
-    "@justeat/f-button": "3.0.0",
+    "@justeat/f-button": "3.0.2",
     "@justeat/f-card": "3.0.0",
     "@justeat/f-error-message": "1.0.0",
     "@justeat/f-form-field": "4.0.0",

--- a/packages/components/organisms/f-contact-preferences/CHANGELOG.md
+++ b/packages/components/organisms/f-contact-preferences/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (to be added to next release)
+------------------------------
+*October 13, 2021*
+
+### Changed
+- Updated version of `f-button`.
+
+
 v0.2.0
 ------------------------------
 *October 12, 2021*

--- a/packages/components/organisms/f-contact-preferences/package.json
+++ b/packages/components/organisms/f-contact-preferences/package.json
@@ -43,7 +43,7 @@
     "@justeat/browserslist-config-fozzie": ">=1.2.0"
   },
   "devDependencies": {
-    "@justeat/f-button": "3.0.0",
+    "@justeat/f-button": "3.0.2",
     "@justeat/f-card": "3.0.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v3.3.1
+------------------------------
+*October 13, 2021*
+
+### Changed
+- "Accept all required cookies" ghost button to outline button.
+- Removed top margin from the banner title.
+- Bump f-button version to add more space between full width buttons.
+
+
 v3.3.0
 ------------------------------
 *October 13, 2021*

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "30kB",
   "files": [
@@ -54,7 +54,7 @@
     "js-cookie": "2.2.1"
   },
   "devDependencies": {
-    "@justeat/f-button": "3.0.0",
+    "@justeat/f-button": "3.0.2",
     "@justeat/f-mega-modal": "3.0.0",
     "@justeat/f-vue-icons": "2.3.0",
     "@justeat/f-wdio-utils": "0.3.0",

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -62,7 +62,7 @@
                     </button-component>
 
                     <button-component
-                        button-type="ghost"
+                        button-type="outline"
                         data-test-id="accept-necessary-cookies-button"
                         is-full-width
                         @click="acceptOnlyNecessaryCookiesActions">
@@ -461,7 +461,7 @@ export default {
 
     .c-cookieBanner-title {
         @include font-size(heading-m);
-        margin: spacing() 0;
+        margin: 0 0 spacing();
         padding: 0;
         color: $color-content-default;
         &:hover,

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (to be added to next release)
+------------------------------
+*October 13, 2021*
+
+### Changed
+- Updated version of `f-button`.
+
+
 v7.0.0
 ------------------------------
 *October 5, 2021*

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.12.13",
-    "@justeat/f-button": "3.0.0",
+    "@justeat/f-button": "3.0.2",
     "@justeat/f-popover": "2.0.0",
     "@justeat/f-vue-icons": "2.4.0",
     "@justeat/f-wdio-utils": "0.3.0",

--- a/packages/components/organisms/f-offers/CHANGELOG.md
+++ b/packages/components/organisms/f-offers/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (to be added to next release)
+------------------------------
+*October 13, 2021*
+
+### Changed
+- Updated version of `f-button`.
+
+
 v1.3.0
 ------------------------------
 *October 5, 2021*

--- a/packages/components/organisms/f-offers/package.json
+++ b/packages/components/organisms/f-offers/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@braze/web-sdk": "3.3.0",
     "@justeat/f-content-cards": "6.0.0-beta.2",
-    "@justeat/f-button": "3.0.0",
+    "@justeat/f-button": "3.0.2",
     "@justeat/f-media-element": "2.0.0",
     "@justeat/f-searchbox": "6.0.0",
     "@justeat/f-trak": "0.7.1",

--- a/packages/components/organisms/f-registration/CHANGELOG.md
+++ b/packages/components/organisms/f-registration/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (to be added to next release)
+------------------------------
+*October 13, 2021*
+
+### Changed
+- Updated version of `f-button`.
+
+
 v2.0.0
 ------------------------------
 *October 5, 2021*

--- a/packages/components/organisms/f-registration/package.json
+++ b/packages/components/organisms/f-registration/package.json
@@ -54,7 +54,7 @@
     "@justeat/browserslist-config-fozzie": ">=1.1.1"
   },
   "devDependencies": {
-    "@justeat/f-button": "3.0.0",
+    "@justeat/f-button": "3.0.2",
     "@justeat/f-card": "3.0.0",
     "@justeat/f-error-message": "1.0.0",
     "@justeat/f-form-field": "4.0.0",

--- a/packages/components/organisms/f-takeawaypay-activation/CHANGELOG.md
+++ b/packages/components/organisms/f-takeawaypay-activation/CHANGELOG.md
@@ -3,12 +3,22 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v2.5.1
+------------------------------
+*October 13, 2021*
+
+### Changed
+- Updated version of `f-button` which have styles for more space between action buttons. Removed custom styles added in v2.5.0.
+
+
 v2.5.0
 ------------------------------
 *October 13, 2021*
 
 ### Changed
 - Added more space between action buttons
+
 
 v2.4.0
 ------------------------------
@@ -19,6 +29,7 @@ v2.4.0
 - Accessibility tests
 - Visual regression tests
 
+
 v2.3.0
 ------------------------------
 *October 08, 2021*
@@ -26,11 +37,13 @@ v2.3.0
 ### Changed
 - Takeaway Pay => Just Eat Pay renaming
 
+
 v2.2.1
 ------------------------------
 *October 06, 2021*
 
 Re-publish to clean up the old styles from the compiled package.
+
 
 v2.2.0
 ------------------------------
@@ -39,12 +52,14 @@ v2.2.0
 ### Changed
 - Reverted Takeaway Pay => Just Eat Pay renaming
 
+
 v2.1.0
 ------------------------------
 *October 05, 2021*
 
 ### Added
 - Visual regression tests
+
 
 v2.0.0
 ------------------------------

--- a/packages/components/organisms/f-takeawaypay-activation/package.json
+++ b/packages/components/organisms/f-takeawaypay-activation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-takeawaypay-activation",
   "description": "Fozzie TakeawayPay Activation - Handles Takeaway Pay activation for users",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "main": "dist/f-takeawaypay-activation.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@justeat/f-globalisation": "1.0.0",
-    "@justeat/f-button": "3.0.0",
+    "@justeat/f-button": "3.0.2",
     "@justeat/f-card": "3.0.0",
     "@justeat/f-vue-icons": "2.6.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",

--- a/packages/components/organisms/f-takeawaypay-activation/src/assets/scss/_takeaway-pay-activation.scss
+++ b/packages/components/organisms/f-takeawaypay-activation/src/assets/scss/_takeaway-pay-activation.scss
@@ -18,9 +18,4 @@
 
 .c-takeawaypayActivation-actions {
     padding-top: spacing(x3);
-
-    a,
-    button {
-        margin-bottom: spacing(x2);
-    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,11 +2147,6 @@
     eslint-config-airbnb-base "14.1.0"
     eslint-plugin-vue "6.2.2"
 
-"@justeat/f-button@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-3.0.0.tgz#62caa85f5e105ee6f9515c3425d64bc595d5b6c0"
-  integrity sha512-aym/16Piul2lWi+t+FCRqO6QTQmwco9Kf1t/kQiFpbB3QjtsG4GkKv4cIUsuCZN3tLpKIWFaVFmq/guMz35JJA==
-
 "@justeat/f-content-cards@6.0.0-beta.2":
   version "6.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-6.0.0-beta.2.tgz#1b77d0d33ad0b8b41d26d78029c848e8444d20b5"


### PR DESCRIPTION
## f-button@3.0.2

### Changed
- Margin between few full width buttons increased from 8px to 16px.

## f-cookie-banner@3.3.1

### Changed
- "Accept all required cookies" ghost button to outline button.
- Removed top margin from the banner title.
- Bump f-button version to add more space between full width buttons.

## f-takeawaypay-activation@2.5.1

### Changed
- Updated version of `f-button` which have styles for more space between action buttons. Removed custom styles added in v2.5.0.


Also updated version of `f-button` for all the components which use button without version bump to avoid storybook styles override. There is no need to release the components as they don't use more than one full width button.