### PR TITLE
f-restaurant-card@v0.5.0 - tidy up component base

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.5.0
+------------------------------
+*October 28, 2021*
+
+### Added
+- Basic dish item styling
+### Updated
+- Broke down parts of card into subcomponents
+- Add hover styling to card title
+- Remove some placeholder text
+- Move logo out of image container for potential fallback options in future
+
 v0.4.0
 ------------------------------
 *October 25, 2021*

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -177,10 +177,14 @@ export default {
   }
 }
 
-.c-restaurantCard:hover {
-    .c-restaurantCard-name {
-        text-decoration: underline;
-    }
+.c-restaurantCard {
+...
+
+  &:hover {
+      .c-restaurantCard-name {
+          text-decoration: underline;
+      }
+  }
 }
 
 .c-restaurantCard-img {

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -10,20 +10,16 @@
         @click="$emit('restaurant-card-clicked')">
 
         <!-- background image -->
-        <div
+        <restaurant-image
+            v-if="!!imgUrl"
             :class="[$style['c-restaurantCard-img']]"
-            :style="`background-image: url(${imgUrl});`"
-            role="img" />
+            :img-url="imgUrl" />
+
         <!-- Logo image -->
-        <img
+        <restaurant-logo
             v-if="!!logoUrl"
-            :src="logoUrl"
-            alt=""
-            width="50"
-            height="50"
-            loading="lazy"
             :class="$style['c-restaurantCard-logo']"
-            data-test-id="restaurant_logo">
+            :logo-url="logoUrl" />
 
         <!-- primary content -->
         <div :class="$style['c-restaurantCard-content']">
@@ -113,9 +109,15 @@
 
 <script>
 import ErrorBoundaryMixin from '../assets/vue/mixins/errorBoundary.mixin';
+import RestaurantImage from './RestaurantImage.vue';
+import RestaurantLogo from './RestaurantLogo.vue';
 
 export default {
     name: 'RestaurantCardV1',
+    components: {
+        RestaurantImage,
+        RestaurantLogo
+    },
     mixins: [ErrorBoundaryMixin],
     // NOTE: These are merely some placeholder props and not indicative of the props we will end up using
     props: {
@@ -157,10 +159,6 @@ export default {
 </script>
 
 <style lang="scss" module>
-$img-borderRadius                         : $radius-rounded-c;
-$logo-borderRadius                        : $radius-rounded-b;
-$logo-borderColor                         : $color-border-default;
-
 .c-restaurantCard {
   text-decoration: none;
   display: grid;
@@ -177,19 +175,21 @@ $logo-borderColor                         : $color-border-default;
 }
 
 .c-restaurantCard-img {
-  background-size: cover;
-  background-position: center;
   width: 100%;
   height: 200px; // TODO: agree with design
-  border-radius: $img-borderRadius;
 
   .c-restaurantCard--listItem & {
       @include media('>mid') {
         min-height: 125px; // TODO: agree with design
         height: 100%;
-        grid-column: 1/2;
       }
   }
+}
+
+.c-restaurantCard-logo {
+  top: spacing(x2);
+  left: spacing(x2);
+  position: absolute;
 }
 
 .c-restaurantCard-content {
@@ -199,14 +199,6 @@ $logo-borderColor                         : $color-border-default;
       grid-column: 2/3;
     }
   }
-}
-
-.c-restaurantCard-logo {
-  border: 1px solid $logo-borderColor;
-  border-radius: $logo-borderRadius;
-  top: spacing(x2);
-  left: spacing(x2);
-  position: absolute;
 }
 
 // placeholder styles - will be extracted to subcomponent

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -25,6 +25,7 @@
         <div :class="$style['c-restaurantCard-content']">
             <!-- Restaurant Name -->
             <h3
+                :class="$style['c-restaurantCard-name']"
                 data-test-id="restaurant_name"
                 data-search-name>
                 {{ name }}
@@ -174,6 +175,12 @@ export default {
         grid-template-columns: minmax(150px, 20%) 1fr;
       }
   }
+}
+
+.c-restaurantCard:hover {
+    .c-restaurantCard-name {
+        text-decoration: underline;
+    }
 }
 
 .c-restaurantCard-img {

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -11,7 +11,7 @@
 
         <!-- background image -->
         <restaurant-image
-            v-if="!!imgUrl"
+            v-if="imgUrl"
             :class="[$style['c-restaurantCard-img']]"
             :img-url="imgUrl" />
 

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -13,19 +13,17 @@
         <div
             :class="[$style['c-restaurantCard-img']]"
             :style="`background-image: url(${imgUrl});`"
-            role="img">
-
-            <!-- Logo image -->
-            <img
-                v-if="!!logoUrl"
-                :src="logoUrl"
-                alt=""
-                width="50"
-                height="50"
-                loading="lazy"
-                :class="$style['c-restaurantCard-logo']"
-                data-test-id="restaurant_logo">
-        </div>
+            role="img" />
+        <!-- Logo image -->
+        <img
+            v-if="!!logoUrl"
+            :src="logoUrl"
+            alt=""
+            width="50"
+            height="50"
+            loading="lazy"
+            :class="$style['c-restaurantCard-logo']"
+            data-test-id="restaurant_logo">
 
         <!-- primary content -->
         <div :class="$style['c-restaurantCard-content']">
@@ -168,6 +166,7 @@ $logo-borderColor                         : $color-border-default;
   display: grid;
   grid-gap: spacing(x2);
   grid-template-columns: 1fr;
+  position: relative;
 
   &.c-restaurantCard--listItem {
       @include media('>mid') {
@@ -183,7 +182,6 @@ $logo-borderColor                         : $color-border-default;
   width: 100%;
   height: 200px; // TODO: agree with design
   border-radius: $img-borderRadius;
-  position: relative;
 
   .c-restaurantCard--listItem & {
       @include media('>mid') {

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -17,7 +17,7 @@
 
         <!-- Logo image -->
         <restaurant-logo
-            v-if="!!logoUrl"
+            v-if="logoUrl"
             :class="$style['c-restaurantCard-logo']"
             :logo-url="logoUrl" />
 
@@ -175,10 +175,6 @@ export default {
         grid-template-columns: minmax(150px, 20%) 1fr;
       }
   }
-}
-
-.c-restaurantCard {
-...
 
   &:hover {
       .c-restaurantCard-name {

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -33,14 +33,8 @@
             <h3
                 data-test-id="restaurant_name"
                 data-search-name>
-                Fake Restaurant
+                {{ name }}
             </h3>
-
-            <!-- stress test the content size -->
-            <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                Eius mollitia distinctio magni enim neque, labore repellat
-                quaerat quam magnam, sint vel, officiis nam voluptas hic.
-                Assumenda illum repudiandae libero impedit?</p>
 
             <!-- Cuisines -->
             <!-- START ERROR BOUNDARY -->
@@ -113,7 +107,9 @@
         </div>
 
         <!-- optional items -->
-        <span :class="[$style['c-restaurantCard-dish']]">DISH RESULT</span>
+        <span
+            v-if="!disabled"
+            :class="[$style['c-restaurantCard-dish']]">DISH RESULT</span>
     </a>
 </template>
 

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -101,9 +101,9 @@
         </div>
 
         <!-- optional items -->
-        <span
+        <restaurant-dish
             v-if="!disabled"
-            :class="[$style['c-restaurantCard-dish']]">DISH RESULT</span>
+            :class="[$style['c-restaurantCard-dish']]" />
     </a>
 </template>
 
@@ -111,12 +111,14 @@
 import ErrorBoundaryMixin from '../assets/vue/mixins/errorBoundary.mixin';
 import RestaurantImage from './RestaurantImage.vue';
 import RestaurantLogo from './RestaurantLogo.vue';
+import RestaurantDish from './RestaurantDish.vue';
 
 export default {
     name: 'RestaurantCardV1',
     components: {
         RestaurantImage,
-        RestaurantLogo
+        RestaurantLogo,
+        RestaurantDish
     },
     mixins: [ErrorBoundaryMixin],
     // NOTE: These are merely some placeholder props and not indicative of the props we will end up using
@@ -201,13 +203,7 @@ export default {
   }
 }
 
-// placeholder styles - will be extracted to subcomponent
 .c-restaurantCard-dish {
-  background: lightgreen;
-  padding: 1rem;
-  border: 2px dashed green;
-  border-radius: 8px;
-
   .c-restaurantCard--listItem & {
       @include media('>mid') {
         grid-column: 1/3;

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
@@ -1,8 +1,14 @@
 <template>
     <div :class="[$style['c-restaurantCard-dish']]">
-        <span :class="[$style['c-restaurantCard-dishTitle']]">Based on your search</span>
-        <span :class="[$style['c-restaurantCard-dishName']]">Half Chicken Roast Chicken</span>
-        <span :class="[$style['c-restaurantCard-dishPrice']]">£5.99</span>
+        <span :class="[$style['c-restaurantCard-dishTitle']]">
+            Based on your search
+        </span>
+        <span :class="[$style['c-restaurantCard-dishName']]">
+            Sausage And Egg Mcmuffin®
+        </span>
+        <span :class="[$style['c-restaurantCard-dishPrice']]">
+            £2.79
+        </span>
     </div>
 </template>
 

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
@@ -30,8 +30,7 @@ export default {
 }
 
 .c-restaurantCard-dishTitle,
-.c-restaurantCard-dishPrice
-{
+.c-restaurantCard-dishPrice {
     color: #04822c;
     font-size: 14px;
 }

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
@@ -31,8 +31,8 @@ export default {
 
 .c-restaurantCard-dishTitle,
 .c-restaurantCard-dishPrice
- {
-    color: #04822C;
+{
+    color: #04822c;
     font-size: 14px;
 }
 

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
@@ -1,0 +1,37 @@
+<template>
+    <div :class="[$style['c-restaurantCard-dish']]">
+        <span :class="[$style['c-restaurantCard-dishTitle']]">Based on your search</span>
+        <span :class="[$style['c-restaurantCard-dishName']]">Half Chicken Roast Chicken</span>
+        <span :class="[$style['c-restaurantCard-dishPrice']]">£5.99</span>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'RestaurantDish'
+};
+</script>
+
+<style lang="scss" module>
+.c-restaurantCard-dish {
+  background-color: $color-green-10;
+  padding: spacing(x2);
+  border-radius: $radius-rounded-b;
+}
+
+.c-restaurantCard-dishTitle {
+    display: block;
+}
+
+.c-restaurantCard-dishTitle,
+.c-restaurantCard-dishPrice
+ {
+    color: #04822C;
+    font-size: 14px;
+}
+
+.c-restaurantCard-dishName {
+    font-weight: $font-weight-extrabold;
+    padding-right: spacing(x0.5);
+}
+</style>

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
@@ -19,6 +19,8 @@ export default {
 </script>
 
 <style lang="scss" module>
+$dish-fontSize:      $font-body-s-paragraph * 1px;
+
 .c-restaurantCard-dish {
   background-color: $color-green-10;
   padding: spacing(x2);
@@ -32,7 +34,7 @@ export default {
 .c-restaurantCard-dishTitle,
 .c-restaurantCard-dishPrice {
     color: $color-green-60;
-    font-size: 14px;
+    font-size: $dish-fontSize;
 }
 
 .c-restaurantCard-dishName {

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
@@ -19,7 +19,7 @@ export default {
 </script>
 
 <style lang="scss" module>
-$dish-fontSize:      $font-body-s-paragraph * 1px;
+$dish-fontSize: $font-body-s-paragraph * 1px;
 
 .c-restaurantCard-dish {
   background-color: $color-green-10;

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantDish.vue
@@ -31,7 +31,7 @@ export default {
 
 .c-restaurantCard-dishTitle,
 .c-restaurantCard-dishPrice {
-    color: #04822c;
+    color: $color-green-60;
     font-size: 14px;
 }
 

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantImage.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantImage.vue
@@ -18,7 +18,7 @@ export default {
 </script>
 
 <style lang="scss" module>
-$img-borderRadius                         : $radius-rounded-c;
+$img-borderRadius : $radius-rounded-c;
 
 .c-restaurantCard-img {
   background-size: cover;

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantImage.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantImage.vue
@@ -1,0 +1,28 @@
+<template>
+    <div
+        :class="[$style['c-restaurantCard-img']]"
+        :style="`background-image: url(${imgUrl});`"
+        role="img" />
+</template>
+
+<script>
+export default {
+    name: 'RestaurantImage',
+    props: {
+        imgUrl: {
+            type: String,
+            required: true
+        }
+    }
+};
+</script>
+
+<style lang="scss" module>
+$img-borderRadius                         : $radius-rounded-c;
+
+.c-restaurantCard-img {
+  background-size: cover;
+  background-position: center;
+  border-radius: $img-borderRadius;
+}
+</style>

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantLogo.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantLogo.vue
@@ -1,0 +1,32 @@
+<template>
+    <img
+        :src="logoUrl"
+        alt=""
+        width="50"
+        height="50"
+        loading="lazy"
+        :class="$style['c-restaurantCard-logo']"
+        data-test-id="restaurant_logo">
+</template>
+
+<script>
+export default {
+    name: 'RestaurantLogo',
+    props: {
+        logoUrl: {
+            type: String,
+            required: true
+        }
+    }
+};
+</script>
+
+<style lang="scss" module>
+$logo-borderRadius                        : $radius-rounded-b;
+$logo-borderColor                         : $color-border-default;
+
+.c-restaurantCard-logo {
+  border: 1px solid $logo-borderColor;
+  border-radius: $logo-borderRadius;
+}
+</style>

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
@@ -30,7 +30,7 @@ export const RestaurantCardComponent = (args, { argTypes }) => ({
 RestaurantCardComponent.args = {
     data: {
         id: '00000',
-        name: 'Fake Restaurant',
+        name: "McDonald's® - Clapham Junction",
         disabled: false,
         logoUrl: restaurantLogo,
         imgUrl: restaurantImage,


### PR DESCRIPTION
### Added
- Basic dish item styling
### Updated
- Broke down parts of card into subcomponents
- Add hover styling to card title
- Remove some placeholder text
- Move logo out of image container for potential fallback options in future

<img width="863" alt="Screenshot 2021-10-28 at 09 22 15" src="https://user-images.githubusercontent.com/16766185/139216604-1b7129dc-a1f7-4da2-8bcb-9cfd5a6a0acf.png">

<img width="436" alt="Screenshot 2021-10-28 at 09 22 38" src="https://user-images.githubusercontent.com/16766185/139216660-4a40ec62-1b8a-417f-961c-d114918b9053.png">

<img width="839" alt="Screenshot 2021-10-28 at 09 29 57" src="https://user-images.githubusercontent.com/16766185/139217963-11e35125-be5b-4d71-9783-66f0c5b661cf.png">

<img width="393" alt="Screenshot 2021-10-28 at 09 30 21" src="https://user-images.githubusercontent.com/16766185/139218024-aae5d951-f804-43b4-982e-c9468655c85c.png">

## Browsers Tested

- [X] Chrome (latest)
- [ ] Internet Explorer 11
- [X] Mobile IPhone 13 mini, safari

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
