### PR TITLE
f-checkout@v3.11.0 - Use card with content for Errors

### DIFF
--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.11.0
+------------------------------
+*November 25, 2021*
+
+### Changed
+- `Error component` uses `BagSadBgIcon` from `f-vue-icons@3.0.0` and `f-card-with-content`.
+
+
 v3.9.0
 ------------------------------
 *November 23, 2021*

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "3.9.0",
+  "version": "3.11.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "120kB",
   "files": [
@@ -61,10 +61,12 @@
     "@justeat/f-alert": "3.0.2",
     "@justeat/f-button": "3.0.2",
     "@justeat/f-card": "3.0.0",
+    "@justeat/f-card-with-content": "0.2.1",
     "@justeat/f-error-message": "1.0.0",
     "@justeat/f-form-field": "4.0.1",
     "@justeat/f-link": "2.0.0",
     "@justeat/f-mega-modal": "3.0.2",
+    "@justeat/f-vue-icons": "3.0.0",
     "@justeat/f-wdio-utils": "0.4.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/pages/f-checkout/src/components/Error.vue
+++ b/packages/components/pages/f-checkout/src/components/Error.vue
@@ -1,45 +1,24 @@
 <template>
     <card
-        has-outline
-        is-page-content-wrapper
-        card-heading-position="center"
         data-test-id="checkout-error-page-component"
-        :class="[$style['c-checkout-error'], $style['c-checkout-error--verticalPadding']]">
-        <!-- TODO: Load image from CDN in future -->
-        <sad-bag-icon-decorator
-            data-test-id="checkout-error-page-image" />
-
-        <h1
-            :class="$style['c-checkout-error-heading']"
-            data-test-id="checkout-error-page-heading">
-            {{ $t(`errorMessages.${errorFormType}.heading`) }}
-        </h1>
-
-        <p
-            :class="$style['c-checkout-error-description']"
-            data-test-id="checkout-error-page-description">
-            {{ $t(`errorMessages.${errorFormType}.description`, { serviceType: serviceType }) }}
-        </p>
-
-        <f-button
-            :class="$style['c-checkout-error-button']"
-            button-size="large"
-            button-type="primary"
-            is-full-width
-            data-test-id="error-page-redirect-button"
-            @click.native="redirectFromErrorPage">
-            {{ $t(`errorMessages.${errorFormType}.buttonText`) }}
-        </f-button>
+        :class="$style['c-checkout-error']"
+        :card-heading="$t(`errorMessages.${errorFormType}.heading`)"
+        :card-description=" $t(`errorMessages.${errorFormType}.description`, { serviceType: serviceType })"
+        :primary-button="primaryButton"
+        @primary-button-click="redirectFromErrorPage">
+        <template
+            #icon>
+            <bag-sad-bg-icon
+                data-test-id="checkout-error-page-image" />
+        </template>
     </card>
 </template>
 
 <script>
 import { mapState } from 'vuex';
-import Card from '@justeat/f-card';
-import FButton from '@justeat/f-button';
-import SadBagIconDecorator from '../assets/images/jet-sad-bag.svg';
-import '@justeat/f-button/dist/f-button.css';
-import '@justeat/f-card/dist/f-card.css';
+import Card from '@justeat/f-card-with-content';
+import { BagSadBgIcon } from '@justeat/f-vue-icons';
+import '@justeat/f-card-with-content/dist/f-card-with-content.css';
 import {
     VUEX_CHECKOUT_MODULE,
     CHECKOUT_ERROR_FORM_TYPE
@@ -49,21 +28,24 @@ import loggerMixin from '../mixins/logger.mixin';
 export default {
     components: {
         Card,
-        FButton,
-        SadBagIconDecorator
+        BagSadBgIcon
     },
+
     mixins: [
         loggerMixin
     ],
+
     props: {
         errorFormType: {
             type: String,
             required: true
         },
+
         redirectUrl: {
             type: String,
             default: ''
         },
+
         serviceType: {
             type: String,
             default: ''
@@ -73,7 +55,13 @@ export default {
     computed: {
         ...mapState(VUEX_CHECKOUT_MODULE, [
             'restaurant'
-        ])
+        ]),
+
+        primaryButton () {
+            return {
+                text: this.$t(`errorMessages.${this.errorFormType}.buttonText`)
+            };
+        }
     },
 
     mounted () {
@@ -102,32 +90,10 @@ export default {
 
 <style lang="scss" module>
 .c-checkout-error {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-
-    &.c-checkout-error--verticalPadding {
-        @include media('<=narrow') {
-            border: none;
-            padding-top: spacing(x2);
-            padding-bottom: spacing(x2);
-        }
+    @include media('<=narrow') {
+        border: none;
+        padding-top: spacing(x2);
+        padding-bottom: spacing(x2);
     }
-}
-
-.c-checkout-error-heading {
-    @include font-size(heading-s);
-    margin-top: spacing(x8);
-    margin-bottom: 0;
-}
-
-.c-checkout-error-description {
-    @include font-size(body-l);
-    margin-top: spacing();
-}
-
-.c-checkout-error-button {
-    margin: spacing(x4) 0 spacing(x0.5);
 }
 </style>

--- a/packages/components/pages/f-checkout/src/components/_tests/Error.test.js
+++ b/packages/components/pages/f-checkout/src/components/_tests/Error.test.js
@@ -1,5 +1,5 @@
 import { VueI18n } from '@justeat/f-globalisation';
-import { shallowMount, createLocalVue } from '@vue/test-utils';
+import { mount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import Error from '../Error.vue';
 import {
@@ -22,7 +22,7 @@ describe('Error', () => {
     beforeEach(() => {
         // Arrange & Act
 
-        wrapper = shallowMount(Error, {
+        wrapper = mount(Error, {
             i18n,
             localVue,
             store: createStore({
@@ -55,7 +55,7 @@ describe('Error', () => {
 
     it('should show the heading', () => {
         // Act
-        const heading = wrapper.find('[data-test-id="checkout-error-page-heading"]');
+        const heading = wrapper.find('[data-test-id="cardWithContent-heading"]');
 
         // Assert
         expect(heading.text()).toMatchSnapshot();
@@ -63,7 +63,7 @@ describe('Error', () => {
 
     it('should show the description', () => {
         // Act
-        const description = wrapper.find('[data-test-id="checkout-error-page-description"]');
+        const description = wrapper.find('[data-test-id="cardWithContent-description"]');
 
         // Assert
         expect(description.text()).toMatchSnapshot();


### PR DESCRIPTION
- `Error component` uses `BagSadBgIcon` from `f-vue-icons@3.0.0` and `f-card-with-content`.