### PR TITLE
f-form-field@4.4.0 - Change label colour for disabled checkbox

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.4.0
+------------------------------
+*December 02, 2021*
+
+### Changed
+- Ensure label and label description colour is correct when checkbox is disabled
+
+
 v4.3.0
 ------------------------------
 *December 01, 2021*

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "main": "dist/f-form-field.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [

--- a/packages/components/atoms/f-form-field/src/components/FormSelectionControl.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormSelectionControl.vue
@@ -123,8 +123,10 @@ export default {
     }
 
     .c-formField-field--checkbox:disabled + label,
-    .c-formField-field--radio:disabled + label {
+    .c-formField-field--radio:disabled + label,
+    .c-formField-field--checkbox:disabled + label span {
         cursor: default;
+        color: $color-content-disabled;
     }
 
     .c-formField-field--checkbox + label:before,


### PR DESCRIPTION
### Changed
- Ensure label and label description colour is correct when checkbox is disabled

![image](https://user-images.githubusercontent.com/20644043/144409187-bd22334a-9553-4986-9e5f-a48c15cdecba.png)

![image](https://user-images.githubusercontent.com/20644043/144409263-323c640b-8167-46ea-bc29-70cac26a7266.png)

