### PR TITLE
f-card-with-content@1.0.0 - Add button & card to peerDep.

### DIFF
--- a/packages/components/molecules/f-card-with-content/CHANGELOG.md
+++ b/packages/components/molecules/f-card-with-content/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.0.0
+------------------------------
+*November 26, 2021*
+
+### Added
+- **Breaking Change**: Added `f-button` dependency to peer dependencies. Now `f-button` should be included as a dependency of the consuming component or application.
+- **Breaking Change**: Added `f-card` dependency to peer dependencies. Now `f-card` should be included as a dependency of the consuming component or application.
+
+### Removed
+- **Breaking Change**: Removed `f-button` styles import from the component. Make sure to import `f-button` styles in your application.
+- **Breaking Change**: Removed `f-card` styles import from the component. Make sure to import `f-card` styles in your application.
+
 
 v0.2.1
 ------------------------------

--- a/packages/components/molecules/f-card-with-content/README.md
+++ b/packages/components/molecules/f-card-with-content/README.md
@@ -35,6 +35,12 @@ yarn add @justeat/f-card-with-content
 npm install @justeat/f-card-with-content
 ```
 
+The package also has dependencies that need to be installed by consuming components/applications:
+
+| Dependency | Command to install | Styles to include |
+| ----- | ----- | ----- |
+| f-button | `yarn add @justeat/f-button` | `import '@justeat/f-button/dist/f-button.css';` |
+| f-card | `yarn add @justeat/f-card` | `import '@justeat/f-card/dist/f-card.css';` |
 
 
 ### Vue Applications

--- a/packages/components/molecules/f-card-with-content/package.json
+++ b/packages/components/molecules/f-card-with-content/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card-with-content",
   "description": "Fozzie Card With Content - A page content card which can contain an image, heading, text, and (primary and secondary) buttons",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "main": "dist/f-card-with-content.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [
@@ -41,7 +41,9 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "peerDependencies": {
-    "@justeat/browserslist-config-fozzie": ">=1.2.0"
+    "@justeat/browserslist-config-fozzie": ">=1.2.0",
+    "@justeat/f-button": "3.x",
+    "@justeat/f-card": "3.x"
   },
   "devDependencies": {
     "@justeat/f-button": "3.2.0",

--- a/packages/components/molecules/f-card-with-content/src/components/CardWithContent.vue
+++ b/packages/components/molecules/f-card-with-content/src/components/CardWithContent.vue
@@ -55,9 +55,7 @@
 
 <script>
 import CardComponent from '@justeat/f-card';
-import '@justeat/f-card/dist/f-card.css';
 import FButton from '@justeat/f-button';
-import '@justeat/f-button/dist/f-button.css';
 
 export default {
     name: 'CardWithContent',

--- a/packages/components/molecules/f-card-with-content/vue.config.js
+++ b/packages/components/molecules/f-card-with-content/vue.config.js
@@ -1,5 +1,7 @@
 const path = require('path');
 
+const PeerDepsExternalsPlugin = require('peer-deps-externals-webpack-plugin');
+
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
@@ -19,5 +21,11 @@ module.exports = {
     },
     pluginOptions: {
         lintStyleOnBuild: true
+    },
+
+    configureWebpack: {
+        plugins: [
+            new PeerDepsExternalsPlugin()
+        ]
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2177,6 +2177,11 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-3.0.2.tgz#9560d0caf56ae0801208ddd0c27cb50d670d54a8"
   integrity sha512-qzZr6ZN01GTs6yFGOvIpwDcdXQKcH1SCF3CN7s9YTNiemWaQAoLo9sfv08fNuawBsxLwX4ZMLzjMY9dioC4vpg==
 
+"@justeat/f-card-with-content@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@justeat/f-card-with-content/-/f-card-with-content-0.2.1.tgz#1af84f431073ad3f5529a4b4db983563d6cf526e"
+  integrity sha512-WGyfr0T/8eFqVUKNrr+PQTO8V3opidzUcT9s0fwJ4uU2q3SU31kqts9shDSgpDXKx7LBNxKqx/W8bUFgEU9Ejw==
+
 "@justeat/f-card@3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-card/-/f-card-3.0.0.tgz#6bc0840adcca276638778a080ea66d6f34309a78"


### PR DESCRIPTION
### Added
- **Breaking Change**: Added `f-button` dependency to peer dependencies. Now `f-button` should be included as a dependency of the consuming component or application.
- **Breaking Change**: Added `f-card` dependency to peer dependencies. Now `f-card` should be included as a dependency of the consuming component or application.

### Removed
- **Breaking Change**: Removed `f-button` styles import from the component. Make sure to import `f-button` styles in your application.
- **Breaking Change**: Removed `f-card` styles import from the component. Make sure to import `f-card` styles in your application.



## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
