### PR TITLE
f-template-subnav@v0.2.2 - Bumped f-navigation-links version to 0.2.1

### DIFF
--- a/packages/components/templates/f-template-subnav/CHANGELOG.md
+++ b/packages/components/templates/f-template-subnav/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.2.2
+------------------------------
+*November 3, 2021*
+
+### Changed
+- Bumped f-navigation-links version to 0.2.1
+
+
 v0.2.1
 ------------------------------
 *October 28, 2021*

--- a/packages/components/templates/f-template-subnav/package.json
+++ b/packages/components/templates/f-template-subnav/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-template-subnav",
   "description": "Fozzie Template Sub Nav - SPA template with breadcrumb, lefthand navigation and centre slot",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "dist/f-template-subnav.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@justeat/f-breadcrumbs": "3.1.0",
-    "@justeat/f-navigation-links": "0.2.0",
+    "@justeat/f-navigation-links": "0.2.1",
     "@justeat/f-wdio-utils": "0.3.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",


### PR DESCRIPTION
### Changed
- Bumped f-navigation-links version to 0.2.1