### PR TITLE
f-offers@v1.4.0 -  upgrading f-button and adjusting top margin

### DIFF
--- a/packages/components/organisms/f-offers/CHANGELOG.md
+++ b/packages/components/organisms/f-offers/CHANGELOG.md
@@ -4,9 +4,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (to be added to next release)
+v1.4.0
 ------------------------------
-*October 13, 2021*
+*November 01, 2021*
 
 ### Changed
 - Updated version of `f-button`.

--- a/packages/components/organisms/f-offers/package.json
+++ b/packages/components/organisms/f-offers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-offers",
   "description": "Fozzie Offers - displays offers to the customers",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "dist/f-offers.umd.min.js",
   "maxBundleSize": "140kB",
   "files": [
@@ -57,7 +57,7 @@
     "@justeat/f-content-cards": "6.0.0-beta.2",
     "@justeat/f-button": "3.0.2",
     "@justeat/f-media-element": "2.0.0",
-    "@justeat/f-searchbox": "6.0.0",
+    "@justeat/f-searchbox": "6.3.0",
     "@justeat/f-trak": "0.7.1",
     "@justeat/f-mega-modal": "3.0.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",

--- a/packages/components/organisms/f-offers/src/components/Offers.vue
+++ b/packages/components/organisms/f-offers/src/components/Offers.vue
@@ -105,6 +105,7 @@ export default {
     justify-content: center;
     width: 100%;
     margin: auto;
+    margin-top: -15px;
     background-color: $color-grey-10;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,6 +2185,15 @@
     lodash.debounce "4.0.8"
     mitt "3.0.0"
 
+"@justeat/f-searchbox@6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-searchbox/-/f-searchbox-6.3.0.tgz#927a567ad0f34ac19a83a8cad90003c0db68040e"
+  integrity sha512-ac59+8MBa4i5iXDoqbU5rOUSqkvahU6yLlBGBVL0ttaUyPdDe69Hw52A9BdTFKuYkgG0esI6GQajfAToK9t90A==
+  dependencies:
+    caniuse-lite "1.0.30001251"
+    lodash.debounce "4.0.8"
+    mitt "3.0.0"
+
 "@justeat/f-services@0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.13.0.tgz#b0fc67948e94800ba176addb9d92cce444d28c8e"


### PR DESCRIPTION
Upgrades the f-button package and adds a temp top margin to the page to account for curves on the header until a better option can be sorted out.
