### PR TITLE
f-account-info@v0.2.0 - Initial UI

### DIFF
--- a/packages/components/pages/f-account-info/CHANGELOG.md
+++ b/packages/components/pages/f-account-info/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.2.0
+------------------------------
+*November 19, 2021*
+
+### Added
+- Initial UI elements - similar to design
+- Initial en-GB translation messages
+
+
 v0.1.0
 ------------------------------
 *November 18, 2021*

--- a/packages/components/pages/f-account-info/package.json
+++ b/packages/components/pages/f-account-info/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-account-info",
   "description": "Fozzie Account Info - The account information page",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/f-account-info.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [

--- a/packages/components/pages/f-account-info/src/components/AccountInfo.vue
+++ b/packages/components/pages/f-account-info/src/components/AccountInfo.vue
@@ -103,9 +103,16 @@
 import { VueGlobalisationMixin } from '@justeat/f-globalisation';
 
 import Card from '@justeat/f-card';
+import '@justeat/f-card/dist/f-card.css';
+
 import FormField from '@justeat/f-form-field';
+import '@justeat/f-form-field/dist/f-form-field.css';
+
 import FLink from '@justeat/f-link';
+import '@justeat/f-link/dist/f-link.css';
+
 import FButton from '@justeat/f-button';
+import '@justeat/f-button/dist/f-button.css';
 
 import tenantConfigs from '../tenants';
 
@@ -153,11 +160,6 @@ export default {
 </script>
 
 <style lang="scss" module>
-@import '@justeat/f-card/dist/f-card.css';
-@import '@justeat/f-form-field/dist/f-form-field.css';
-@import '@justeat/f-link/dist/f-link.css';
-@import '@justeat/f-button/dist/f-button.css';
-
 .c-accountInfo-customerCareLink {
     display: block;
     margin-bottom: spacing(x4);

--- a/packages/components/pages/f-account-info/src/components/AccountInfo.vue
+++ b/packages/components/pages/f-account-info/src/components/AccountInfo.vue
@@ -1,49 +1,178 @@
 <template>
-    <div
-        :class="$style['c-accountInfo']"
-        data-test-id="accountInfo">
-        {{ copy.text }}
-    </div>
+    <card
+        :card-heading="$t('accountDetails')"
+        data-test-id="account-info-card"
+        has-outline
+        is-page-content-wrapper>
+        <h2
+            class="u-spacingBottom--large">
+            {{ $t('yourDetails') }}
+        </h2>
+
+        <form
+            method="post"
+            @submit.prevent="onFormSubmit">
+            <form-field
+                :label-text="$t('fields.emailAddressLabel')"
+                disabled
+                :placeholder="$t('fields.emailAddressPlaceholder')"
+                class="u-spacingBottom--large"
+                :value="fields.emailAddress"
+                name="note" />
+
+            <f-link
+                is-distinct
+                :class="$style['c-accountInfo-customerCareLink']"
+                href="/help"
+                target="_blank">
+                {{ $t('contactCustomerCareTeam') }}
+            </f-link>
+
+            <form-field
+                :label-text="$t('fields.firstNameLabel')"
+                :placeholder="$t('fields.firstNamePlaceholder')"
+                :value="fields.firstName"
+                name="note" />
+
+            <form-field
+                :label-text="$t('fields.lastNameLabel')"
+                :placeholder="$t('fields.lastNamePlaceholder')"
+                :value="fields.lastName"
+                name="note" />
+
+            <h2
+                class="u-spacingBottom--large">
+                {{ $t('deliveryAddress') }}
+            </h2>
+
+            <form-field
+                :label-text="$t('fields.addressLabel')"
+                :placeholder="$t('fields.line1Placeholder')"
+                :value="fields.line1" />
+
+            <form-field
+                :placeholder="$t('fields.line2Placeholder')"
+                :value="fields.line2" />
+
+            <form-field
+                :placeholder="$t('fields.line3Placeholder')"
+                :value="fields.line3" />
+
+            <form-field
+                :label-text="$t('fields.cityLabel')"
+                :placeholder="$t('fields.cityPlaceholder')"
+                :value="fields.city" />
+
+            <form-field
+                :label-text="$t('fields.postcodeLabel')"
+                :placeholder="$t('fields.postcodePlaceholder')"
+                :value="fields.postcode" />
+
+            <f-button
+                :class="[$style['c-accountInfo-submitButton']]"
+                data-test-id="account-info-submit-button"
+                button-type="primary"
+                button-size="large"
+                is-full-width
+                action-type="submit">
+                {{ $t('buttons.saveChanges') }}
+            </f-button>
+        </form>
+
+        <f-button
+            :class="[$style['c-accountInfo-changePasswordButton']]"
+            data-test-id="account-info-submit-button"
+            button-type="secondary"
+            button-size="large"
+            is-full-width
+            action-type="submit">
+            {{ $t('buttons.changePassword') }}
+        </f-button>
+
+        <hr>
+
+        <p>{{ $t('deleteAccountMessage') }}</p>
+
+        <f-link
+            is-distinct
+            href="/help"
+            target="_blank">
+            {{ $t('deleteAccountLink') }}
+        </f-link>
+    </card>
 </template>
 
 <script>
-import { globalisationServices } from '@justeat/f-services';
+import { VueGlobalisationMixin } from '@justeat/f-globalisation';
+
+import Card from '@justeat/f-card';
+import '@justeat/f-card/dist/f-card.css';
+
+import FormField from '@justeat/f-form-field';
+import '@justeat/f-form-field/dist/f-form-field.css';
+
+import FLink from '@justeat/f-link';
+import '@justeat/f-link/dist/f-link.css';
+
+import FButton from '@justeat/f-button';
+import '@justeat/f-button/dist/f-button.css';
+
 import tenantConfigs from '../tenants';
 
-// eslint-disable-next-line no-unused-vars
-import AccountInfoServiceApi from '../services/AccountInfoServiceApi';
-
 export default {
-    name: 'AccountInfo',
-    components: {},
+    components: {
+        Card,
+        FormField,
+        FLink,
+        FButton
+    },
+
+    mixins: [
+        VueGlobalisationMixin
+    ],
+
     props: {
         locale: {
             type: String,
             default: ''
         }
     },
-    data () {
-        const locale = globalisationServices.getLocale(tenantConfigs, this.locale, this.$i18n);
-        const localeConfig = tenantConfigs[locale];
 
+    data () {
         return {
-            copy: { ...localeConfig }
+            fields: {
+                emailAddress: null,
+                firstName: null,
+                lastName: null,
+                line1: null,
+                line2: null,
+                line3: null,
+                city: null,
+                postcode: null
+            },
+            tenantConfigs
         };
+    },
+
+    methods: {
+        onFormSubmit () {
+            this.$log.info('Submitted Form', 'account-info');
+        }
     }
 };
 </script>
 
 <style lang="scss" module>
-
-.c-accountInfo {
-    display: flex;
-    justify-content: center;
-    min-height: 80vh;
-    width: 80vw;
-    margin: auto;
-    border: 1px solid red;
-    font-family: $font-family-base;
-    @include font-size(heading-m);
+.c-accountInfo-customerCareLink {
+    display: block;
+    margin-bottom: spacing(x4);
 }
 
+.c-accountInfo-submitButton {
+    margin-top: spacing(x4);
+}
+
+.c-accountInfo-changePasswordButton {
+    margin-top: spacing(x2);
+}
 </style>

--- a/packages/components/pages/f-account-info/src/components/AccountInfo.vue
+++ b/packages/components/pages/f-account-info/src/components/AccountInfo.vue
@@ -1,7 +1,7 @@
 <template>
     <card
         :card-heading="$t('accountDetails')"
-        data-test-id="account-info-card"
+        data-test-id="account-info"
         has-outline
         is-page-content-wrapper>
         <h2
@@ -103,16 +103,9 @@
 import { VueGlobalisationMixin } from '@justeat/f-globalisation';
 
 import Card from '@justeat/f-card';
-import '@justeat/f-card/dist/f-card.css';
-
 import FormField from '@justeat/f-form-field';
-import '@justeat/f-form-field/dist/f-form-field.css';
-
 import FLink from '@justeat/f-link';
-import '@justeat/f-link/dist/f-link.css';
-
 import FButton from '@justeat/f-button';
-import '@justeat/f-button/dist/f-button.css';
 
 import tenantConfigs from '../tenants';
 
@@ -160,6 +153,11 @@ export default {
 </script>
 
 <style lang="scss" module>
+@import '@justeat/f-card/dist/f-card.css';
+@import '@justeat/f-form-field/dist/f-form-field.css';
+@import '@justeat/f-link/dist/f-link.css';
+@import '@justeat/f-button/dist/f-button.css';
+
 .c-accountInfo-customerCareLink {
     display: block;
     margin-bottom: spacing(x4);

--- a/packages/components/pages/f-account-info/src/components/AccountInfo.vue
+++ b/packages/components/pages/f-account-info/src/components/AccountInfo.vue
@@ -17,8 +17,7 @@
                 disabled
                 :placeholder="$t('fields.emailAddressPlaceholder')"
                 class="u-spacingBottom--large"
-                :value="fields.emailAddress"
-                name="note" />
+                :value="fields.emailAddress" />
 
             <f-link
                 is-distinct
@@ -31,14 +30,12 @@
             <form-field
                 :label-text="$t('fields.firstNameLabel')"
                 :placeholder="$t('fields.firstNamePlaceholder')"
-                :value="fields.firstName"
-                name="note" />
+                :value="fields.firstName" />
 
             <form-field
                 :label-text="$t('fields.lastNameLabel')"
                 :placeholder="$t('fields.lastNamePlaceholder')"
-                :value="fields.lastName"
-                name="note" />
+                :value="fields.lastName" />
 
             <h2
                 class="u-spacingBottom--large">

--- a/packages/components/pages/f-account-info/src/components/_tests/AccountInfo.test.js
+++ b/packages/components/pages/f-account-info/src/components/_tests/AccountInfo.test.js
@@ -1,7 +1,7 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import { VueI18n } from '@justeat/f-globalisation';
 
-import ContactPreferences from '../AccountInfo.vue';
+import AccountInfo from '../AccountInfo.vue';
 import tenantConfigs from '../../tenants';
 
 const localVue = createLocalVue();
@@ -19,7 +19,7 @@ describe('AccountInfo', () => {
     it('should be defined', () => {
         // Arrange
         // Act
-        const wrapper = shallowMount(ContactPreferences, {
+        const wrapper = shallowMount(AccountInfo, {
             i18n,
             localVue
         });

--- a/packages/components/pages/f-account-info/src/components/_tests/AccountInfo.test.js
+++ b/packages/components/pages/f-account-info/src/components/_tests/AccountInfo.test.js
@@ -1,10 +1,30 @@
-import { shallowMount } from '@vue/test-utils';
-import AccountInfo from '../AccountInfo.vue';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import { VueI18n } from '@justeat/f-globalisation';
+
+import ContactPreferences from '../AccountInfo.vue';
+import tenantConfigs from '../../tenants';
+
+const localVue = createLocalVue();
+
+localVue.use(VueI18n);
+
+const i18n = {
+    locale: 'en-GB',
+    messages: {
+        'en-GB': tenantConfigs['en-GB'].messages
+    }
+};
 
 describe('AccountInfo', () => {
     it('should be defined', () => {
-        const propsData = {};
-        const wrapper = shallowMount(AccountInfo, { propsData });
+        // Arrange
+        // Act
+        const wrapper = shallowMount(ContactPreferences, {
+            i18n,
+            localVue
+        });
+
+        // Assert
         expect(wrapper.exists()).toBe(true);
     });
 });

--- a/packages/components/pages/f-account-info/src/tenants/en-AU.js
+++ b/packages/components/pages/f-account-info/src/tenants/en-AU.js
@@ -1,4 +1,0 @@
-export default {
-    locale: 'en-AU',
-    text: 'I am a AccountInfo Component (AU)'
-};

--- a/packages/components/pages/f-account-info/src/tenants/en-GB.js
+++ b/packages/components/pages/f-account-info/src/tenants/en-GB.js
@@ -1,4 +1,32 @@
+const messages = {
+    accountDetails: 'Account Details',
+    yourDetails: 'Your details',
+    contactCustomerCareTeam: "If you'd like to change your email address, get in touch with our customer care team.",
+    deliveryAddress: 'Delivery Address',
+    fields: {
+        emailAddressLabel: 'Email address',
+        emailAddressPlaceholder: 'Your email address...',
+        firstNameLabel: 'First name*',
+        firstNamePlaceholder: 'Your first name...',
+        lastNameLabel: 'Last name*',
+        lastNamePlaceholder: 'Your last name...',
+        addressLabel: 'Address*',
+        line1Placeholder: 'Address Line 1...',
+        line2Placeholder: 'Address Line 2...',
+        line3Placeholder: 'Address Line 3...',
+        cityLabel: 'City*',
+        cityPlaceholder: 'City...',
+        postcodeLabel: 'Postcode*',
+        postcodePlaceholder: 'Postcode...'
+    },
+    buttons: {
+        saveChanges: 'Save changes',
+        changePassword: 'Change password'
+    },
+    deleteAccountMessage: 'Do you want to delete your Just Eat account?',
+    deleteAccountLink: 'Delete my account'
+};
+
 export default {
-    locale: 'en-GB',
-    text: 'I am a AccountInfo Component (GB)'
+    messages
 };

--- a/packages/components/pages/f-account-info/src/tenants/en-IE.js
+++ b/packages/components/pages/f-account-info/src/tenants/en-IE.js
@@ -1,4 +1,0 @@
-export default {
-    locale: 'en-IE',
-    text: 'I am a AccountInfo Component (IE)'
-};

--- a/packages/components/pages/f-account-info/src/tenants/en-NZ.js
+++ b/packages/components/pages/f-account-info/src/tenants/en-NZ.js
@@ -1,4 +1,0 @@
-export default {
-    locale: 'en-NZ',
-    text: 'I am a AccountInfo Component (NZ)'
-};

--- a/packages/components/pages/f-account-info/src/tenants/es-ES.js
+++ b/packages/components/pages/f-account-info/src/tenants/es-ES.js
@@ -1,4 +1,0 @@
-export default {
-    locale: 'es-ES',
-    text: 'I am a AccountInfo Component (ES)'
-};

--- a/packages/components/pages/f-account-info/src/tenants/index.js
+++ b/packages/components/pages/f-account-info/src/tenants/index.js
@@ -1,17 +1,7 @@
 import uk from './en-GB';
-import au from './en-AU';
-import nz from './en-NZ';
-import es from './es-ES';
-import ie from './en-IE';
-import it from './it-IT';
 
 const tenantConfigs = {
-    'en-GB': uk,
-    'en-AU': au,
-    'en-NZ': nz,
-    'es-ES': es,
-    'en-IE': ie,
-    'it-IT': it
+    'en-GB': uk
 };
 
 export default tenantConfigs;

--- a/packages/components/pages/f-account-info/src/tenants/it-IT.js
+++ b/packages/components/pages/f-account-info/src/tenants/it-IT.js
@@ -1,4 +1,0 @@
-export default {
-    locale: 'it-IT',
-    text: 'I am a AccountInfo Component (IT)'
-};

--- a/packages/components/pages/f-account-info/test-utils/component-objects/f-accountInfo-selectors.js
+++ b/packages/components/pages/f-account-info/test-utils/component-objects/f-accountInfo-selectors.js
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export const COMPONENT = '[data-test-id="accountInfo"]';
+export const COMPONENT = '[data-test-id="account-info"]';

--- a/packages/components/pages/f-account-info/test/component/f-accountInfo.component.spec.js
+++ b/packages/components/pages/f-account-info/test/component/f-accountInfo.component.spec.js
@@ -1,10 +1,14 @@
 const AccountInfo = require('../../test-utils/component-objects/f-accountInfo.component');
 
-const accountInfo = new AccountInfo();
+let accountInfo;
 
 describe('f-accountInfo component tests', () => {
     beforeEach(() => {
+        accountInfo = new AccountInfo();
+
         accountInfo.load();
+
+        accountInfo.waitForComponent();
     });
 
     it('should display the f-accountInfo component', () => {


### PR DESCRIPTION
Not a complete component; just a development - adding rough UI from designs.

I may split to sub-internal-components later

v0.2.0
------------------------------
*November 19, 2021*

### Added
- Initial UI elements - similar to design
- Initial en-GB translation messages

![image](https://user-images.githubusercontent.com/10741583/142450980-2629bfbb-fa69-4f32-9eed-ce3e19aed756.png)

