### PR TITLE
generator-component@2.5.0 - Added visual regression option and changed file names

### DIFF
--- a/packages/tools/generator-component/CHANGELOG.md
+++ b/packages/tools/generator-component/CHANGELOG.md
@@ -10,7 +10,6 @@ v2.5.0
 ### Added
 - Prompt option for visual regression
 - Spec templates for visual regression
-- `getHyphenatedName` function for transforming the name of a component when answered in `camelCase`
 
 ### Changed
 - component names in `test-utils` and `test`

--- a/packages/tools/generator-component/CHANGELOG.md
+++ b/packages/tools/generator-component/CHANGELOG.md
@@ -5,11 +5,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v2.5.0
 ------------------------------
-*December 6, 2021*
+*December 7, 2021*
 
 ### Added
 - Prompt option for visual regression
-- Spec templates for visual regression
+- Spec templates for visual regression (mobile and desktop)
 
 ### Changed
 - component names in `test-utils` and `test`

--- a/packages/tools/generator-component/CHANGELOG.md
+++ b/packages/tools/generator-component/CHANGELOG.md
@@ -3,6 +3,20 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.5.0
+------------------------------
+*December 6, 2021*
+
+### Added
+- Prompt option for visual regression
+- `getHyphenatedName` function for transforming the name of a component when answered in `camelCase`
+
+### Changed
+- component names in `test-utils` and `test`
+
+### Removed
+- Unused functions from within the component object - `open()` and `load()`
+
 
 v2.4.0
 ------------------------------

--- a/packages/tools/generator-component/CHANGELOG.md
+++ b/packages/tools/generator-component/CHANGELOG.md
@@ -9,6 +9,7 @@ v2.5.0
 
 ### Added
 - Prompt option for visual regression
+- Spec templates for visual regression
 - `getHyphenatedName` function for transforming the name of a component when answered in `camelCase`
 
 ### Changed

--- a/packages/tools/generator-component/generators/app/index.js
+++ b/packages/tools/generator-component/generators/app/index.js
@@ -38,6 +38,7 @@ Yeoman Generator version: {white v${pkg.version}}
             isComponent: (this.answers.componentType === 'uiComponent'),
             isService: (this.answers.componentType === 'service'),
             needsComponentTests: (this.answers.componentType === 'service' ? false : this.answers.needsComponentTests),
+            needsVisualTests: (this.answers.componentType === 'service' ? false : this.answers.needsVisualTests),
             needsComponentTranslations: (this.answers.componentType === 'service' ? false : this.answers.needsComponentTranslations),
             needsBundlewatch: (this.answers.needsBundlewatch),
             needsTestingApiMocks: (this.answers.componentType === 'service' ? false : this.answers.needsTestingApiMocks)
@@ -57,7 +58,8 @@ Yeoman Generator version: {white v${pkg.version}}
         }
 
         this.ignorePatterns = [
-            ...(this.config.needsComponentTests ? [] : ['**/*/test/specs/component']),
+            ...(this.config.needsComponentTests ? [] : ['**/*/test/component']),
+            ...(this.config.needsVisualTests ? [] : ['**/*/test/visual']),
             ...(this.config.needsComponentTranslations ? [] : ['**/*/src/tenants']),
             ...(this.config.needsTestingApiMocks ? [] : ['**/*/src/services']),
             ...(this.config.isComponent ? [
@@ -80,7 +82,7 @@ Yeoman Generator version: {white v${pkg.version}}
                 // Modify any files containing the keyword `Skeleton` to be replaced with the name of the component
                 .replace(/(Skeleton)/g, this.nameTransformations.filename)
                 // Modify any files containing the keyword `f-skeleton` to be replaced with the name of the component
-                .replace(/(f-skeleton)/g, `f-${this.nameTransformations.class}`)
+                .replace(/(f-skeleton)/g, `f-${this.nameTransformations.default}`)
                 // Certain template files have been prefixed with "__" to stop them being indexed by our tooling (such as Jest and Storybook files)
                 // So we need to remove these prefixes before writing the files to our dest directory
                 .replace(/__/g, '');

--- a/packages/tools/generator-component/generators/app/prompts.js
+++ b/packages/tools/generator-component/generators/app/prompts.js
@@ -88,6 +88,15 @@ const prompts = [
         }
     },
     {
+        message: 'Does your component require Visual Regression Tests?',
+        name: 'needsVisualTests',
+        type: 'confirm',
+        default: false,
+        when: function shouldShowThisQuestion (answers) {
+            return answers.componentType === 'uiComponent';
+        }
+    },
+    {
         message: 'Does your component require API mocks?',
         name: 'needsTestingApiMocks',
         type: 'confirm',

--- a/packages/tools/generator-component/generators/app/services.js
+++ b/packages/tools/generator-component/generators/app/services.js
@@ -6,13 +6,12 @@ const utils = require('./utils');
  * @returns Object – transformed group of names to be used in the generator template files
  */
 function transformName (name) {
-    // prevents component folders from being generated in `camelCase`
-    const normalisedName = utils.getHyphenatedName(name).toLowerCase();
+    const normalisedName = name.toLowerCase();
 
     return {
         class: utils.getComponentClassName(normalisedName), // (c-)header or (c-)userMessage,
         component: utils.getComponentName(normalisedName), // e.g VButton or UserMessage,
-        default: normalisedName, // e.g. header or user-message
+        default: name, // e.g. header or user-message
         filename: utils.getComponentFilename(normalisedName), // Header(.vue) or UserMessage(.vue)
         readme: utils.getReadmeName(normalisedName), // Header or User Message
         template: utils.getComponentTemplateName(normalisedName) // v-header or user-message

--- a/packages/tools/generator-component/generators/app/services.js
+++ b/packages/tools/generator-component/generators/app/services.js
@@ -1,4 +1,4 @@
-const utils = require('./utils.js');
+const utils = require('./utils');
 
 /**
  *
@@ -6,15 +6,16 @@ const utils = require('./utils.js');
  * @returns Object – transformed group of names to be used in the generator template files
  */
 function transformName (name) {
-    const normalisedName = name.toLowerCase();
+    // prevents component folders from being generated in `camelCase`
+    const normalisedName = utils.getHyphenatedName(name).toLowerCase();
 
     return {
         class: utils.getComponentClassName(normalisedName), // (c-)header or (c-)userMessage,
         component: utils.getComponentName(normalisedName), // e.g VButton or UserMessage,
-        default: name, // e.g. header or user-message
+        default: normalisedName, // e.g. header or user-message
         filename: utils.getComponentFilename(normalisedName), // Header(.vue) or UserMessage(.vue)
         readme: utils.getReadmeName(normalisedName), // Header or User Message
-        template: utils.getComponentTemplateName(normalisedName) // v-header or user-message,
+        template: utils.getComponentTemplateName(normalisedName) // v-header or user-message
     };
 }
 

--- a/packages/tools/generator-component/generators/app/templates/__package__.json
+++ b/packages/tools/generator-component/generators/app/templates/__package__.json
@@ -35,12 +35,12 @@
     "build": "vite build",
     "lint": "eslint \"!(dist)/**/*.{js,vue}\""<% } %>,
     "lint:fix": "yarn lint --fix"<% if(config.isComponent) { %>,
-    "lint:style": "vue-cli-service lint:style",
-    "test:coverage": "jest test:unit --coverage",
-    "test": "vue-cli-service test:unit"<% if(config.needsComponentTests) { %>,
+    "lint:style": "vue-cli-service lint:style"<% } else { %>,
+    "test:coverage": "jest test:unit --coverage"<% } %>,
+    "test": "vue-cli-service test:unit"<% if(config.isComponent) { %><% if(config.needsComponentTests) { %>,
     "test-component:chrome": "cross-env-shell TEST_TYPE=component wdio ../../../../wdio-chrome.conf.js"<% } %>,
     "test-a11y:chrome": "cross-env-shell TEST_TYPE=a11y wdio ../../../../wdio-chrome.conf.js"<% if(config.needsVisualTests) { %>,
-    "test:visual": "cross-env-shell PERCY_TOKEN=${PERCY_TOKEN_F_<%= name.class.toUpperCase() %>} TEST_TYPE=visual percy exec -- wdio ../../../../wdio-chrome.conf.js"<% } %><% } %>
+    "test:visual": "cross-env-shell PERCY_TOKEN=${PERCY_TOKEN_F_<%= name.default.toUpperCase().replace('-', '_') %>} TEST_TYPE=visual percy exec -- wdio ../../../../wdio-chrome.conf.js"<% } %><% } %>
   },
   "browserslist": [
     "extends @justeat/browserslist-config-fozzie"

--- a/packages/tools/generator-component/generators/app/templates/__package__.json
+++ b/packages/tools/generator-component/generators/app/templates/__package__.json
@@ -52,7 +52,7 @@
     "@justeat/browserslist-config-fozzie": ">=1.2.0"
   },
   "devDependencies": {
-<% if(config.isComponent) { %>    "@justeat/f-wdio-utils": "0.4.0",
+<% if(config.isComponent) { %>    "@justeat/f-wdio-utils": "0.5.0",
     "node-sass-magic-importer": "5.3.2",
     "@samhammer/vue-cli-plugin-stylelint": "2.1.0",
     "@vue/cli-plugin-babel": "4.5.15",

--- a/packages/tools/generator-component/generators/app/templates/__package__.json
+++ b/packages/tools/generator-component/generators/app/templates/__package__.json
@@ -6,9 +6,9 @@
   "module": "dist/f-<%= name.default %>.es.js"<% } %><% if(config.needsBundlewatch) { %>,
   "maxBundleSize": "<%= bundlewatchMaxSize %>kB"<% } %>,
   "files": [
-    "dist"<% if(config.needsComponentTests) { %>,
-    "test-utils"<% } %><% if(config.needsTestingApiMocks) { %>,
-    "src/services"<% } %>
+    "dist",
+    "test-utils",
+    "src/services"
   ],
   "homepage": "https://github.com/justeat/fozzie-components/tree/master/<%= componentFolder %>f-<%= name.default %>",
   "contributors": [
@@ -38,8 +38,9 @@
     "lint:style": "vue-cli-service lint:style"<% } else { %>,
     "test:coverage": "jest test:unit --coverage"<% } %>,
     "test": "vue-cli-service test:unit"<% if(config.needsComponentTests) { %>,
-    "test-component:chrome": "cross-env-shell TEST_TYPE=component wdio ../../../../wdio-chrome.conf.js",
-    "test-a11y:chrome": "cross-env-shell TEST_TYPE=a11y wdio ../../../../wdio-chrome.conf.js"<% } %>
+    "test-component:chrome": "cross-env-shell TEST_TYPE=component wdio ../../../../wdio-chrome.conf.js"<% } %>,
+    "test-a11y:chrome": "cross-env-shell TEST_TYPE=a11y wdio ../../../../wdio-chrome.conf.js"<% if(config.needsVisualTests) { %>,
+    "test:visual": "cross-env-shell PERCY_TOKEN=${PERCY_TOKEN_F_<%= name.class.toUpperCase() %>} TEST_TYPE=visual percy exec -- wdio ../../../../wdio-chrome.conf.js"<% } %>
   },
   "browserslist": [
     "extends @justeat/browserslist-config-fozzie"

--- a/packages/tools/generator-component/generators/app/templates/__package__.json
+++ b/packages/tools/generator-component/generators/app/templates/__package__.json
@@ -6,9 +6,9 @@
   "module": "dist/f-<%= name.default %>.es.js"<% } %><% if(config.needsBundlewatch) { %>,
   "maxBundleSize": "<%= bundlewatchMaxSize %>kB"<% } %>,
   "files": [
-    "dist",
-    "test-utils",
-    "src/services"
+    "dist"<% if(config.needsComponentTests) { %>,
+    "test-utils"<% } %><% if(config.needsTestingApiMocks) { %>,
+    "src/services"<% } %>
   ],
   "homepage": "https://github.com/justeat/fozzie-components/tree/master/<%= componentFolder %>f-<%= name.default %>",
   "contributors": [
@@ -35,12 +35,12 @@
     "build": "vite build",
     "lint": "eslint \"!(dist)/**/*.{js,vue}\""<% } %>,
     "lint:fix": "yarn lint --fix"<% if(config.isComponent) { %>,
-    "lint:style": "vue-cli-service lint:style"<% } else { %>,
-    "test:coverage": "jest test:unit --coverage"<% } %>,
+    "lint:style": "vue-cli-service lint:style",
+    "test:coverage": "jest test:unit --coverage",
     "test": "vue-cli-service test:unit"<% if(config.needsComponentTests) { %>,
     "test-component:chrome": "cross-env-shell TEST_TYPE=component wdio ../../../../wdio-chrome.conf.js"<% } %>,
     "test-a11y:chrome": "cross-env-shell TEST_TYPE=a11y wdio ../../../../wdio-chrome.conf.js"<% if(config.needsVisualTests) { %>,
-    "test:visual": "cross-env-shell PERCY_TOKEN=${PERCY_TOKEN_F_<%= name.class.toUpperCase() %>} TEST_TYPE=visual percy exec -- wdio ../../../../wdio-chrome.conf.js"<% } %>
+    "test:visual": "cross-env-shell PERCY_TOKEN=${PERCY_TOKEN_F_<%= name.class.toUpperCase() %>} TEST_TYPE=visual percy exec -- wdio ../../../../wdio-chrome.conf.js"<% } %><% } %>
   },
   "browserslist": [
     "extends @justeat/browserslist-config-fozzie"

--- a/packages/tools/generator-component/generators/app/templates/src/components/Skeleton.vue
+++ b/packages/tools/generator-component/generators/app/templates/src/components/Skeleton.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         :class="$style['c-<%= name.class %>']"
-        data-test-id="<%= name.class %>"><% if (config.needsComponentTranslations) { %>
+        data-test-id="<%= name.default %>-component"><% if (config.needsComponentTranslations) { %>
         {{ copy.text }}<%
         } else { %>
         I am a <%= name.component %> Component (GB)<% } %>

--- a/packages/tools/generator-component/generators/app/templates/test-utils/component-objects/f-skeleton-selectors.js
+++ b/packages/tools/generator-component/generators/app/templates/test-utils/component-objects/f-skeleton-selectors.js
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export const COMPONENT = '[data-test-id="<%= name.class %>"]';
+export const COMPONENT = '[data-test-id="<%= name.default %>-component"]';

--- a/packages/tools/generator-component/generators/app/templates/test-utils/component-objects/f-skeleton.component.js
+++ b/packages/tools/generator-component/generators/app/templates/test-utils/component-objects/f-skeleton.component.js
@@ -1,7 +1,7 @@
 const Page = require('@justeat/f-wdio-utils/src/page.object');
 const { COMPONENT } = require('./f-<%= name.default %>-selectors');
 
-module.exports = class <%= name.component %> extends Page {
+module.exports = class <%= name.filename %> extends Page {
     constructor () {
         super('<%= storybook.componentCategory.toLowerCase().slice(0, -1) %>', '<%= name.default %>-component');
     }

--- a/packages/tools/generator-component/generators/app/templates/test-utils/component-objects/f-skeleton.component.js
+++ b/packages/tools/generator-component/generators/app/templates/test-utils/component-objects/f-skeleton.component.js
@@ -10,8 +10,8 @@ module.exports = class <%= name.filename %> extends Page {
         return $(COMPONENT);
     }
     
-    waitForComponent (timeoutMs) {
-        super.waitForComponent(this.component, timeoutMs);
+    waitForComponent () {
+        super.waitForComponent(this.component);
     }
 
     isComponentDisplayed () {

--- a/packages/tools/generator-component/generators/app/templates/test-utils/component-objects/f-skeleton.component.js
+++ b/packages/tools/generator-component/generators/app/templates/test-utils/component-objects/f-skeleton.component.js
@@ -10,8 +10,8 @@ module.exports = class <%= name.filename %> extends Page {
         return $(COMPONENT);
     }
     
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    waitForComponent (timeoutMs) {
+        super.waitForComponent(this.component, timeoutMs);
     }
 
     isComponentDisplayed () {

--- a/packages/tools/generator-component/generators/app/templates/test-utils/component-objects/f-skeleton.component.js
+++ b/packages/tools/generator-component/generators/app/templates/test-utils/component-objects/f-skeleton.component.js
@@ -1,25 +1,15 @@
 const Page = require('@justeat/f-wdio-utils/src/page.object');
-const { COMPONENT } = require('./f-<%= name.class %>-selectors');
+const { COMPONENT } = require('./f-<%= name.default %>-selectors');
 
-module.exports = class <%= name.filename %> extends Page {
+module.exports = class <%= name.component %> extends Page {
     constructor () {
         super('<%= storybook.componentCategory.toLowerCase().slice(0, -1) %>', '<%= name.default %>-component');
     }
 
-    // eslint-disable-next-line class-methods-use-this
     get component () {
-        // eslint-disable-next-line no-undef
         return $(COMPONENT);
     }
-
-    load () {
-        super.load(this.component);
-    }
-
-    open (url) {
-        super.open(url);
-    }
-
+    
     waitForComponent () {
         super.waitForComponent(this.component);
     }

--- a/packages/tools/generator-component/generators/app/templates/test/accessibility/axe-accessibility.spec.js
+++ b/packages/tools/generator-component/generators/app/templates/test/accessibility/axe-accessibility.spec.js
@@ -9,7 +9,7 @@ describe('Accessibility tests', () => {
         <%= name.class %>.load();
     });
 
-    it('a11y - should test f-<%= name.class %> component WCAG compliance', () => {
+    it('a11y - should test f-<%= name.default %> component WCAG compliance', () => {
         // Act
         const axeResults = getAccessibilityTestResults('f-<%= name.default %>');
 

--- a/packages/tools/generator-component/generators/app/templates/test/accessibility/axe-accessibility.spec.js
+++ b/packages/tools/generator-component/generators/app/templates/test/accessibility/axe-accessibility.spec.js
@@ -1,6 +1,6 @@
 import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper';
 
-const <%= name.filename %> = require('../../test-utils/component-objects/f-<%= name.class %>.component');
+const <%= name.filename %> = require('../../test-utils/component-objects/f-<%= name.default %>.component');
 
 const <%= name.class %> = new <%= name.filename %>();
 
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-<%= name.class %> component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-<%= name.class %>');
+        const axeResults = getAccessibilityTestResults('f-<%= name.default %>');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/tools/generator-component/generators/app/templates/test/component/f-skeleton.component.__spec__.js
+++ b/packages/tools/generator-component/generators/app/templates/test/component/f-skeleton.component.__spec__.js
@@ -2,7 +2,7 @@ const <%= name.filename %> = require('../../test-utils/component-objects/f-<%= n
 
 const <%= name.class %> = new <%= name.filename %>();
 
-describe('f-<%= name.class %> component tests', () => {
+describe('f-<%= name.default %> component tests', () => {
     beforeEach(() => {
         <%= name.class %>.load();
     });

--- a/packages/tools/generator-component/generators/app/templates/test/visual/f-skeleton.visual.desktop.__spec__.js
+++ b/packages/tools/generator-component/generators/app/templates/test/visual/f-skeleton.visual.desktop.__spec__.js
@@ -2,7 +2,7 @@ const <%= name.filename %> = require('../../test-utils/component-objects/f-<%= n
 
 const <%= name.class %> = new <%= name.filename %>();
 
-describe('f-<%= name.class %> Desktop visual tests', () => {
+describe('f-<%= name.default %> Desktop visual tests', () => {
     beforeEach(() => {
         <%= name.class %>.load();
     });

--- a/packages/tools/generator-component/generators/app/templates/test/visual/f-skeleton.visual.desktop.__spec__.js
+++ b/packages/tools/generator-component/generators/app/templates/test/visual/f-skeleton.visual.desktop.__spec__.js
@@ -2,7 +2,7 @@ const <%= name.filename %> = require('../../test-utils/component-objects/f-<%= n
 
 const <%= name.class %> = new <%= name.filename %>();
 
-describe('f-<%= name.class %> component tests', () => {
+describe('f-<%= name.class %> Desktop visual tests', () => {
     beforeEach(() => {
         <%= name.class %>.load();
     });

--- a/packages/tools/generator-component/generators/app/templates/test/visual/f-skeleton.visual.mobile.__spec__.js
+++ b/packages/tools/generator-component/generators/app/templates/test/visual/f-skeleton.visual.mobile.__spec__.js
@@ -1,0 +1,14 @@
+const <%= name.filename %> = require('../../test-utils/component-objects/f-<%= name.class %>.component');
+
+const <%= name.class %> = new <%= name.filename %>();
+
+describe('f-<%= name.class %> Mobile visual tests', () => {
+    beforeEach(() => {
+        <%= name.class %>.load();
+    });
+
+    it('should display the f-<%= name.class %> component', () => {
+        // Assert
+        expect(<%= name.class %>.isComponentDisplayed()).toBe(true);
+    });
+});

--- a/packages/tools/generator-component/generators/app/templates/test/visual/f-skeleton.visual.mobile.__spec__.js
+++ b/packages/tools/generator-component/generators/app/templates/test/visual/f-skeleton.visual.mobile.__spec__.js
@@ -1,13 +1,13 @@
-const <%= name.filename %> = require('../../test-utils/component-objects/f-<%= name.class %>.component');
+const <%= name.filename %> = require('../../test-utils/component-objects/f-<%= name.default %>.component');
 
 const <%= name.class %> = new <%= name.filename %>();
 
-describe('f-<%= name.class %> Mobile visual tests', () => {
+describe('f-<%= name.default %> Mobile visual tests', () => {
     beforeEach(() => {
         <%= name.class %>.load();
     });
 
-    it('should display the f-<%= name.class %> component', () => {
+    it('should display the f-<%= name.default %> component', () => {
         // Assert
         expect(<%= name.class %>.isComponentDisplayed()).toBe(true);
     });

--- a/packages/tools/generator-component/generators/app/utils.js
+++ b/packages/tools/generator-component/generators/app/utils.js
@@ -8,20 +8,6 @@ function toTitleCase (str) {
     return trim(_.startCase(str));
 }
 
-function isCamelCase (str) {
-    return /[A-Z]/.test(str);
-}
-
-function splitCamelCase (str) {
-    return str.split(/(?=[A-Z])/);
-}
-
-function replaceCamelCaseWithHyphens (str) {
-    return splitCamelCase(str)
-    .join('-')
-    .toLowerCase();
-}
-
 function replaceHyphensWithWhitespace (str) {
     return str.replace(/-/g, ' ');
 }
@@ -34,11 +20,6 @@ function hasMultipleWords (str) {
 
 function prefixWithV (str) {
     return `v-${str}`;
-}
-
-function getHyphenatedName (str) {
-    // avoids incorrect naming when generating a component
-    return isCamelCase ? replaceCamelCaseWithHyphens(str) : str;
 }
 
 function getComponentName (str) {
@@ -67,7 +48,6 @@ function getReadmeName (str) {
 
 module.exports = {
     getComponentFilename,
-    getHyphenatedName,
     getComponentTemplateName,
     getComponentName,
     getComponentClassName,

--- a/packages/tools/generator-component/generators/app/utils.js
+++ b/packages/tools/generator-component/generators/app/utils.js
@@ -8,6 +8,20 @@ function toTitleCase (str) {
     return trim(_.startCase(str));
 }
 
+function isCamelCase (str) {
+    return /[A-Z]/.test(str);
+}
+
+function splitCamelCase (str) {
+    return str.split(/(?=[A-Z])/);
+}
+
+function replaceCamelCaseWithHyphens (str) {
+    return splitCamelCase(str)
+    .join('-')
+    .toLowerCase();
+}
+
 function replaceHyphensWithWhitespace (str) {
     return str.replace(/-/g, ' ');
 }
@@ -20,6 +34,11 @@ function hasMultipleWords (str) {
 
 function prefixWithV (str) {
     return `v-${str}`;
+}
+
+function getHyphenatedName (str) {
+    // avoids incorrect naming when generating a component
+    return isCamelCase ? replaceCamelCaseWithHyphens(str) : str;
 }
 
 function getComponentName (str) {
@@ -48,6 +67,7 @@ function getReadmeName (str) {
 
 module.exports = {
     getComponentFilename,
+    getHyphenatedName,
     getComponentTemplateName,
     getComponentName,
     getComponentClassName,

--- a/packages/tools/generator-component/package.json
+++ b/packages/tools/generator-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/generator-component",
   "description": "Generator Component – A generator for Fozzie components",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "files": [
     "generators"
   ],


### PR DESCRIPTION
### Added
- Prompt option for visual regression
- Spec templates for visual regression

### Changed
-names in `test-utils` and `test` from `componentName` to `component-name`
-`f-wdio-utils` to latest version

### Removed
- Unused functions from within the component object - `open()` and `load()`