### PR TITLE
f-feature-management@0.7.1 - Enable store namespacing

### DIFF
--- a/packages/services/f-feature-management/CHANGELOG.md
+++ b/packages/services/f-feature-management/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.7.1
+------------------------------
+*November 23, 2021*
+
+### Changed 
+ - Enable namespacing for store
+
 v0.7.0
 ------------------------------
 *November 18, 2021*

--- a/packages/services/f-feature-management/package.json
+++ b/packages/services/f-feature-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-feature-management",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Service for querying feature values provided by Feature Management",
   "main": "dist/f-feature-management.umd.js",
   "module": "dist/f-feature-management.es.js",

--- a/packages/services/f-feature-management/src/vue/store/features.module.js
+++ b/packages/services/f-feature-management/src/vue/store/features.module.js
@@ -1,6 +1,8 @@
 import SET_FM_CONFIG_JSON from './mutation.types';
 
 export default {
+    namespaced: true,
+
     state: () => ({
         configJson: {}
     }),


### PR DESCRIPTION
Simply adding the 'namespaced' flag to the store.
