### PR TITLE
f-promotions-showcase@0.1.0 🌟 Creates initial version from generator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ commands:
             - packages/components/molecules/f-breadcrumbs/dist
             - packages/components/molecules/f-media-element/dist
             - packages/components/molecules/f-mega-modal/dist
+            - packages/components/molecules/f-promotions-showcase/dist
             - packages/components/molecules/f-restaurant-card/dist
             - packages/components/molecules/f-searchbox/dist
             - packages/components/molecules/f-skeleton-loader/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v5.0.1
+ ------------------------------
+ *October 20, 2021*
+
+### Added
+- `f-promotions-showcase` to Circle CI cache
+
+
 v5.0.0
 ------------------------------
  *October 21, 2021*
@@ -51,8 +59,8 @@ v4.6.2
 
 
 v4.6.1
- ------------------------------
- *October 12, 2021*
+------------------------------
+*October 12, 2021*
 
 ### Added
 - `f-contact-preferences` to Circle CI cache.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build\"",

--- a/packages/components/molecules/f-promotions-showcase/.eslintignore
+++ b/packages/components/molecules/f-promotions-showcase/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/components/molecules/f-promotions-showcase/CHANGELOG.md
+++ b/packages/components/molecules/f-promotions-showcase/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+v0.1.0
+------------------------------
+*October 19, 2021*
+
+### Added
+- Initial version of promotions-showcase component
+- Add your change under the following headings: `Added`/`Changed`/`Deprecated`/`Removed`/`Fixed`/`Security`
+

--- a/packages/components/molecules/f-promotions-showcase/LICENSE
+++ b/packages/components/molecules/f-promotions-showcase/LICENSE
@@ -1,0 +1,17 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+Copyright (c) Just Eat Holding Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/components/molecules/f-promotions-showcase/README.md
+++ b/packages/components/molecules/f-promotions-showcase/README.md
@@ -1,0 +1,127 @@
+<div align="center">
+
+# f-promotions-showcase
+
+<img width="125" alt="Fozzie Bear" src="../../../../bear.png" />
+
+A place for promotional messages to be displayed
+
+</div>
+
+---
+
+[![npm version](https://badge.fury.io/js/%40justeat%2Ff-promotions-showcase.svg)](https://badge.fury.io/js/%40justeat%2Ff-promotions-showcase)
+[![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
+[![Coverage Status](https://coveralls.io/repos/github/justeat/f-promotions-showcase/badge.svg)](https://coveralls.io/github/justeat/f-promotions-showcase)
+[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-promotions-showcase/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-promotions-showcase?targetFile=package.json)
+
+---
+
+## Usage
+
+### Installation
+
+Install the module using npm or Yarn:
+
+```sh
+yarn add @justeat/f-promotions-showcase
+```
+
+```sh
+npm install @justeat/f-promotions-showcase
+```
+
+
+
+### Vue Applications
+
+You can import it in your Vue SFC like this (please note that styles have to be imported separately):
+
+```js
+import PromotionsShowcase from '@justeat/f-promotions-showcase';
+import '@justeat/f-promotions-showcase/dist/f-promotions-showcase.css';
+
+export default {
+    components: {
+        PromotionsShowcase
+    }
+}
+```
+
+If you are using Webpack, you can import the component dynamically to separate the `promotions-showcase` bundle from the main `bundle.client.js`:
+
+```js
+import '@justeat/f-promotions-showcase/dist/f-promotions-showcase.css';
+
+export default {
+    components: {
+        // …
+        PromotionsShowcase: () => import(/* webpackChunkName: "promotions-showcase" */ '@justeat/f-promotions-showcase')
+    }
+}
+```
+
+## Configuration
+
+### Props
+
+There may be props that allow you to customise its functionality.
+
+The props that can be defined are as follows (if any):
+
+| Prop  | Type  | Default | Description |
+| ----- | ----- | ------- | ----------- |
+
+### Events
+
+The events that can be subscribed to are as follows (if any):
+
+| Event | Description |
+| ----- | ----------- |
+
+## Development
+
+Start by cloning the repository and installing the required dependencies:
+
+```sh
+$ git clone git@github.com:justeat/fozzie-components.git
+$ cd fozzie-components
+$ yarn
+```
+
+Change directory to the `f-promotions-showcase` package:
+
+```sh
+$ cd packages/components/molecules/f-promotions-showcase
+```
+
+## Testing
+
+To test all components, run from root directory.
+To test only `f-promotions-showcase`, run from the `./fozzie-components/packages/components/molecules/f-promotions-showcase` directory.
+
+### Unit and Integration tests
+
+```sh
+yarn test
+```
+
+### Component and Accessibility Tests
+
+```bash
+# Note: Ensure Storybook is running when running the following commands
+cd ./fozzie-components
+
+yarn storybook:build
+yarn storybook:serve-static
+```
+
+yarn test-component:chrome
+```
+### Accessibility tests
+```bash
+yarn test-a11y:chrome
+```
+## Documentation to be completed once module is in stable state.
+
+

--- a/packages/components/molecules/f-promotions-showcase/babel.config.js
+++ b/packages/components/molecules/f-promotions-showcase/babel.config.js
@@ -1,0 +1,26 @@
+module.exports = api => {
+    // Use `isTest` to determine what presets and plugins to use with jest
+    const isTest = api.env('test');
+    const presets = [];
+    const plugins = [
+        '@babel/plugin-proposal-optional-chaining' // https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining
+    ];
+    const builtIns = (api.env('development') ? 'entry' : false);
+
+    if (!isTest) {
+        api.cache(true); // Caches the computed babel config function – https://babeljs.io/docs/en/config-files#apicache
+        presets.push(['@vue/app', { useBuiltIns: builtIns }]);
+        // Alias for @babel/preset-env
+        // Hooks into browserslist to provide smart Babel transforms
+        // https://babeljs.io/docs/en/babel-preset-env
+        presets.push('@babel/env');
+    } else {
+        // use current node version for transpiling test files
+        presets.push(['@babel/env', { targets: { node: 'current' } }]);
+    }
+
+    return {
+        presets,
+        plugins
+    };
+};

--- a/packages/components/molecules/f-promotions-showcase/jest.config.js
+++ b/packages/components/molecules/f-promotions-showcase/jest.config.js
@@ -1,0 +1,42 @@
+module.exports = {
+    moduleFileExtensions: [
+        'js',
+        'json',
+        'vue'
+    ],
+
+    transform: {
+        '^.+\\.js$': 'babel-jest',
+        '^.+\\.vue$': 'vue-jest',
+        '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub'
+    },
+
+    transformIgnorePatterns: [
+        'node_modules/(?!(lodash-es)/)'
+    ],
+
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+        '^~include-media/(.*)$': '<rootDir>../../node_modules/include-media/$1',
+        '^~@justeat/(.*)$': '<rootDir>../../node_modules/@justeat/$1',
+        '\\.(css|scss)$': 'jest-transform-stub'
+    },
+
+    snapshotSerializers: [
+        'jest-serializer-vue'
+    ],
+
+    globals: {
+        'vue-jest': {
+            hideStyleWarn: true // We hide style warnings given the first time we run the tests it complains about some styles. The second time the tests are run, the warning disappears. https://github.com/vuejs/vue-jest/issues/178#issuecomment-529175129
+        }
+    },
+
+    modulePathIgnorePatterns: [
+        './test/accessibility/',
+        './test/component/'
+    ],
+
+    testURL: 'http://localhost/'
+
+};

--- a/packages/components/molecules/f-promotions-showcase/package.json
+++ b/packages/components/molecules/f-promotions-showcase/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@justeat/f-promotions-showcase",
+  "description": "Fozzie Promotions Showcase - A place for promotional messages to be displayed",
+  "version": "0.1.0",
+  "main": "dist/f-promotions-showcase.umd.min.js", 
+  "maxBundleSize": "20kB",
+  "files": [
+    "dist" 
+  ],
+  "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/components/molecules/f-promotions-showcase",
+  "contributors": [
+    "Github contributors <https://github.com/justeat/fozzie-components/graphs/contributors>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:justeat/fozzie-components.git"
+  },
+  "bugs": {
+    "url": "https://github.com/justeat/fozzie-components/issues"
+  },
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "keywords": [
+    "fozzie"
+  ],
+  "scripts": {
+    "prepublishOnly": "yarn lint && yarn test && yarn build",
+    "build": "vue-cli-service build --target lib --name f-promotions-showcase ./src/index.js",
+    "lint": "vue-cli-service lint",
+    "lint:fix": "yarn lint --fix",
+    "lint:style": "vue-cli-service lint:style",
+    "test": "vue-cli-service test:unit"
+  },
+  "browserslist": [
+    "extends @justeat/browserslist-config-fozzie"
+  ],
+  "dependencies": {
+    "@justeat/f-services": "1.7.0"
+  },
+  "peerDependencies": {
+    "@justeat/browserslist-config-fozzie": ">=1.2.0"
+  },
+  "devDependencies": {
+    "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
+    "@vue/cli-plugin-babel": "4.4.6",
+    "@vue/cli-plugin-eslint": "3.9.2",
+    "@vue/cli-plugin-unit-jest": "4.4.6",
+    "@justeat/f-wdio-utils": "0.3.0",
+    "@vue/test-utils": "1.0.3",
+    "node-sass-magic-importer": "5.3.2"
+  }
+}

--- a/packages/components/molecules/f-promotions-showcase/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-promotions-showcase/src/assets/scss/common.scss
@@ -1,0 +1,6 @@
+// Set $theme variable so that fozzie doesn't complain when vars are imported below
+// n.b. This variables isn't actually used (unless there are theme specific vars from fozzie)
+// Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
+$theme: 'jet' !default;
+
+@import  '~@justeat/fozzie/src/scss/fozzie';

--- a/packages/components/molecules/f-promotions-showcase/src/components/PromotionsShowcase.vue
+++ b/packages/components/molecules/f-promotions-showcase/src/components/PromotionsShowcase.vue
@@ -1,0 +1,32 @@
+<template>
+    <div
+        :class="$style['c-promotionsShowcase']"
+        data-test-id="promotionsShowcase">
+        I am a PromotionsShowcase Component (GB)
+    </div>
+</template>
+
+<script>
+
+export default {
+    name: 'PromotionsShowcase',
+    components: {},
+    props: {
+    }
+};
+</script>
+
+<style lang="scss" module>
+
+.c-promotionsShowcase {
+    display: flex;
+    justify-content: center;
+    min-height: 80vh;
+    width: 80vw;
+    margin: auto;
+    border: 1px solid $color-red;
+    font-family: $font-family-base;
+    @include font-size(heading-m);
+}
+
+</style>

--- a/packages/components/molecules/f-promotions-showcase/src/components/_tests/PromotionsShowcase.test.js
+++ b/packages/components/molecules/f-promotions-showcase/src/components/_tests/PromotionsShowcase.test.js
@@ -1,0 +1,10 @@
+import { shallowMount } from '@vue/test-utils';
+import PromotionsShowcase from '../PromotionsShowcase.vue';
+
+describe('PromotionsShowcase', () => {
+    it('should be defined', () => {
+        const propsData = {};
+        const wrapper = shallowMount(PromotionsShowcase, { propsData });
+        expect(wrapper.exists()).toBe(true);
+    });
+});

--- a/packages/components/molecules/f-promotions-showcase/src/index.js
+++ b/packages/components/molecules/f-promotions-showcase/src/index.js
@@ -1,0 +1,38 @@
+
+/**
+ * @overview Fozzie Promotions Showcase Component JS Wrapper
+ *
+ * @module f-promotions-showcase
+ */
+
+
+// Import vue component
+import PromotionsShowcase from '@/components/PromotionsShowcase.vue';
+
+// Declare install function executed by Vue.use()
+export function install (Vue) {
+    if (install.installed) return;
+    install.installed = true;
+    Vue.component('PromotionsShowcase', PromotionsShowcase);
+}
+
+// Create module definition for Vue.use()
+const plugin = {
+    install
+};
+
+// Auto-install when vue is found (eg. in browser via <script> tag)
+let GlobalVue = null;
+if (typeof window !== 'undefined') {
+    GlobalVue = window.Vue;
+} else if (typeof global !== 'undefined') {
+    GlobalVue = global.Vue;
+}
+if (GlobalVue) {
+    GlobalVue.use(plugin);
+}
+
+// To allow use as module (npm/webpack/etc.) export component
+export default PromotionsShowcase;
+
+

--- a/packages/components/molecules/f-promotions-showcase/stories/PromotionsShowcase.stories.js
+++ b/packages/components/molecules/f-promotions-showcase/stories/PromotionsShowcase.stories.js
@@ -1,0 +1,20 @@
+// Uncomment the import below to add prop controls to your Story (and add `withKnobs` to the decorators array)
+// import {
+//     withKnobs, select, boolean
+// } from '@storybook/addon-knobs';
+import { withA11y } from '@storybook/addon-a11y';
+import PromotionsShowcase from '../src/components/PromotionsShowcase.vue';
+
+export default {
+    title: 'Components/Molecules',
+    decorators: [withA11y]
+};
+
+export const PromotionsShowcaseComponent = () => ({
+    components: { PromotionsShowcase },
+    props: {
+    },
+    template: `<promotions-showcase />`
+});
+
+PromotionsShowcaseComponent.storyName = 'f-promotions-showcase';

--- a/packages/components/molecules/f-promotions-showcase/test-utils/component-objects/README.md
+++ b/packages/components/molecules/f-promotions-showcase/test-utils/component-objects/README.md
@@ -1,0 +1,13 @@
+# What is a component object?
+A component object is a file that is used to define the UI selectors / functionality of a component that is then utilised by WebDriverIO for browser-based automation testing.
+
+# Usage
+Please add a component object if this component is interacted with as part of browser-based automation tests. This can be done either by:
+- Component tests for this component.
+In this scenario, the component object should be imported into the WebDriverIO spec file.
+
+- Component tests for a parent component.
+In this scenario, the component object should be imported into the parent component object.
+
+- System tests as part of a consuming application.
+In this scenario, the `test-utils` folder needs to be added to the `files` section within `package.json` so that it can be imported by the consuming application.

--- a/packages/components/molecules/f-promotions-showcase/test-utils/component-objects/f-promotionsShowcase-selectors.js
+++ b/packages/components/molecules/f-promotions-showcase/test-utils/component-objects/f-promotionsShowcase-selectors.js
@@ -1,0 +1,1 @@
+export const COMPONENT = '[data-test-id="promotionsShowcase"]';

--- a/packages/components/molecules/f-promotions-showcase/test-utils/component-objects/f-promotionsShowcase.component.js
+++ b/packages/components/molecules/f-promotions-showcase/test-utils/component-objects/f-promotionsShowcase.component.js
@@ -1,0 +1,19 @@
+const Page = require('@justeat/f-wdio-utils/src/page.object');
+const { COMPONENT } = require('./f-promotionsShowcase-selectors')
+
+module.exports = class PromotionsShowcase extends Page {
+
+    get component () { return $(COMPONENT); }
+
+    open () {
+        super.openComponent('molecule', 'promotionsShowcase-component');
+    }
+
+    waitForComponent () {
+        super.waitForComponent(this.component);
+    }
+
+    isComponentDisplayed () {
+        return this.component.isDisplayed();
+    }
+}

--- a/packages/components/molecules/f-promotions-showcase/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/molecules/f-promotions-showcase/test/accessibility/axe-accessibility.spec.js
@@ -1,0 +1,18 @@
+import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper';
+
+const PromotionsShowcase = require('../../test-utils/component-objects/f-promotionsShowcase.component');
+const promotionsShowcase = new PromotionsShowcase();
+
+describe('Accessibility tests', () => {
+    beforeEach(() => {
+        promotionsShowcase.open();
+        promotionsShowcase.waitForComponent();
+    });
+    it('a11y - should test f-promotionsShowcase component WCAG compliance', () => {
+        // Act
+        const axeResults = getAccessibilityTestResults('f-promotionsShowcase');
+
+        // Assert
+        expect(axeResults.violations.length).toBe(0);
+    });
+});

--- a/packages/components/molecules/f-promotions-showcase/test/component/README.md
+++ b/packages/components/molecules/f-promotions-showcase/test/component/README.md
@@ -1,0 +1,3 @@
+# Usage
+This directory will contain WebDriverIO spec files that will allow you to test your component in isolation within the browser.
+If this component is a shared / common component that other components are dependent on, then you may delete this directory as it's likely the component can be tested indirectly.

--- a/packages/components/molecules/f-promotions-showcase/test/component/f-promotionsShowcase.component.desktop.spec.js
+++ b/packages/components/molecules/f-promotions-showcase/test/component/f-promotionsShowcase.component.desktop.spec.js
@@ -1,0 +1,17 @@
+const PromotionsShowcase = require('../../test-utils/component-objects/f-promotionsShowcase.component');
+const { buildUrl } = require('@justeat/f-wdio-utils/src/storybook-extensions.js');
+
+describe('f-promotionsShowcase component tests', () => {
+    beforeEach(() => {
+
+        const pageUrl = buildUrl(promotionsShowcase.componentType, promotionsShowcase.componentName, promotionsShowcase.path);
+
+        promotionsShowcase.open(pageUrl)
+        promotionsShowcase.waitForComponent();
+    });
+
+    it('should display the f-promotionsShowcase component', () => {
+        // Assert
+        expect(promotionsShowcase.isComponentDisplayed()).toBe(true);
+    });
+});

--- a/packages/components/molecules/f-promotions-showcase/vue.config.js
+++ b/packages/components/molecules/f-promotions-showcase/vue.config.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../../../config/sassOptions')(rootDir);
+
+// vue.config.js
+module.exports = {
+    chainWebpack: config => {
+        config.module
+            .rule('scss-importer')
+            .test(/\.scss$/)
+            .use('importer')
+            .loader('sass-loader')
+            .options({
+                ...sassOptions,
+                // eslint-disable-next-line quotes
+                additionalData: `@import "../assets/scss/common.scss";`
+            });
+    },
+    pluginOptions: {
+        lintStyleOnBuild: true
+    }
+};


### PR DESCRIPTION
### Added
- Initial version of promotions-showcase component - created from generator
- Added circleci dist cache config

The intention is that this component becomes a place that particular promotional messaging can be housed, with flexibility to support different needs depending on the consuming component. The initial goal for this is the Menu page in order to surface the different offers/offer types that the restaurant supports, and as is currently rolling out for apps. An example of how this will look can be seen here:
![image](https://user-images.githubusercontent.com/6674452/137898641-52640295-e4b7-4327-b9ea-cc20549c5dd9.png)
