### PR TITLE
f-breadcrumbs@2.1.0 - Render <span> not <a> if no URL is given

### DIFF
--- a/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
+++ b/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.1.0
+------------------------------
+*October 21, 2021*
+
+### Changed
+- If no URL is given, render `<span>` instead of `<a>` or `<router-link>`.
+
+### Added
+- Unit test coverage
+
+
 v2.0.0
 ------------------------------
 *October 5, 2021*

--- a/packages/components/molecules/f-breadcrumbs/package.json
+++ b/packages/components/molecules/f-breadcrumbs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-breadcrumbs",
   "description": "Fozzie Bread Crumbs – Provides clickable paths back to previous pages",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "dist/f-breadcrumbs.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
+++ b/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
@@ -14,7 +14,7 @@
                     :key="`${index}_separator`"
                     :class="$style['c-breadcrumbs-item']">
                     <router-link
-                        v-if="routerLink"
+                        v-if="routerLink && url"
                         :to="url"
                         :class="[
                             $style['c-breadcrumbs-link'],
@@ -23,7 +23,7 @@
                         {{ name }}
                     </router-link>
                     <a
-                        v-else
+                        v-else-if="url"
                         :href="url"
                         :class="[
                             $style['c-breadcrumbs-link'],
@@ -31,6 +31,14 @@
                         ]">
                         {{ name }}
                     </a>
+                    <span
+                        v-else
+                        :class="[
+                            $style['c-breadcrumbs-text'],
+                            linkActiveClass(index)
+                        ]">
+                        {{ name }}
+                    </span>
                 </li>
             </template>
         </ul>
@@ -94,6 +102,10 @@ $breadcrumbs-active-font-weight: $font-weight-regular;
             display: block;
         }
     }
+}
+.c-breadcrumbs-text {
+    color: $breadcrumbs-text-colour;
+    font-weight: $breadcrumbs-not-active-font-weight;
 }
 .c-breadcrumbs-link {
     color: $breadcrumbs-text-colour;

--- a/packages/components/molecules/f-breadcrumbs/src/components/tests/Breadcrumbs.test.js
+++ b/packages/components/molecules/f-breadcrumbs/src/components/tests/Breadcrumbs.test.js
@@ -1,10 +1,149 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, RouterLinkStub } from '@vue/test-utils';
 import BreadCrumbs from '../Breadcrumbs.vue';
 
 describe('BreadCrumbs', () => {
     it('should be defined', () => {
+        // Arrange
         const propsData = {};
+
+        // Act
         const wrapper = shallowMount(BreadCrumbs, { propsData });
+
+        // Assert
         expect(wrapper.exists()).toBe(true);
+    });
+
+    it('should render a link when a url is supplied', () => {
+        // Arrange
+        const propsData = {
+            links: [{
+                name: 'Link 1',
+                url: '/link/1',
+                routerLink: false
+            }]
+        };
+
+        // Act
+        const wrapper = shallowMount(BreadCrumbs, { propsData });
+        const breadcrumbLinks = wrapper.findAll('li > a');
+
+        // Assert
+        expect(breadcrumbLinks).toHaveLength(1);
+    });
+
+    it('should render a router link if routerLink is true', () => {
+        // Arrange
+        const propsData = {
+            links: [{
+                name: 'Router Link 1',
+                url: '/routerlink/1',
+                routerLink: true
+            }]
+        };
+
+        // Act
+        const wrapper = shallowMount(BreadCrumbs, {
+            propsData,
+            stubs: {
+                RouterLink: RouterLinkStub
+            }
+        });
+        const breadcrumbRouterLinks = wrapper.findAllComponents(RouterLinkStub);
+
+        // Assert
+        expect(breadcrumbRouterLinks).toHaveLength(1);
+    });
+
+    it('should render a link for each url supplied', () => {
+        // Arrange
+        const propsData = {
+            links: [
+                {
+                    name: 'Link 1',
+                    url: '/link/1',
+                    routerLink: false
+                },
+                {
+                    name: 'Link 2',
+                    url: '/link/2',
+                    routerLink: false
+                }
+            ]
+        };
+
+        // Act
+        const wrapper = shallowMount(BreadCrumbs, { propsData });
+        const breadcrumbLinks = wrapper.findAll('li > a');
+
+        // Assert
+        expect(breadcrumbLinks).toHaveLength(2);
+    });
+
+    it.each([
+        ['empty', ''],
+        ['undefined', undefined],
+        ['null', null]
+    ])('should render a span when url is %s', (_, url) => {
+        // Arrange
+        const propsData = {
+            links: [{
+                name: 'Text 1',
+                url,
+                routerLink: false
+            }]
+        };
+
+        // Act
+        const wrapper = shallowMount(BreadCrumbs, { propsData });
+        const breadcrumbSpans = wrapper.findAll('li > span');
+
+        // Assert
+        expect(breadcrumbSpans).toHaveLength(1);
+    });
+
+    it('should render a span if router link url is missing', () => {
+        // Arrange
+        const propsData = {
+            links: [{
+                name: 'Router Link 1',
+                url: '',
+                routerLink: true
+            }]
+        };
+
+        // Act
+        const wrapper = shallowMount(BreadCrumbs, { propsData });
+        const breadcrumbSpans = wrapper.findAll('li > span');
+
+        // Assert
+        expect(breadcrumbSpans).toHaveLength(1);
+    });
+
+    it('should render a mix of links and spans when not all links have urls', () => {
+        // Arrange
+        const propsData = {
+            links: [
+                {
+                    name: 'Link 1',
+                    url: '/link/1',
+                    routerLink: false
+                },
+                {
+                    name: 'Link 2',
+                    url: '',
+                    routerLink: false
+                }
+            ]
+        };
+
+        // Act
+        const wrapper = shallowMount(BreadCrumbs, { propsData });
+
+        const breadcrumbLinks = wrapper.findAll('li > a');
+        const breadcrumbSpans = wrapper.findAll('li > span');
+
+        // Assert
+        expect(breadcrumbLinks).toHaveLength(1);
+        expect(breadcrumbSpans).toHaveLength(1);
     });
 });


### PR DESCRIPTION
### Changed
- If no URL is given, render `<span>` instead of `<a>` or `<router-link>`.

### Added
- Unit test coverage