### PR TITLE
global - adding customized local indentname to solve our css bleed issues

### DIFF
--- a/packages/components/atoms/f-button/vue.config.js
+++ b/packages/components/atoms/f-button/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/atoms/f-card/vue.config.js
+++ b/packages/components/atoms/f-card/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/atoms/f-error-message/vue.config.js
+++ b/packages/components/atoms/f-error-message/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/atoms/f-form-field/vue.config.js
+++ b/packages/components/atoms/f-form-field/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/atoms/f-link/vue.config.js
+++ b/packages/components/atoms/f-link/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/atoms/f-popover/vue.config.js
+++ b/packages/components/atoms/f-popover/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/atoms/f-spinner/vue.config.js
+++ b/packages/components/atoms/f-spinner/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/molecules/f-alert/vue.config.js
+++ b/packages/components/molecules/f-alert/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/molecules/f-breadcrumbs/vue.config.js
+++ b/packages/components/molecules/f-breadcrumbs/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/molecules/f-media-element/vue.config.js
+++ b/packages/components/molecules/f-media-element/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/molecules/f-mega-modal/vue.config.js
+++ b/packages/components/molecules/f-mega-modal/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/molecules/f-navigation-links/vue.config.js
+++ b/packages/components/molecules/f-navigation-links/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/molecules/f-promotions-showcase/vue.config.js
+++ b/packages/components/molecules/f-promotions-showcase/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/molecules/f-restaurant-card/vue.config.js
+++ b/packages/components/molecules/f-restaurant-card/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/molecules/f-searchbox/vue.config.js
+++ b/packages/components/molecules/f-searchbox/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/molecules/f-skeleton-loader/vue.config.js
+++ b/packages/components/molecules/f-skeleton-loader/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/molecules/f-tabs/vue.config.js
+++ b/packages/components/molecules/f-tabs/vue.config.js
@@ -1,10 +1,22 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/packages/components/molecules/f-user-message/vue.config.js
+++ b/packages/components/molecules/f-user-message/vue.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const packageJson = require('./package.json');
 
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
@@ -6,6 +7,17 @@ const devServer = require('./vue.config.devServer');
 
 // vue.config.js
 module.exports = {
+    css: {
+        requireModuleExtension: false,
+        loaderOptions: {
+            css: {
+                modules: {
+                    localIdentName: `[name]__${packageJson.version}--[hash:base64:7]`
+                },
+                localsConvention: 'camelCaseOnly'
+            }
+        }
+    },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')


### PR DESCRIPTION
I have been experiencing issues with our css bleeds and after speaking with @dandel10n I had an idea as to why this was causing us issues. 

The problem lies in how css modules is setting class names, the hash used in the class name is consistent across builds of a component, so when two version exist together i.e registration page pulls latest f-button but checkout pulls an older version the css class names are identical when css modules spits them out. 

This would normally not be an issue for general use cases with css modules, but with our use case this causes an issue where the two versions of styles compete. To solve this (with some inspiration from @benwhite-deltas I have changed the outputted class names to include the package json version number. this will enable to version of button to be used within coreweb or storybook at the same time. 

I will open as draft for now as this will involve updating all components to fix this. if we agree that the webpack change that applies to all would not need changing on a case by case basis then I will create a global config file to avoid repetition.
