### PR TITLE
f-template-subnav@v0.2.0 - Main layout of components and initial styling (2)

### DIFF
--- a/packages/components/organisms/f-template-subnav/CHANGELOG.md
+++ b/packages/components/organisms/f-template-subnav/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.2.0
+------------------------------
+*October 28, 2021*
+
+### Added
+- f-breadcrumbs, f-navigation-links and styling
+
+
 v0.1.0
 ------------------------------
 *October 26, 2021*

--- a/packages/components/organisms/f-template-subnav/README.md
+++ b/packages/components/organisms/f-template-subnav/README.md
@@ -67,12 +67,69 @@ export default {
 
 ### Props
 
-There may be props that allow you to customise its functionality.
+This component requires data that it needs to pass on to embedded components. This can be done using the following props:
 
-The props that can be defined are as follows (if any):
+| Prop  | Type  | Default | Required | Description |
+| ----- | ----- | ------- | ----- | ----------- |
+| breadcrumbs-links | array | [ ] | No (*but expected*) | An array of links objects (_see example #1 below_) |
+| navigation-links | array | [ ] | No (*but expected*) | An array of links objects (_see example #2 below_) |
 
-| Prop  | Type  | Default | Description |
-| ----- | ----- | ------- | ----------- |
+Example #1
+```js
+[
+  {
+    id: 'accountNavLinkInfo'  // Test Data Id
+    url: '/account/info',     // Url
+    name: 'Your account',     // Text Label
+    selected: false
+  },
+  {
+    id: 'accountNavLinkOrderHistory',
+    url: '/order-history',
+    name: 'Your orders',
+    selected: true            // True indicates the currently selected item
+  }
+]
+```
+Example #2
+```js
+[
+  {
+    // Start of breadcrumb
+    name: 'Link 1',
+    url: '/link/1',
+    routerLink: false
+  },
+  {
+    name: 'Link 2',
+    url: '/link/2',
+    routerLink: true
+  },
+  {
+    // End of (Current Active Page) breadcrumb
+    name: 'Link 2'
+  }
+];
+```
+### Slots
+
+This component has a space (main body) for a dynamic component to be added at runtime via a slot, see an example below:
+
+```js
+  <template-sub-nav
+      :breadcrumb-links="breadcrumbLinks"
+      :navigation-links="navigationLinks">
+```
+The Slot component is then added here:
+```
+      <contact-preferences
+          :auth-token="authToken"
+          :locale="locale"
+          :smart-gateway-base-url="settings.smartGatewayBaseUrl" />
+```
+```js
+  </template-sub-nav>
+```
 
 ## Development
 
@@ -100,6 +157,8 @@ To test only `f-template-subnav`, run from the `./fozzie-components/packages/com
 ```sh
 yarn test
 ```
-## Documentation to be completed once module is in stable state.
+### Component and Accessibility Tests
+
+As this component holds no, or very little, logic it only needs visual testing which will be the responsibility of the consuming component.
 
 

--- a/packages/components/organisms/f-template-subnav/package.json
+++ b/packages/components/organisms/f-template-subnav/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-template-subnav",
   "description": "Fozzie Template Sub Nav - SPA template with breadcrumb, lefthand navigation and centre slot",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/f-template-subnav.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [
@@ -42,6 +42,8 @@
     "@justeat/browserslist-config-fozzie": ">=1.2.0"
   },
   "devDependencies": {
+    "@justeat/f-breadcrumbs": "3.1.0",
+    "@justeat/f-navigation-links": "0.2.0",
     "@justeat/f-wdio-utils": "0.3.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-template-subnav/src/components/TemplateSubNav.vue
+++ b/packages/components/organisms/f-template-subnav/src/components/TemplateSubNav.vue
@@ -1,27 +1,102 @@
 <template>
     <div
-        :class="$style['c-templateSubNav']"
         data-test-id="templateSubNav">
-        I am a TemplateSubNav Component (GB)
+        <div
+            :class="$style['c-breadcrumb-container']">
+            <bread-crumbs
+                :links="breadcrumbLinks" />
+        </div>
+
+        <div
+            :class="$style['c-main-container']">
+            <div
+                :class="$style['c-navigation']">
+                <navigation-links
+                    :links="navigationLinks" />
+            </div>
+
+            <div
+                :class="$style['c-account-page']">
+                <slot />
+            </div>
+        </div>
     </div>
 </template>
 
 <script>
+import BreadCrumbs from '@justeat/f-breadcrumbs';
+import NavigationLinks from '@justeat/f-navigation-links';
+import '@justeat/f-breadcrumbs/dist/f-breadcrumbs.css';
+import '@justeat/f-navigation-links/dist/f-navigation-links.css';
+
 export default {
-    components: { },
-    props: { }
+    name: 'TemplateSubNav',
+
+    components: {
+        BreadCrumbs,
+        NavigationLinks
+    },
+
+    props: {
+        breadcrumbLinks: {
+            type: Array,
+            default: () => []
+        },
+        navigationLinks: {
+            type: Array,
+            default: () => []
+        }
+    }
 };
 </script>
 
 <style lang="scss" module>
-.c-templateSubNav {
+
+.c-breadcrumb-container {
+    padding-top: 10px;
+    padding-bottom: 1px;
+}
+
+.c-main-container {
     display: flex;
-    justify-content: center;
-    min-height: 80vh;
-    width: 80vw;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding-top: spacing(x5);
+    padding-bottom: spacing(x5);
+}
+
+.c-breadcrumb-container,
+.c-main-container {
     margin: auto;
-    border: 1px solid $color-red;
-    font-family: $font-family-base;
-    @include font-size(heading-m);
+    max-width: #{$layout-max-width}px;
+    padding-left: #{$layout-margin}px;
+    padding-right: #{$layout-margin}px;
+
+    @include media('<wide') {
+        padding-left: #{$layout-margin--mid}px;
+        padding-right: #{$layout-margin--mid}px;
+    }
+
+    @include media('<narrow') {
+        padding-left: #{$layout-margin--narrow}px;
+        padding-right: #{$layout-margin--narrow}px;
+    }
+}
+
+.c-navigation {
+    flex-basis: 15rem;
+    flex-grow: 1;
+}
+
+.c-navigation,
+.c-breadcrumb-container {
+    @include media('<mid') {
+        display: none;
+    }
+}
+
+.c-account-page {
+    flex-basis: 0;
+    flex-grow: 999;
 }
 </style>

--- a/packages/components/organisms/f-template-subnav/stories/TemplateSubNav.stories.js
+++ b/packages/components/organisms/f-template-subnav/stories/TemplateSubNav.stories.js
@@ -6,10 +6,80 @@ export default {
     decorators: [withA11y]
 };
 
-export const TemplateSubNavComponent = () => ({
+export const TemplateSubNavComponent = (args, { argTypes }) => ({
     components: { TemplateSubNav },
-    props: {},
-    template: '<template-subnav v-bind="$props" />'
+    props: Object.keys(argTypes),
+    template: `<template-sub-nav
+                    v-bind='$props'>
+                    <div
+                        :style="{'text-align':'center',
+                                'border-radius': '12px',
+                                'height': '500px',
+                                'background-color': '#d3d3ff'}">
+                        Dynamic Page goes here via a 'Slot'
+                    </div>
+               </template-sub-nav>`
 });
 
 TemplateSubNavComponent.storyName = 'f-template-subnav';
+
+/**
+ * Arguments without specified controls
+ * @type {{routerLinks: boolean}}
+ */
+TemplateSubNavComponent.args = {
+    navigationLinks: [
+        {
+            id: 'link1',
+            url: '/account/info',
+            name: 'Your account',
+            selected: false
+        },
+        {
+            id: 'link2',
+            url: '/order-history',
+            name: 'Your orders',
+            selected: false
+        },
+        {
+            id: 'link3',
+            url: '/account/paymentoptions',
+            name: 'Your saved cards',
+            selected: false
+        },
+        {
+            id: 'link4',
+            url: '/member/addressbook',
+            name: 'Your address book',
+            selected: false
+        },
+        {
+            id: 'link5',
+            url: '/account/credit',
+            name: 'Redeem a voucher',
+            selected: false
+        },
+        {
+            id: 'link6',
+            url: '/giftcards/redeem',
+            name: 'Redeem a gift card',
+            selected: false
+        },
+        {
+            id: 'link7',
+            url: '/account/preferences',
+            name: 'Contact preferences',
+            selected: true
+        }
+    ],
+    breadcrumbLinks: [
+        {
+            name: 'Home',
+            url: '/',
+            routerLink: false
+        },
+        {
+            name: 'Contact Preferences'
+        }
+    ]
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2123,13 +2123,6 @@
     eslint-config-airbnb-base "14.1.0"
     eslint-plugin-vue "6.2.2"
 
-"@justeat/f-breadcrumbs@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-breadcrumbs/-/f-breadcrumbs-2.0.0.tgz#805f357170869a9401e8f1bf3dcd6868ed86f20d"
-  integrity sha512-1qP3mMmON9xpyuiK89yXZ+FzTZ9L/6TmKvAvJjWCwyzGz56MnwFfb4bBI/1N4K16jSsXc4dIQvFJSfuMURIztQ==
-  dependencies:
-    "@justeat/f-services" "1.0.0"
-
 "@justeat/f-button@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-3.0.2.tgz#9560d0caf56ae0801208ddd0c27cb50d670d54a8"


### PR DESCRIPTION
### Added
- f-breadcrumbs, f-navigation-links and styling

___

Example of the generic layout:

![image](https://user-images.githubusercontent.com/1353060/139302769-c008b971-447a-4f70-aa4d-0b4598b58bd4.png)

___

Example of it in use:

Desktop
![image](https://user-images.githubusercontent.com/1353060/139275282-94c9bc68-7a59-4ba5-a539-d0970ef2213e.png)

Mobile
![image](https://user-images.githubusercontent.com/1353060/139275518-bbf6ace7-418e-4a68-b9fa-e087025efff0.png)
