### PR TITLE
fozzie-components@v5.3.0 – #globalconfig Node engine updated to v12 and lerna config update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v5.3.0
+------------------------------
+*November 9, 2021*
+
+### Added
+- `templates` and `pages` component directories added to lerna config.
+
+### Changed
+- Updated engine from Node v10 > v12 on all packages (as we only test in Node 12+).
+
+
 v5.2.0
 ------------------------------
 *November 5, 2021*

--- a/lerna.json
+++ b/lerna.json
@@ -6,6 +6,8 @@
     "packages/components/atoms/*",
     "packages/components/molecules/*",
     "packages/components/organisms/*",
+    "packages/components/templates/*",
+    "packages/components/pages/*",
     "packages/services/*",
     "packages/tools/*"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build\"",
@@ -98,7 +98,7 @@
     "Github contributors <https://github.com/justeat/fozzie-components/graphs/contributors>"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://github.com/justeat/fozzie-components",
   "keywords": [
@@ -122,6 +122,5 @@
     "packages/services/*",
     "packages/tools/*"
   ],
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-error-message/package.json
+++ b/packages/components/atoms/f-error-message/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-image-tile/package.json
+++ b/packages/components/atoms/f-image-tile/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-link/package.json
+++ b/packages/components/atoms/f-link/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-popover/package.json
+++ b/packages/components/atoms/f-popover/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-spinner/package.json
+++ b/packages/components/atoms/f-spinner/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-breadcrumbs/package.json
+++ b/packages/components/molecules/f-breadcrumbs/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-card-with-content/package.json
+++ b/packages/components/molecules/f-card-with-content/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-media-element/package.json
+++ b/packages/components/molecules/f-media-element/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-navigation-links/package.json
+++ b/packages/components/molecules/f-navigation-links/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-promotions-showcase/package.json
+++ b/packages/components/molecules/f-promotions-showcase/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-skeleton-loader/package.json
+++ b/packages/components/molecules/f-skeleton-loader/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-tabs/package.json
+++ b/packages/components/molecules/f-tabs/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-user-message/package.json
+++ b/packages/components/molecules/f-user-message/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/organisms/f-status-banner/package.json
+++ b/packages/components/organisms/f-status-banner/package.json
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-contact-preferences/package.json
+++ b/packages/components/pages/f-contact-preferences/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-loyalty/package.json
+++ b/packages/components/pages/f-loyalty/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-registration/package.json
+++ b/packages/components/pages/f-registration/package.json
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-takeawaypay-activation/package.json
+++ b/packages/components/pages/f-takeawaypay-activation/package.json
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-analytics/package.json
+++ b/packages/services/f-analytics/package.json
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-braze-adapter/package.json
+++ b/packages/services/f-braze-adapter/package.json
@@ -19,7 +19,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-compatibility/package.json
+++ b/packages/services/f-compatibility/package.json
@@ -7,7 +7,7 @@
   "module": "dist/f-compatibility.es.js",
   "source": "src/index.js",
   "files": [
-    "dist" 
+    "dist"
   ],
   "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/services/f-compatibility",
   "contributors": [
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-consumer-oidc/package.json
+++ b/packages/services/f-consumer-oidc/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-development-context/package.json
+++ b/packages/services/f-development-context/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-feature-management-vue/package.json
+++ b/packages/services/f-feature-management-vue/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-feature-management/package.json
+++ b/packages/services/f-feature-management/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-globalisation/package.json
+++ b/packages/services/f-globalisation/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-http/package.json
+++ b/packages/services/f-http/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-performance/package.json
+++ b/packages/services/f-performance/package.json
@@ -19,7 +19,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-services/package.json
+++ b/packages/services/f-services/package.json
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-statistics/package.json
+++ b/packages/services/f-statistics/package.json
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-test-data-creator/package.json
+++ b/packages/services/f-test-data-creator/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-wdio-utils/package.json
+++ b/packages/services/f-wdio-utils/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -37,7 +37,7 @@
     "Github contributors <https://github.com/justeat/fozzie-components/graphs/contributors>"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/tools/f-vue-icons/package.json
+++ b/packages/tools/f-vue-icons/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"

--- a/packages/tools/generator-component/package.json
+++ b/packages/tools/generator-component/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie",


### PR DESCRIPTION
### Added
- `templates` and `pages` component directories added to lerna config.

### Changed
- Updated engine from Node v10 > v12 on all packages (as we only test in Node 12+).