### PR TITLE
fozzie-components@4.7.0 - fozzie package version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,37 +4,45 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.7.0
+------------------------------
+*October 19, 2021*
+
+### Changed
+- `fozzie` package version bump.
+
+
 v4.6.3
- ------------------------------
- *October 18, 2021*
+------------------------------
+*October 18, 2021*
 
 ### Added
-- `f-compatibility` to Circle CI cache
+- `f-compatibility` to Circle CI cache.
 
 
 v4.6.2
- ------------------------------
- *October 18, 2021*
+------------------------------
+*October 18, 2021*
 
 ### Added
-- `f-navigation-links` to Circle CI cache
+- `f-navigation-links` to Circle CI cache.
 
 
 v4.6.1
- ------------------------------
- *October 12, 2021*
+------------------------------
+*October 12, 2021*
 
 ### Added
-- `f-contact-preferences` to Circle CI cache
+- `f-contact-preferences` to Circle CI cache.
 
 
 v4.6.0
- ------------------------------
- *October 8, 2021*
+------------------------------
+*October 8, 2021*
 
  ### Changed
- - Always run visual tests against master
- - Only run visual tests against changed packages
+ - Always run visual tests against master.
+ - Only run visual tests against changed packages.
 
 
 v4.5.0
@@ -42,7 +50,7 @@ v4.5.0
 *October 8, 2021*
 
 ### Updated
-- webdriverIO to v91
+- webdriverIO to v91.
 
 
 v4.4.0
@@ -50,7 +58,7 @@ v4.4.0
 *October 7, 2021*
 
 ### Added
-- Conditional logic to visual regression tests (via new `visual-regression-preflight.js` script)
+- Conditional logic to visual regression tests (via new `visual-regression-preflight.js` script).
 - Custom Github Action for triggering Circle CI pipeline when `wip` tag is removed.
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "4.6.3",
+  "version": "4.7.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build\"",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/preset-env": "7.14.9",
     "@justeat/browserslist-config-fozzie": "1.2.0",
     "@justeat/eslint-config-fozzie": "3.4.1",
-    "@justeat/fozzie": "6.0.0-beta.5",
+    "@justeat/fozzie": "6.0.0-beta.9",
     "@justeat/stylelint-config-fozzie": "2.2.0",
     "@percy/cli": "1.0.0-beta.52",
     "@percy/webdriverio": "2.0.0",

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.5.0
+------------------------------
+*October 19, 2021*
+
+### Changed
+- Specified cookie banner text font size to be 14px as default paragraph font size now is 16px.
+- Cookie policy link to use f-link.
+
+
 v3.4.0
 ------------------------------
 *October 18, 2021*

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -11,6 +11,7 @@ v3.5.0
 ### Changed
 - Specified cookie banner text font size to be 14px as default paragraph font size now is 16px.
 - Cookie policy link to use f-link.
+- Increased max bundle size from 30 to 40kB.
 
 
 v3.4.0

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "30kB",
   "files": [
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@justeat/f-button": "3.0.2",
+    "@justeat/f-link": "2.0.0",
     "@justeat/f-mega-modal": "3.0.2",
     "@justeat/f-vue-icons": "2.3.0",
     "@justeat/f-wdio-utils": "0.3.0",

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -3,7 +3,7 @@
   "description": "Fozzie Cookie Banner – Cookie Banner",
   "version": "3.5.0",
   "main": "dist/f-cookie-banner.umd.min.js",
-  "maxBundleSize": "30kB",
+  "maxBundleSize": "40kB",
   "files": [
     "dist",
     "test-utils"

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -39,13 +39,13 @@
 
                         <p :class="$style['c-cookieBanner-text']">
                             {{ copy.textLine3 }}
-                            <a
+                            <v-link
                                 data-test-id="cookie-policy-link"
+                                is-distinct
                                 :href="copy.cookiePolicyLinkUrl"
-                                :class="$style['c-cookieBanner-link']"
                                 target="_blank">
                                 {{ copy.cookiePolicyLinkText }}
-                            </a>
+                            </v-link>
                             {{ copy.textLine4 }}
                         </p>
                     </div>
@@ -100,6 +100,8 @@ import ButtonComponent from '@justeat/f-button';
 import '@justeat/f-button/dist/f-button.css';
 import MegaModal from '@justeat/f-mega-modal';
 import '@justeat/f-mega-modal/dist/f-mega-modal.css';
+import VLink from '@justeat/f-link';
+import '@justeat/f-link/dist/f-link.css';
 import LegacyBanner from './LegacyBanner.vue';
 import ReopenBannerLink from './ReopenBannerLink.vue';
 import tenantConfigs from '../tenants';
@@ -110,7 +112,8 @@ export default {
         ButtonComponent,
         LegacyBanner,
         MegaModal,
-        ReopenBannerLink
+        ReopenBannerLink,
+        VLink
     },
 
     props: {
@@ -477,6 +480,7 @@ export default {
     .c-cookieBanner-text {
         margin: 0;
         padding: 0;
+        @include font-size(body-s);
     }
 
     .c-cookieBanner-content {

--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v6.0.1
+------------------------------
+*October 18, 2021*
+
+### Changed
+- Specified feedback block text font size to be 14px as default paragraph font size now is 16px.
+
+
 v6.0.0
 ------------------------------
 *October 5, 2021*

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "main": "dist/f-footer.umd.min.js",
   "maxBundleSize": "80kB",
   "files": [

--- a/packages/components/organisms/f-footer/src/components/FeedbackBlock.vue
+++ b/packages/components/organisms/f-footer/src/components/FeedbackBlock.vue
@@ -66,6 +66,7 @@ $feedback-btn-font-size: 'body-s';
 
 .c-feedback-text {
     margin: 0 0 spacing(x0.5) 0;
+    @include font-size(body-s);
 }
 
 .c-feedback-button {

--- a/packages/components/organisms/f-footer/src/components/LegalField.vue
+++ b/packages/components/organisms/f-footer/src/components/LegalField.vue
@@ -51,6 +51,7 @@ export default {
 
     p {
         margin: 0;
+        @include font-size(body-s);
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2359,10 +2359,10 @@
   dependencies:
     "@justeat/f-services" "1.7.0"
 
-"@justeat/fozzie@6.0.0-beta.5":
-  version "6.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-6.0.0-beta.5.tgz#a2a357f96cd3e8a9076a9d0e4d58f687a4184398"
-  integrity sha512-YUBCnFGRDXb9DILjo8Ui8YdAZQ95ml25mGcYJQ1lNzlK29xcfnaJzQwSv1U5sfbKfhHZeyHGHRpN3071tREhFA==
+"@justeat/fozzie@6.0.0-beta.9":
+  version "6.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-6.0.0-beta.9.tgz#21b72acc64fd5b3c5f7683c110d6109c07b56111"
+  integrity sha512-2nRdmuhZ1dMTXiN+SQExgk/qVHi9yg395lOjSG5pk9lYmi0R6QCnM1XxmIjsD2onQztpPnLAU6gAohxoz1INwA==
   dependencies:
     "@justeat/f-dom" "1.1.0"
     "@justeat/f-logger" "0.8.1"


### PR DESCRIPTION
## fozzie-components@4.7.0

### Changed
- `fozzie` package version bump.

## f-footer@6.0.1

### Changed
- Specified feedback block text font size to be 14px as default paragraph font size now is 16px.

## f-cookie-banner@3.5.0

### Changed
- Specified cookie banner text font size to be 14px as default paragraph font size now is 16px.
- Cookie policy link to use f-link.