### PR TITLE
f-link@2.1.0 - Support router-link

### DIFF
--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.1.0
+------------------------------
+*October 25, 2021*
+
+### Added
+- Support for `router-link`.
+- `isRouterLink` prop.
+
+### Changed
+- `href` from implicit attribute to (required) prop.
+
+
 v2.0.0
 ------------------------------
 *October 5, 2021*

--- a/packages/components/atoms/f-link/README.md
+++ b/packages/components/atoms/f-link/README.md
@@ -71,7 +71,9 @@ The props that can be defined are as follows (if any):
 
 | Prop  | Type  | Default | Description |
 | ----- | ----- | ------- | ----------- |
-| `isExternalSite` | `String` | `false` | Sets aria description to 'Opens and external site' or 'Opens and external site in a new window/screen/tab' depending on target of link.|
+| `href` | `String` | This is a required prop | The URL or path of the link. For a `router-link` this will be mapped to the `to` attribute. |
+| `isExternalSite` | `Boolean` | `false` | Sets aria description to 'Opens and external site' or 'Opens and external site in a new window/screen/tab' depending on target of link.|
+| `isRouterLink` | `Boolean` | `false` | Determines whether to configure the link as a Vue Router router-link. |
 | `isBold` | `Boolean` | `false` | Sets link text to bold. |
 | `hasTextDecoration` | `Boolean` | `true` | Adds underline to link text. |
 | `isFullWidth` | `Boolean` | `false` | Link set as full width. |
@@ -126,5 +128,3 @@ cd ./fozzie-components/packages/components/atoms/f-link
 yarn test-component:chrome
 ```
 ## Documentation to be completed once module is in stable state.
-
-

--- a/packages/components/atoms/f-link/package.json
+++ b/packages/components/atoms/f-link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-link",
   "description": "Fozzie Link - Fozzie link component",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "dist/f-link.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -1,6 +1,7 @@
 <template>
     <span>
-        <a
+        <component
+            :is="linkType"
             :class="[
                 $style['o-link'], {
                     [$style['o-link--bold']]: isBold,
@@ -11,9 +12,9 @@
                 }]"
             data-test-id="link-component"
             :aria-describedby="descriptionId"
-            v-bind="$attrs">
+            v-bind="linkAttributes">
             <slot />
-        </a>
+        </component>
         <span
             v-if="ariaDescription"
             :id="descriptionId"
@@ -33,7 +34,17 @@ export default {
     name: 'VLink',
 
     props: {
+        href: {
+            type: String,
+            required: true
+        },
+
         isExternalSite: {
+            type: Boolean,
+            default: false
+        },
+
+        isRouterLink: {
             type: Boolean,
             default: false
         },
@@ -97,6 +108,21 @@ export default {
 
         descriptionId () {
             return this.ariaDescription ? this.uid : null;
+        },
+
+        linkAttributes () {
+            return {
+                ...this.$attrs,
+                ...(this.isRouterLink ? {
+                    to: this.href
+                } : {
+                    href: this.href
+                })
+            };
+        },
+
+        linkType () {
+            return this.isRouterLink ? 'router-link' : 'a';
         }
     }
 };

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, RouterLinkStub } from '@vue/test-utils';
 import VLink from '../Link.vue';
 
 const $style = {
@@ -8,10 +8,16 @@ const $style = {
     'o-link--noBreak': 'o-link--noBreak'
 };
 
+const mocks = {
+    $style
+};
+
 describe('Link', () => {
     it('should be defined', () => {
         // Arrange
-        const propsData = { };
+        const propsData = {
+            href: '/'
+        };
 
         // Act
         const wrapper = shallowMount(VLink, {
@@ -27,15 +33,14 @@ describe('Link', () => {
             it('should apply `o-link--bold` class to link if true', () => {
                 // Arrange
                 const propsData = {
+                    href: '/',
                     isBold: true
                 };
 
                 // Act
                 const wrapper = shallowMount(VLink, {
                     propsData,
-                    mocks: {
-                        $style
-                    }
+                    mocks
                 });
 
                 const link = wrapper.find('[data-test-id="link-component"]');
@@ -49,15 +54,14 @@ describe('Link', () => {
             it('should apply `o-link--noDecoration` class to link if false', () => {
                 // Arrange
                 const propsData = {
-                    hasTextDecoration: false
+                    hasTextDecoration: false,
+                    href: '/'
                 };
 
                 // Act
                 const wrapper = shallowMount(VLink, {
                     propsData,
-                    mocks: {
-                        $style
-                    }
+                    mocks
                 });
 
                 const link = wrapper.find('[data-test-id="link-component"]');
@@ -71,15 +75,14 @@ describe('Link', () => {
             it('should apply `o-link--full` class to link if true', () => {
                 // Arrange
                 const propsData = {
+                    href: '/',
                     isFullWidth: true
                 };
 
                 // Act
                 const wrapper = shallowMount(VLink, {
                     propsData,
-                    mocks: {
-                        $style
-                    }
+                    mocks
                 });
 
                 const link = wrapper.find('[data-test-id="link-component"]');
@@ -93,21 +96,65 @@ describe('Link', () => {
             it('should apply `o-link--noBreak` class to link if true', () => {
                 // Arrange
                 const propsData = {
+                    href: '/',
                     noLineBreak: true
                 };
 
                 // Act
                 const wrapper = shallowMount(VLink, {
                     propsData,
-                    mocks: {
-                        $style
-                    }
+                    mocks
                 });
 
                 const link = wrapper.find('[data-test-id="link-component"]');
 
                 // Assert
                 expect(link.attributes('class')).toContain('o-link--noBreak');
+            });
+        });
+
+        describe('isRouterLink ::', () => {
+            it('should render a router link when true', () => {
+                // Arrange
+                const propsData = {
+                    href: '/',
+                    isRouterLink: true
+                };
+
+                // Act
+                const wrapper = shallowMount(VLink, {
+                    propsData,
+                    mocks,
+                    stubs: {
+                        RouterLink: RouterLinkStub
+                    }
+                });
+
+                const routerLink = wrapper.findComponent(RouterLinkStub);
+
+                // Assert
+                expect(routerLink.exists()).toBe(true);
+            });
+
+            it('should render an anchor tag when false', () => {
+                // Arrange
+                const propsData = {
+                    href: '/',
+                    isRouterLink: false
+                };
+
+                // Act
+                const wrapper = shallowMount(VLink, {
+                    propsData,
+                    mocks
+                });
+
+                const link = wrapper.find('[data-test-id="link-component"]');
+                const routerLink = wrapper.findComponent(RouterLinkStub);
+
+                // Assert
+                expect(link.element.tagName).toBe('A');
+                expect(routerLink.exists()).toBe(false);
             });
         });
     });
@@ -125,6 +172,7 @@ describe('Link', () => {
                 ])('should return `%s` when `isExternalSite` is %s', (expected, isExternalSite) => {
                     // Arrange
                     const propsData = {
+                        href: '/',
                         isExternalSite,
                         target: '_blank'
                     };
@@ -146,6 +194,7 @@ describe('Link', () => {
                 ])('should return `%s` when `isExternalSite` is %s', (expected, isExternalSite) => {
                     // Arrange
                     const propsData = {
+                        href: '/',
                         isExternalSite
                     };
 

--- a/packages/components/atoms/f-link/stories/Link.stories.js
+++ b/packages/components/atoms/f-link/stories/Link.stories.js
@@ -15,6 +15,10 @@ export const VLinkComponent = () => ({
         };
     },
     props: {
+        isRouterLink: {
+            default: boolean('Is a router link?', false)
+        },
+
         isExternalSite: {
             default: boolean('Opens an external site', false)
         },
@@ -51,7 +55,8 @@ export const VLinkComponent = () => ({
 
     template: `<v-link
                     :data-test-id="dataTestId"
-                    href="https://www.just-eat.co.uk/"
+                    href="/"
+                    :is-router-link="isRouterLink"
                     :is-bold="isBold"
                     :has-text-decoration="hasTextDecoration"
                     :is-full-width="isFullWidth"

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.46.0
+------------------------------
+*October 25, 2021*
+
+### Added
+- `storybook-vue-router` setup to work with `f-link`.
+
+
 v0.45.1
 ------------------------------
 *October 22, 2021*

--- a/packages/storybook/config/storybook/preview.js
+++ b/packages/storybook/config/storybook/preview.js
@@ -1,5 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 import Vue from 'vue';
+import StoryRouter from 'storybook-vue-router';
+
 import setupContext from '../../context';
 import jetPieThemeDocs from './jetPieThemeDocs';
 import './scss-loader.scss';
@@ -7,6 +9,10 @@ import './scss-loader.scss';
 setupContext();
 
 Vue.config.devtools = true;
+
+export const decorators = [StoryRouter({}, {
+    mode: 'history'
+})];
 
 export const parameters = {
     docs: {

--- a/packages/storybook/config/storybook/story.config.js
+++ b/packages/storybook/config/storybook/story.config.js
@@ -23,25 +23,22 @@ const getChangedPackageStories = () => {
 };
 
 const getStoryFiles = () => {
-
-    // Executed if Storybook is running in VS Code via the launch.json command. 
+    // Executed if Storybook is running in VS Code via the launch.json command.
     if (process.env.VS_DEBUGGER) {
         return [process.env.CURRENT_STORY_FILE];
     }
 
     // Executed if the storybook:serve-changed script is executed by CircleCI.
-    else if (process.env.CHANGED_ONLY) {
+    if (process.env.CHANGED_ONLY) {
         return getChangedPackageStories();
     }
 
     // Executed if the storybook:serve script is executed.
-    else {
-        return [
-            '../../../**/*.stories.@(js|mdx)',
-            '../../../../stories/**/*.stories.@(js|mdx)'
-        ];
-    }
-}
+    return [
+        '../../../**/*.stories.@(js|mdx)',
+        '../../../../stories/**/*.stories.@(js|mdx)'
+    ];
+};
 
 module.exports = {
     getStoryFiles

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.45.1",
+  "version": "0.46.0",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
@@ -10,7 +10,8 @@
   "dependencies": {
     "http-server": "0.12.3",
     "vue": "2.6.10",
-    "vue-i18n": "8.22.1"
+    "vue-i18n": "8.22.1",
+    "vue-router": "3.5.2"
   },
   "devDependencies": {
     "@justeat/f-http": "0.8.0",
@@ -26,6 +27,7 @@
     "node-sass-magic-importer": "5.3.2",
     "npm-run-all": "4.1.5",
     "path": "0.12.7",
+    "storybook-vue-router": "1.0.7",
     "vue-cli-plugin-storybook": "2.0.0"
   },
   "bugs": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23297,6 +23297,11 @@ storybook-addon-outline@^1.4.1:
     "@storybook/core-events" "^6.3.0"
     ts-dedent "^2.1.1"
 
+storybook-vue-router@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/storybook-vue-router/-/storybook-vue-router-1.0.7.tgz#366451212149d9d0a32557545b244667bb01768e"
+  integrity sha512-R+DYARQ40YVbMbV5moLDmQvodJX5FQPVy5cULb782P1gD5rAkulWtgt8yrM7pmjYru+LTPdLS4blrFPnWlb0sQ==
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"


### PR DESCRIPTION
## storybook

### Added
- `storybook-vue-router` setup to work with `f-link`.

## f-link

### Added
- Support for `router-link`.
- `isRouterLink` prop.

### Changed
- `href` from implicit attribute to (required) prop.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
