### PR TITLE
f-breadcrumbs@2.2.0 - Replace `<span>` with `<template>`

### DIFF
--- a/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
+++ b/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.2.0
+------------------------------
+*October 27, 2021*
+
+### Changed
+- Replace `<span>` with `<template>`.
+- Simplify and shuffle around styles accordingly.
+
+
 v2.1.0
 ------------------------------
 *October 21, 2021*

--- a/packages/components/molecules/f-breadcrumbs/package.json
+++ b/packages/components/molecules/f-breadcrumbs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-breadcrumbs",
   "description": "Fozzie Bread Crumbs – Provides clickable paths back to previous pages",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "dist/f-breadcrumbs.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
+++ b/packages/components/molecules/f-breadcrumbs/src/components/Breadcrumbs.vue
@@ -12,33 +12,24 @@
                 </li>
                 <li
                     :key="`${index}_separator`"
-                    :class="$style['c-breadcrumbs-item']">
+                    :class="[
+                        $style['c-breadcrumbs-item'],
+                        $style['c-breadcrumbs-text'],
+                        linkActiveClass(index)
+                    ]">
                     <router-link
                         v-if="routerLink && url"
-                        :to="url"
-                        :class="[
-                            $style['c-breadcrumbs-link'],
-                            linkActiveClass(index)
-                        ]">
+                        :to="url">
                         {{ name }}
                     </router-link>
                     <a
                         v-else-if="url"
-                        :href="url"
-                        :class="[
-                            $style['c-breadcrumbs-link'],
-                            linkActiveClass(index)
-                        ]">
+                        :href="url">
                         {{ name }}
                     </a>
-                    <span
-                        v-else
-                        :class="[
-                            $style['c-breadcrumbs-text'],
-                            linkActiveClass(index)
-                        ]">
+                    <template v-else>
                         {{ name }}
-                    </span>
+                    </template>
                 </li>
             </template>
         </ul>
@@ -57,19 +48,21 @@ export default {
     },
     methods: {
         /**
-       * Function to add active class to the last link
-       * @param index
-       * @returns {*|string}
-       */
+        * Function to add active class to the last link
+        * @param index
+        * @returns {*|string}
+        */
         linkActiveClass (index) {
-            return index === this.links.length - 1 ? this.$style['c-breadcrumbs-link--active'] : '';
+            const lastIndex = this.links.length - 1;
+            return index !== lastIndex ?
+                this.$style['c-breadcrumbs-link'] :
+                this.$style['c-breadcrumbs-link--active'];
         }
     }
 };
 </script>
 
 <style lang="scss" module>
-
 $breadcrumbs-text-colour: $color-content-light;
 $breadcrumbs-background-colour: rgba($color-black, 0.6);
 $breadcrumbs-border-radius: $radius-rounded-c;
@@ -103,18 +96,25 @@ $breadcrumbs-active-font-weight: $font-weight-regular;
         }
     }
 }
-.c-breadcrumbs-text {
-    color: $breadcrumbs-text-colour;
-    font-weight: $breadcrumbs-not-active-font-weight;
-}
+.c-breadcrumbs-text,
 .c-breadcrumbs-link {
-    color: $breadcrumbs-text-colour;
-    font-weight: $breadcrumbs-not-active-font-weight;
-    cursor: pointer;
-    text-decoration: none;
-    &:hover {
-        text-decoration: underline;
+    &, & > a {
         color: $breadcrumbs-text-colour;
+        font-weight: $breadcrumbs-not-active-font-weight;
+    }
+
+    a {
+        cursor: pointer;
+        text-decoration: none;
+        &:hover {
+            text-decoration: underline;
+            color: $breadcrumbs-text-colour;
+        }
+    }
+}
+.c-breadcrumbs-link--active {
+    &, & > a {
+        font-weight: $breadcrumbs-active-font-weight;
     }
 }
 .c-breadcrumbs-separator {
@@ -126,8 +126,4 @@ $breadcrumbs-active-font-weight: $font-weight-regular;
         margin-top: 2px;
     }
 }
-.c-breadcrumbs-link--active {
-    font-weight: $breadcrumbs-active-font-weight;
-}
-
 </style>

--- a/packages/components/molecules/f-breadcrumbs/src/components/tests/Breadcrumbs.test.js
+++ b/packages/components/molecules/f-breadcrumbs/src/components/tests/Breadcrumbs.test.js
@@ -83,7 +83,7 @@ describe('BreadCrumbs', () => {
         ['empty', ''],
         ['undefined', undefined],
         ['null', null]
-    ])('should render a span when url is %s', (_, url) => {
+    ])('should render a text node when url is %s', (_, url) => {
         // Arrange
         const propsData = {
             links: [{
@@ -95,13 +95,15 @@ describe('BreadCrumbs', () => {
 
         // Act
         const wrapper = shallowMount(BreadCrumbs, { propsData });
-        const breadcrumbSpans = wrapper.findAll('li > span');
+        const breadcrumbElements = wrapper.findAll('li');
+        const breadcrumbLinks = wrapper.findAll('li > a');
 
         // Assert
-        expect(breadcrumbSpans).toHaveLength(1);
+        expect(breadcrumbElements).toHaveLength(1); // There are no separators
+        expect(breadcrumbLinks).toHaveLength(0);
     });
 
-    it('should render a span if router link url is missing', () => {
+    it('should render a text node if router link url is missing', () => {
         // Arrange
         const propsData = {
             links: [{
@@ -113,10 +115,12 @@ describe('BreadCrumbs', () => {
 
         // Act
         const wrapper = shallowMount(BreadCrumbs, { propsData });
-        const breadcrumbSpans = wrapper.findAll('li > span');
+        const breadcrumbElements = wrapper.findAll('li');
+        const breadcrumbLinks = wrapper.findAll('li > a');
 
         // Assert
-        expect(breadcrumbSpans).toHaveLength(1);
+        expect(breadcrumbElements).toHaveLength(1); // There are no separators
+        expect(breadcrumbLinks).toHaveLength(0);
     });
 
     it('should render a mix of links and spans when not all links have urls', () => {
@@ -140,10 +144,10 @@ describe('BreadCrumbs', () => {
         const wrapper = shallowMount(BreadCrumbs, { propsData });
 
         const breadcrumbLinks = wrapper.findAll('li > a');
-        const breadcrumbSpans = wrapper.findAll('li > span');
+        const breadcrumbElements = wrapper.findAll('li');
 
         // Assert
         expect(breadcrumbLinks).toHaveLength(1);
-        expect(breadcrumbSpans).toHaveLength(1);
+        expect(breadcrumbElements).toHaveLength(3); // Includes separator
     });
 });


### PR DESCRIPTION
### Changed
- Replace `<span>` with `<template>`.
- Simplify and shuffle around styles accordingly.

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
