### PR TITLE
f-card@3.2.0 - Add prop cardSizeCustom to allow two different widths.

### DIFF
--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.2.0
+------------------------------
+*November 23, 2021*
+
+### Added
+- `cardSizeCustom` prop to allow two custom sizes for the accounts page, medium & large.
+
+
 v3.1.0
 ------------------------------
 *November 19, 2021*

--- a/packages/components/atoms/f-card/README.md
+++ b/packages/components/atoms/f-card/README.md
@@ -73,6 +73,7 @@ The props that can be defined are as follows:
 | `isPageContentWrapper`    | `Boolean`  |  No        | `false` | When set to `true`, applies styles to make the card act like a page content wrapper.<br><br>The card will be full width on narrow devices, and then a fixed width above a certain breakpoint width (about 480px), when the card will be centred on the page. |
 | `hasFullWidthFooter` | `Boolean` | No | `false` | When set to `true`, named slot `full-width-bottom-element` can be passed to render full width content at the bottom of the card without card paddings. |
 | `hasInnerSpacingLarge` | `Boolean` | No | `false` | When set to `true`, padding around the card increases from 16px to 32px. |
+| `cardSizeCustom` | `String` | No | `''` | Can be set to either `medium` (600px max-width) or `large` (808px max-width) |
 
 ### CSS Classes
 

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card",
   "description": "Fozzie Card Component – Used for providing wrapper card styling to an element (or group of elements)",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "main": "dist/f-card.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -4,7 +4,8 @@
         :class="[
             $style['c-card'], {
                 [$style['c-card--outline']]: hasOutline,
-                [$style['c-card--pageContentWrapper']]: isPageContentWrapper
+                [$style['c-card--pageContentWrapper']]: isPageContentWrapper,
+                [$style[`c-card--cardSizeCustom--${cardSizeCustom}`]]: cardSizeCustom !== ''
             }]">
         <div
             data-test-id="card-inner"
@@ -67,6 +68,11 @@ export default {
         hasInnerSpacingLarge: {
             type: Boolean,
             default: false
+        },
+        cardSizeCustom: {
+            type: String,
+            default: '',
+            validator: value => ['', 'medium', 'large'].indexOf(value) !== -1
         }
     }
 };
@@ -141,5 +147,14 @@ $card--pageContentWrapper-width           : 472px; // so that it falls on our 8p
 
     .c-card-heading--rightAligned {
         text-align: right;
+    }
+
+    // The two card sizes used on the accounts page. e.g Previous orders & contact preferences cards.
+    .c-card--cardSizeCustom--large {
+        max-width: 808px;
+    }
+
+    .c-card--cardSizeCustom--medium {
+        max-width: 600px;
     }
 </style>

--- a/packages/components/atoms/f-card/src/components/_tests/Card.test.js
+++ b/packages/components/atoms/f-card/src/components/_tests/Card.test.js
@@ -7,7 +7,9 @@ const $style = {
     'c-card--pageContentWrapper': 'c-card--pageContentWrapper',
     'c-card-heading--centerAligned': 'c-card-heading--centerAligned',
     'c-card-heading--rightAligned': 'c-card-heading--rightAligned',
-    'c-card-innerSpacing--large': 'c-card-innerSpacing--large'
+    'c-card-innerSpacing--large': 'c-card-innerSpacing--large',
+    'c-card--cardSizeCustom--large': 'c-card--cardSizeCustom--large',
+    'c-card--cardSizeCustom--medium': 'c-card--cardSizeCustom--medium'
 };
 
 describe('Card', () => {
@@ -221,6 +223,35 @@ describe('Card', () => {
                     // Assert
                     expect(wrapper.find('[data-test-id="card-inner"]').attributes('class')).not.toContain('c-card-innerSpacing--large');
                 });
+            });
+        });
+
+        describe('`cardSizeCustom`', () => {
+            it('should default to an empty string if it is not set', () => {
+                // Arrange & Act
+                const wrapper = shallowMount(Card, { propsData: {} });
+
+                // Assert
+                expect(wrapper.vm.cardSizeCustom).toBe('');
+            });
+
+            it.each([
+                ['c-card--cardSizeCustom--large', 'large'],
+                ['c-card--cardSizeCustom--medium', 'medium']
+            ])('should add %s class to the card container if the `cardSizeCustom` prop is set to %s', (cssClass, propValue) => {
+                // Arrange & Act
+                const wrapper = shallowMount(Card, {
+                    propsData: {
+                        cardSizeCustom: propValue
+                    },
+                    mocks: {
+                        $style
+                    }
+                });
+                const card = wrapper.find('[data-test-id="card-component"]');
+
+                // Assert
+                expect(card.attributes('class')).toContain(cssClass);
             });
         });
     });

--- a/packages/components/atoms/f-card/stories/card.stories.js
+++ b/packages/components/atoms/f-card/stories/card.stories.js
@@ -23,6 +23,7 @@ export const CardComponent = (args, { argTypes }) => ({
             :card-heading="cardHeading"
             :card-heading-position="cardHeadingPosition"
             :card-heading-tag="cardHeadingTag"
+            :card-size-custom="cardSizeCustom"
             :has-outline="hasOutline"
             :is-page-content-wrapper="isPageContentWrapper"
             :has-inner-spacing-large="hasInnerSpacingLarge"
@@ -41,7 +42,8 @@ CardComponent.args = {
     hasOutline: false,
     isPageContentWrapper: false,
     hasFullWidthFooter: false,
-    hasInnerSpacingLarge: false
+    hasInnerSpacingLarge: false,
+    cardSizeCustom: 'medium'
 };
 
 CardComponent.argTypes = {
@@ -50,6 +52,9 @@ CardComponent.argTypes = {
     },
     cardHeadingTag: {
         control: { type: 'select', options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] }
+    },
+    cardSizeCustom: {
+        control: { type: 'select', options: ['medium', 'large'] }
     }
 };
 


### PR DESCRIPTION
We need two sized cards for the accounts pages, rather than setting the sizes on multiple components (f-contact-preferences, f-previous-orders etc) we will use this prop to change the width as it is rendered instead of using css styles in multiple places.

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
