### PR TITLE
f-user-message@3.1.0 - icing phase 2 changes

### DIFF
--- a/packages/components/molecules/f-user-message/CHANGELOG.md
+++ b/packages/components/molecules/f-user-message/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.1.0
+------------------------------
+*October 18, 2021*
+
+### Changed
+- Background and text colour to be in line with default warning message.
+
+### Removed
+- Font-family and font-weight declaration as comes from fozzie and there is no need to override.
+
+
 v3.0.0
 ------------------------------
 *October 5, 2021*

--- a/packages/components/molecules/f-user-message/package.json
+++ b/packages/components/molecules/f-user-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-user-message",
   "description": "Fozzie User Message – Globalised User Message Component",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "dist/f-user-message.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/molecules/f-user-message/src/components/UserMessage.vue
+++ b/packages/components/molecules/f-user-message/src/components/UserMessage.vue
@@ -64,9 +64,11 @@ export default {
 </script>
 
 <style lang="scss" module>
+$userMessage-textColour : $color-content-default;
+
 .c-userMessage {
-    color: $color-content-light;
-    background-color: $color-support-brand-01;
+    color: $userMessage-textColour;
+    background-color: $color-support-warning-02;
     max-width: 100%;
 }
 
@@ -86,7 +88,7 @@ export default {
     }
 
     svg {
-        fill: $color-content-light;
+        fill: $userMessage-textColour;
         min-width: 28px;
         max-width: 28px;
         width: 28px;
@@ -98,8 +100,6 @@ export default {
 
 .c-userMessage-text {
     margin: 0 0 0 spacing(x2);
-    font-family: $font-family-base;
-    font-weight: $font-weight-regular;
     @include font-size(body-s);
 
     @include media('>=mid') {


### PR DESCRIPTION
### Changed
- Background and text colour to be in line with default warning message.

### Removed
- Font-family and font-weight declaration as comes from fozzie and there is no need to override.

Before:
![Screenshot 2021-10-18 at 10 29 05](https://user-images.githubusercontent.com/19548183/137705882-e08a8b40-cfc1-40a6-96d4-190027cfb35c.png)

After:
![Screenshot 2021-10-18 at 10 31 33](https://user-images.githubusercontent.com/19548183/137705906-304b7651-bdc3-4574-a836-da4fc57f5d37.png)


