### PR TITLE
f-header@8.0.0 - Fix invisible icons in mobile nav for highlight theme, and add `tallBelowMid` prop

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,6 +4,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v7.4.0
+------------------------------
+*December 9, 2021*
+
+### Changed
+- Fix some display issues for highlight theme
+  - Make icons visible in mobile nav.
+  - Reduce header height for mobile viewports.
+
+### Added
+- Supporting visual regression tests.
+
+
 v7.3.0
 ------------------------------
 *December 6, 2021*

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -9,9 +9,7 @@ v7.4.0
 *December 9, 2021*
 
 ### Changed
-- Fix some display issues for highlight theme
-  - Make icons visible in mobile nav.
-  - Reduce header height for mobile viewports.
+- Make icons visible in mobile nav for highlight theme.
 
 ### Added
 - Supporting visual regression tests.

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v7.4.0
+v8.0.0
 ------------------------------
 *December 9, 2021*
 
@@ -12,6 +12,7 @@ v7.4.0
 - Make icons visible in mobile nav for highlight theme.
 
 ### Added
+- (BREAKING) `tallBelowMid` prop to support taller header for mobile viewports (currently used in highlight theme).
 - Supporting visual regression tests.
 
 

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-header/src/assets/scss/navigation.scss
+++ b/packages/components/organisms/f-header/src/assets/scss/navigation.scss
@@ -35,7 +35,7 @@ $nav-featureLinkIcon-height        : 28px;
 
 $nav-icon-color                    : $color-interactive-primary;
 $nav-icon-color--transparent       : $color-interactive-inverse;
-$nav-icon-color--mobileWhiteBg     : $color-content-interactive-tertiary;
+$nav-icon-color--mobileWhiteBg     : $color-content-interactive-secondary;
 $nav-icon-size                     : 24px;
 
 $nav-toggleIcon-left               : spacing(x2);

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -5,7 +5,8 @@
             $style['c-header'],
             headerBackgroundClass,
             transparentBackgroundClasses,
-            { [$style['c-header--navInView']]: mobileNavIsOpen }
+            { [$style['c-header--navInView']]: mobileNavIsOpen },
+            { [$style['c-header--tallBelowMid']]: tallBelowMid }
         ]"
         data-test-id='header-component'>
         <skip-to-main
@@ -131,6 +132,11 @@ export default {
         showCountrySelector: {
             type: Boolean,
             default: false
+        },
+
+        tallBelowMid: {
+            type: Boolean,
+            default: false
         }
     },
 
@@ -248,7 +254,16 @@ html:global(.is-navInView) {
 
     .c-header--highlightBg {
         background-color: $color-support-brand-01;
-        min-height: 88px;
+
+        @include media('>mid') {
+            min-height: 88px;
+        }
+    }
+
+    .c-header--tallBelowMid {
+        @include media('<=mid') {
+            min-height: 88px;
+        }
     }
 
     .c-header-container {

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -248,10 +248,7 @@ html:global(.is-navInView) {
 
     .c-header--highlightBg {
         background-color: $color-support-brand-01;
-
-        @include media('>mid') {
-            min-height: 88px;
-        }
+        min-height: 88px;
     }
 
     .c-header-container {

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -248,7 +248,10 @@ html:global(.is-navInView) {
 
     .c-header--highlightBg {
         background-color: $color-support-brand-01;
-        min-height: 88px;
+
+        @include media('>mid') {
+            min-height: 88px;
+        }
     }
 
     .c-header-container {

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -13,7 +13,7 @@
                 'is-hidden--noJS',
                 $style['c-nav-trigger'],
                 $style['c-nav-toggle'],
-                { [$style['c-nav-toggle--altColour']]: isAltColour },
+                { [$style['c-nav-toggle--altColour']]: isAltColour || (headerBackgroundTheme === 'highlight' && navIsOpen) },
                 { [$style['is-open']]: navIsOpen }
             ]"
             :aria-expanded="navIsOpen ? 'true' : 'false'"
@@ -405,7 +405,7 @@ export default {
 
         isAltColour () {
             const isMobileNavOpen = this.navIsOpen && this.isBelowMid;
-            return (this.headerBackgroundTheme === 'transparent' && !isMobileNavOpen) || this.headerBackgroundTheme === 'highlight';
+            return ['transparent', 'highlight'].includes(this.headerBackgroundTheme) && !isMobileNavOpen;
         },
 
         /**

--- a/packages/components/organisms/f-header/stories/header.stories.js
+++ b/packages/components/organisms/f-header/stories/header.stories.js
@@ -31,7 +31,8 @@ export const HeaderComponent = (args, { argTypes }) => ({
             :show-country-selector="showCountrySelector"
             :custom-nav-links="customNavLinks"
             :key="locale"
-            :show-skip-link="showSkipLink" />`
+            :show-skip-link="showSkipLink"
+            :tall-below-mid="tallBelowMid" />`
 });
 
 HeaderComponent.storyName = 'f-header';
@@ -46,7 +47,8 @@ HeaderComponent.args = {
     showSkipLink: true,
     showOffersLink: false,
     showDeliveryEnquiry: false,
-    logoLinkDisabled: false
+    logoLinkDisabled: false,
+    tallBelowMid: false
 };
 
 HeaderComponent.argTypes = {
@@ -114,5 +116,9 @@ HeaderComponent.argTypes = {
 
     logoLinkDisabled: {
         description: 'Prevents the header logo from also being a link'
+    },
+
+    tallBelowMid: {
+        description: 'Makes the header taller for narrower viewports'
     }
 };

--- a/packages/components/organisms/f-header/test/visual/f-header.visual.mobile.spec.js
+++ b/packages/components/organisms/f-header/test/visual/f-header.visual.mobile.spec.js
@@ -53,6 +53,30 @@ describe('Shared - f-header component tests', () => {
         browser.percyScreenshot(`f-header - Theme colours - ${theme}`, 'mobile');
     });
 
+    forEach([
+        'white',
+        'highlight',
+        'transparent'
+    ]).it('should display the mobile nav correctly for theme %s', theme => {
+        // Arrange
+        const controls = [
+            'locale:en-GB',
+            'showOffersLink:true',
+            'showDeliveryEnquiry:true',
+            `headerBackgroundTheme:${theme}`
+        ].join(';');
+
+        header = new Header();
+        header.path += `&args=${controls}`;
+
+        // Act
+        header.load();
+        header.openMobileNavigationBar();
+
+        // Assert
+        browser.percyScreenshot(`f-header - Mobile nav theme colours - ${theme}`, 'mobile');
+    });
+
     it('should display all available countries', () => {
         // Arrange
         const controls = 'locale:en-GB';

--- a/packages/components/organisms/f-header/test/visual/f-header.visual.mobile.spec.js
+++ b/packages/components/organisms/f-header/test/visual/f-header.visual.mobile.spec.js
@@ -163,4 +163,24 @@ describe('Shared - f-header component tests', () => {
         // Assert
         browser.percyScreenshot('f-header - custom nav links only', 'mobile');
     });
+
+    forEach([
+        'highlight'
+    ]).it('should display correctly with tallBelowMid prop', theme => {
+        // Arrange
+        const controls = [
+            'locale:en-GB',
+            `headerBackgroundTheme:${theme}`,
+            'tallBelowMid:true'
+        ].join(';');
+
+        header = new Header();
+        header.path += `&args=${controls}`;
+
+        // Act
+        header.load();
+
+        // Assert
+        browser.percyScreenshot(`f-header - tallBelowMid - ${theme}`, 'mobile');
+    });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2429,6 +2429,13 @@
   dependencies:
     "@justeat/f-services" "1.7.0"
 
+"@justeat/f-wdio-utils@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.4.0.tgz#6916a392777c88bc84e0d5a258e7e94c64ff7800"
+  integrity sha512-CQ69zuqvPGIAmDAF+EZM9dnBoIizBIMrl4L2tpvk27oRPKycQGgFIjfq1v/wTgVNwVXVJNCEG6zEKNjccSl+Ew==
+  dependencies:
+    "@justeat/f-services" "1.7.0"
+
 "@justeat/fozzie@6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-6.0.0.tgz#95dbb84020852c5bf0917d9dbc2f7a49145efd8b"


### PR DESCRIPTION
### Changed
- Fix some display issues for highlight theme
  - Make icons visible in mobile nav.
  - Reduce header height for mobile viewports.

### Added
- Supporting visual regression tests.

---

## UI Review Checks

- [x] Tests have been [created|updated]

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
