### PR TITLE
f-takeawaypay-activation@2.8.0 - Update visual regression tests to include UK and AU tenants

### DIFF
--- a/packages/components/pages/f-takeawaypay-activation/CHANGELOG.md
+++ b/packages/components/pages/f-takeawaypay-activation/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.8.0
+------------------------------
+*December 1, 2021*
+
+### Changed
+- Update visual regression tests to include UK and AU tenants, as they have different branding (JustEat Pay / Menulog Pay).
 
 v2.7.0
 ------------------------------

--- a/packages/components/pages/f-takeawaypay-activation/package.json
+++ b/packages/components/pages/f-takeawaypay-activation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-takeawaypay-activation",
   "description": "Fozzie TakeawayPay Activation - Handles Takeaway Pay activation for users",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "main": "dist/f-takeawaypay-activation.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/pages/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-authenticated.visual.desktop.spec.js
+++ b/packages/components/pages/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-authenticated.visual.desktop.spec.js
@@ -1,3 +1,5 @@
+import forEach from 'mocha-each';
+
 const TakeawayPayComponent = require('../../test-utils/component-objects/f-takeawaypayActivation.component');
 const { AUTHENTICATION_JWT } = require('../../test-utils/constants/f-takeawaypayActivation');
 
@@ -13,23 +15,32 @@ describe('f-takeawaypay-activation - Authenticated - Desktop Visual Tests', () =
             .withQuery('knob-Home URL', '/home')
             .withQuery('knob-Login URL', '/account/login')
             .withQuery('knob-Registration URL', '/account/register');
+    });
+
+    forEach(['en-GB', 'en-AU'])
+    .it('should display user details when the user is logged in and tenant is "%s"', tenant => {
+        // Arrange
+        takeawayPayComponent.withQuery('knob-Locale', tenant);
 
         // Act
         takeawayPayComponent.load('loggedIn');
-    });
 
-    it('should display user details when the user is logged in.', () => {
         // Assert
-        browser.percyScreenshot('f-takeawaypay-activation - Authenticated', 'desktop');
+        browser.percyScreenshot(`f-takeawaypay-activation - Authenticated - ${tenant}`, 'desktop');
     });
 
-    it('should display a successful message when the activation is successful', () => {
+    forEach(['en-GB', 'en-AU'])
+    .it('should display a successful message when the activation is successful and tenant is "%s"', tenant => {
+        // Arrange
+        takeawayPayComponent.withQuery('knob-Locale', tenant);
+
         // Act
+        takeawayPayComponent.load('loggedIn');
         takeawayPayComponent.clickActivateTakeawayPayButton();
         takeawayPayComponent.waitForActivationSuccessComponent();
         browser.pause(500);
 
         // Assert
-        browser.percyScreenshot('f-takeawaypay-activation - Successful activation', 'desktop');
+        browser.percyScreenshot(`f-takeawaypay-activation - Successful activation - ${tenant}`, 'desktop');
     });
 });

--- a/packages/components/pages/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-authenticated.visual.mobile.spec.js
+++ b/packages/components/pages/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-authenticated.visual.mobile.spec.js
@@ -1,3 +1,5 @@
+import forEach from 'mocha-each';
+
 const TakeawayPayComponent = require('../../test-utils/component-objects/f-takeawaypayActivation.component');
 const { AUTHENTICATION_JWT } = require('../../test-utils/constants/f-takeawaypayActivation');
 
@@ -13,23 +15,32 @@ describe('f-takeawaypay-activation - Authenticated - Mobile Visual Tests', () =>
             .withQuery('knob-Home URL', '/home')
             .withQuery('knob-Login URL', '/account/login')
             .withQuery('knob-Registration URL', '/account/register');
+    });
+
+    forEach(['en-GB', 'en-AU'])
+    .it('should display user details when the user is logged in and tenant is "%s"', tenant => {
+        // Arrange
+        takeawayPayComponent.withQuery('knob-Locale', tenant);
 
         // Act
         takeawayPayComponent.load('loggedIn');
-    });
 
-    it('should display user details when the user is logged in.', () => {
         // Assert
-        browser.percyScreenshot('f-takeawaypay-activation - Authenticated', 'mobile');
+        browser.percyScreenshot(`f-takeawaypay-activation - Authenticated - ${tenant}`, 'mobile');
     });
 
-    it('should display a successful message when the activation is successful', () => {
+    forEach(['en-GB', 'en-AU'])
+    .it('should display a successful message when the activation is successful and tenant is "%s"', tenant => {
+        // Arrange
+        takeawayPayComponent.withQuery('knob-Locale', tenant);
+
         // Act
+        takeawayPayComponent.load('loggedIn');
         takeawayPayComponent.clickActivateTakeawayPayButton();
         takeawayPayComponent.waitForActivationSuccessComponent();
         browser.pause(500);
 
         // Assert
-        browser.percyScreenshot('f-takeawaypay-activation - Successful activation', 'mobile');
+        browser.percyScreenshot(`f-takeawaypay-activation - Successful activation - ${tenant}`, 'mobile');
     });
 });

--- a/packages/components/pages/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-error.visual.desktop.spec.js
+++ b/packages/components/pages/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-error.visual.desktop.spec.js
@@ -1,3 +1,5 @@
+import forEach from 'mocha-each';
+
 const TakeawayPayComponent = require('../../test-utils/component-objects/f-takeawaypayActivation.component');
 
 let takeawayPayComponent;
@@ -12,13 +14,17 @@ describe('f-takeawaypay-activation - Error page - Desktop Visual Tests', () => {
             .withQuery('knob-Home URL', '/home')
             .withQuery('knob-Login URL', '/account/login')
             .withQuery('knob-Registration URL', '/account/register');
+    });
+
+    forEach(['en-GB', 'en-AU'])
+    .it('should display the component when there is an error and tenant is "%s"', tenant => {
+        // Arrange
+        takeawayPayComponent.withQuery('knob-Locale', tenant);
 
         // Act
         takeawayPayComponent.load('error');
-    });
 
-    it('should display the component when there is an error.', () => {
         // Assert
-        browser.percyScreenshot('f-takeawaypay-activation - Error', 'desktop');
+        browser.percyScreenshot(`f-takeawaypay-activation - Error - ${tenant}`, 'desktop');
     });
 });

--- a/packages/components/pages/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-error.visual.mobile.spec.js
+++ b/packages/components/pages/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-error.visual.mobile.spec.js
@@ -1,3 +1,5 @@
+import forEach from 'mocha-each';
+
 const TakeawayPayComponent = require('../../test-utils/component-objects/f-takeawaypayActivation.component');
 
 let takeawayPayComponent;
@@ -12,13 +14,17 @@ describe('f-takeawaypay-activation - Error page - Mobile Visual Tests', () => {
             .withQuery('knob-Home URL', '/home')
             .withQuery('knob-Login URL', '/account/login')
             .withQuery('knob-Registration URL', '/account/register');
+    });
+
+    forEach(['en-GB', 'en-AU'])
+    .it('should display the component when there is an error and tenant is "%s"', tenant => {
+         // Arrange
+         takeawayPayComponent.withQuery('knob-Locale', tenant);
 
         // Act
         takeawayPayComponent.load('error');
-    });
 
-    it('should display the component when there is an error.', () => {
         // Assert
-        browser.percyScreenshot('f-takeawaypay-activation - Error', 'mobile');
+        browser.percyScreenshot(`f-takeawaypay-activation - Error - ${tenant}`, 'mobile');
     });
 });

--- a/packages/components/pages/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-unauthenticated.visual.desktop.spec.js
+++ b/packages/components/pages/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-unauthenticated.visual.desktop.spec.js
@@ -1,3 +1,5 @@
+import forEach from 'mocha-each';
+
 const TakeawayPayComponent = require('../../test-utils/component-objects/f-takeawaypayActivation.component');
 
 let takeawayPayComponent;
@@ -6,13 +8,17 @@ describe('f-takeawaypay-activation - Unauthenticated - Desktop Visual Tests', ()
     beforeEach(() => {
         // Arrange
         takeawayPayComponent = new TakeawayPayComponent();
+    });
+
+    forEach(['en-GB', 'en-AU'])
+    .it('should display the component when the user is not logged in and tenant is "%s"', tenant => {
+        // Arrange
+        takeawayPayComponent.withQuery('knob-Locale', tenant);
 
         // Act
         takeawayPayComponent.load();
-    });
 
-    it('should display the component when the user is not logged in.', () => {
         // Assert
-        browser.percyScreenshot('f-takeawaypay-activation - Unauthenticated', 'desktop');
+        browser.percyScreenshot(`f-takeawaypay-activation - Unauthenticated - ${tenant}`, 'desktop');
     });
 });

--- a/packages/components/pages/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-unauthenticated.visual.mobile.spec.js
+++ b/packages/components/pages/f-takeawaypay-activation/test/visual/f-takeawaypay-activation-unauthenticated.visual.mobile.spec.js
@@ -1,3 +1,5 @@
+import forEach from 'mocha-each';
+
 const TakeawayPayComponent = require('../../test-utils/component-objects/f-takeawaypayActivation.component');
 
 let takeawayPayComponent;
@@ -6,13 +8,17 @@ describe('f-takeawaypay-activation - Unauthenticated - Mobile Visual Tests', () 
     beforeEach(() => {
         // Arrange
         takeawayPayComponent = new TakeawayPayComponent();
+    });
+
+    forEach(['en-GB', 'en-AU'])
+    .it('should display the component when the user is not logged in and tenant is "%s"', tenant => {
+        // Arrange
+        takeawayPayComponent.withQuery('knob-Locale', tenant);
 
         // Act
         takeawayPayComponent.load();
-    });
 
-    it('should display the component when the user is not logged in.', () => {
         // Assert
-        browser.percyScreenshot('f-takeawaypay-activation - Unauthenticated', 'mobile');
+        browser.percyScreenshot(`f-takeawaypay-activation - Unauthenticated - ${tenant}`, 'mobile');
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2403,6 +2403,13 @@
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
 
+"@justeat/f-vue-icons@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-3.0.0.tgz#25207d9c706c530a7fda0a7bc121134295c1bad0"
+  integrity sha512-8mgBcRuciU4MnqabZkhd+F6awuFAIHRbQnUh4ZQc3cgdZC+eIgPgyrLLURg5HNJOXhi6ojhqAFUqJNb1Rc1ZMQ==
+  dependencies:
+    babel-helper-vue-jsx-merge-props "2.0.3"
+
 "@justeat/f-wdio-utils@0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.1.0.tgz#e8a62dd2d03c2cf14ce1fa7d50540c2171b8fc38"


### PR DESCRIPTION
v2.8.0
------------------------------
*December 1, 2021*

### Changed
- Update visual regression tests to include UK and AU tenants, as they have different branding (JustEat Pay / Menulog Pay).

## Browsers Tested

- [x] Chrome (latest)