### PR TITLE
f-contact-preferences@0.8.0 - Update card version to pull in new props.

### DIFF
--- a/packages/components/pages/f-contact-preferences/CHANGELOG.md
+++ b/packages/components/pages/f-contact-preferences/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.8.0
+------------------------------
+*November 26, 2021*
+
+### Changed
+- `f-card` wrapping component adds two props to control padding & size.
+
+### Added
+- New version of f-card (pulls in the two new props).
+
 
 v0.7.0
 ------------------------------

--- a/packages/components/pages/f-contact-preferences/package.json
+++ b/packages/components/pages/f-contact-preferences/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-contact-preferences",
   "description": "Fozzie Contact Preferences - Fozzie user contact preferences form component",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "dist/f-contact-preferences.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@justeat/f-button": "3.0.2",
-    "@justeat/f-card": "3.0.0",
+    "@justeat/f-card": "3.3.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",

--- a/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
+++ b/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
@@ -4,7 +4,8 @@
         <card-component
             v-if="!shouldShowErrorPage"
             :card-heading="$t('heading')"
-            is-page-content-wrapper
+            has-inner-spacing-large
+            :card-size-custom="'medium'"
             has-outline>
             <form @submit.prevent="onFormSubmit">
                 <div

--- a/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
+++ b/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
@@ -55,9 +55,9 @@
                 </div>
 
                 <f-button
+                    :class="$style['c-contact-preferences-btn']"
                     data-test-id="contact-preferences-submit-button"
                     button-type="primary"
-                    is-full-width
                     action-type="submit"
                     :is-loading="isFormSubmitting">
                     {{ $t('saveChangesButton') }}
@@ -245,5 +245,13 @@ export default {
 
 .c-contactPreferences-subtitle {
     @include font-size(heading-s);
+}
+
+.c-contact-preferences-btn {
+    width: 100%;
+
+    @include media('>narrow') {
+        width: inherit;
+    }
 }
 </style>


### PR DESCRIPTION
PR allows the card to have a different padding setting and a medium max-width (600px).

PR changes [1](https://github.com/justeat/fozzie-components/pull/1503) & [2](https://github.com/justeat/fozzie-components/pull/1482)

Screenshot:

![Screenshot 2021-11-26 at 10 34 22](https://user-images.githubusercontent.com/2299779/143567450-fd685cd3-986c-4bdb-98e2-1b809b062931.png)

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
