### PR TITLE
f-form-field@4.5.0  - Remove utility class and add unscoped class for parent styling

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -12,7 +12,7 @@ v4.5.0
 
 ### Added
 - Styles from `u-spacing` to label description class
-- Unscoped class to label and label desscription for parent styling
+- Unscoped class to label and label description for parent styling
 
 
 v4.4.0

--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.5.0
+------------------------------
+*December 06, 2021*
+
+### Removed
+- `u-spacing` class from label description
+
+### Added
+- Styles from `u-spacing` to label description class
+- Unscoped class to label and label desscription for parent styling
+
+
 v4.4.0
 ------------------------------
 *December 02, 2021*

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field – Fozzie Form Field Component",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "main": "dist/f-form-field.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -2,6 +2,7 @@
     <div
         :data-theme-formfield="theme"
         :class="[
+            'c-formField',
             $style['c-formField'], {
                 [$style['c-formField--invalid']]: hasError,
                 [$style['c-formField--grouped']]: isFieldGrouped

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -2,7 +2,6 @@
     <div
         :data-theme-formfield="theme"
         :class="[
-            'c-formField',
             $style['c-formField'], {
                 [$style['c-formField--invalid']]: hasError,
                 [$style['c-formField--grouped']]: isFieldGrouped

--- a/packages/components/atoms/f-form-field/src/components/FormLabel.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormLabel.vue
@@ -4,6 +4,7 @@
         :id="`label-${labelFor}`"
         :for="labelFor"
         :class="[
+            'c-formField-label',
             $style['o-form-label'],
             $style['c-formField-label'], {
                 [$style['c-formField-label--disabled']]: isDisabled
@@ -22,8 +23,7 @@
             v-if="labelDescription"
             :data-test-id="testId.description"
             :class="[
-                'u-spacingTop',
-                'u-spacingBottom--large',
+                'c-formField-label-description',
                 $style['c-formField-label-description']
             ]">
             {{ labelDescription }}
@@ -106,5 +106,7 @@ $form-label-weight              : $font-weight-bold;
 
 .c-formField-label-description {
     display: block;
+    margin-top: spacing();
+    margin-bottom: spacing(x2);
 }
 </style>


### PR DESCRIPTION
### Removed
- `u-spacing` class from label description

### Added
- Styles from `u-spacing` to label description class
- Unscoped class to label and label description for parent styling