### PR TITLE
#trivial - f-template-subnav - Exported some test selector files

### DIFF
--- a/packages/components/organisms/f-template-subnav/package.json
+++ b/packages/components/organisms/f-template-subnav/package.json
@@ -5,7 +5,8 @@
   "main": "dist/f-template-subnav.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [
-    "dist"
+    "dist",
+    "test-utils"
   ],
   "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/components/organisms/f-template-subnav",
   "contributors": [

--- a/packages/components/organisms/f-template-subnav/test-utils/component-objects/README.md
+++ b/packages/components/organisms/f-template-subnav/test-utils/component-objects/README.md
@@ -1,0 +1,13 @@
+# What is a component object?
+A component object is a file that is used to define the UI selectors / functionality of a component that is then utilised by WebDriverIO for browser-based automation testing.
+
+# Usage
+Please add a component object if this component is interacted with as part of browser-based automation tests. This can be done either by:
+- Component tests for this component.
+In this scenario, the component object should be imported into the WebDriverIO spec file.
+
+- Component tests for a parent component.
+In this scenario, the component object should be imported into the parent component object.
+
+- System tests as part of a consuming application.
+In this scenario, the `test-utils` folder needs to be added to the `files` section within `package.json` so that it can be imported by the consuming application.

--- a/packages/components/organisms/f-template-subnav/test-utils/component-objects/f-template-subnav-selectors.js
+++ b/packages/components/organisms/f-template-subnav/test-utils/component-objects/f-template-subnav-selectors.js
@@ -1,0 +1,5 @@
+const COMPONENT = '[data-test-id="templateSubNav"]';
+
+export default {
+    COMPONENT
+};

--- a/packages/components/organisms/f-template-subnav/test-utils/component-objects/f-template-subnav-selectors.js
+++ b/packages/components/organisms/f-template-subnav/test-utils/component-objects/f-template-subnav-selectors.js
@@ -1,5 +1,0 @@
-const COMPONENT = '[data-test-id="templateSubNav"]';
-
-export default {
-    COMPONENT
-};

--- a/packages/components/organisms/f-template-subnav/test-utils/component-objects/f-template-subnav.component.js
+++ b/packages/components/organisms/f-template-subnav/test-utils/component-objects/f-template-subnav.component.js
@@ -1,0 +1,22 @@
+/* eslint-disable class-methods-use-this */
+const Page = require('@justeat/f-wdio-utils/src/page.object');
+const { COMPONENT } = require('./f-template-subnav-selectors');
+
+module.exports = class TemplateSubNav extends Page {
+    constructor () {
+        super('organisms', 'template-subnav-component');
+    }
+
+    get component () {
+        // eslint-disable-next-line no-undef
+        return $(COMPONENT);
+    }
+
+    waitForComponent () {
+        super.waitForComponent(this.component);
+    }
+
+    isComponentDisplayed () {
+        return this.component.isDisplayed();
+    }
+};

--- a/packages/components/organisms/f-template-subnav/test-utils/component-objects/f-template-subnav.component.js
+++ b/packages/components/organisms/f-template-subnav/test-utils/component-objects/f-template-subnav.component.js
@@ -1,6 +1,5 @@
 /* eslint-disable class-methods-use-this */
 const Page = require('@justeat/f-wdio-utils/src/page.object');
-const { COMPONENT } = require('./f-template-subnav-selectors');
 
 module.exports = class TemplateSubNav extends Page {
     constructor () {
@@ -8,8 +7,7 @@ module.exports = class TemplateSubNav extends Page {
     }
 
     get component () {
-        // eslint-disable-next-line no-undef
-        return $(COMPONENT);
+        return $('[data-test-id="templateSubNav"]');
     }
 
     waitForComponent () {


### PR DESCRIPTION
To allow CoreWeb to get a handle on the presented page we need to expose some helper test files.