### PR TITLE
f-wdio-utils@v0.5.0 - Expose the timeout option on `waitForComponent()` method

### DIFF
--- a/packages/services/f-wdio-utils/CHANGELOG.md
+++ b/packages/services/f-wdio-utils/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.5.0
+------------------------------
+*November 7, 2021*
+
+### Changed
+- `waitForComponent` - Expose the timeout option on the underlying `waitForExist` method.
+
+
 v0.4.0
 ------------------------------
 *November 4, 2021*

--- a/packages/services/f-wdio-utils/package.json
+++ b/packages/services/f-wdio-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-wdio-utils",
   "description": "Fozzie Wdio Utils - webdriverIO page object",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "files": [
     "src/"
   ],

--- a/packages/services/f-wdio-utils/src/page.object.js
+++ b/packages/services/f-wdio-utils/src/page.object.js
@@ -1,6 +1,8 @@
 const { buildUrl } = require('./storybook-extensions');
 
 class Page {
+    #defaultWaitTimeout = 500;
+
     constructor (componentType, componentName) {
         this.title = 'Component URLS';
         this.componentType = componentType;
@@ -19,8 +21,8 @@ class Page {
         return this;
     }
 
-    waitForComponent (component) {
-        component.waitForExist();
+    waitForComponent (component, timeoutMs = this.#defaultWaitTimeout) {
+        component.waitForExist({ timeout: timeoutMs });
     }
 
     withQuery (name, value) {


### PR DESCRIPTION
### Changed
- `waitForComponent` - Expose the timeout option on the underlying `waitForExist` method.
---
spec - https://webdriver.io/docs/api/element/waitForExist/