### PR TITLE
f-button@v3.1.0 - Add spacing to buttons following a p tag.

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.1.0
+------------------------------
+*October 18, 2021*
+
+### Added
+- Add spacing to buttons following a paragraph tag. This matches the current behaviour in Fozzie.
+
+
 v3.0.2
 ------------------------------
 *October 13, 2021*

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "main": "dist/f-button.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -320,6 +320,10 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
     &:visited {
         text-decoration: none;
     }
+
+    p + & {
+        margin-top: spacing(x2);
+    }
 }
     .o-button-content {
         display: flex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,6 +2147,11 @@
     eslint-config-airbnb-base "14.1.0"
     eslint-plugin-vue "6.2.2"
 
+"@justeat/f-button@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-3.0.2.tgz#9560d0caf56ae0801208ddd0c27cb50d670d54a8"
+  integrity sha512-qzZr6ZN01GTs6yFGOvIpwDcdXQKcH1SCF3CN7s9YTNiemWaQAoLo9sfv08fNuawBsxLwX4ZMLzjMY9dioC4vpg==
+
 "@justeat/f-content-cards@6.0.0-beta.2":
   version "6.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-6.0.0-beta.2.tgz#1b77d0d33ad0b8b41d26d78029c848e8444d20b5"


### PR DESCRIPTION
### Added
- Add spacing to buttons following a paragraph tag. This matches the current behaviour in Fozzie.