### PR TITLE
f-statistics@v0.4.0 - Ability to provide properties during initialisation

### DIFF
--- a/packages/services/f-statistics/CHANGELOG.md
+++ b/packages/services/f-statistics/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.4.0
+------------------------------
+*October 19, 2021*
+
+### Added
+- Ability to pass in custom properties during initialization which stick around
+- Above properties are now published with every statistic
+
+
 v0.3.0
 ------------------------------
 *September 01, 2021*

--- a/packages/services/f-statistics/README.md
+++ b/packages/services/f-statistics/README.md
@@ -64,7 +64,7 @@ const statisticsConfiguration = {
 
 // Optional (provide properties to publish with every statistic)
 const baseProperties = {
-  my-experiment-bucket: 'Bucket 1'
+  my_experiment_bucket: 'Bucket 1'
 };
 
 // Initialise a new instance of the statistics client

--- a/packages/services/f-statistics/README.md
+++ b/packages/services/f-statistics/README.md
@@ -15,23 +15,23 @@ A service for publishing statistics from the client side
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-statistics/badge.svg)](https://coveralls.io/github/justeat/f-statistics)
 [![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-statistics/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-statistics?targetFile=package.json)
 
-> This package is MVP not designed for production use at this stage.
+> This package is an MVP (not yet stable), if you want to use it contact the team first.
 
-The purpose of this service is to abstract away the responsibility for pushing statistics. It is not responsible for collecting stats of any kind.
+- `f-statistics` is responsible for transporting statistics provided to it; for example response time statistics from `f-http`.
 
-It is abstracted so that a myriad of statistic generators can rely on this interface; and should we wish to redirect where statistics go or apply properties to all statistics, this package can isolate those changes in an easily upgradeable format.
-
-It is likely that the current method of transporting statistics is temporary.
+- It is likely the transportation method may change.
 
 ## Benefits (Now)
-- Easy to provide statistics and not need to worry about how they are transported
-- Ability to switch underlying providers in future if we wish - Just Log for now.
+- Hide away how statistics are transported from every day development.
+- Ability to be flexible with where our statistics are transported.
+- Ability for properties to be provided during initialisation, which are included in every publication.
 
 ## Benefits (Soon)
-- Batching options
-- Sampling options
+- Batching options - to decrease network usage
+- Sampling options - to increase scalability
 
-<hr></br>
+
+<hr>
 
 ## Usage
 
@@ -62,8 +62,13 @@ const statisticsConfiguration = {
     featureName: 'your website name'
 };
 
+// Optional (provide properties to publish with every statistic)
+const baseProperties = {
+  my-experiment-bucket: 'Bucket 1'
+};
+
 // Initialise a new instance of the statistics client
-const statisticsClient = new StatisticsModule(justLog, statsConfiguration);
+const statisticsClient = new StatisticsModule(justLog, statsConfiguration, baseProperties);
 
 // Publish a statistic
 statisticsClient.publish({

--- a/packages/services/f-statistics/package.json
+++ b/packages/services/f-statistics/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@justeat/f-statistics",
   "description": "Javascript client for transporting statistics",
-  "version": "0.3.0",
-  "maxBundleSize": "100kB",
+  "version": "0.4.0",
+  "maxBundleSize": "10kB",
   "main": "dist/f-statistics.umd.js",
   "module": "dist/f-statistics.es.js",
   "source": "src/index.js",

--- a/packages/services/f-statistics/src/index.js
+++ b/packages/services/f-statistics/src/index.js
@@ -8,25 +8,25 @@ export default class StatisticsClient {
     };
 
     constructor (justLogInstance, options = {}, basePayload = {}) {
-        this.basePayload = {
-            ...basePayload,
-            ...this.basePayload
-        };
-
         this.configuration = {
             ...defaultOptions,
             ...options
         };
 
+        this.basePayload = {
+            ...basePayload,
+            ...this.basePayload,
+            je_feature_for: this.configuration?.featureName || 'Unspecified',
+            je_environment: this.configuration?.environment || 'Unspecified'
+        };
+
         this.justLogInstance = justLogInstance;
     }
 
-    publish (message, payload) {
+    publish (message, statisticPayload) {
         this.justLogInstance.info(message, {
-            je_feature_for: this.configuration?.featureName || 'Unspecified',
-            je_environment: this.configuration?.environment || 'Unspecified',
             ...this.basePayload,
-            ...payload
+            ...statisticPayload
         });
     }
 }

--- a/packages/services/f-statistics/src/index.js
+++ b/packages/services/f-statistics/src/index.js
@@ -2,7 +2,17 @@
 import defaultOptions from './defaultOptions';
 
 export default class StatisticsClient {
-    constructor (justLogInstance, options = {}) {
+    basePayload = {
+        je_feature: 'f-statistics',
+        je_logType: 'client-stats'
+    };
+
+    constructor (justLogInstance, options = {}, basePayload = {}) {
+        this.basePayload = {
+            ...basePayload,
+            ...this.basePayload
+        };
+
         this.configuration = {
             ...defaultOptions,
             ...options
@@ -13,10 +23,9 @@ export default class StatisticsClient {
 
     publish (message, payload) {
         this.justLogInstance.info(message, {
-            je_feature: 'f-statistics',
             je_feature_for: this.configuration?.featureName || 'Unspecified',
-            je_logType: 'client-stats',
             je_environment: this.configuration?.environment || 'Unspecified',
+            ...this.basePayload,
             ...payload
         });
     }

--- a/packages/services/f-statistics/src/index.js
+++ b/packages/services/f-statistics/src/index.js
@@ -2,11 +2,6 @@
 import defaultOptions from './defaultOptions';
 
 export default class StatisticsClient {
-    basePayload = {
-        je_feature: 'f-statistics',
-        je_logType: 'client-stats'
-    };
-
     constructor (justLogInstance, options = {}, basePayload = {}) {
         this.configuration = {
             ...defaultOptions,
@@ -15,7 +10,8 @@ export default class StatisticsClient {
 
         this.basePayload = {
             ...basePayload,
-            ...this.basePayload,
+            je_feature: 'f-statistics',
+            je_logType: 'client-stats',
             je_feature_for: this.configuration?.featureName || 'Unspecified',
             je_environment: this.configuration?.environment || 'Unspecified'
         };

--- a/packages/services/f-statistics/src/tests/index.test.js
+++ b/packages/services/f-statistics/src/tests/index.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import StatisticsClient from '../index';
 
 describe('f-statistics', () => {
@@ -6,8 +7,112 @@ describe('f-statistics', () => {
         expect(StatisticsClient).toBeDefined();
     });
 
-    it('should define expected method', () => {
+    describe('constructor ::', () => {
+        it('should expose base payload when none is provided', () => {
+            // Arrange
+            const expectedPayload = {
+                je_feature: 'f-statistics',
+                je_logType: 'client-stats'
+            };
+
+            // Act
+            const statisticsClient = new StatisticsClient();
+
+            // Assert
+            expect(statisticsClient.basePayload).toEqual(expectedPayload);
+        });
+
+        it('should merge base payload when additional properties are provided', () => {
+            // Arrange
+            const expectedPayload = {
+                je_feature: 'f-statistics',
+                je_logType: 'client-stats',
+                a_test_property: 'this is a test'
+            };
+
+            // Act
+            const statisticsClient = new StatisticsClient(null, null, { a_test_property: 'this is a test' });
+
+            // Assert
+            expect(statisticsClient.basePayload).toEqual(expectedPayload);
+        });
+
+        it('should use default payload as merge priority over provided payload', () => {
+            // Arrange
+            const expectedPayload = {
+                je_feature: 'f-statistics',
+                je_logType: 'client-stats',
+                a_test_property: 'this is a test'
+            };
+
+            // Act
+            const statisticsClient = new StatisticsClient(null, null, {
+                a_test_property: 'this is a test',
+                je_feature: 'a modified value'
+            });
+
+            // Assert
+            expect(statisticsClient.basePayload).toEqual(expectedPayload);
+        });
+    });
+
+    describe('publish ::', () => {
+        let publications = [];
+
+        const justLogMock = {
+            info: (message, payload) => {
+                publications = [
+                    payload,
+                    ...publications
+                ];
+            }
+        };
+
+        beforeEach(() => {
+            publications = [];
+        });
+
+        it('should define expected publish method', () => {
         // Arrange, Act & Assert
-        expect(new StatisticsClient().publish).toBeDefined();
+            expect(new StatisticsClient().publish).toBeDefined();
+        });
+
+        it('should publish logs with expected properties', () => {
+            // Arrange
+            const statisticsClient = new StatisticsClient(justLogMock, null, null);
+
+            const expectedPayload = {
+                je_environment: 'test',
+                je_feature: 'f-statistics',
+                je_feature_for: 'Generic Front End',
+                je_logType: 'client-stats',
+                testValue: 'A test value'
+            };
+
+            // Act
+            statisticsClient.publish('Test message', { testValue: 'A test value' });
+
+            // Assert
+            expect(publications[0]).toEqual(expectedPayload);
+        });
+
+        it('should publish logs with additional base payload properties when provided', () => {
+            // Arrange
+            const statisticsClient = new StatisticsClient(justLogMock, null, { a_base_payload_property: 'This is a test' });
+
+            const expectedPayload = {
+                je_environment: 'test',
+                je_feature: 'f-statistics',
+                je_feature_for: 'Generic Front End',
+                je_logType: 'client-stats',
+                a_base_payload_property: 'This is a test'
+            };
+
+            // Act
+            statisticsClient.publish('Test message', {});
+
+            // Assert
+            expect(publications[0]).toEqual(expectedPayload);
+        });
     });
 });

--- a/packages/services/f-statistics/src/tests/index.test.js
+++ b/packages/services/f-statistics/src/tests/index.test.js
@@ -12,7 +12,9 @@ describe('f-statistics', () => {
             // Arrange
             const expectedPayload = {
                 je_feature: 'f-statistics',
-                je_logType: 'client-stats'
+                je_logType: 'client-stats',
+                je_environment: 'test',
+                je_feature_for: 'Generic Front End'
             };
 
             // Act
@@ -27,6 +29,8 @@ describe('f-statistics', () => {
             const expectedPayload = {
                 je_feature: 'f-statistics',
                 je_logType: 'client-stats',
+                je_environment: 'test',
+                je_feature_for: 'Generic Front End',
                 a_test_property: 'this is a test'
             };
 
@@ -42,6 +46,8 @@ describe('f-statistics', () => {
             const expectedPayload = {
                 je_feature: 'f-statistics',
                 je_logType: 'client-stats',
+                je_environment: 'test',
+                je_feature_for: 'Generic Front End',
                 a_test_property: 'this is a test'
             };
 


### PR DESCRIPTION
We want to add properties during initialisation from the web host, which will go up with every stat. For things like experiment / feature buckets, or code versions.

Non breaking and optional.

https://github.com/tommcclean/fozzie-components/blob/f-statistics%40v0.4.0/packages/services/f-statistics/README.md

```
v0.4.0
------------------------------
*October 19, 2021*

### Added
- Ability to pass in custom properties during initialization which stick around
- Above properties are now published with every statistic
```