### PR TITLE
f-card@3.1.0

### DIFF
--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -3,12 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.1.0
+------------------------------
+*November 19, 2021*
+
+### Added
+- `hasInnerSpacingLarge` prop to allow large spacing around the edges of the card.
+
+
 v3.0.1
 ------------------------------
 *November 15, 2021*
 
 ### Changed
  - Page content wrapper padding now only applies to immediate children
+
 
 v3.0.0
 ------------------------------

--- a/packages/components/atoms/f-card/README.md
+++ b/packages/components/atoms/f-card/README.md
@@ -72,6 +72,7 @@ The props that can be defined are as follows:
 | `hasOutline`              | `Boolean`  |  No        | `false` | When set to `true`, an outline is applied to the card component.  |
 | `isPageContentWrapper`    | `Boolean`  |  No        | `false` | When set to `true`, applies styles to make the card act like a page content wrapper.<br><br>The card will be full width on narrow devices, and then a fixed width above a certain breakpoint width (about 480px), when the card will be centred on the page. |
 | `hasFullWidthFooter` | `Boolean` | No | `false` | When set to `true`, named slot `full-width-bottom-element` can be passed to render full width content at the bottom of the card without card paddings. |
+| `hasInnerSpacingLarge` | `Boolean` | No | `false` | When set to `true`, padding around the card increases from 16px to 32px. |
 
 ### CSS Classes
 

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card",
   "description": "Fozzie Card Component – Used for providing wrapper card styling to an element (or group of elements)",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "main": "dist/f-card.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [
@@ -32,7 +32,7 @@
     "lint:fix": "yarn lint --fix",
     "lint:style": "vue-cli-service lint:style",
     "test": "vue-cli-service test:unit",
-    "test-a11y:chrome": "cross-env-shell TEST_TYPE=a11y wdio ../../../../wdio-chrome.conf.js", 
+    "test-a11y:chrome": "cross-env-shell TEST_TYPE=a11y wdio ../../../../wdio-chrome.conf.js",
     "test-component:chrome": "cross-env-shell TEST_TYPE=component wdio ../../../../wdio-chrome.conf.js"
   },
   "browserslist": [

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -6,7 +6,12 @@
                 [$style['c-card--outline']]: hasOutline,
                 [$style['c-card--pageContentWrapper']]: isPageContentWrapper
             }]">
-        <div :class="[$style['c-card-innerSpacing']]">
+        <div
+            data-test-id="card-inner"
+            :class="[
+                [$style['c-card-innerSpacing']], {
+                    [$style['c-card-innerSpacing--large']]: hasInnerSpacingLarge
+                }]">
             <component
                 :is="cardHeadingTag"
                 v-if="cardHeading"
@@ -58,6 +63,10 @@ export default {
         hasFullWidthFooter: {
             type: Boolean,
             default: false
+        },
+        hasInnerSpacingLarge: {
+            type: Boolean,
+            default: false
         }
     }
 };
@@ -69,6 +78,7 @@ $card-bgColor                             : $color-container-default;
 $card-borderColor                         : $color-border-default;
 $card-borderRadius                        : $radius-rounded-c;
 $card-padding                             : spacing(x2);
+$card-padding-large                       : spacing(x4);
 $card--pageContentWrapper-width           : 472px; // so that it falls on our 8px spacing grid
 
 .c-card {
@@ -78,6 +88,10 @@ $card--pageContentWrapper-width           : 472px; // so that it falls on our 8p
 }
     .c-card-innerSpacing {
         padding: $card-padding;
+
+        &.c-card-innerSpacing--large {
+            padding: $card-padding-large;
+        }
     }
 
     .c-card--outline {

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -90,7 +90,13 @@ $card--pageContentWrapper-width           : 472px; // so that it falls on our 8p
         padding: $card-padding;
 
         &.c-card-innerSpacing--large {
-            padding: $card-padding-large;
+            padding: $card-padding-large $card-padding;
+        }
+
+        @include media('>=mid') {
+            &.c-card-innerSpacing--large {
+                padding: $card-padding-large;
+            }
         }
     }
 

--- a/packages/components/atoms/f-card/src/components/_tests/Card.test.js
+++ b/packages/components/atoms/f-card/src/components/_tests/Card.test.js
@@ -6,7 +6,8 @@ const $style = {
     'c-card--outline': 'c-card--outline',
     'c-card--pageContentWrapper': 'c-card--pageContentWrapper',
     'c-card-heading--centerAligned': 'c-card-heading--centerAligned',
-    'c-card-heading--rightAligned': 'c-card-heading--rightAligned'
+    'c-card-heading--rightAligned': 'c-card-heading--rightAligned',
+    'c-card-innerSpacing--large': 'c-card-innerSpacing--large'
 };
 
 describe('Card', () => {
@@ -184,6 +185,42 @@ describe('Card', () => {
                 expect(heading.validator('h4')).toBeTruthy();
                 expect(heading.validator('h5')).toBeTruthy();
                 expect(heading.validator('h6')).toBeTruthy();
+            });
+        });
+
+        describe('`hasInnerSpacingLarge`', () => {
+            describe('when `truthy`', () => {
+                it('should add a modifier class `c-card-innerSpacing--large` which will increase the size of the padding around the card', () => {
+                    // Arrange & Act
+                    const wrapper = shallowMount(Card, {
+                        propsData: {
+                            hasInnerSpacingLarge: true
+                        },
+                        mocks: {
+                            $style
+                        }
+                    });
+
+                    // Assert
+                    expect(wrapper.find('[data-test-id="card-inner"]').attributes('class')).toContain('c-card-innerSpacing--large');
+                });
+            });
+
+            describe('when `falsey`', () => {
+                it('should not add a modifier class `c-card-innerSpacing--large`', () => {
+                    // Arrange & Act
+                    const wrapper = shallowMount(Card, {
+                        propsData: {
+                            hasInnerSpacingLarge: false
+                        },
+                        mocks: {
+                            $style
+                        }
+                    });
+
+                    // Assert
+                    expect(wrapper.find('[data-test-id="card-inner"]').attributes('class')).not.toContain('c-card-innerSpacing--large');
+                });
             });
         });
     });

--- a/packages/components/atoms/f-card/stories/card.stories.js
+++ b/packages/components/atoms/f-card/stories/card.stories.js
@@ -25,6 +25,7 @@ export const CardComponent = (args, { argTypes }) => ({
             :card-heading-tag="cardHeadingTag"
             :has-outline="hasOutline"
             :is-page-content-wrapper="isPageContentWrapper"
+            :has-inner-spacing-large="hasInnerSpacingLarge"
             :has-full-width-footer="hasFullWidthFooter">
             <p>Some Card Content</p>
             <template v-slot:cardFooter>
@@ -39,7 +40,8 @@ CardComponent.args = {
     cardHeadingTag: 'h1',
     hasOutline: false,
     isPageContentWrapper: false,
-    hasFullWidthFooter: false
+    hasFullWidthFooter: false,
+    hasInnerSpacingLarge: false
 };
 
 CardComponent.argTypes = {


### PR DESCRIPTION
Allows a larger padding size around the f-card container.

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
