### PR TITLE
#trivial - f-contact-preferences - Added missing dependency ref.

### DIFF
--- a/packages/components/pages/f-contact-preferences/package.json
+++ b/packages/components/pages/f-contact-preferences/package.json
@@ -41,7 +41,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.7.0"
+    "@justeat/f-services": "1.7.0",
+    "@justeat/f-globalisation": "1.0.0"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0",


### PR DESCRIPTION
### Added 
- Added missing ref. : globalisation": "1.0.0" to the f-contact-preferences package.json