### PR TITLE
f-header@7.3.0 - Add support for custom navigation links

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v7.3.0
+------------------------------
+*December 1, 2021*
+
+### Added
+- Support for custom links in the nav via `customNavLinks` prop.
+- Relevant knobs to component story.
+
+
 v7.2.0
 ------------------------------
 *December 1, 2021*

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -6,11 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v7.3.0
 ------------------------------
-*December 1, 2021*
+*December 6, 2021*
 
 ### Added
 - Support for custom links in the nav via `customNavLinks` prop.
-- Relevant knobs to component story.
+- Visual tests (currently skipped because of [storybook issue](https://github.com/storybookjs/storybook/issues/14420)).
+
+### Changed
+- Story now uses controls instead of knobs.
 
 
 v7.2.0

--- a/packages/components/organisms/f-header/README.md
+++ b/packages/components/organisms/f-header/README.md
@@ -71,19 +71,20 @@ The props that can be defined are as follows:
 | Prop                      | Type          | Default | Description |
 | :---                      |     :---:     |  :---:  | :---        |
 | locale                    | `String`      | `en-GB` | Sets the locale of the component (which determines what theme and translations to use.<br><br>If the application consuming the `f-header` component is using the vue `i18n` module, then the locale from that module will be used when this prop isn't defined. When this prop is defined, it takes precedence over the locale defined by the `i18n` module.<br><br>If not defined and the `i18n` module isn't present, the default locale used is `en-GB`.|
-| errorLog                  | `Function`    | `-`    | Function passed in for logging errors with the `fetchUserInfo` method. |
+| customNavLinks            | `Array`       | `[]`    | Array containing objects representing the custom links. To contain `text`, `url` and `gtm` properties. |
+| errorLog                  | `Function`    | `-`     | Function passed in for logging errors with the `fetchUserInfo` method. |
 | headerBackgroundTheme     | `String`      | `white` | Sets the background theme for the header component.<br><br>When set to `white` the header will be white with the default logo colour.<br>When set to `transparent` the header will be transparent with a white logo.<br>When set to `highlight` the header will use the primary brand colour as the background colour with a white logo. |
-| isOrderCountSupported     | `Boolean`     | `true` | ?? |
+| isOrderCountSupported     | `Boolean`     | `true`  | ?? |
 | isLogoLinkDisabled        | `Boolean`     | `false` | Whether the company logo is disabled from allowing the user to navigate home
 | orderCountUrl             | `String`      | `false` | ?? |
 | showDeliveryEnquiry       | `Boolean`     | `false` | Defines if it is necessary to show the "Deliver with Just Eat" link in the header. |
 | showOffersLink            | `Boolean`     | `false` | Defines whether the offers link should be shown in the navigation. |
-| showHelpLink              | `Boolean`     | `true` | Defines whether the help link should be shown in the navigation. |
-| showLoginInfo             | `Boolean`     | `true` | Defines whether the login & user info icon should be shown in the navigation. |
-| userInfoProp              | `Object`      | `{}`     | Optional object conaining user details. If not provided `userInfoProp` is set via XHR call to `/api/account/details` |
+| showHelpLink              | `Boolean`     | `true`  | Defines whether the help link should be shown in the navigation. |
+| showLoginInfo             | `Boolean`     | `true`  | Defines whether the login & user info icon should be shown in the navigation. |
+| userInfoProp              | `Object`      | `{}`    | Optional object conaining user details. If not provided `userInfoProp` is set via XHR call to `/api/account/details` |
 | userInfoUrl               | `String`      | `/api/account/details` | URL to call to retrieve the userInfo (when `userInfoProp` isn't set). |
 | showCountrySelector       | `Boolean`     | `false` | Defines whether the country selector should be shown in the navigation. |
-| showSkipLink | `Boolean` | `true` | Set to false if you need to remove skip-to-main-content link from the header. |
+| showSkipLink              | `Boolean`     | `true`  | Set to false if you need to remove skip-to-main-content link from the header. |
 
 **Important:** if you're adding a new property to show/hide something on the navigation bar, you probably want to check the `hasNavigationLinks` computed property, since you might have to update it.
 

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -24,6 +24,7 @@
 
             <navigation
                 :copy="copy"
+                :custom-nav-links="customNavLinks"
                 :show-delivery-enquiry="showDeliveryEnquiryWithContent"
                 :show-offers-link="showOffersLinkWithContent"
                 :show-help-link="showHelpLink"
@@ -60,6 +61,11 @@ export default {
         locale: {
             type: String,
             default: ''
+        },
+
+        customNavLinks: {
+            type: Array,
+            default: () => []
         },
 
         errorLog: {

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -348,7 +348,8 @@ export default {
 
         customNavLinks: {
             type: Array,
-            default: () => []
+            default: () => [],
+            validator: links => links.every(link => link.text && link.url)
         }
     },
 

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -82,6 +82,19 @@
                 :class="$style['c-nav-list']"
                 data-test-id="nav-list">
                 <li
+                    v-for="(customNavLink, index) in customNavLinks"
+                    :key="`custom-nav-link-${index}`"
+                    :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
+                    <nav-link
+                        :tabindex="tabIndex"
+                        :text="customNavLink.text"
+                        :href="customNavLink.url"
+                        :data-trak="customNavLink.gtm && analyticsObjects.navigation.clickHeaderLink({ ...customNavLink.gtm })"
+                        :is-alt-colour="isAltColour"
+                        :background-theme="headerBackgroundTheme" />
+                </li>
+
+                <li
                     :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
                     <nav-link
                         v-if="showOffersLink"
@@ -331,6 +344,11 @@ export default {
         showCountrySelector: {
             type: Boolean,
             default: false
+        },
+
+        customNavLinks: {
+            type: Array,
+            default: () => []
         }
     },
 
@@ -402,7 +420,8 @@ export default {
             return this.showOffersLink ||
                 this.showHelpLink ||
                 this.showDeliveryEnquiry ||
-                this.showLoginInfo;
+                this.showLoginInfo ||
+                this.customNavLinks.length > 0;
         },
 
         isCountrySelectorClosedOnMobileView () {

--- a/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
+++ b/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
@@ -11,7 +11,6 @@ import {
 import CountrySelector from '../CountrySelector.vue';
 import Navigation from '../Navigation.vue';
 
-
 const $style = {
     'is-open': 'is-open',
     'c-nav-toggle--altColour': 'c-nav-toggle--altColour',
@@ -20,12 +19,10 @@ const $style = {
 
 let wrapper;
 
-
 let mockWidth = desktopWidth;
 
 function setMobileViewport () { mockWidth = mobileWidth; }
 function setDesktopViewport () { mockWidth = desktopWidth; }
-
 
 jest.mock('@justeat/f-services', () => ({
     axiosServices: {
@@ -780,6 +777,28 @@ describe('Navigation', () => {
             expect(wrapper.vm.hasNavigationLinks).toBe(true);
         });
 
+        it('should return true if customNavLinks are provided', () => {
+            // Arrange & Act
+            wrapper = shallowMount(Navigation, {
+                propsData: {
+                    ...defaultPropsData,
+                    showLoginInfo: false,
+                    customNavLinks: [
+                        {
+                            text: 'Test',
+                            url: '/test',
+                            gtm: {
+                                label: 'test-label'
+                            }
+                        }
+                    ]
+                }
+            });
+
+            // Assert
+            expect(wrapper.vm.hasNavigationLinks).toBe(true);
+        });
+
         it('should return false if there are no underlying links to show', () => {
             // Arrange & Act
             wrapper = shallowMount(Navigation, {
@@ -788,7 +807,8 @@ describe('Navigation', () => {
                     showLoginInfo: false,
                     showOffersLink: false,
                     showHelpLink: false,
-                    showDeliveryEnquiry: false
+                    showDeliveryEnquiry: false,
+                    customNavLinks: []
                 }
             });
 

--- a/packages/components/organisms/f-header/src/components/_tests/__snapshots__/Header.test.js.snap
+++ b/packages/components/organisms/f-header/src/components/_tests/__snapshots__/Header.test.js.snap
@@ -5,7 +5,7 @@ exports[`Header should render default component markup 1`] = `
   <skip-to-main-stub text="Skip to main content" transparentbg="true"></skip-to-main-stub>
   <div class="c-header-container">
     <logo-stub theme="je" companyname="Just Eat" logogtmlabel="click_logo" headerbackgroundtheme="transparent"></logo-stub>
-    <navigation-stub copy="[object Object]" showdeliveryenquiry="true" showhelplink="true" showlogininfo="true" userinfourl="/api/account/details" ordercounturl="/api/analytics/ordercount" isordercountsupported="true" headerbackgroundtheme="transparent"></navigation-stub>
+    <navigation-stub copy="[object Object]" showdeliveryenquiry="true" showhelplink="true" showlogininfo="true" userinfourl="/api/account/details" ordercounturl="/api/analytics/ordercount" isordercountsupported="true" headerbackgroundtheme="transparent" customnavlinks=""></navigation-stub>
   </div>
 </header>
 `;

--- a/packages/components/organisms/f-header/stories/header.stories.js
+++ b/packages/components/organisms/f-header/stories/header.stories.js
@@ -1,68 +1,26 @@
-import {
-    withKnobs, boolean, select, object
-} from '@storybook/addon-knobs';
 import { withA11y } from '@storybook/addon-a11y';
 import VueHeader from '../src/components/Header.vue';
 
-import { customNavLinks, userInfo } from '../test-utils/helpers/objects';
+import { userInfo } from '../test-utils/helpers/objects';
 
 export default {
     title: 'Components/Organisms',
-    decorators: [withKnobs, withA11y],
+    decorators: [withA11y],
     parameters: {
         layout: 'fullscreen'
     }
 };
 
-export const HeaderComponent = () => ({
-    components: { VueHeader },
-    props: {
-        locale: {
-            default: select('Locale', ['en-GB', 'en-AU', 'da-DK', 'en-IE', 'en-NZ', 'es-ES', 'it-IT', 'nb-NO'])
-        },
-        logoLinkDisabled: {
-            default: boolean('Disable logo link', false)
-        },
-        showOffersLink: {
-            default: boolean('Show offers link', false)
-        },
-        showDeliveryEnquiry: {
-            default: boolean('Show delivery enquiry', false)
-        },
-        headerBackgroundTheme: {
-            default: select('Header theme', ['white', 'highlight', 'transparent'])
-        },
-        showLoginInfo: {
-            default: boolean('Show login/user info link', true)
-        },
-        isLoggedIn: {
-            default: boolean('Is logged in?', true)
-        },
-        userInfoProp: {
-            default: object('User info (if logged in)', userInfo)
-        },
-        showHelpLink: {
-            default: boolean('Show help link', true)
-        },
-        showCountrySelector: {
-            default: boolean('Show country selector', true)
-        },
-        showSkipLink: {
-            default: boolean('Show skip link', true)
-        },
-        showCustomNavLinks: {
-            default: boolean('Show custom nav links?', false)
-        },
-        customNavLinks: {
-            default: object('Custom nav links', customNavLinks)
-        }
+export const HeaderComponent = (args, { argTypes }) => ({
+    components: {
+        VueHeader
     },
-    parameters: {
-        notes: 'some documentation here'
-    },
+
+    props: Object.keys(argTypes),
+
     template: `
         <vue-header
-            :user-info-prop="isLoggedIn && userInfoProp"
+            :user-info-prop="userInfoProp"
             :show-offers-link="showOffersLink"
             :show-help-link="showHelpLink"
             :locale="locale"
@@ -71,9 +29,98 @@ export const HeaderComponent = () => ({
             :show-delivery-enquiry="showDeliveryEnquiry"
             :show-login-info="showLoginInfo"
             :show-country-selector="showCountrySelector"
-            :custom-nav-links="showCustomNavLinks ? customNavLinks : []"
+            :custom-nav-links="customNavLinks"
             :key="locale"
             :show-skip-link="showSkipLink" />`
 });
 
 HeaderComponent.storyName = 'f-header';
+HeaderComponent.args = {
+    locale: 'en-GB',
+    headerBackgroundTheme: 'white',
+    showLoginInfo: true,
+    userInfoProp: userInfo,
+    customNavLinks: [],
+    showCountrySelector: true,
+    showOffersLink: false,
+    showDeliveryEnquiry: false,
+    showHelpLink: true,
+    logoLinkDisabled: false,
+    showSkipLink: true
+};
+
+HeaderComponent.argTypes = {
+    locale: {
+        control: { type: 'select' },
+        defaultValue: 'en-GB',
+        description: 'Select a tenant',
+        options: ['en-GB', 'en-AU', 'da-DK', 'en-IE', 'en-NZ', 'es-ES', 'it-IT', 'nb-NO']
+    },
+
+    headerBackgroundTheme: {
+        control: { type: 'select' },
+        description: 'Choose a theme for the header',
+        options: ['white', 'highlight', 'transparent']
+    },
+
+    showLoginInfo: {
+        control: { type: 'boolean' },
+        description: 'For unauthenticated users, shows the "Login" link. For authenticated users, shows their name and contains links to the account pages.'
+    },
+
+    userInfoProp: {
+        description: 'Configure the user details; set to false to simulate a logged out user',
+        control: { type: 'object' }
+    },
+
+    // Not currently possible to set complex values (i.e., arrays) for controls via query strings.
+    // https://storybook.js.org/docs/vue/essentials/controls#dealing-with-complex-values
+    // https://github.com/storybookjs/storybook/issues/14420
+    customNavLinks: {
+        description: 'Array of objects representing custom navigation links. Each object should contain the properties `text` and `url`, and (optionally) a `gtm` object containing tracking properties.'
+    //     options: ['Empty', 'CustomLink', 'CustomLinkWithGtm'],
+    //     mapping: {
+    //         Empty: [],
+    //         CustomLink: [{ text: 'Custom Link', url: '/custom' }],
+    //         CustomLinkWithGtm: [{ text: 'Custom Link (with GTM)', url: '/custom', gtm: { label: 'custom-link' } }]
+    //     },
+    //     control: {
+    //         type: 'select',
+    //         labels: {
+    //             Empty: 'No custom links',
+    //             CustomLink: 'Custom link',
+    //             CustomLinkWithGtm: 'Custom link (with GTM label)'
+    //         }
+    //     }
+    },
+
+    showCountrySelector: {
+        control: { type: 'boolean' },
+        description: 'Shows the country selector which contains links to our sites in other countries.'
+    },
+
+    showOffersLink: {
+        control: { type: 'boolean' },
+        description: 'Shows the link to the "For You" page'
+    },
+
+    showDeliveryEnquiry: {
+        control: { type: 'boolean' },
+        description: 'Shows the "Deliver with Just Eat" link'
+    },
+
+    showHelpLink: {
+        control: { type: 'boolean' },
+        description: 'Shows the link to the "Help" page'
+    },
+
+    logoLinkDisabled: {
+        control: { type: 'boolean' },
+        description: 'Prevents the header logo from also being a link'
+    },
+
+    showSkipLink: {
+        control: { type: 'boolean' },
+        description: 'Includes the "Skip to main content" link'
+    }
+};

--- a/packages/components/organisms/f-header/stories/header.stories.js
+++ b/packages/components/organisms/f-header/stories/header.stories.js
@@ -4,7 +4,7 @@ import {
 import { withA11y } from '@storybook/addon-a11y';
 import VueHeader from '../src/components/Header.vue';
 
-import { userInfo } from '../test-utils/helpers/objects';
+import { customNavLinks, userInfo } from '../test-utils/helpers/objects';
 
 export default {
     title: 'Components/Organisms',
@@ -49,6 +49,12 @@ export const HeaderComponent = () => ({
         },
         showSkipLink: {
             default: boolean('Show skip link', true)
+        },
+        showCustomNavLinks: {
+            default: boolean('Show custom nav links?', false)
+        },
+        customNavLinks: {
+            default: object('Custom nav links', customNavLinks)
         }
     },
     parameters: {
@@ -65,6 +71,7 @@ export const HeaderComponent = () => ({
             :show-delivery-enquiry="showDeliveryEnquiry"
             :show-login-info="showLoginInfo"
             :show-country-selector="showCountrySelector"
+            :custom-nav-links="showCustomNavLinks ? customNavLinks : []"
             :key="locale"
             :show-skip-link="showSkipLink" />`
 });

--- a/packages/components/organisms/f-header/stories/header.stories.js
+++ b/packages/components/organisms/f-header/stories/header.stories.js
@@ -42,17 +42,16 @@ HeaderComponent.args = {
     userInfoProp: userInfo,
     customNavLinks: [],
     showCountrySelector: true,
+    showHelpLink: true,
+    showSkipLink: true,
     showOffersLink: false,
     showDeliveryEnquiry: false,
-    showHelpLink: true,
-    logoLinkDisabled: false,
-    showSkipLink: true
+    logoLinkDisabled: false
 };
 
 HeaderComponent.argTypes = {
     locale: {
         control: { type: 'select' },
-        defaultValue: 'en-GB',
         description: 'Select a tenant',
         options: ['en-GB', 'en-AU', 'da-DK', 'en-IE', 'en-NZ', 'es-ES', 'it-IT', 'nb-NO']
     },
@@ -64,13 +63,12 @@ HeaderComponent.argTypes = {
     },
 
     showLoginInfo: {
-        control: { type: 'boolean' },
         description: 'For unauthenticated users, shows the "Login" link. For authenticated users, shows their name and contains links to the account pages.'
     },
 
     userInfoProp: {
-        description: 'Configure the user details; set to false to simulate a logged out user',
-        control: { type: 'object' }
+        control: { type: 'object' },
+        description: 'Configure the user details; set to `false` (in RAW mode) to simulate a logged out user'
     },
 
     // Not currently possible to set complex values (i.e., arrays) for controls via query strings.
@@ -95,32 +93,26 @@ HeaderComponent.argTypes = {
     },
 
     showCountrySelector: {
-        control: { type: 'boolean' },
         description: 'Shows the country selector which contains links to our sites in other countries.'
     },
 
+    showHelpLink: {
+        description: 'Shows the link to the "Help" page'
+    },
+
+    showSkipLink: {
+        description: 'Includes the "Skip to main content" link'
+    },
+
     showOffersLink: {
-        control: { type: 'boolean' },
         description: 'Shows the link to the "For You" page'
     },
 
     showDeliveryEnquiry: {
-        control: { type: 'boolean' },
         description: 'Shows the "Deliver with Just Eat" link'
     },
 
-    showHelpLink: {
-        control: { type: 'boolean' },
-        description: 'Shows the link to the "Help" page'
-    },
-
     logoLinkDisabled: {
-        control: { type: 'boolean' },
         description: 'Prevents the header logo from also being a link'
-    },
-
-    showSkipLink: {
-        control: { type: 'boolean' },
-        description: 'Includes the "Skip to main content" link'
     }
 };

--- a/packages/components/organisms/f-header/test-utils/helpers/objects.js
+++ b/packages/components/organisms/f-header/test-utils/helpers/objects.js
@@ -10,6 +10,20 @@ export const userInfo = {
     }
 };
 
+export const customNavLinks = [
+    {
+        text: 'Custom Link 1',
+        url: '/custom/1',
+        gtm: {
+            label: 'custom-1'
+        }
+    },
+    {
+        text: 'Custom Link 2',
+        url: '/custom/2'
+    }
+];
+
 export default {
     userInfo
 };

--- a/packages/components/organisms/f-header/test/visual/f-header.visual.desktop.spec.js
+++ b/packages/components/organisms/f-header/test/visual/f-header.visual.desktop.spec.js
@@ -17,13 +17,14 @@ describe('Shared - f-header component tests', () => {
     ])
         .it('should display component', (tenant, isLoggedIn) => {
             // Arrange
-            header = new Header();
-            header.withQuery('&knob-Locale', tenant);
-            // Both props below should only show for UK
-            header.withQuery('&knob-Show offers link', 'true');
-            header.withQuery('&knob-Show delivery enquiry', 'true');
+            header = new Header()
+                .withQuery('&knob-Locale', tenant)
 
-            header.withQuery('&knob-Is logged in?', isLoggedIn);
+                // Both props below should only show for UK
+                .withQuery('&knob-Show offers link', 'true')
+                .withQuery('&knob-Show delivery enquiry', 'true')
+
+                .withQuery('&knob-Is logged in?', isLoggedIn);
 
             if (isLoggedIn) {
                 header.withQuery('&knob-User info (if logged in)', JSON.stringify(userInfo));
@@ -39,9 +40,9 @@ describe('Shared - f-header component tests', () => {
     forEach(['white', 'highlight', 'transparent'])
         .it('should display the "%s" header theme', theme => {
             // Arrange
-            header = new Header();
-            header.withQuery('&knob-Locale', 'en-GB');
-            header.withQuery('&knob-Header theme', theme);
+            header = new Header()
+                .withQuery('&knob-Locale', 'en-GB')
+                .withQuery('&knob-Header theme', theme);
 
             // Act
             header.load();
@@ -51,8 +52,9 @@ describe('Shared - f-header component tests', () => {
         });
 
     it('should display all available countries', () => {
-        header = new Header();
-        header.withQuery('&knob-Locale', 'en-GB');
+        // Arrange
+        header = new Header()
+            .withQuery('&knob-Locale', 'en-GB');
 
         // Act
         header.load();
@@ -64,9 +66,10 @@ describe('Shared - f-header component tests', () => {
 
     forEach(['Show login/user info link', 'Show help link', 'Show country selector'])
         .it('should not display "%s" ', knobName => {
-            header = new Header();
-            header.withQuery('&knob-Locale', 'en-GB');
-            header.withQuery(`&knob-${knobName}`, 'false');
+            // Arrange
+            header = new Header()
+                .withQuery('&knob-Locale', 'en-GB')
+                .withQuery(`&knob-${knobName}`, 'false');
 
             // Act
             header.load();
@@ -76,8 +79,9 @@ describe('Shared - f-header component tests', () => {
         });
 
     it('should display all user account options', () => {
-        header = new Header();
-        header.withQuery('&knob-Locale', 'en-GB');
+        // Arrange
+        header = new Header()
+            .withQuery('&knob-Locale', 'en-GB');
 
         // Act
         header.load();
@@ -85,5 +89,20 @@ describe('Shared - f-header component tests', () => {
 
         // Assert
         browser.percyScreenshot('f-header - User Account dropdown', 'desktop');
+    });
+
+    it('should display any custom links', () => {
+        // Arrange
+        header = new Header()
+            .withQuery('&knob-Locale', 'en-GB')
+            .withQuery('&knob-Show offers link', false)
+            .withQuery('&knob-Show delivery enquiry', false)
+            .withQuery('&knob-Show custom nav links?', true);
+
+        // Act
+        header.load();
+
+        // Assert
+        browser.percyScreenshot('f-header - with custom nav links', 'desktop');
     });
 });

--- a/packages/components/organisms/f-header/test/visual/f-header.visual.desktop.spec.js
+++ b/packages/components/organisms/f-header/test/visual/f-header.visual.desktop.spec.js
@@ -105,4 +105,23 @@ describe('Shared - f-header component tests', () => {
         // Assert
         browser.percyScreenshot('f-header - with custom nav links', 'desktop');
     });
+
+    it('should be able to show only custom links', () => {
+        // Arrange
+        header = new Header()
+            .withQuery('&knob-Locale', 'en-GB')
+            .withQuery('&knob-Show help link', false)
+            .withQuery('&knob-Show offers link', false)
+            .withQuery('&knob-Show country selector', false)
+            .withQuery('&knob-Show delivery enquiry', false)
+            .withQuery('&knob-Show login/user info link', false)
+
+            .withQuery('&knob-Show custom nav links?', true);
+
+        // Act
+        header.load();
+
+        // Assert
+        browser.percyScreenshot('f-header - custom nav links only', 'desktop');
+    });
 });

--- a/packages/components/organisms/f-header/test/visual/f-header.visual.desktop.spec.js
+++ b/packages/components/organisms/f-header/test/visual/f-header.visual.desktop.spec.js
@@ -1,7 +1,5 @@
 import forEach from 'mocha-each';
 
-import { userInfo } from '../../test-utils/helpers/objects';
-
 const Header = require('../../test-utils/component-objects/f-header.component');
 
 let header;
@@ -14,47 +12,52 @@ describe('Shared - f-header component tests', () => {
         ['en-IE', true], ['en-IE', false],
         ['it-IT', true], ['it-IT', false],
         ['es-ES', true], ['es-ES', false]
-    ])
-        .it('should display component', (tenant, isLoggedIn) => {
-            // Arrange
-            header = new Header()
-                .withQuery('&knob-Locale', tenant)
+    ]).it('should display component', (tenant, isLoggedIn) => {
+        // Arrange
+        const controls = [
+            `locale:${tenant}`,
+            'showOffersLink:true', // Should show for AU, IE, NZ and UK only
+            'showDeliveryEnquiry:true', // Should show for AU, IE, NZ and UK only
+            ...(isLoggedIn ? [] : ['userInfoProp:!undefined'])
+        ].join(';');
 
-                // Both props below should only show for UK
-                .withQuery('&knob-Show offers link', 'true')
-                .withQuery('&knob-Show delivery enquiry', 'true')
+        header = new Header();
+        header.path += `&args=${controls}`;
 
-                .withQuery('&knob-Is logged in?', isLoggedIn);
+        // Act
+        header.load();
 
-            if (isLoggedIn) {
-                header.withQuery('&knob-User info (if logged in)', JSON.stringify(userInfo));
-            }
+        // Assert
+        browser.percyScreenshot(`f-header - Base state - isLoggedIn: ${isLoggedIn} - ${tenant}`, 'desktop');
+    });
 
-            // Act
-            header.load();
+    forEach([
+        'white',
+        'highlight',
+        'transparent'
+    ]).it('should display the "%s" header theme', theme => {
+        // Arrange
+        const controls = [
+            'locale:en-GB',
+            `headerBackgroundTheme:${theme}`
+        ].join(';');
 
-            // Assert
-            browser.percyScreenshot(`f-header - Base state - isLoggedIn: ${isLoggedIn} - ${tenant}`, 'desktop');
-        });
+        header = new Header();
+        header.path += `&args=${controls}`;
 
-    forEach(['white', 'highlight', 'transparent'])
-        .it('should display the "%s" header theme', theme => {
-            // Arrange
-            header = new Header()
-                .withQuery('&knob-Locale', 'en-GB')
-                .withQuery('&knob-Header theme', theme);
+        // Act
+        header.load();
 
-            // Act
-            header.load();
-
-            // Assert
-            browser.percyScreenshot(`f-header - Theme colours - ${theme}`, 'desktop');
-        });
+        // Assert
+        browser.percyScreenshot(`f-header - Theme colours - ${theme}`, 'desktop');
+    });
 
     it('should display all available countries', () => {
         // Arrange
-        header = new Header()
-            .withQuery('&knob-Locale', 'en-GB');
+        const controls = 'locale:en-GB';
+
+        header = new Header();
+        header.path += `&args=${controls}`;
 
         // Act
         header.load();
@@ -64,24 +67,33 @@ describe('Shared - f-header component tests', () => {
         browser.percyScreenshot('f-header - Country list', 'desktop');
     });
 
-    forEach(['Show login/user info link', 'Show help link', 'Show country selector'])
-        .it('should not display "%s" ', knobName => {
-            // Arrange
-            header = new Header()
-                .withQuery('&knob-Locale', 'en-GB')
-                .withQuery(`&knob-${knobName}`, 'false');
+    forEach([
+        'showLoginInfo',
+        'showHelpLink',
+        'showCountrySelector'
+    ]).it('should not display "%s" ', knobName => {
+        // Arrange
+        const controls = [
+            'locale:en-GB',
+            `${knobName}:false`
+        ].join(';');
 
-            // Act
-            header.load();
+        header = new Header();
+        header.path += `&args=${controls}`;
 
-            // Assert
-            browser.percyScreenshot(`f-header - ${knobName} - False`, 'desktop');
-        });
+        // Act
+        header.load();
+
+        // Assert
+        browser.percyScreenshot(`f-header - ${knobName} - False`, 'desktop');
+    });
 
     it('should display all user account options', () => {
         // Arrange
-        header = new Header()
-            .withQuery('&knob-Locale', 'en-GB');
+        const controls = 'locale:en-GB';
+
+        header = new Header();
+        header.path += `&args=${controls}`;
 
         // Act
         header.load();
@@ -91,35 +103,50 @@ describe('Shared - f-header component tests', () => {
         browser.percyScreenshot('f-header - User Account dropdown', 'desktop');
     });
 
-    it('should display any custom links', () => {
+    // Not currently possible to set complex values (i.e., arrays) for controls via query strings.
+    // https://storybook.js.org/docs/vue/essentials/controls#dealing-with-complex-values
+    // https://github.com/storybookjs/storybook/issues/14420
+    it.skip('should display any custom links', () => {
         // Arrange
-        header = new Header()
-            .withQuery('&knob-Locale', 'en-GB')
-            .withQuery('&knob-Show offers link', false)
-            .withQuery('&knob-Show delivery enquiry', false)
-            .withQuery('&knob-Show custom nav links?', true);
+        const controls = [
+            'locale:en-GB',
+            'showOffersLink:false',
+            'showDeliveryEnquiry:false'
+            // Set custom links here
+        ].join(';');
+
+        header = new Header();
+        header.path += `&args=${controls}`;
 
         // Act
         header.load();
+        header.openMobileNavigationBar();
 
         // Assert
         browser.percyScreenshot('f-header - with custom nav links', 'desktop');
     });
 
-    it('should be able to show only custom links', () => {
+    // Not currently possible to set complex values (i.e., arrays) for controls via query strings.
+    // https://storybook.js.org/docs/vue/essentials/controls#dealing-with-complex-values
+    // https://github.com/storybookjs/storybook/issues/14420
+    it.skip('should be able to show only custom links', () => {
         // Arrange
-        header = new Header()
-            .withQuery('&knob-Locale', 'en-GB')
-            .withQuery('&knob-Show help link', false)
-            .withQuery('&knob-Show offers link', false)
-            .withQuery('&knob-Show country selector', false)
-            .withQuery('&knob-Show delivery enquiry', false)
-            .withQuery('&knob-Show login/user info link', false)
+        const controls = [
+            'locale:en-GB',
+            'showHelpLink:false',
+            'showLoginInfo:false',
+            'showOffersLink:false',
+            'showCountrySelector:false',
+            'showDeliveryEnquiry:false'
+            // Set custom links here
+        ].join(';');
 
-            .withQuery('&knob-Show custom nav links?', true);
+        header = new Header();
+        header.path += `&args=${controls}`;
 
         // Act
         header.load();
+        header.openMobileNavigationBar();
 
         // Assert
         browser.percyScreenshot('f-header - custom nav links only', 'desktop');

--- a/packages/components/organisms/f-header/test/visual/f-header.visual.mobile.spec.js
+++ b/packages/components/organisms/f-header/test/visual/f-header.visual.mobile.spec.js
@@ -17,13 +17,14 @@ describe('Shared - f-header component tests', () => {
     ])
         .it('should display component', (tenant, isLoggedIn) => {
             // Arrange
-            header = new Header();
-            header.withQuery('&knob-Locale', tenant);
-            // Both props below should only show for UK
-            header.withQuery('&knob-Show offers link', 'true');
-            header.withQuery('&knob-Show delivery enquiry', 'true');
+            header = new Header()
+                .withQuery('&knob-Locale', tenant)
 
-            header.withQuery('&knob-Is logged in?', isLoggedIn);
+                // Both props below should only show for UK
+                .withQuery('&knob-Show offers link', 'true')
+                .withQuery('&knob-Show delivery enquiry', 'true')
+
+                .withQuery('&knob-Is logged in?', isLoggedIn);
 
             if (isLoggedIn) {
                 header.withQuery('&knob-User info (if logged in)', JSON.stringify(userInfo));
@@ -40,9 +41,9 @@ describe('Shared - f-header component tests', () => {
     forEach(['white', 'highlight', 'transparent'])
         .it('should display the "%s" header theme', theme => {
             // Arrange
-            header = new Header();
-            header.withQuery('&knob-Locale', 'en-GB');
-            header.withQuery('&knob-Header theme', theme);
+            header = new Header()
+                .withQuery('&knob-Locale', 'en-GB')
+                .withQuery('&knob-Header theme', theme);
 
             // Act
             header.load();
@@ -52,8 +53,9 @@ describe('Shared - f-header component tests', () => {
         });
 
     it('should display all avalible countries', () => {
-        header = new Header();
-        header.withQuery('&knob-Locale', 'en-GB');
+        // Arrange
+        header = new Header()
+            .withQuery('&knob-Locale', 'en-GB');
 
         // Act
         header.load();
@@ -66,9 +68,10 @@ describe('Shared - f-header component tests', () => {
 
     forEach(['Show login/user info link', 'Show help link', 'Show country selector'])
         .it('should not display "%s" ', knobName => {
-            header = new Header();
-            header.withQuery('&knob-Locale', 'en-GB');
-            header.withQuery(`&knob-${knobName}`, 'false');
+            // Arrange
+            header = new Header()
+                .withQuery('&knob-Locale', 'en-GB')
+                .withQuery(`&knob-${knobName}`, 'false');
 
             // Act
             header.load();
@@ -77,4 +80,20 @@ describe('Shared - f-header component tests', () => {
             // Assert
             browser.percyScreenshot(`f-header - ${knobName} - False`, 'mobile');
         });
+
+    it('should display any custom links', () => {
+        // Arrange
+        header = new Header()
+            .withQuery('&knob-Locale', 'en-GB')
+            .withQuery('&knob-Show offers link', false)
+            .withQuery('&knob-Show delivery enquiry', false)
+            .withQuery('&knob-Show custom nav links?', true);
+
+        // Act
+        header.load();
+        header.openMobileNavigationBar();
+
+        // Assert
+        browser.percyScreenshot('f-header - with custom nav links', 'mobile');
+    });
 });

--- a/packages/components/organisms/f-header/test/visual/f-header.visual.mobile.spec.js
+++ b/packages/components/organisms/f-header/test/visual/f-header.visual.mobile.spec.js
@@ -96,4 +96,24 @@ describe('Shared - f-header component tests', () => {
         // Assert
         browser.percyScreenshot('f-header - with custom nav links', 'mobile');
     });
+
+    it('should be able to show only custom links', () => {
+        // Arrange
+        header = new Header()
+            .withQuery('&knob-Locale', 'en-GB')
+            .withQuery('&knob-Show help link', false)
+            .withQuery('&knob-Show offers link', false)
+            .withQuery('&knob-Show country selector', false)
+            .withQuery('&knob-Show delivery enquiry', false)
+            .withQuery('&knob-Show login/user info link', false)
+
+            .withQuery('&knob-Show custom nav links?', true);
+
+        // Act
+        header.load();
+        header.openMobileNavigationBar();
+
+        // Assert
+        browser.percyScreenshot('f-header - custom nav links only', 'mobile');
+    });
 });

--- a/packages/components/organisms/f-header/test/visual/f-header.visual.mobile.spec.js
+++ b/packages/components/organisms/f-header/test/visual/f-header.visual.mobile.spec.js
@@ -1,7 +1,5 @@
 import forEach from 'mocha-each';
 
-import { userInfo } from '../../test-utils/helpers/objects';
-
 const Header = require('../../test-utils/component-objects/f-header.component');
 
 let header;
@@ -14,48 +12,53 @@ describe('Shared - f-header component tests', () => {
         ['en-IE', true], ['en-IE', false],
         ['it-IT', true], ['it-IT', false],
         ['es-ES', true], ['es-ES', false]
-    ])
-        .it('should display component', (tenant, isLoggedIn) => {
-            // Arrange
-            header = new Header()
-                .withQuery('&knob-Locale', tenant)
-
-                // Both props below should only show for UK
-                .withQuery('&knob-Show offers link', 'true')
-                .withQuery('&knob-Show delivery enquiry', 'true')
-
-                .withQuery('&knob-Is logged in?', isLoggedIn);
-
-            if (isLoggedIn) {
-                header.withQuery('&knob-User info (if logged in)', JSON.stringify(userInfo));
-            }
-
-            // Act
-            header.load();
-            header.openMobileNavigationBar();
-
-            // Assert
-            browser.percyScreenshot(`f-header - Base state - isLoggedIn: ${isLoggedIn} - ${tenant}`, 'mobile');
-        });
-
-    forEach(['white', 'highlight', 'transparent'])
-        .it('should display the "%s" header theme', theme => {
-            // Arrange
-            header = new Header()
-                .withQuery('&knob-Locale', 'en-GB')
-                .withQuery('&knob-Header theme', theme);
-
-            // Act
-            header.load();
-
-            // Assert
-            browser.percyScreenshot(`f-header - Theme colours - ${theme}`, 'mobile');
-        });
-
-    it('should display all avalible countries', () => {
+    ]).it('should display component', (tenant, isLoggedIn) => {
         // Arrange
-        header = new Header()
-            .withQuery('&knob-Locale', 'en-GB');
+        const controls = [
+            `locale:${tenant}`,
+            'showOffersLink:true', // Should show for AU, IE, NZ and UK only
+            'showDeliveryEnquiry:true', // Should show for AU, IE, NZ and UK only
+            ...(isLoggedIn ? [] : ['userInfoProp:!undefined'])
+        ].join(';');
+
+        header = new Header();
+        header.path += `&args=${controls}`;
+
+        // Act
+        header.load();
+        header.openMobileNavigationBar();
+
+        // Assert
+        browser.percyScreenshot(`f-header - Base state - isLoggedIn: ${isLoggedIn} - ${tenant}`, 'mobile');
+    });
+
+    forEach([
+        'white',
+        'highlight',
+        'transparent'
+    ]).it('should display the "%s" header theme', theme => {
+        // Arrange
+        const controls = [
+            'locale:en-GB',
+            `headerBackgroundTheme:${theme}`
+        ].join(';');
+
+        header = new Header();
+        header.path += `&args=${controls}`;
+
+        // Act
+        header.load();
+
+        // Assert
+        browser.percyScreenshot(`f-header - Theme colours - ${theme}`, 'mobile');
+    });
+
+    it('should display all available countries', () => {
+        // Arrange
+        const controls = 'locale:en-GB';
+
+        header = new Header();
+        header.path += `&args=${controls}`;
 
         // Act
         header.load();
@@ -66,28 +69,42 @@ describe('Shared - f-header component tests', () => {
         browser.percyScreenshot('f-header - Country list', 'mobile');
     });
 
-    forEach(['Show login/user info link', 'Show help link', 'Show country selector'])
-        .it('should not display "%s" ', knobName => {
-            // Arrange
-            header = new Header()
-                .withQuery('&knob-Locale', 'en-GB')
-                .withQuery(`&knob-${knobName}`, 'false');
-
-            // Act
-            header.load();
-            header.openMobileNavigationBar();
-
-            // Assert
-            browser.percyScreenshot(`f-header - ${knobName} - False`, 'mobile');
-        });
-
-    it('should display any custom links', () => {
+    forEach([
+        'showLoginInfo',
+        'showHelpLink',
+        'showCountrySelector'
+    ]).it('should not display "%s" ', knobName => {
         // Arrange
-        header = new Header()
-            .withQuery('&knob-Locale', 'en-GB')
-            .withQuery('&knob-Show offers link', false)
-            .withQuery('&knob-Show delivery enquiry', false)
-            .withQuery('&knob-Show custom nav links?', true);
+        const controls = [
+            'locale:en-GB',
+            `${knobName}:false`
+        ].join(';');
+
+        header = new Header();
+        header.path += `&args=${controls}`;
+
+        // Act
+        header.load();
+        header.openMobileNavigationBar();
+
+        // Assert
+        browser.percyScreenshot(`f-header - ${knobName} - False`, 'mobile');
+    });
+
+    // Not currently possible to set complex values (i.e., arrays) for controls via query strings.
+    // https://storybook.js.org/docs/vue/essentials/controls#dealing-with-complex-values
+    // https://github.com/storybookjs/storybook/issues/14420
+    it.skip('should display any custom links', () => {
+        // Arrange
+        const controls = [
+            'locale:en-GB',
+            'showOffersLink:false',
+            'showDeliveryEnquiry:false'
+            // Set custom links here
+        ].join(';');
+
+        header = new Header();
+        header.path += `&args=${controls}`;
 
         // Act
         header.load();
@@ -97,17 +114,23 @@ describe('Shared - f-header component tests', () => {
         browser.percyScreenshot('f-header - with custom nav links', 'mobile');
     });
 
-    it('should be able to show only custom links', () => {
+    // Not currently possible to set complex values (i.e., arrays) for controls via query strings.
+    // https://storybook.js.org/docs/vue/essentials/controls#dealing-with-complex-values
+    // https://github.com/storybookjs/storybook/issues/14420
+    it.skip('should be able to show only custom links', () => {
         // Arrange
-        header = new Header()
-            .withQuery('&knob-Locale', 'en-GB')
-            .withQuery('&knob-Show help link', false)
-            .withQuery('&knob-Show offers link', false)
-            .withQuery('&knob-Show country selector', false)
-            .withQuery('&knob-Show delivery enquiry', false)
-            .withQuery('&knob-Show login/user info link', false)
+        const controls = [
+            'locale:en-GB',
+            'showHelpLink:false',
+            'showLoginInfo:false',
+            'showOffersLink:false',
+            'showCountrySelector:false',
+            'showDeliveryEnquiry:false'
+            // Set custom links here
+        ].join(';');
 
-            .withQuery('&knob-Show custom nav links?', true);
+        header = new Header();
+        header.path += `&args=${controls}`;
 
         // Act
         header.load();


### PR DESCRIPTION
### Added
- Support for custom links in the nav via `customNavLinks` prop.
- Relevant knobs to component story.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
