### PR TITLE
f-status-banner@5.0.0 - Add peerDep, update changelog.

### DIFF
--- a/packages/components/organisms/f-status-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-status-banner/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v5.0.0
+------------------------------
+*December 9, 2021*
+
+### Added
+- **Breaking Change**: Added `f-searchbox` dependency to peer dependencies. Now `f-searchbox` should be included as a dependency of the consuming component or application.
+
+### Removed
+- **Breaking Change**: Removed `f-searchbox` styles import from the component. Make sure to import `f-searchbox` styles in your application.
+
 
 v4.0.0
 ------------------------------

--- a/packages/components/organisms/f-status-banner/README.md
+++ b/packages/components/organisms/f-status-banner/README.md
@@ -61,6 +61,12 @@ export default {
 }
 ```
 
+The package also has dependencies that need to be installed by consuming components/applications:
+
+| Dependency | Command to install | Styles to include |
+| ----- | ----- | ----- |
+| f-searchbox | `yarn add @justeat/f-searchbox` | `import '@justeat/f-searchbox/dist/f-searchbox.css';` |
+
 ## Configuration
 
 ### Props

--- a/packages/components/organisms/f-status-banner/package.json
+++ b/packages/components/organisms/f-status-banner/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0",
-    "@justeat/f-searchbox": "6.0.0"
+    "@justeat/f-searchbox": "6.x.x"
   },
   "devDependencies": {
     "@justeat/f-searchbox": "6.0.0",

--- a/packages/components/organisms/f-status-banner/package.json
+++ b/packages/components/organisms/f-status-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-status-banner",
   "description": "Fozzie Status Banner - Global status page",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "main": "dist/f-status-banner.umd.min.js",
   "maxBundleSize": "60kB",
   "files": [
@@ -45,7 +45,8 @@
     "@justeat/f-services": "1.7.0"
   },
   "peerDependencies": {
-    "@justeat/browserslist-config-fozzie": ">=1.2.0"
+    "@justeat/browserslist-config-fozzie": ">=1.2.0",
+    "@justeat/f-searchbox": "6.0.0"
   },
   "devDependencies": {
     "@justeat/f-searchbox": "6.0.0",

--- a/packages/components/organisms/f-status-banner/src/components/MainBannerContainer.vue
+++ b/packages/components/organisms/f-status-banner/src/components/MainBannerContainer.vue
@@ -18,7 +18,6 @@
 
 <script>
 import SearchBox from '@justeat/f-searchbox';
-import '@justeat/f-searchbox/dist/f-searchbox.css';
 import PageBanner from './PageBanner.vue';
 
 export default {

--- a/packages/components/organisms/f-status-banner/stories/StatusBanner.stories.js
+++ b/packages/components/organisms/f-status-banner/stories/StatusBanner.stories.js
@@ -2,6 +2,8 @@
 // import {
 //     withKnobs, select, boolean
 // } from '@storybook/addon-knobs';
+import '@justeat/f-searchbox/dist/f-searchbox.css'; // these styles are imported to fix visual regression tests
+
 import Vue from 'vue';
 import Vuex from 'vuex';
 import { withA11y } from '@storybook/addon-a11y';

--- a/packages/components/organisms/f-status-banner/vue.config.js
+++ b/packages/components/organisms/f-status-banner/vue.config.js
@@ -1,5 +1,7 @@
 const path = require('path');
 
+const PeerDepsExternalsPlugin = require('peer-deps-externals-webpack-plugin');
+
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
@@ -19,5 +21,10 @@ module.exports = {
     },
     pluginOptions: {
         lintStyleOnBuild: true
+    },
+    configureWebpack: {
+        plugins: [
+            new PeerDepsExternalsPlugin()
+        ]
     }
 };


### PR DESCRIPTION
### Added
- **Breaking Change**: Added `f-searchbox` dependency to peer dependencies. Now `f-searchbox` should be included as a dependency of the consuming component or application.

### Removed
- **Breaking Change**: Removed `f-searchbox` styles import from the component. Make sure to import `f-searchbox` styles in your application.


- [x] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
