### PR TITLE
f-content-cards@v7.0.0 - Update beta to master

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v5.0.0-beta.2
+------------------------------
+*September 02, 2021*
+
+### Changed
+- Updating braze adapter version
+
+
 v6.0.0
 ------------------------------
 *October 5, 2021*

--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -3,13 +3,29 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v6.0.0-beta.0
+------------------------------
+*September 20, 2021*
 
-v5.0.0-beta.2
+### Changed
+- Changed version number to prevent conflict with main branch as v5 has now been used
+
+
+v5.0.0-beta.2 (INCORRECT VERSION NOW DUE TO MASTER USING V5)
 ------------------------------
 *September 02, 2021*
 
 ### Changed
 - Updating braze adapter version
+
+
+v5.0.0-beta.1 (INCORRECT VERSION NOW DUE TO MASTER USING V5)
+------------------------------
+*July 26, 2021*
+
+### Changed
+- Updated content cards to use beta 4 of braze adapter
+- Updated tests to account for change in braze adapter
 
 
 v6.0.0
@@ -37,15 +53,6 @@ v5.0.0-beta.0
 
 ### Updated
 - New font JETSansDigital
-
-
-v5.0.0-beta.1
-------------------------------
-*July 26, 2021*
-
-### Changed
-- Updated content cards to use beta 4 of braze adapter
-- Updated tests to account for change in braze adapter
 
 
 v4.8.0

--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v7.0.0
+------------------------------
+*November 23, 2021*
+
+### Changed
+- Version bump to pull it out of beta into master
+
+
 v6.0.0-beta.2
 ------------------------------
 *September 27, 2021*

--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v6.0.0-beta.1
+------------------------------
+*September 20, 2021*
+
+### Changed
+- Updating braze adapter version
+- Adding finer detailed logs
+- Updated unit tests
+
+
 v6.0.0-beta.0
 ------------------------------
 *September 20, 2021*

--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v6.0.0-beta.2
+------------------------------
+*September 27, 2021*
+
+### Changed
+- Version bump braze adapter
+
+
 v6.0.0-beta.1
 ------------------------------
 *September 20, 2021*

--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -31,6 +31,15 @@ v5.0.0-beta.0
 - New font JETSansDigital
 
 
+v5.0.0-beta.1
+------------------------------
+*July 26, 2021*
+
+### Changed
+- Updated content cards to use beta 4 of braze adapter
+- Updated tests to account for change in braze adapter
+
+
 v4.8.0
 ------------------------------
 *July 22, 2021*

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@braze/web-sdk": "^3.3.0",
-    "@justeat/f-braze-adapter": "4.0.0-beta.3",
+    "@justeat/f-braze-adapter": "4.0.0-beta.4",
     "@justeat/f-vue-icons": "1.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -50,10 +50,12 @@
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
-    "vue": "2.x"
+    "vue": "2.x",
+    "@braze/web-sdk": ">=3.3.0"
   },
   "devDependencies": {
-    "@justeat/f-braze-adapter": "3.5.0",
+    "@braze/web-sdk": "^3.3.0",
+    "@justeat/f-braze-adapter": "4.0.0-beta.3",
     "@justeat/f-vue-icons": "1.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "main": "dist/f-content-cards.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@braze/web-sdk": "^3.3.0",
-    "@justeat/f-braze-adapter": "4.0.0-beta.6",
+    "@justeat/f-braze-adapter": "4.0.0",
     "@justeat/f-vue-icons": "1.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@braze/web-sdk": "^3.3.0",
-    "@justeat/f-braze-adapter": "4.0.0-beta.5",
+    "@justeat/f-braze-adapter": "4.0.0-beta.6",
     "@justeat/f-vue-icons": "1.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -3,7 +3,7 @@
   "description": "Fozzie Content Cards",
   "version": "7.0.0",
   "main": "dist/f-content-cards.umd.min.js",
-  "maxBundleSize": "70kB",
+  "maxBundleSize": "75kB",
   "files": [
     "dist",
     "docs"

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -51,7 +51,8 @@
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
     "vue": "2.x",
-    "@braze/web-sdk": ">=3.3.0"
+    "@braze/web-sdk": ">=3.3.0",
+    "date-fns": ">=2.17.0"
   },
   "devDependencies": {
     "@braze/web-sdk": "^3.3.0",
@@ -66,10 +67,10 @@
     "color": "3.1.3",
     "copy-to-clipboard": "3.3.1",
     "crypto-js": "4.0.0",
-    "date-fns": "2.17.0",
     "faker": "4.1.0",
     "node-sass-magic-importer": "5.3.2",
     "vue": "2.6.10",
-    "xhr-mock": "2.5.1"
+    "xhr-mock": "2.5.1",
+    "date-fns": "^2.17.0"
   }
 }

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@braze/web-sdk": "^3.3.0",
-    "@justeat/f-braze-adapter": "4.0.0-beta.4",
+    "@justeat/f-braze-adapter": "4.0.0-beta.5",
     "@justeat/f-vue-icons": "1.2.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-content-cards/src/components/_tests/ContentCards.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/_tests/ContentCards.test.js
@@ -45,6 +45,16 @@ const createCard = type => ({
     voucherCode
 });
 
+const mockLogger = {
+    logError: jest.fn(),
+    logWarn: jest.fn(),
+    logInfo: jest.fn()
+};
+
+const mocks = {
+    $logger: mockLogger
+};
+
 const createMetadataCards = cardTypes => cardTypes.map(type => createCard(type));
 
 const scopedSlots = {
@@ -72,7 +82,8 @@ describe('ContentCards', () => {
             },
             scopedSlots: {
                 default: '<div></div>'
-            }
+            },
+            mocks
         });
 
         // Assert
@@ -100,7 +111,8 @@ describe('ContentCards', () => {
                 },
                 scopedSlots: {
                     default: '<div></div>'
-                }
+                },
+                mocks
             });
             await instance.vm.$nextTick();
         });
@@ -129,7 +141,8 @@ describe('ContentCards', () => {
                 apiKey,
                 userId
             },
-            scopedSlots
+            scopedSlots,
+            mocks
         });
         instance.vm.metadataContentCards(cards);
         await instance.vm.$nextTick();
@@ -172,7 +185,7 @@ describe('ContentCards', () => {
                     <div :data-test-id="card.type" v-for="card in cards"></div>
                 </content-cards>
             `
-        });
+        }, { mocks });
 
         // Act
         await instance.vm.testCustomCards();
@@ -193,7 +206,8 @@ describe('ContentCards', () => {
                         userId,
                         testId
                     },
-                    scopedSlots
+                    scopedSlots,
+                    mocks
                 });
             });
 
@@ -219,7 +233,8 @@ describe('ContentCards', () => {
                         userId,
                         testId
                     },
-                    scopedSlots
+                    scopedSlots,
+                    mocks
                 });
 
                 // Act
@@ -254,7 +269,8 @@ describe('ContentCards', () => {
                         userId,
                         testId
                     },
-                    scopedSlots
+                    scopedSlots,
+                    mocks
                 });
                 instance.vm.metadataContentCards(cards);
                 await instance.vm.$nextTick();
@@ -283,7 +299,8 @@ describe('ContentCards', () => {
                 apiKey,
                 userId
             },
-            scopedSlots
+            scopedSlots,
+            mocks
         });
         instance.vm.metadataContentCards(cards);
         await instance.vm.$nextTick();
@@ -313,6 +330,7 @@ describe('ContentCards', () => {
                 stubs: {
                     PromotionCard
                 },
+                mocks,
                 scopedSlots: {
                     default: `
                         <div slot-scope="{ cards }">
@@ -579,7 +597,8 @@ describe('ContentCards', () => {
                     apiKey,
                     userId
                 },
-                scopedSlots
+                scopedSlots,
+                mocks
             });
 
             // Act
@@ -607,64 +626,6 @@ describe('ContentCards', () => {
 
         it('should emit an event containing the loading status when appboy is initialised', async () => {
             await testEmitter(HAS_LOADED, true);
-        });
-    });
-
-    describe('logging callback', () => {
-        const testMessage = '__TEST_MESSAGE__';
-        const testPayload = { test: 'PAYLOAD' };
-
-        it('should return a function with the correct logging parameters when callback is called', async () => {
-            // Arrange
-            const loggingType = 'logInfo';
-            const instance = shallowMount(ContentCards, {
-                propsData: {
-                    apiKey,
-                    userId,
-                    groupCards: true,
-                    testId
-                },
-                mocks: {
-                    $logger: {
-                        logInfo: jest.fn()
-                    }
-                },
-                scopedSlots
-            });
-
-            // Act
-            const loggingCallback = instance.vm.handleLogging(instance.vm.$logger);
-            loggingCallback(loggingType, testMessage, testPayload);
-            await instance.vm.$nextTick();
-
-            // Assert
-            expect(instance.vm.$logger.logInfo).toHaveBeenCalledWith(testMessage, null, testPayload);
-        });
-        it('should NOT return a function when the callback is called with incorrect logging type', async () => {
-            // Arrange
-            const loggingType = 'foo';
-            const instance = shallowMount(ContentCards, {
-                propsData: {
-                    apiKey,
-                    userId,
-                    groupCards: true,
-                    testId
-                },
-                mocks: {
-                    $logger: {
-                        logInfo: jest.fn()
-                    }
-                },
-                scopedSlots
-            });
-
-            // Act
-            const loggingCallback = instance.vm.handleLogging(instance.vm.$logger);
-            loggingCallback(loggingType, testMessage, testPayload);
-            await instance.vm.$nextTick();
-
-            // Assert
-            expect(instance.vm.$logger.logInfo).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
@@ -80,6 +80,9 @@
 import parseISO from 'date-fns/parseISO';
 import format from 'date-fns/format';
 import lightFormat from 'date-fns/lightFormat';
+import {
+    da, enAU, enNZ, enGB, es, it, nb
+} from 'date-fns/locale';
 
 import CardCase from './CardCase.vue';
 
@@ -223,9 +226,7 @@ export default {
     },
 
     mounted () {
-        this.getDateFnsLocale(this.copy.locale).then(locale => {
-            this.dateFnsLocale = locale;
-        });
+        this.dateFnsLocale = this.getDateFnsLocale(this.copy.locale);
     },
 
     inject: [
@@ -237,33 +238,33 @@ export default {
          * Takes the locale and lazyloads the correct date locale from the date-fns library
          * @param locale
          * @returns {
-         *  Promise<module:date-fns/locale/da> |
-         *  Promise<module:date-fns/locale/en-AU> |
-         *  Promise<module:date-fns/locale/en-GB> |
-         *  Promise<module:date-fns/locale/en-NZ> |
-         *  Promise<module:date-fns/locale/es> |
-         *  Promise<module:date-fns/locale/it> |
-         *  Promise<module:date-fns/locale/nb>
+         *  da |
+         *  enAU |
+         *  enGB |
+         *  enNZ |
+         *  es |
+         *  it |
+         *  nb
          * }
          */
         getDateFnsLocale (locale) {
             switch (locale) {
                 case 'da-DK':
-                    return import(/* webpackChunkName: "date-fns-locale-da" */ 'date-fns/locale/da');
+                    return da;
                 case 'en-AU':
-                    return import(/* webpackChunkName: "date-fns-locale-en-AU" */ 'date-fns/locale/en-AU');
+                    return enAU;
                 case 'en-GB':
                 case 'en-IE':
                 default:
-                    return import(/* webpackChunkName: "date-fns-locale-en-GB" */ 'date-fns/locale/en-GB');
+                    return enGB;
                 case 'en-NZ':
-                    return import(/* webpackChunkName: "date-fns-locale-en-NZ" */ 'date-fns/locale/en-NZ');
+                    return enNZ;
                 case 'es-ES':
-                    return import(/* webpackChunkName: "date-fns-locale-es" */ 'date-fns/locale/es');
+                    return es;
                 case 'it-IT':
-                    return import(/* webpackChunkName: "date-fns-locale-it" */ 'date-fns/locale/it');
+                    return it;
                 case 'nb-NO':
-                    return import(/* webpackChunkName: "date-fns-locale-nb" */ 'date-fns/locale/nb');
+                    return nb;
             }
         }
     }

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
@@ -288,7 +288,7 @@ $stampCard-responsive-tabletViewBreakpoint: '<=mid';
 
 .c-stampCard1 {
     text-decoration: initial;
-    width: 392px;
+    max-width: 392px;
     display: flex;
     flex-direction: column;
     padding: spacing(x2);
@@ -305,12 +305,13 @@ $stampCard-responsive-tabletViewBreakpoint: '<=mid';
     }
 
     @include media($stampCard-responsive-tabletViewBreakpoint) {
-        width: 344px;
+        max-width: 344px;
     }
 
     @include media($stampCard-responsive-mobileViewBreakpoint) {
         width: auto;
         box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.12);
+        max-width: none;
     }
 }
 

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
@@ -83,6 +83,10 @@ import lightFormat from 'date-fns/lightFormat';
 import {
     da, enAU, enNZ, enGB, es, it, nb
 } from 'date-fns/locale';
+import EmptyStamp15 from './images/stamp-empty-15.svg';
+import FullStamp15 from './images/stamp-full-15.svg';
+import EmptyStamp10 from './images/stamp-empty-10.svg';
+import FullStamp10 from './images/stamp-full-10.svg';
 
 import CardCase from './CardCase.vue';
 
@@ -97,10 +101,10 @@ export default {
     name: 'StampCard1',
 
     components: {
-        EmptyStamp15: () => import('./images/stamp-empty-15.svg'),
-        FullStamp15: () => import('./images/stamp-full-15.svg'),
-        EmptyStamp10: () => import('./images/stamp-empty-10.svg'),
-        FullStamp10: () => import('./images/stamp-full-10.svg'),
+        EmptyStamp15,
+        FullStamp15,
+        EmptyStamp10,
+        FullStamp10,
         CardCase
     },
 

--- a/packages/components/organisms/f-content-cards/vue.config.js
+++ b/packages/components/organisms/f-content-cards/vue.config.js
@@ -6,6 +6,7 @@ const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
 // vue.config.js
 module.exports = {
+    configureWebpack: { externals: ['@braze/web-sdk'] },
     chainWebpack: config => {
         config.module
             .rule('scss-importer')

--- a/yarn.lock
+++ b/yarn.lock
@@ -10375,10 +10375,10 @@ date-fns@2.16.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
-date-fns@2.17.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.17.0.tgz#afa55daea539239db0a64e236ce716ef3d681ba1"
-  integrity sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==
+date-fns@^2.17.0:
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.25.0.tgz#8c5c8f1d958be3809a9a03f4b742eba894fc5680"
+  integrity sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w==
 
 dateformat@^3.0.0, dateformat@^3.0.3:
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2172,18 +2172,6 @@
   dependencies:
     "@justeat/f-services" "1.0.0"
 
-"@justeat/f-braze-adapter@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-braze-adapter/-/f-braze-adapter-3.5.0.tgz#008b89ab02f72d53b1ef8c464546da8d8df2e852"
-  integrity sha512-YsULFKoxllze/TzRO8G0sXcERcePjtjGq+lMsRnGU9faUxO9KpEFBCjs82bdZZMIYTPUSDpiHKd2Dxhqga3Gdw==
-  dependencies:
-    appboy-web-sdk "2.5.2"
-    date-fns "2.16.1"
-    lodash.findindex "4.6.0"
-    lodash.orderby "4.6.0"
-    lodash.startswith "4.2.1"
-    lodash.uniq "4.5.0"
-
 "@justeat/f-button@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-3.0.2.tgz#9560d0caf56ae0801208ddd0c27cb50d670d54a8"
@@ -2221,6 +2209,14 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-4.0.1.tgz#c6a868d39a3d3361af9e29b44f0d8bc21e30da8d"
   integrity sha512-DSF1NJFKBb/tZDCCUyTGXcnKWC5FvPa9TIcCy0n57OLfQOJ9A53VfxVpRoW8VjlRZu/bl6nYx4kukZq+iHmx5Q==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+    "@justeat/f-vue-icons" "2.5.0"
+
+"@justeat/f-form-field@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-4.5.0.tgz#931d5d643090c2fce46ecf8302b3333013fb3d7d"
+  integrity sha512-EJLkg0vzxS+BE16mZ2Q2r7bB3jvZd8EFW8jB5GmACSqtsCe0iLLFSfY2cPlDx3oZ1nZMoRse/T2foCrjH5c7dg==
   dependencies:
     "@justeat/f-services" "1.0.0"
     "@justeat/f-vue-icons" "2.5.0"
@@ -6613,11 +6609,6 @@ app-root-dir@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/app-root-dir/-/app-root-dir-1.0.2.tgz#38187ec2dea7577fff033ffcb12172692ff6e118"
   integrity sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=
-
-appboy-web-sdk@2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/appboy-web-sdk/-/appboy-web-sdk-2.5.2.tgz#e01ad9fbd744bc48da5bc91a3b3e71493f1a52bd"
-  integrity sha512-Gh5yAgEH/N7Wc3A0Pm8wZNb7uTygdHCB2BiJlI/0HZbJ1iWiA5SjGplTjovPZtrJK22AGcqRp9XVtea3EBYC9w==
 
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"


### PR DESCRIPTION
Moves the beta branch of content cards into master ready for use in f-loyalty page, Also includes a few minor style changes to allow make stamp cards size better on mobile widths.

Previous PR's covered in the beta for reference: 

- #1239
- #1282 
- #1299
- #1149 