### PR TITLE
generator-component@v2.4.0 – template and page options added to generator

### DIFF
--- a/packages/tools/generator-component/CHANGELOG.md
+++ b/packages/tools/generator-component/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.4.0
+------------------------------
+*November 10, 2021*
+
+### Added
+- Prompt options for `template` and `page` components.
+
+### Changed
+- Updated minor package dependency versions.
+- `axios` moved to be a devDependency (as should be a peerDependency if required by a component).
+
+
 v2.3.4
 ------------------------------
 *November 5, 2021*

--- a/packages/tools/generator-component/generators/app/prompts.js
+++ b/packages/tools/generator-component/generators/app/prompts.js
@@ -38,8 +38,16 @@ const prompts = [
                 value: 'molecule'
             },
             {
-                name: 'An Organism – A combination of atoms and molecules that make up a larger component e.g. header, checkout',
+                name: 'An Organism – A combination of atoms and molecules that make up a larger component e.g. header, footer',
                 value: 'organism'
+            },
+            {
+                name: 'A Template – a layout component that is intended to handle page level layout decisions e.g. a sideNav layout which positions a set of links next to a block of body content',
+                value: 'template'
+            },
+            {
+                name: 'A Page – A combination of components that makes up a page view e.g. checkout, registration',
+                value: 'page'
             }
         ],
         when: function shouldShowThisQuestion (answers) {
@@ -59,7 +67,7 @@ const prompts = [
         message: 'Does your component require Bundlewatch checks?',
         name: 'needsBundlewatch',
         type: 'confirm',
-        default: true,
+        default: true
     },
     {
         message: "What size limit do you want in place for your bundles (in kB)? e.g. '15'",

--- a/packages/tools/generator-component/generators/app/templates/__package__.json
+++ b/packages/tools/generator-component/generators/app/templates/__package__.json
@@ -23,16 +23,16 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "fozzie"
   ],
   "scripts": {
     "prepublishOnly": "yarn lint && yarn test && yarn build"<% if(config.isComponent) { %>,
-    "build": "vue-cli-service build --target lib --name f-<%= name.default %> ./src/index.js"<% } %><% if(config.isService) { %>,
-    "build": "vite build"<% } %><% if(config.isComponent) { %>,
+    "build": "vue-cli-service build --target lib --name f-<%= name.default %> ./src/index.js",
     "lint": "vue-cli-service lint"<% } else { %>,
+    "build": "vite build",
     "lint": "eslint \"!(dist)/**/*.{js,vue}\""<% } %>,
     "lint:fix": "yarn lint --fix"<% if(config.isComponent) { %>,
     "lint:style": "vue-cli-service lint:style"<% } else { %>,
@@ -45,8 +45,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],<% if(config.isComponent) { %>
   "dependencies": {
-    "@justeat/f-services": "1.7.0"<% if(config.needsTestingApiMocks) { %>,
-    "axios": "0.21.1"<% } %>
+    "@justeat/f-services": "1.7.0"
   },<% } %>
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"
@@ -54,13 +53,15 @@
   "devDependencies": {
 <% if(config.isComponent) { %>    "@justeat/f-wdio-utils": "0.4.0",
     "node-sass-magic-importer": "5.3.2",
-    "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
-    "@vue/cli-plugin-babel": "4.4.6",
+    "@samhammer/vue-cli-plugin-stylelint": "2.1.0",
+    "@vue/cli-plugin-babel": "4.5.15",
     "@vue/cli-plugin-eslint": "3.9.2",
-    "@vue/cli-plugin-unit-jest": "4.4.6",
-    "@vue/test-utils": "1.0.3"<% } else { %>    "vite": "2.6.9",
-    "core-js": "3.6.5",
+    "@vue/cli-plugin-unit-jest": "4.5.15",
+    "@vue/test-utils": "1.2.2"<% } else { %>    "vite": "2.6.13",
+    "core-js": "3.19.1",
     "eslint": "7.32.0",
-    "jest-extended": "0.11.5"<% } %>
+    "jest-extended": "0.11.5"<% } %><% if(config.needsTestingApiMocks) { %>,
+    "axios": "0.24.0"<%
+    } %>
   }
 }

--- a/packages/tools/generator-component/package.json
+++ b/packages/tools/generator-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/generator-component",
   "description": "Generator Component – A generator for Fozzie components",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "files": [
     "generators"
   ],


### PR DESCRIPTION
### Added
- Prompt options for `template` and `page` components.

### Changed
- Updated minor package dependency versions.
- `axios` moved to be a devDependency (as should be a peerDependency if required by a component).