### PR TITLE
f-link@2.2.0 - Use $attrs to choose `<router-link>` or `<a>`

### DIFF
--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -9,10 +9,7 @@ v2.2.0
 *October 27, 2021*
 
 ### Removed
-- `href` prop in favour of deferring to `$attrs`.
-
-### Changed
-- Make storybook props dynamic to avoid `to` and `href` from interfering with each other.
+- `isRouterLink` and `href` props, in favour of deferring to `$attrs`.
 
 
 v2.1.0

--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.2.0
+------------------------------
+*October 27, 2021*
+
+### Removed
+- `href` prop in favour of deferring to `$attrs`.
+
+### Changed
+- Make storybook props dynamic to avoid `to` and `href` from interfering with each other.
+
+
 v2.1.0
 ------------------------------
 *October 25, 2021*

--- a/packages/components/atoms/f-link/README.md
+++ b/packages/components/atoms/f-link/README.md
@@ -71,9 +71,8 @@ The props that can be defined are as follows (if any):
 
 | Prop  | Type  | Default | Description |
 | ----- | ----- | ------- | ----------- |
-| `href` | `String` | This is a required prop | The URL or path of the link. For a `router-link` this will be mapped to the `to` attribute. |
+| `href` / `to` | `String` | `n/a` (this is an expected attribute rather than a required prop) | The URL or path of the link. Pass in `href` for `<a>`, or `to` for `<router-link>`. |
 | `isExternalSite` | `Boolean` | `false` | Sets aria description to 'Opens and external site' or 'Opens and external site in a new window/screen/tab' depending on target of link.|
-| `isRouterLink` | `Boolean` | `false` | Determines whether to configure the link as a Vue Router router-link. |
 | `isBold` | `Boolean` | `false` | Sets link text to bold. |
 | `hasTextDecoration` | `Boolean` | `true` | Adds underline to link text. |
 | `isFullWidth` | `Boolean` | `false` | Link set as full width. |

--- a/packages/components/atoms/f-link/package.json
+++ b/packages/components/atoms/f-link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-link",
   "description": "Fozzie Link - Fozzie link component",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "dist/f-link.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -12,7 +12,7 @@
                 }]"
             data-test-id="link-component"
             :aria-describedby="descriptionId"
-            v-bind="linkAttributes">
+            v-bind="$attrs">
             <slot />
         </component>
         <span
@@ -34,11 +34,6 @@ export default {
     name: 'VLink',
 
     props: {
-        href: {
-            type: String,
-            required: true
-        },
-
         isExternalSite: {
             type: Boolean,
             default: false
@@ -110,19 +105,14 @@ export default {
             return this.ariaDescription ? this.uid : null;
         },
 
-        linkAttributes () {
-            return {
-                ...this.$attrs,
-                ...(this.isRouterLink ? {
-                    to: this.href
-                } : {
-                    href: this.href
-                })
-            };
-        },
-
         linkType () {
-            return this.isRouterLink ? 'router-link' : 'a';
+            if (this.$attrs.href) {
+                return 'a';
+            }
+            if (this.$attrs.to) {
+                return 'router-link';
+            }
+            return 'a';
         }
     }
 };

--- a/packages/components/atoms/f-link/src/components/_tests/Link.test.js
+++ b/packages/components/atoms/f-link/src/components/_tests/Link.test.js
@@ -15,9 +15,7 @@ const mocks = {
 describe('Link', () => {
     it('should be defined', () => {
         // Arrange
-        const propsData = {
-            href: '/'
-        };
+        const propsData = {};
 
         // Act
         const wrapper = shallowMount(VLink, {
@@ -28,14 +26,73 @@ describe('Link', () => {
         expect(wrapper.exists()).toBe(true);
     });
 
+    it('should render a router link when given the `to` attribute', () => {
+        // Arrange
+        const propsData = {
+            to: '/'
+        };
+
+        // Act
+        const wrapper = shallowMount(VLink, {
+            propsData,
+            mocks,
+            stubs: {
+                RouterLink: RouterLinkStub
+            }
+        });
+
+        const routerLink = wrapper.findComponent(RouterLinkStub);
+
+        // Assert
+        expect(routerLink.exists()).toBe(true);
+    });
+
+    it('should render an anchor tag when given the `href` attribute', () => {
+        // Arrange
+        const propsData = {
+            href: '/'
+        };
+
+        // Act
+        const wrapper = shallowMount(VLink, {
+            propsData,
+            mocks
+        });
+
+        const link = wrapper.find('[data-test-id="link-component"]');
+        const routerLink = wrapper.findComponent(RouterLinkStub);
+
+        // Assert
+        expect(link.element.tagName).toBe('A');
+        expect(routerLink.exists()).toBe(false);
+    });
+
+    it('should render an anchor tag when given both the `href` and `to` attributes', () => {
+        // Arrange
+        const propsData = {
+            href: '/',
+            to: '/'
+        };
+
+        // Act
+        const wrapper = shallowMount(VLink, {
+            propsData,
+            mocks
+        });
+
+        const link = wrapper.find('[data-test-id="link-component"]');
+        const routerLink = wrapper.findComponent(RouterLinkStub);
+
+        // Assert
+        expect(link.element.tagName).toBe('A');
+        expect(routerLink.exists()).toBe(false);
+    });
+
     describe('props :: ', () => {
         describe('isBold :: ', () => {
             it('should apply `o-link--bold` class to link if true', () => {
                 // Arrange
-                const propsData = {
-                    href: '/',
-                    isBold: true
-                };
+                const propsData = { isBold: true };
 
                 // Act
                 const wrapper = shallowMount(VLink, {
@@ -53,10 +110,7 @@ describe('Link', () => {
         describe('hasTextDecoration :: ', () => {
             it('should apply `o-link--noDecoration` class to link if false', () => {
                 // Arrange
-                const propsData = {
-                    hasTextDecoration: false,
-                    href: '/'
-                };
+                const propsData = { hasTextDecoration: false };
 
                 // Act
                 const wrapper = shallowMount(VLink, {
@@ -74,10 +128,7 @@ describe('Link', () => {
         describe('isFullWidth :: ', () => {
             it('should apply `o-link--full` class to link if true', () => {
                 // Arrange
-                const propsData = {
-                    href: '/',
-                    isFullWidth: true
-                };
+                const propsData = { isFullWidth: true };
 
                 // Act
                 const wrapper = shallowMount(VLink, {
@@ -95,10 +146,7 @@ describe('Link', () => {
         describe('noLineBreak :: ', () => {
             it('should apply `o-link--noBreak` class to link if true', () => {
                 // Arrange
-                const propsData = {
-                    href: '/',
-                    noLineBreak: true
-                };
+                const propsData = { noLineBreak: true };
 
                 // Act
                 const wrapper = shallowMount(VLink, {
@@ -110,51 +158,6 @@ describe('Link', () => {
 
                 // Assert
                 expect(link.attributes('class')).toContain('o-link--noBreak');
-            });
-        });
-
-        describe('isRouterLink ::', () => {
-            it('should render a router link when true', () => {
-                // Arrange
-                const propsData = {
-                    href: '/',
-                    isRouterLink: true
-                };
-
-                // Act
-                const wrapper = shallowMount(VLink, {
-                    propsData,
-                    mocks,
-                    stubs: {
-                        RouterLink: RouterLinkStub
-                    }
-                });
-
-                const routerLink = wrapper.findComponent(RouterLinkStub);
-
-                // Assert
-                expect(routerLink.exists()).toBe(true);
-            });
-
-            it('should render an anchor tag when false', () => {
-                // Arrange
-                const propsData = {
-                    href: '/',
-                    isRouterLink: false
-                };
-
-                // Act
-                const wrapper = shallowMount(VLink, {
-                    propsData,
-                    mocks
-                });
-
-                const link = wrapper.find('[data-test-id="link-component"]');
-                const routerLink = wrapper.findComponent(RouterLinkStub);
-
-                // Assert
-                expect(link.element.tagName).toBe('A');
-                expect(routerLink.exists()).toBe(false);
             });
         });
     });
@@ -172,7 +175,6 @@ describe('Link', () => {
                 ])('should return `%s` when `isExternalSite` is %s', (expected, isExternalSite) => {
                     // Arrange
                     const propsData = {
-                        href: '/',
                         isExternalSite,
                         target: '_blank'
                     };
@@ -193,10 +195,7 @@ describe('Link', () => {
                     [externalLinkMessage, true]
                 ])('should return `%s` when `isExternalSite` is %s', (expected, isExternalSite) => {
                     // Arrange
-                    const propsData = {
-                        href: '/',
-                        isExternalSite
-                    };
+                    const propsData = { isExternalSite };
 
                     // Act
                     const wrapper = shallowMount(VLink, {

--- a/packages/components/atoms/f-link/stories/Link.stories.js
+++ b/packages/components/atoms/f-link/stories/Link.stories.js
@@ -1,4 +1,4 @@
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
 import VLink from '../src/components/Link.vue';
 
@@ -15,6 +15,14 @@ export const VLinkComponent = () => ({
         };
     },
     props: {
+        href: {
+            default: text('Anchor link path', '/')
+        },
+
+        to: {
+            default: text('Router link path (href must be empty for this to be applied)', '')
+        },
+
         isRouterLink: {
             default: boolean('Is a router link?', false)
         },
@@ -55,7 +63,9 @@ export const VLinkComponent = () => ({
 
     template: `<v-link
                     :data-test-id="dataTestId"
-                    href="/"
+                    v-bind="{
+                        ...(href ? { href } : to ? { to } : {})
+                    }"
                     :is-router-link="isRouterLink"
                     :is-bold="isBold"
                     :has-text-decoration="hasTextDecoration"


### PR DESCRIPTION
### Removed
- `isRouterLink` and `href` props, in favour of deferring to `$attrs`.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
