### PR TITLE
f-contact-preferences@v0.5.1 - Added an api provider layer for GET/POST

### DIFF
--- a/packages/components/pages/f-contact-preferences/CHANGELOG.md
+++ b/packages/components/pages/f-contact-preferences/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.5.1
+------------------------------
+*November 11, 2021*
+
+### Added
+- Api provider for getting and saving consumer preferences data.
+
+
 v0.5.0
 ------------------------------
 *November 4, 2021*

--- a/packages/components/pages/f-contact-preferences/package.json
+++ b/packages/components/pages/f-contact-preferences/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-contact-preferences",
   "description": "Fozzie Contact Preferences - Fozzie user contact preferences form component",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "dist/f-contact-preferences.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [

--- a/packages/components/pages/f-contact-preferences/src/constants.js
+++ b/packages/components/pages/f-contact-preferences/src/constants.js
@@ -1,0 +1,11 @@
+export const UPDATE_PREFERENCES = 'updatePreferences';
+export const UPDATE_PREFERENCE = 'updatePreference';
+
+export const STOP_LOADING_SPINNER_EVENT = 'stop-spinner';
+
+export const CONSUMER_PREFERENCES_URL = 'consumer/preferences';
+
+export const CONVERSATION_ID_NAME = 'x-je-conversation';
+
+export const NON_EDITABLE_PREFERENCE_KEYS = ['orderstatus'];
+export const NON_VISIBLE_PREFERENCE_KEYS = ['reviewmeal'];

--- a/packages/components/pages/f-contact-preferences/src/services/providers/_tests/contactPreferences.api.test.js
+++ b/packages/components/pages/f-contact-preferences/src/services/providers/_tests/contactPreferences.api.test.js
@@ -65,14 +65,17 @@ describe('ContactPreferencesApi Provider', () => {
     describe('When creating a new instance', () => {
         it('should not throw error when instance is created with valid parameters', () => {
             // Act
-            const instance = () => new ContactPreferencesApi({
+            const createInstance = () => new ContactPreferencesApi({
                 httpClient: httpMock,
                 cookies: cookiesMock,
                 baseUrl: baseUrlMock
             });
 
             // Assert
-            expect(instance).not.toThrowError();
+            let instance;
+            expect(() => {
+                instance = createInstance();
+            }).not.toThrowError();
             expect(instance).toBeDefined();
         });
     });

--- a/packages/components/pages/f-contact-preferences/src/services/providers/_tests/contactPreferences.api.test.js
+++ b/packages/components/pages/f-contact-preferences/src/services/providers/_tests/contactPreferences.api.test.js
@@ -136,7 +136,7 @@ describe('ContactPreferencesApi Provider', () => {
             const expectedBody = bodyMock;
             const expectedHeaders = {
                 Authorization: `Bearer ${authTokenMock}`,
-                'x-je-conversation': `${conversationId}`
+                'x-je-conversation': conversationId
             };
 
             // Act

--- a/packages/components/pages/f-contact-preferences/src/services/providers/_tests/contactPreferences.api.test.js
+++ b/packages/components/pages/f-contact-preferences/src/services/providers/_tests/contactPreferences.api.test.js
@@ -102,7 +102,7 @@ describe('ContactPreferencesApi Provider', () => {
             const expectedUri = `${baseUrlMock}/consumer/preferences`;
             const expectedHeaders = {
                 Authorization: `Bearer ${authTokenMock}`,
-                'x-je-conversation': `${conversationId}`
+                'x-je-conversation': conversationId
             };
 
             // Act

--- a/packages/components/pages/f-contact-preferences/src/services/providers/_tests/contactPreferences.api.test.js
+++ b/packages/components/pages/f-contact-preferences/src/services/providers/_tests/contactPreferences.api.test.js
@@ -1,0 +1,146 @@
+import ContactPreferencesApi from '../contactPreferences.api';
+
+let apiProvider;
+let httpMock;
+const httpGetSpy = jest.fn();
+const httpPostSpy = jest.fn();
+let cookiesMock;
+const cookiesSetSpy = jest.fn();
+const baseUrlMock = 'https://smartGatewayBaseUrl.com';
+const authTokenMock = 'some-auth-token';
+const conversationId = 'b7386108-95e6-4e73-9421-5b066c089153';
+const bodyMock = {
+    Preference: [{
+        DisplayName: 'Order status',
+        Sort: 1,
+        Key: 'orderstatus',
+        Push: false,
+        Email: true,
+        Sms: true
+    }, {
+        DisplayName: 'Review meal',
+        Sort: 2,
+        Key: 'reviewmeal',
+        Push: false,
+        Email: false,
+        Sms: false
+    }, {
+        DisplayName: 'News & offers',
+        Sort: 3,
+        Key: 'news',
+        Push: false,
+        Email: true,
+        Sms: false
+    }
+    ],
+    DeviceToken: null,
+    DeviceType: null,
+    PhoneNumber: null,
+    PreferenceVersionViewed: 0
+};
+
+describe('ContactPreferencesApi Provider', () => {
+    beforeEach(() => {
+        // Arrange mocks/spies
+        httpMock = {
+            get: httpGetSpy,
+            post: httpPostSpy
+        };
+        cookiesMock = {
+            set: cookiesSetSpy
+        };
+
+        // Arrange - sut
+        apiProvider = new ContactPreferencesApi({
+            httpClient: httpMock,
+            cookies: cookiesMock,
+            baseUrl: baseUrlMock
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('When creating a new instance', () => {
+        it('should not throw error when instance is created with valid parameters', () => {
+            // Act
+            const instance = () => new ContactPreferencesApi({
+                httpClient: httpMock,
+                cookies: cookiesMock,
+                baseUrl: baseUrlMock
+            });
+
+            // Assert
+            expect(instance).not.toThrowError();
+            expect(instance).toBeDefined();
+        });
+    });
+
+    describe('When calling `getPreferences`', () => {
+        it('should set the cookie with a new conversation id if not provided with one', async () => {
+            // Act
+            await apiProvider.getPreferences(authTokenMock);
+
+            // Assert
+            expect(cookiesSetSpy).toHaveBeenCalledWith('x-je-conversation', expect.anything());
+        });
+
+        it('should not set the cookie if already provided with a conversation id', async () => {
+            // Act
+            await apiProvider.getPreferences(authTokenMock, conversationId);
+
+            // Assert
+            expect(cookiesSetSpy).not.toHaveBeenCalled();
+        });
+
+        it('should send the correct parameters', async () => {
+            // Arrange
+            const expectedUri = `${baseUrlMock}/consumer/preferences`;
+            const expectedHeaders = {
+                Authorization: `Bearer ${authTokenMock}`,
+                'x-je-conversation': `${conversationId}`
+            };
+
+            // Act
+            await apiProvider.getPreferences(authTokenMock, conversationId);
+
+            // Assert
+            expect(httpGetSpy).toHaveBeenCalledWith(expectedUri, expectedHeaders);
+        });
+    });
+
+    describe('When calling `postPreferences`', () => {
+        it('should set the cookie with a new conversation id if not provided with one', async () => {
+            // Act
+            await apiProvider.postPreferences(authTokenMock, bodyMock);
+
+            // Assert
+            expect(cookiesSetSpy).toHaveBeenCalledWith('x-je-conversation', expect.anything());
+        });
+
+        it('should not set the cookie if already provided with a conversation id', async () => {
+            // Act
+            await apiProvider.postPreferences(authTokenMock, bodyMock, conversationId);
+
+            // Assert
+            expect(cookiesSetSpy).not.toHaveBeenCalled();
+        });
+
+        it('should send the correct parameters', async () => {
+            // Arrange
+            const expectedUri = `${baseUrlMock}/consumer/preferences`;
+            const expectedBody = bodyMock;
+            const expectedHeaders = {
+                Authorization: `Bearer ${authTokenMock}`,
+                'x-je-conversation': `${conversationId}`
+            };
+
+            // Act
+            await apiProvider.postPreferences(authTokenMock, bodyMock, conversationId);
+
+            // Assert
+            expect(httpPostSpy).toHaveBeenCalledWith(expectedUri, expectedBody, expectedHeaders);
+        });
+    });
+});

--- a/packages/components/pages/f-contact-preferences/src/services/providers/contactPreferences.api.js
+++ b/packages/components/pages/f-contact-preferences/src/services/providers/contactPreferences.api.js
@@ -1,0 +1,45 @@
+import { v4 as uuid } from 'uuid';
+import {
+    CONSUMER_PREFERENCES_URL,
+    CONVERSATION_ID_NAME
+} from '../../constants';
+
+const GetSetConversationId = cookies => {
+    const conversationId = uuid();
+
+    cookies.set(CONVERSATION_ID_NAME, conversationId);
+
+    return conversationId;
+};
+
+export default class ContactPreferencesApi {
+    constructor ({
+        httpClient, cookies, baseUrl
+    } = {}) {
+        this.httpClient = httpClient;
+        this.cookies = cookies;
+        this.baseUrl = baseUrl;
+    }
+
+    async getPreferences (authToken, conversationId = GetSetConversationId(this.cookies)) {
+        const headers = {
+            [CONVERSATION_ID_NAME]: conversationId,
+            Authorization: authToken ? `Bearer ${authToken}` : ''
+        };
+
+        const response = await this.httpClient.get(`${this.baseUrl}/${CONSUMER_PREFERENCES_URL}`, headers);
+
+        return response;
+    }
+
+    async postPreferences (authToken, body, conversationId = GetSetConversationId(this.cookies)) {
+        const headers = {
+            [CONVERSATION_ID_NAME]: conversationId,
+            Authorization: authToken ? `Bearer ${authToken}` : ''
+        };
+
+        const response = await this.httpClient.post(`${this.baseUrl}/${CONSUMER_PREFERENCES_URL}`, body, headers);
+
+        return response;
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2384,6 +2384,14 @@
   dependencies:
     qwery "^4.0.0"
 
+"@justeat/f-form-field@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-4.0.1.tgz#c6a868d39a3d3361af9e29b44f0d8bc21e30da8d"
+  integrity sha512-DSF1NJFKBb/tZDCCUyTGXcnKWC5FvPa9TIcCy0n57OLfQOJ9A53VfxVpRoW8VjlRZu/bl6nYx4kukZq+iHmx5Q==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+    "@justeat/f-vue-icons" "2.5.0"
+
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-0.2.0.tgz#90ec559642c165b6325669c506c417abe09fa5dd"


### PR DESCRIPTION
### Added
- Api provider for getting and saving consumer preferences data.