### PR TITLE
f-button@3.0.3 - f-seleton-loader@2.1.0 - f-user-message@3.1.0 - Design team feedback

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.0.3
+------------------------------
+*October 15, 2021*
+
+### Changed
+- Each button size vertical padding reduced by 1px to make button height 56px/48px/40px/32px instead of 58px/50px/42px/34px.
+
+
 v3.0.2
 ------------------------------
 *October 13, 2021*

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "main": "dist/f-button.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -191,7 +191,7 @@ export default {
 $btn-default-borderRadius              : $radius-rounded-e;
 $btn-default-font-size                 : 'heading-s';
 $btn-default-weight                    : $font-weight-bold;
-$btn-default-padding                   : 10px spacing(x3);
+$btn-default-padding                   : 9px spacing(x3);
 $btn-default-outline-color             : $color-focus;
 $btn-default-loading-opacity           : 0.35;
 $btn-default-iconHeight                : 18px;
@@ -246,18 +246,18 @@ $btn-link-loading-colorOpaque          : rgba($btn-link-loading-color, $btn-defa
 $btn-disabled-bgColor                  : $color-disabled-01;
 $btn-disabled-textColor                : $color-content-disabled;
 
-$btn-sizeLarge-padding                 : 14px spacing(x3);
+$btn-sizeLarge-padding                 : 13px spacing(x3);
 $btn-sizeLarge-loading-color           : $color-content-interactive-light;
 $btn-sizeLarge-loading-colorOpaque     : rgba($btn-sizeLarge-loading-color, $btn-default-loading-opacity);
 
 $btn-sizeSmall-font-size               : 'body-l';
-$btn-sizeSmall-padding                 : spacing() spacing(x2);
+$btn-sizeSmall-padding                 : 7px spacing(x2);
 $btn-sizeSmall-iconHeight              : 15px;
 $btn-sizeSmall-iconSpacing             : 2.5px;
 $btn-sizeSmall-iconSideSpacing         : $btn-sizeSmall-iconSpacing + spacing();
 
 $btn-sizeXSmall-font-size              : 'body-s';
-$btn-sizeXSmall-padding                : 6px spacing();
+$btn-sizeXSmall-padding                : 5px spacing();
 $btn-sizeXSmall-iconHeight             : 12px;
 $btn-sizeXSmall-iconSpacing            : 2px;
 $btn-sizeXSmall-iconSideSpacing        : $btn-sizeXSmall-iconSpacing + spacing();

--- a/packages/components/molecules/f-skeleton-loader/CHANGELOG.md
+++ b/packages/components/molecules/f-skeleton-loader/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.1.0
+------------------------------
+*October 15, 2021*
+
+### Changed
+- Rounded corners for all the skeleton blocks.
+
+
 v2.0.0
 ------------------------------
 *October 5, 2021*

--- a/packages/components/molecules/f-skeleton-loader/package.json
+++ b/packages/components/molecules/f-skeleton-loader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-skeleton-loader",
   "description": "Fozzie Skeleton Loader - Provides a visual indication that another component is loading. ",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "dist/f-skeleton-loader.umd.min.js",
   "maxBundleSize": "10kB",
   "files": [

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Heading.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Heading.vue
@@ -13,6 +13,7 @@ export default {};
 .c-heading {
     height: $skeleton-loader-heading-height;
     width: 65%;
+    border-radius: $radius-rounded-a;
 }
 
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Image.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Image.vue
@@ -12,6 +12,7 @@ export default {
 
 .c-image {
     height: $skeleton-loader-image-height;
+    border-radius: $radius-rounded-c;
 }
 
 </style>

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCardData.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCardData.vue
@@ -27,6 +27,7 @@ export default {
     width: 96%;
     margin: auto;
     padding: spacing();
+    border-radius: 0 0 $radius-rounded-c $radius-rounded-c;
 }
 
 .c-restaurantData-textWrapper {

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCardHeader.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/RestaurantCardHeader.vue
@@ -28,6 +28,7 @@ $restaurant-logo-width: 48px;
     width: 96%;
     padding-bottom: spacing(x2);
     position: relative;
+    border-radius: $radius-rounded-c $radius-rounded-c 0 0;
 }
 
 .c-restaurantCardHeader-logo {

--- a/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Text.vue
+++ b/packages/components/molecules/f-skeleton-loader/src/components/skeletons/Text.vue
@@ -14,6 +14,7 @@ export default {
     flex: 1 0 auto;
     height: $skeleton-loader-text-height;
     margin-bottom: spacing();
+    border-radius: $radius-rounded-a;
 }
 
 </style>

--- a/packages/components/molecules/f-user-message/CHANGELOG.md
+++ b/packages/components/molecules/f-user-message/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.1.0
+------------------------------
+*October 15, 2021*
+
+### Changed
+- Background and text colour to be in line with default warning message.
+
+
 v3.0.0
 ------------------------------
 *October 5, 2021*

--- a/packages/components/molecules/f-user-message/package.json
+++ b/packages/components/molecules/f-user-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-user-message",
   "description": "Fozzie User Message – Globalised User Message Component",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "dist/f-user-message.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/molecules/f-user-message/src/components/UserMessage.vue
+++ b/packages/components/molecules/f-user-message/src/components/UserMessage.vue
@@ -65,8 +65,8 @@ export default {
 
 <style lang="scss" module>
 .c-userMessage {
-    color: $color-content-light;
-    background-color: $color-support-brand-01;
+    color: $color-content-default;
+    background-color: $color-support-warning-02;
     max-width: 100%;
 }
 
@@ -86,7 +86,7 @@ export default {
     }
 
     svg {
-        fill: $color-content-light;
+        fill: $color-content-default;
         min-width: 28px;
         max-width: 28px;
         width: 28px;


### PR DESCRIPTION
## f-button@3.0.3

### Changed
- Each button size vertical padding reduced by 1px to make button height 56px/48px/40px/32px instead of 58px/50px/42px/34px.

## f-seleton-loader@2.1.0

### Changed
- Rounded corners for all the skeleton blocks.

Before:
![Screenshot 2021-10-15 at 14 56 32](https://user-images.githubusercontent.com/19548183/137499159-766c2466-211c-486a-abb5-64b99ea5d023.png)

After:
![Screenshot 2021-10-15 at 14 55 22](https://user-images.githubusercontent.com/19548183/137499135-b80a8c5b-85dd-4f2e-9bfd-2fd14bc4c362.png)
f-user-message@3.1.0

### Changed
- Background and text colour to be in line with default warning message.

Before:
![Screenshot 2021-10-15 at 14 57 48](https://user-images.githubusercontent.com/19548183/137499279-93c72fe9-2e9a-4d97-a405-f9119e4f4f47.png)

After:
![Screenshot 2021-10-15 at 14 54 55](https://user-images.githubusercontent.com/19548183/137498940-a4ba742c-db34-44f5-a9c9-5df46ac15dda.png)


