### PR TITLE
f-mega-modal@4.0.0 - f-button to the peer deps

### DIFF
--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.0.0
+------------------------------
+*November 26, 2021*
+
+### Added
+- **Breaking Change**: Added `f-button` dependency to peer dependencies. Now `f-button` should be included as a dependency of the consuming componet or application.
+
+### Removed
+- **Breaking Change**: Removed `f-button` styles import from the component. Make sure to import `f-button` styles in your application.
+
+
 v3.0.2
 ------------------------------
 *October 15, 2021*

--- a/packages/components/molecules/f-mega-modal/README.md
+++ b/packages/components/molecules/f-mega-modal/README.md
@@ -29,6 +29,12 @@ yarn add @justeat/f-mega-modal
 npm install @justeat/f-mega-modal
 ```
 
+The package also has dependencies that need to be installed by consuming components/applications:
+
+| Dependency | Command to install | Styles to include |
+| ----- | ----- | ----- |
+| f-button | `yarn add @justeat/f-button` | `import '@justeat/f-button/dist/f-button.css';` |
+
 ### Vue Applications
 
 You can import it in your Vue SFC like this (please note that styles have to be imported separately):

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "main": "dist/f-mega-modal.common.js",
   "maxBundleSize": "6kB",
   "files": [
@@ -40,10 +40,11 @@
   ],
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
+    "@justeat/f-button": "3.x",
     "body-scroll-lock": "3.x"
   },
   "devDependencies": {
-    "@justeat/f-button": "3.0.2",
+    "@justeat/f-button": "3.2.0",
     "@justeat/f-vue-icons": "2.4.0",
     "@justeat/f-wdio-utils": "0.4.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -65,7 +65,6 @@
 import { CrossIcon } from '@justeat/f-vue-icons';
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 import FButton from '@justeat/f-button';
-import '@justeat/f-button/dist/f-button.css';
 
 export default {
     components: {

--- a/packages/components/molecules/f-mega-modal/vue.config.js
+++ b/packages/components/molecules/f-mega-modal/vue.config.js
@@ -1,5 +1,7 @@
 const path = require('path');
 
+const PeerDepsExternalsPlugin = require('peer-deps-externals-webpack-plugin');
+
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
@@ -16,12 +18,13 @@ module.exports = {
                 // eslint-disable-next-line quotes
                 additionalData: `@import "../assets/scss/common.scss";`
             });
-
-        config.externals({
-            'body-scroll-lock': 'body-scroll-lock'
-        });
     },
     pluginOptions: {
         lintStyleOnBuild: true
+    },
+    configureWebpack: {
+        plugins: [
+            new PeerDepsExternalsPlugin()
+        ]
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2240,6 +2240,11 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-3.0.0.tgz#2e635096c2a6a8fd7da308479a2126748716dcbf"
   integrity sha512-ZbAgBrqn3a2furQ5F0FLffbsMZar9aIDsRG/2uWnsv6uY0KIHgJi08kH2XK5NzDzckHih2uMN37JiYpQMw6rNQ==
 
+"@justeat/f-mega-modal@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-3.0.2.tgz#81f2b5ca8519a6eca93f5643857df2a9c924666d"
+  integrity sha512-3M+wpcjOIIw3hKbtZqyRl3mwdi2zz90wFAJc5RtJciJ/VwD73bHNjvABRl/At+JZj2p0Ongjg11ezSayoKMGJg==
+
 "@justeat/f-searchbox@6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-searchbox/-/f-searchbox-6.0.0.tgz#fa6ea41ca3ccde26d5ed65511a96f1a728a9fc88"


### PR DESCRIPTION
### Added
- **Breaking Change**: Added `f-button` dependency to peer dependencies. Now `f-button` should be included as a dependency of the consuming componet or application.

### Removed
- **Breaking Change**: Removed `f-button` styles import from the component. Make sure to import `f-button` styles in your application.