### PR TITLE
f-form-field@4.3.0 - Ensure labelDescription prop is passed to checkbox label

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.3.0
+------------------------------
+*December 01, 2021*
+
+### Changed
+- Ensure `labelDescription` prop is passed to checkbox label.
+
 
 v4.2.0
 ------------------------------
@@ -60,7 +67,7 @@ v2.2.0
 
 ### Changed
 - Stories to reflect our designs more accurately.
-- Small renamings to match the above. 
+- Small renamings to match the above.
 
 
 v2.1.0

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "main": "dist/f-form-field.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [

--- a/packages/components/atoms/f-form-field/src/components/FormSelectionControl.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormSelectionControl.vue
@@ -20,7 +20,9 @@
 
         <form-label
             :id="`label-${$attrs.id}`"
+            data-test-id="andy"
             :label-for="$attrs.id"
+            :label-description="$attrs.labelDescription"
         >
             {{ labelText }}
         </form-label>

--- a/packages/components/atoms/f-form-field/src/components/FormSelectionControl.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormSelectionControl.vue
@@ -20,7 +20,7 @@
 
         <form-label
             :id="`label-${$attrs.id}`"
-            data-test-id="andy"
+            data-test-id="selection-control-form-label"
             :label-for="$attrs.id"
             :label-description="$attrs.labelDescription"
         >

--- a/packages/components/atoms/f-form-field/src/components/_tests/FormSelectionControl.test.js
+++ b/packages/components/atoms/f-form-field/src/components/_tests/FormSelectionControl.test.js
@@ -40,7 +40,7 @@ describe('FormSelectionControl', () => {
                 const wrapper = shallowMount(FormSelectionControl, { propsData, attrs: { ...attrs, labelDescription: expected } });
 
                 // Assert
-                expect(wrapper.find('[data-test-id="andy"]').attributes('labeldescription')).toBe(expected);
+                expect(wrapper.find('[data-test-id="selection-control-form-label"]').attributes('labeldescription')).toBe(expected);
             });
         });
     });

--- a/packages/components/atoms/f-form-field/src/components/_tests/FormSelectionControl.test.js
+++ b/packages/components/atoms/f-form-field/src/components/_tests/FormSelectionControl.test.js
@@ -32,6 +32,17 @@ describe('FormSelectionControl', () => {
                 expect(wrapper.find('input').element.value).toBe(propsData.value);
             });
         });
+
+        describe('form-label ::', () => {
+            it('should pass labelDescription from $attrs as prop to <form-label>', () => {
+                // Arrange & Act
+                const expected = 'My label desc';
+                const wrapper = shallowMount(FormSelectionControl, { propsData, attrs: { ...attrs, labelDescription: expected } });
+
+                // Assert
+                expect(wrapper.find('[data-test-id="andy"]').attributes('labeldescription')).toBe(expected);
+            });
+        });
     });
 
     describe('props ::', () => {

--- a/packages/components/atoms/f-form-field/stories/Checkbox.stories.js
+++ b/packages/components/atoms/f-form-field/stories/Checkbox.stories.js
@@ -18,6 +18,9 @@ export const CheckboxComponent = () => ({
         labelText: {
             default: text('Label Text', 'Checkbox Label')
         },
+        labelDescription: {
+            default: text('Label Description', '')
+        },
         value: {
             default: text('Value', 'checkboxLabel')
         },
@@ -40,6 +43,7 @@ export const CheckboxComponent = () => ({
     template:
         `<form-field
             :label-text="labelText"
+            :label-description="labelDescription"
             :value="value"
             :has-error="hasError"
             :is-grouped="isGrouped"


### PR DESCRIPTION
### Changed
- Ensure `labelDescription` prop is passed to checkbox label.

![image](https://user-images.githubusercontent.com/20644043/144232557-ebbcab12-571b-45e3-9113-7bc3cc8e9e81.png)
