### PR TITLE
f-cookie-banner@3.5.1 - Ensure Observer exists before calling disconnect

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -8,7 +8,7 @@ v3.5.1
 *October 29, 2021*
 
 ### Fixed
-- ResizeObserver disconnect not called when legacy mode or shouldAbsolutePositionReopenLink = false.
+- Ensure ResizeObserver disconnect is only called when bodyObserver exists
 
 
 v3.5.0

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.5.1
+------------------------------
+*October 29, 2021*
+
+### Fixed
+- ResizeObserver disconnect not called when legacy mode or shouldAbsolutePositionReopenLink = false.
+
 
 v3.5.0
 ------------------------------
@@ -10,8 +17,6 @@ v3.5.0
 
 ### Changed
 - Specified cookie banner text font size to be 14px as default paragraph font size now is 16px.
-- Cookie policy link to use f-link.
-- Increased max bundle size from 30 to 40kB.
 
 
 v3.4.0

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -17,6 +17,8 @@ v3.5.0
 
 ### Changed
 - Specified cookie banner text font size to be 14px as default paragraph font size now is 16px.
+- Cookie policy link to use f-link.
+- Increased max bundle size from 30 to 40kB.
 
 
 v3.4.0

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -209,8 +209,9 @@ export default {
     },
 
     destroyed () {
-        if (typeof window === 'object' && typeof this.bodyObserver.disconnect === 'function') {
-            this.bodyObserver.disconnect();
+        if (typeof window === 'object') {
+            // eslint-disable-next-line no-unused-expressions
+            this.bodyObserver?.disconnect();
         }
     },
 

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -209,7 +209,7 @@ export default {
     },
 
     destroyed () {
-        if (typeof ResizeObserver === 'function') {
+        if (typeof window === 'object' && typeof this.bodyObserver.disconnect === 'function') {
             this.bodyObserver.disconnect();
         }
     },

--- a/packages/components/organisms/f-cookie-banner/src/components/_tests/CookieBanner.test.js
+++ b/packages/components/organisms/f-cookie-banner/src/components/_tests/CookieBanner.test.js
@@ -113,6 +113,37 @@ describe('CookieBanner', () => {
                     expect(wrapper.vm.bodyObserver.observe).toHaveBeenCalledWith(mockBodyHTMLHtmlElement);
                 });
 
+                it('should not create ResizeObserver when legacy shouldShowLegacyBanner = true', () => {
+                    // Arrange
+                    const propsData = { shouldShowLegacyBanner: true };
+
+                    // Act
+                    const wrapper = shallowMount(CookieBanner, {
+                        localVue,
+                        i18n,
+                        propsData
+                    });
+
+                    // Assert
+                    expect(wrapper.vm.bodyObserver).toBeUndefined();
+                });
+
+
+                it('should not create ResizeObserver when legacy shouldAbsolutePositionReopenLink = false', () => {
+                    // Arrange
+                    const propsData = { shouldShowLegacyBanner: true };
+
+                    // Act
+                    const wrapper = shallowMount(CookieBanner, {
+                        localVue,
+                        i18n,
+                        propsData
+                    });
+
+                    // Assert
+                    expect(wrapper.vm.bodyObserver).toBeUndefined();
+                });
+
                 it('should update data.bodyHeight with the contentRect.height when observe is triggered', async () => {
                     // Arrange
                     const propsData = {};


### PR DESCRIPTION
### Fixed

- Ensure ResizeObserver disconnect is only called when bodyObserver exists