### PR TITLE
f-header@v7.1.1 - Update component exports.

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v7.1.1
+------------------------------
+*November18, 2021*
+
+### Changed
+- Replaced ES exports with node exports to allow external applications to access the components.
+
 v7.1.0
 ------------------------------
 *November 1, 2021*

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v7.1.1
 ------------------------------
-*November18, 2021*
+*November 19, 2021*
 
 ### Changed
 - Replaced ES exports with node exports to allow external applications to access the components.

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.selectors.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.selectors.js
@@ -1,8 +1,8 @@
-export const HEADER_COMPONENT = '[data-test-id="header-component"]';
-export const HEADER_LOGO = '[data-test-id="header-logo"]';
-export const MOBILE_NAVIGATION_BAR = '[data-test-id="nav-toggle"]';
+exports.HEADER_COMPONENT = '[data-test-id="header-component"]';
+exports.HEADER_LOGO = '[data-test-id="header-logo"]';
+exports.MOBILE_NAVIGATION_BAR = '[data-test-id="nav-toggle"]';
 
-export const NAVIGATION = {
+exports.NAVIGATION = {
     offersIcon: {
         link: '[data-test-id="offers-iconLink"]'
     },


### PR DESCRIPTION
### Changed
- Replaced ES exports with node exports to allow external applications to access the components.