### PR TITLE
f-cookie-banner@v3.6.1 - changes to cookie banner URL to fix browser test

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v3.6.1
+------------------------------
+*December 01, 2021*
+
+### Fixed
+- Issue with browser test and URL being used.
+
+
 v3.6.0
 ------------------------------
 *November 03, 2021*

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-cookie-banner/src/tenants/es-ES.js
+++ b/packages/components/organisms/f-cookie-banner/src/tenants/es-ES.js
@@ -8,7 +8,7 @@ const messages = {
     textLine3: 'Para más detalles sobre las cookies y tecnologías que usamos, visite nuestro ',
     textLine4: '. El uso de este banner provocará que se instale una cookie en su dispositivo para recordar sus preferencias.',
     cookiePolicyLinkText: 'aviso sobre cookies',
-    cookiePolicyLinkUrl: 'https://www.just-eat.es/cookies-policy',
+    cookiePolicyLinkUrl: 'https://www.just-eat.es/politica-de-cookies',
     reopenCookieBannerLinkText:  'Administrar mis preferencias de cookies'
 };
 

--- a/packages/components/organisms/f-cookie-banner/src/tenants/es-ES.js
+++ b/packages/components/organisms/f-cookie-banner/src/tenants/es-ES.js
@@ -8,7 +8,7 @@ const messages = {
     textLine3: 'Para más detalles sobre las cookies y tecnologías que usamos, visite nuestro ',
     textLine4: '. El uso de este banner provocará que se instale una cookie en su dispositivo para recordar sus preferencias.',
     cookiePolicyLinkText: 'aviso sobre cookies',
-    cookiePolicyLinkUrl: 'https://www.just-eat.es/politica-de-cookies',
+    cookiePolicyLinkUrl: 'https://www.just-eat.es/info/politica-de-cookies',
     reopenCookieBannerLinkText:  'Administrar mis preferencias de cookies'
 };
 


### PR DESCRIPTION
Minor change to fix the browser test that is blocking master and PR's doing full builds.