### PR TITLE
f-card@3.0.1 - Ensure page content wrapper inner spacing style only applies to immediate children

### DIFF
--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.0.1
+------------------------------
+*November 15, 2021*
+
+### Changed
+ - Page content wrapper padding now only applies to immediate children
 
 v3.0.0
 ------------------------------

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card",
   "description": "Fozzie Card Component – Used for providing wrapper card styling to an element (or group of elements)",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "dist/f-card.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -98,7 +98,7 @@ $card--pageContentWrapper-width           : 472px; // so that it falls on our 8p
             margin: spacing(x5) auto;
         }
 
-        .c-card-innerSpacing {
+        & > .c-card-innerSpacing {
             padding: spacing(x3) 6% 0;
 
             @include media('>=narrow') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,6 +2153,13 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-3.0.2.tgz#9560d0caf56ae0801208ddd0c27cb50d670d54a8"
   integrity sha512-qzZr6ZN01GTs6yFGOvIpwDcdXQKcH1SCF3CN7s9YTNiemWaQAoLo9sfv08fNuawBsxLwX4ZMLzjMY9dioC4vpg==
 
+"@justeat/f-card@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-card/-/f-card-3.0.0.tgz#6bc0840adcca276638778a080ea66d6f34309a78"
+  integrity sha512-X/XF1yo6whfSZ46i4kaz7VZlLe+U27SDOa8x+N3Vn5dakgYDRhdiIvgsDm8d1v6GX8eB4addlmlb/OkJ+9G42g==
+  dependencies:
+    "@justeat/f-services" "0.13.0"
+
 "@justeat/f-content-cards@6.0.0-beta.2":
   version "6.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-6.0.0-beta.2.tgz#1b77d0d33ad0b8b41d26d78029c848e8444d20b5"
@@ -2204,17 +2211,15 @@
   dependencies:
     "@justeat/f-services" "1.7.0"
 
-"@justeat/f-link@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-link/-/f-link-2.2.0.tgz#91a52ccf925bb971a1360adb9b19d531d8a2bb49"
-  integrity sha512-iq9XyTpfbMjWxoRRZjZxJCiVRTsZjWp1PD+9T5GzDnTGDROR9AvkCWi4VhZ7PPCXxG9pzhEXbB7mp2iiNEai8Q==
-  dependencies:
-    "@justeat/f-services" "1.7.0"
-
 "@justeat/f-mega-modal@3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-3.0.0.tgz#2e635096c2a6a8fd7da308479a2126748716dcbf"
   integrity sha512-ZbAgBrqn3a2furQ5F0FLffbsMZar9aIDsRG/2uWnsv6uY0KIHgJi08kH2XK5NzDzckHih2uMN37JiYpQMw6rNQ==
+
+"@justeat/f-navigation-links@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@justeat/f-navigation-links/-/f-navigation-links-0.2.1.tgz#badc3af5e498da0a8e9fb835fe612d5f24edc2b2"
+  integrity sha512-v3LM7ZUTwr0aIRKY+xUHQQm3nw5+U9V5cCUI2rxOwFu7E2VyHRgMebICdviPDTzI5NemSUC1mPPle18YQ6ET6A==
 
 "@justeat/f-searchbox@6.0.0":
   version "6.0.0"


### PR DESCRIPTION
Currently page content wrapper styling is applied to the inner div of all descendant cards. This is unwanted behaviour when you have cards nested within a page-content-wrapper card (which is a common use case).

## Browsers Tested

- [x] Chrome (latest)