### PR TITLE
f-navigation-links@1.0.0 - move f-links to peer deps

### DIFF
--- a/packages/components/molecules/f-navigation-links/CHANGELOG.md
+++ b/packages/components/molecules/f-navigation-links/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v1.0.0
+------------------------------
+*December 9, 2021*
+
+### Added
+- **Breaking Change**: Added `f-link` dependency to peer dependencies. Now `f-link` should be included as a dependency of the consuming component or application.
+
+### Removed
+- **Breaking Change**: Removed `f-link` styles import from the component. Make sure to import `f-link` styles in your application.
+
+
 v0.3.0
 ------------------------------
 *November 9, 2021*

--- a/packages/components/molecules/f-navigation-links/README.md
+++ b/packages/components/molecules/f-navigation-links/README.md
@@ -59,6 +59,12 @@ export default {
 }
 ```
 
+The package also has dependencies that need to be installed by consuming components/applications:
+
+| Dependency | Command to install | Styles to include |
+| ----- | ----- | ----- |
+| f-link | `yarn add @justeat/f-link` | `import '@justeat/f-link/dist/f-link.css';` |
+
 ## Configuration
 
 ### Props

--- a/packages/components/molecules/f-navigation-links/package.json
+++ b/packages/components/molecules/f-navigation-links/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-navigation-links",
   "description": "Fozzie Navigation Links - A component to display a collection of supplied links",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "main": "dist/f-navigation-links.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [
@@ -41,7 +41,8 @@
   ],
   "dependencies": {},
   "peerDependencies": {
-    "@justeat/browserslist-config-fozzie": ">=1.2.0"
+    "@justeat/browserslist-config-fozzie": ">=1.2.0",
+    "@justeat/f-link": "2.x.x"
   },
   "devDependencies": {
     "@justeat/f-link": "2.3.0",

--- a/packages/components/molecules/f-navigation-links/src/components/NavigationLinks.vue
+++ b/packages/components/molecules/f-navigation-links/src/components/NavigationLinks.vue
@@ -22,7 +22,6 @@
 
 <script>
 import VLink from '@justeat/f-link';
-import '@justeat/f-link/dist/f-link.css';
 
 export default {
     name: 'NavigationLinks',

--- a/packages/components/molecules/f-navigation-links/vue.config.js
+++ b/packages/components/molecules/f-navigation-links/vue.config.js
@@ -1,5 +1,7 @@
 const path = require('path');
 
+const PeerDepsExternalsPlugin = require('peer-deps-externals-webpack-plugin');
+
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
@@ -19,5 +21,10 @@ module.exports = {
     },
     pluginOptions: {
         lintStyleOnBuild: true
+    },
+    configureWebpack: {
+        plugins: [
+            new PeerDepsExternalsPlugin()
+        ]
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,14 +2220,6 @@
     "@justeat/f-services" "1.0.0"
     "@justeat/f-vue-icons" "2.5.0"
 
-"@justeat/f-form-field@4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-4.5.0.tgz#931d5d643090c2fce46ecf8302b3333013fb3d7d"
-  integrity sha512-EJLkg0vzxS+BE16mZ2Q2r7bB3jvZd8EFW8jB5GmACSqtsCe0iLLFSfY2cPlDx3oZ1nZMoRse/T2foCrjH5c7dg==
-  dependencies:
-    "@justeat/f-services" "1.0.0"
-    "@justeat/f-vue-icons" "2.5.0"
-
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-0.2.0.tgz#90ec559642c165b6325669c506c417abe09fa5dd"
@@ -2264,6 +2256,11 @@
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-3.0.2.tgz#81f2b5ca8519a6eca93f5643857df2a9c924666d"
   integrity sha512-3M+wpcjOIIw3hKbtZqyRl3mwdi2zz90wFAJc5RtJciJ/VwD73bHNjvABRl/At+JZj2p0Ongjg11ezSayoKMGJg==
+
+"@justeat/f-navigation-links@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-navigation-links/-/f-navigation-links-0.3.0.tgz#73475aec7110f8be32b58e2d5250f62ba92295a8"
+  integrity sha512-qcImxIiXRY57/54Piu/i9zZ6k7mRsnxHHcdnuPJvGAxbWDPNJIcWgJL07tMEedLVeZ+OM3Pg9KEkC983Hrc8vg==
 
 "@justeat/f-searchbox@6.0.0":
   version "6.0.0"
@@ -2434,6 +2431,13 @@
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.1.0.tgz#e8a62dd2d03c2cf14ce1fa7d50540c2171b8fc38"
   integrity sha512-m2WfTJWR5Yako3hKEZ7SL3zDvZQA7VQ9hbUBnk02lxMYSKSqeHmLPICaLGtPXCIDBEuESFk2kscHSQc3GBxxmg==
+  dependencies:
+    "@justeat/f-services" "1.7.0"
+
+"@justeat/f-wdio-utils@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.4.0.tgz#6916a392777c88bc84e0d5a258e7e94c64ff7800"
+  integrity sha512-CQ69zuqvPGIAmDAF+EZM9dnBoIizBIMrl4L2tpvk27oRPKycQGgFIjfq1v/wTgVNwVXVJNCEG6zEKNjccSl+Ew==
   dependencies:
     "@justeat/f-services" "1.7.0"
 


### PR DESCRIPTION
### Added
- **Breaking Change**: Added `f-link` dependency to peer dependencies. Now `f-link` should be included as a dependency of the consuming componet or application.

### Removed
- **Breaking Change**: Removed `f-link` styles import from the component. Make sure to import `f-link` styles in your application.