### PR TITLE
storybook@v0.47.0 - Add new log context

### DIFF
--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.47.0
+------------------------------
+*November 03, 2021*
+
+### Added
+- New `log` context item so we can phase out the `logger` one.
+
 
 v0.46.0
 ------------------------------

--- a/packages/storybook/context/index.js
+++ b/packages/storybook/context/index.js
@@ -1,6 +1,7 @@
 import i18nContext from './i18n.context';
 import cookieContext from './cookie.context';
 import loggerContext from './logger.context';
+import logContext from './log.context';
 import dataLayer from './dataLayer.context';
 import httpContext from './http.context';
 import analyticsContext from './analytics.context';
@@ -9,6 +10,7 @@ const initialise = () => {
     i18nContext();
     cookieContext();
     loggerContext();
+    logContext();
     dataLayer();
     httpContext();
     analyticsContext();

--- a/packages/storybook/context/log.context.js
+++ b/packages/storybook/context/log.context.js
@@ -14,7 +14,7 @@ export default () => {
         logPayload.message = message || 'No message provided';
         logPayload.Level = level || 'error';
         logPayload.mode = mode || '';
-        logPayload.tags = tagsArr;
+        logPayload.tags = tagsArr.join(' ');
     };
 
     const log = {

--- a/packages/storybook/context/log.context.js
+++ b/packages/storybook/context/log.context.js
@@ -1,0 +1,37 @@
+import Vue from 'vue';
+
+const LEVEL = {
+    Error: 'Error',
+    Info: 'Info',
+    Warn: 'Warn'
+};
+
+export default () => {
+    const appendStandardProperties = (logPayload, message, level, mode, tags) => {
+        let tagsArr = [];
+        if (tags) { tagsArr = Array.isArray(tags) ? tags : [tags]; }
+
+        logPayload.message = message || 'No message provided';
+        logPayload.Level = level || 'error';
+        logPayload.mode = mode || '';
+        logPayload.tags = tagsArr;
+    };
+
+    const log = {
+        error (message, exception, tags, payload = {}) {
+            appendStandardProperties(payload, message, LEVEL.Error, 'client', tags);
+            console.error(message, payload);
+        },
+        warn (message, tags, payload = {}) {
+            appendStandardProperties(payload, message, LEVEL.Warn, 'client', tags);
+            console.warn(message, payload);
+        },
+        info (message, tags, payload = {}) {
+            appendStandardProperties(payload, message, LEVEL.Info, 'client', tags);
+            console.info(message, payload);
+        }
+    };
+
+    Vue.prototype.$log = log;
+};
+

--- a/packages/storybook/context/log.context.js
+++ b/packages/storybook/context/log.context.js
@@ -14,7 +14,7 @@ export default () => {
         logPayload.message = message || 'No message provided';
         logPayload.Level = level || 'error';
         logPayload.mode = mode || '';
-        logPayload.tags = tagsArr.join(' ');
+        logPayload.tags = tagsArr;
     };
 
     const log = {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/storybook",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",


### PR DESCRIPTION
We are introducing a new log interface, In time we will phase over to this and remove the legacy one. 

#### The new log interface was created to solve a few problems...

1. The previous interface required you to provide the `store` when logging, this was not ideal
2. Because of the step above; many components abstracted the logging behind a `logInvoker` which complicates the code and creates duplication
3. The previous interface did not accept an `exception` object for errors; which means sentry capture is challenging, as if you do not provide an exception; it assumes the error happens in the logger itself
    - We could not simply rely on the existing payload for this; as sometimes javascript errors include sensitive information we don't want to log. Sentry however can santize. 
4. It was not mandatory to tag log messages, which means some messages might not be appropriated to the correct feature / team

The new interface solves all of these problems.

### OLD_INTERFACE
- `this.$logger.logError(message, store, payload)`
- `this.$logger.logWarn(message, store, payload)`
- `this.$logger.logInfo(message, store, payload)`

### NEW_INTERFACE 
> Tag accepts both a string and an array of strings
- `this.$log.error(message, exception, tags, payload)`
- `this.$log.warn(message, tags, payload)`
- `this.$log.info(message, tags, payload)`

<hr>

### EXAMPLE_OLD_USAGE
- Wrapped in a logInvoker abstraction
```
logInvoker({
  message: 'TakeawayPay account linking fetched availability',
  data: availabilityLogData(employeeId),
  logMethod: logger.logInfo,
  store
});
```

### EXAMPLE_NEW_USAGE
- We can delete logInvoker abstractions (there are many of them)
```
log.info(
  'TakeawayPay account linking fetched availability',
  'takeawaypay',
  availabilityLogData(employeeId)
);
```