### PR TITLE
f-checkout@2.5.2 and other packages vesion bump to fix bad release

### DIFF
--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.0.2
+------------------------------
+*October 15, 2021*
+
+Republish to fix a bad previous publish.
+
+
 v3.0.1
 ------------------------------
 *October 14, 2021*

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-alert",
   "description": "Fozzie Alert – Fozzie Alert Component",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "dist/f-alert.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.0.2
+------------------------------
+*October 15, 2021*
+
+Republish to fix a bad previous publish.
+
+
 v3.0.1
 ------------------------------
 *October 14, 2021*

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "dist/f-mega-modal.common.js",
   "maxBundleSize": "6kB",
   "files": [

--- a/packages/components/organisms/f-checkout/CHANGELOG.md
+++ b/packages/components/organisms/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.5.2
+------------------------------
+*October 15, 2021*
+
+### Changed
+- Updated version of `f-alert`, `f-mega-modal` to fix previous bad release.
+
+
 v2.5.1
 ------------------------------
 *October 14, 2021*

--- a/packages/components/organisms/f-checkout/package.json
+++ b/packages/components/organisms/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "120kB",
   "files": [
@@ -62,13 +62,13 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.12.13",
-    "@justeat/f-alert": "3.0.1",
+    "@justeat/f-alert": "3.0.2",
     "@justeat/f-button": "3.0.2",
     "@justeat/f-card": "3.0.0",
     "@justeat/f-error-message": "1.0.0",
     "@justeat/f-form-field": "4.0.0",
     "@justeat/f-link": "2.0.0",
-    "@justeat/f-mega-modal": "3.0.1",
+    "@justeat/f-mega-modal": "3.0.2",
     "@justeat/f-wdio-utils": "0.3.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.3.3
+------------------------------
+*October 15, 2021*
+
+- Bump `f-mega-modal` version to fix a bad previous publish.
+
+
 v3.3.2
 ------------------------------
 *October 14, 2021*

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "30kB",
   "files": [
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@justeat/f-button": "3.0.2",
-    "@justeat/f-mega-modal": "3.0.1",
+    "@justeat/f-mega-modal": "3.0.2",
     "@justeat/f-vue-icons": "2.3.0",
     "@justeat/f-wdio-utils": "0.3.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,9 +4,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (to be added to next release)
+v7.0.1
 ------------------------------
-*October 13, 2021*
+*October 15, 2021*
 
 ### Changed
 - Updated version of `f-button`.

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-registration/CHANGELOG.md
+++ b/packages/components/organisms/f-registration/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.2
+------------------------------
+*October 15, 2021*
+
+Republish to fix a bad previous publish.
+
+
 v2.0.1
 ------------------------------
 *October 14, 2021*

--- a/packages/components/organisms/f-registration/package.json
+++ b/packages/components/organisms/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "dist/f-registration.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [


### PR DESCRIPTION
## f-alert@3.0.2

Republish to fix a bad previous publish.

## f-mega-modal@3.0.2

Republish to fix a bad previous publish.

## f-checkout@2.5.2

### Changed
- Updated version of `f-alert`, `f-mega-modal` to fix previous bad release.

## f-cookie-banner@3.3.3

- Bump `f-mega-modal` version to fix a bad previous publish.

## f-header@7.0.1

### Changed
- Updated version of `f-button`.