### PR TITLE
#trivial - f-account-info - Renamed `fields` to `consumer` in preparation of the Store State model

### DIFF
--- a/packages/components/pages/f-account-info/src/components/AccountInfo.vue
+++ b/packages/components/pages/f-account-info/src/components/AccountInfo.vue
@@ -9,60 +9,60 @@
             {{ $t('yourDetails') }}
         </h2>
 
-        <email-address-field :email-address="values.emailAddress" />
+        <email-address-field :email-address="consumer.emailAddress" />
 
         <form
             method="post"
             @submit.prevent="onFormSubmit">
             <form-field
-                v-model="fields.firstName"
+                v-model="consumer.firstName"
                 maxlength="50"
-                :label-text="$t('fields.firstNameLabel')"
-                :placeholder="$t('fields.firstNamePlaceholder')"
+                :label-text="$t('consumer.firstNameLabel')"
+                :placeholder="$t('consumer.firstNamePlaceholder')"
                 @blur="onBlur('firstName')">
                 <template
-                    v-if="$v.fields.firstName.$invalid"
+                    v-if="$v.consumer.firstName.$invalid"
                     #error>
-                    <f-error-message v-show="!$v.fields.firstName.required && $v.fields.firstName.$dirty">
+                    <f-error-message v-show="!$v.consumer.firstName.required && $v.consumer.firstName.$dirty">
                         {{ $t('validation.firstNameRequired') }}
                     </f-error-message>
-                    <f-error-message v-show="!$v.fields.firstName.isValidName">
+                    <f-error-message v-show="!$v.consumer.firstName.isValidName">
                         {{ $t('validation.firstNameInvalid') }}
                     </f-error-message>
                 </template>
             </form-field>
 
             <form-field
-                v-model="fields.lastName"
+                v-model="consumer.lastName"
                 maxlength="50"
-                :label-text="$t('fields.lastNameLabel')"
-                :placeholder="$t('fields.lastNamePlaceholder')"
+                :label-text="$t('consumer.lastNameLabel')"
+                :placeholder="$t('consumer.lastNamePlaceholder')"
                 @blur="onBlur('lastName')">
                 <template
-                    v-if="$v.fields.lastName.$invalid"
+                    v-if="$v.consumer.lastName.$invalid"
                     #error>
-                    <f-error-message v-show="!$v.fields.lastName.required && $v.fields.lastName.$dirty">
+                    <f-error-message v-show="!$v.consumer.lastName.required && $v.consumer.lastName.$dirty">
                         {{ $t('validation.lastNameRequired') }}
                     </f-error-message>
-                    <f-error-message v-show="!$v.fields.lastName.isValidName">
+                    <f-error-message v-show="!$v.consumer.lastName.isValidName">
                         {{ $t('validation.lastNameInvalid') }}
                     </f-error-message>
                 </template>
             </form-field>
 
             <form-field
-                v-model="fields.phoneNumber"
+                v-model="consumer.phoneNumber"
                 maxlength="16"
-                :label-text="$t('fields.phoneNumberLabel')"
-                :placeholder="$t('fields.phoneNumberPlaceholder')"
+                :label-text="$t('consumer.phoneNumberLabel')"
+                :placeholder="$t('consumer.phoneNumberPlaceholder')"
                 @blur="onBlur('phoneNumber')">
                 <template
-                    v-if="$v.fields.phoneNumber.$invalid"
+                    v-if="$v.consumer.phoneNumber.$invalid"
                     #error>
-                    <f-error-message v-show="!$v.fields.phoneNumber.required && $v.fields.phoneNumber.$dirty">
+                    <f-error-message v-show="!$v.consumer.phoneNumber.required && $v.consumer.phoneNumber.$dirty">
                         {{ $t('validation.phoneNumberRequired') }}
                     </f-error-message>
-                    <f-error-message v-show="!$v.fields.phoneNumber.isValidPhoneNumber && $v.fields.phoneNumber.required && $v.fields.phoneNumber.$dirty">
+                    <f-error-message v-show="!$v.consumer.phoneNumber.isValidPhoneNumber && $v.consumer.phoneNumber.required && $v.consumer.phoneNumber.$dirty">
                         {{ $t('validation.phoneNumberInvalid') }}
                     </f-error-message>
                 </template>
@@ -74,58 +74,58 @@
             </h2>
 
             <form-field
-                v-model="fields.line1"
+                v-model="consumer.line1"
                 maxlength="50"
-                :label-text="$t('fields.addressLabel')"
-                :placeholder="$t('fields.line1Placeholder')"
+                :label-text="$t('consumer.addressLabel')"
+                :placeholder="$t('consumer.line1Placeholder')"
                 @blur="onBlur('line1')">
                 <template
-                    v-if="$v.fields.line1.$invalid"
+                    v-if="$v.consumer.line1.$invalid"
                     #error>
-                    <f-error-message v-show="!$v.fields.line1.required && $v.fields.line1.$dirty">
+                    <f-error-message v-show="!$v.consumer.line1.required && $v.consumer.line1.$dirty">
                         {{ $t('validation.line1Required') }}
                     </f-error-message>
                 </template>
             </form-field>
 
             <form-field
-                v-model="fields.line2"
+                v-model="consumer.line2"
                 maxlength="50"
-                :placeholder="$t('fields.line2Placeholder')" />
+                :placeholder="$t('consumer.line2Placeholder')" />
 
             <form-field
-                v-model="fields.line3"
+                v-model="consumer.line3"
                 maxlength="50"
-                :placeholder="$t('fields.line3Placeholder')" />
+                :placeholder="$t('consumer.line3Placeholder')" />
 
             <form-field
-                v-model="fields.locality"
+                v-model="consumer.locality"
                 maxlength="50"
-                :label-text="$t('fields.localityLabel')"
-                :placeholder="$t('fields.localityPlaceholder')"
+                :label-text="$t('consumer.localityLabel')"
+                :placeholder="$t('consumer.localityPlaceholder')"
                 @blur="onBlur('locality')">
                 <template
-                    v-if="$v.fields.locality.$invalid"
+                    v-if="$v.consumer.locality.$invalid"
                     #error>
-                    <f-error-message v-show="!$v.fields.locality.required && $v.fields.locality.$dirty">
+                    <f-error-message v-show="!$v.consumer.locality.required && $v.consumer.locality.$dirty">
                         {{ $t('validation.localityRequired') }}
                     </f-error-message>
                 </template>
             </form-field>
 
             <form-field
-                v-model="fields.postcode"
+                v-model="consumer.postcode"
                 maxlength="50"
-                :label-text="$t('fields.postcodeLabel')"
-                :placeholder="$t('fields.postcodePlaceholder')"
+                :label-text="$t('consumer.postcodeLabel')"
+                :placeholder="$t('consumer.postcodePlaceholder')"
                 @blur="onBlur('postcode')">
                 <template
-                    v-if="$v.fields.postcode.$invalid"
+                    v-if="$v.consumer.postcode.$invalid"
                     #error>
-                    <f-error-message v-show="!$v.fields.postcode.required && $v.fields.postcode.$dirty">
+                    <f-error-message v-show="!$v.consumer.postcode.required && $v.consumer.postcode.$dirty">
                         {{ $t('validation.postcodeRequired') }}
                     </f-error-message>
-                    <f-error-message v-show="!$v.fields.postcode.isValidPostcode && $v.fields.postcode.required">
+                    <f-error-message v-show="!$v.consumer.postcode.isValidPostcode && $v.consumer.postcode.required">
                         {{ $t('validation.postcodeInvalid') }}
                     </f-error-message>
                 </template>
@@ -214,7 +214,7 @@ export default {
 
     data () {
         return {
-            fields: {
+            consumer: {
                 firstName: null,
                 lastName: null,
                 phoneNumber: null,
@@ -253,14 +253,11 @@ export default {
         initialise () {
             try {
                 // TODO - Dummy data to be replaced with next ticket
-                this.values = {
-                    emailAddress: 'mr.jazz@town.com'
-                };
-
-                this.fields = {
+                this.consumer = {
                     firstName: 'Max',
                     lastName: 'Legend',
                     phoneNumber: 1234567890,
+                    emailAddress: 'mr.jazz@town.com',
                     line1: '1 Wardour Street',
                     line2: undefined,
                     line3: null,

--- a/packages/components/pages/f-account-info/src/components/AccountInfo.vue
+++ b/packages/components/pages/f-account-info/src/components/AccountInfo.vue
@@ -160,24 +160,19 @@
 
 <script>
 import { VueGlobalisationMixin } from '@justeat/f-globalisation';
-
 import FErrorMessage from '@justeat/f-error-message';
 import '@justeat/f-error-message/dist/f-error-message.css';
-
 import FCard from '@justeat/f-card';
 import '@justeat/f-card/dist/f-card.css';
-
 import FormField from '@justeat/f-form-field';
 import '@justeat/f-form-field/dist/f-form-field.css';
-
 import FButton from '@justeat/f-button';
 import '@justeat/f-button/dist/f-button.css';
-
 import EmailAddressField from './EmailAddressField.vue';
 import DeleteAccount from './DeleteAccount.vue';
-
 import AccountInfoValidationMixin from './AccountInfoValidationMixin.vue';
 import tenantConfigs from '../tenants';
+import ConsumerApi from '../services/providers/Consumer.api';
 import {
     EVENT_SPINNER_STOP_LOADING
 } from '../constants';
@@ -218,15 +213,18 @@ export default {
                 firstName: null,
                 lastName: null,
                 phoneNumber: null,
+                emailAddress: null,
                 line1: null,
                 line2: null,
                 line3: null,
                 locality: null,
                 postcode: null
             },
-            values: {
-                emailAddress: null
-            },
+            consumerApi: new ConsumerApi({
+                httpClient: this.$http,
+                cookies: this.$cookies,
+                baseUrl: this.smartGatewayBaseUrl
+            }),
             tenantConfigs,
             isFormSubmitting: false
         };

--- a/packages/components/pages/f-account-info/src/components/AccountInfoValidationMixin.vue
+++ b/packages/components/pages/f-account-info/src/components/AccountInfoValidationMixin.vue
@@ -6,7 +6,7 @@ import { validations } from '@justeat/f-services';
 export default {
     validations () {
         const validationRules = {
-            fields: {
+            consumer: {
                 firstName: {
                     required,
                     isValidName: this.isValidName
@@ -52,11 +52,11 @@ export default {
         },
 
         isValidPhoneNumber () {
-            return validations.isValidPhoneNumber(this.fields.phoneNumber, this.$i18n.locale);
+            return validations.isValidPhoneNumber(this.consumer.phoneNumber, this.$i18n.locale);
         },
 
         isValidPostcode () {
-            return validations.isValidPostcode(this.fields.postcode, this.$i18n.locale);
+            return validations.isValidPostcode(this.consumer.postcode, this.$i18n.locale);
         },
 
         /**
@@ -70,7 +70,7 @@ export default {
         },
 
         onBlur (field) {
-            const fieldValidation = this.$v.fields[field];
+            const fieldValidation = this.$v.consumer[field];
 
             if (fieldValidation) {
                 fieldValidation.$touch();

--- a/packages/components/pages/f-account-info/src/components/EmailAddressField.vue
+++ b/packages/components/pages/f-account-info/src/components/EmailAddressField.vue
@@ -1,9 +1,9 @@
 <template>
     <div>
         <form-field
-            :label-text="$t('fields.emailAddressLabel')"
+            :label-text="$t('consumer.emailAddressLabel')"
             disabled
-            :placeholder="$t('fields.emailAddressPlaceholder')"
+            :placeholder="$t('consumer.emailAddressPlaceholder')"
             class="u-spacingBottom--large"
             :value="emailAddress" />
 

--- a/packages/components/pages/f-account-info/src/components/_tests/AccountInfo.test.js
+++ b/packages/components/pages/f-account-info/src/components/_tests/AccountInfo.test.js
@@ -10,7 +10,7 @@ import {
 
 const createStore = ({ state = {}, actions = {} } = {}) => new Vuex.Store({
     modules: {
-        fContactPreferencesModule: {
+        fAccountInfoModule: {
             state,
             actions,
             namespaced: true
@@ -22,7 +22,7 @@ let sutProps;
 
 describe('AccountInfo', () => {
     beforeEach(() => {
-        // Arrange & Act
+        // Arrange
         sutProps = {
             authToken: token,
             isAuthFinished: true,

--- a/packages/components/pages/f-account-info/src/components/_tests/AccountInfoValidationMixin.test.js
+++ b/packages/components/pages/f-account-info/src/components/_tests/AccountInfoValidationMixin.test.js
@@ -110,7 +110,7 @@ describe('AccountInfoValidationMixin', () => {
                     render () {},
                     data () {
                         return {
-                            fields: {},
+                            consumer: {},
                             tenantConfigs
                         };
                     },
@@ -121,7 +121,7 @@ describe('AccountInfoValidationMixin', () => {
             it('should return false when all fields have valid inputs', async () => {
                 // Arrange
                 baseComponent.data = () => ({
-                    fields: {
+                    consumer: {
                         firstName: 'Roger',
                         lastName: 'Black',
                         phoneNumber: '1234567890',

--- a/packages/components/pages/f-account-info/src/tenants/en-GB.js
+++ b/packages/components/pages/f-account-info/src/tenants/en-GB.js
@@ -3,7 +3,7 @@ const messages = {
     yourDetails: 'Your details',
     contactCustomerCareTeam: "If you'd like to change your email address, get in touch with our customer care team.",
     deliveryAddress: 'Delivery Address',
-    fields: {
+    consumer: {
         emailAddressLabel: 'Email address',
         emailAddressPlaceholder: 'Your email address...',
         firstNameLabel: 'First name*',


### PR DESCRIPTION
When the Store State is wired up to the Template the Store exposes the model `consumer` on its State, so all the refs. to `fields` need to be changed to `consumer`.
Also imported the `ConsumerApi` in preparation for the Store.