### PR TITLE
f-searchbox@v4.0.0-beta.37 – Moving components to peerDeps

### DIFF
--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -4,12 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (to be added to next release)
+v4.0.0-beta.37
 ------------------------------
-*October 13, 2021*
+*December 9, 2021*
 
-### Changed
-- Updated version of `f-button`.
+### Added
+- **Breaking Change**: Added `f-button`, `f-error-message` & `f-mega-modal` dependency to peer dependencies. Now `f-button`, `f-error-message` & `f-mega-modal` should be included as dependencies of the consuming component or application.
+
+### Removed
+- **Breaking Change**: Removed `f-button`, `f-error-message` & `f-mega-modal` styles import from the component. Make sure to import `f-button`, `f-error-message` & `f-mega-modal` styles in your application.
 
 
 v4.0.0-beta.36

--- a/packages/components/molecules/f-searchbox/README.md
+++ b/packages/components/molecules/f-searchbox/README.md
@@ -56,6 +56,16 @@
     }
 
     ```
+
+The package also has dependencies that need to be installed by consuming components/applications:
+
+| Dependency        | Command to install                  | Styles to include                                      |
+| ----------------- | ----------------------------------- | ------------------------------------------------------ |
+| f-button          | `yarn add @justeat/f-button`        | `import '@justeat/f-button/dist/f-button.css';`        |
+| f-error-message   | `yarn add @justeat/f-error-message` | `import '@justeat/f-button/dist/f-error-message.css';` |
+| f-mega-modal      | `yarn add @justeat/f-mega-modal`    | `import '@justeat/f-button/dist/f-mega-modal.css';`    |
+
+
 ## Development
 It is recommended to run the following commands at the root of the monorepo in order to install dependencies and allow you to view components in isolation via Storybook.
 

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-searchbox",
   "description": "Fozzie Searchbox – Just Eat Takeaway Global Searchbox",
-  "version": "4.0.0-beta.36",
+  "version": "4.0.0-beta.37",
   "main": "dist/f-searchbox.umd.min.js",
   "maxBundleSize": "60kB",
   "files": [
@@ -54,14 +54,17 @@
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
+    "@justeat/f-button": "3.x",
+    "@justeat/f-error-message": "1.x",
+    "@justeat/f-mega-modal": "3.x",
     "vue": "2.x",
     "vuex": "3.5.1"
   },
   "devDependencies": {
-    "@justeat/f-button": "3.0.2",
+    "@justeat/f-button": "3.2.0",
     "@justeat/f-error-message": "1.0.0",
     "@justeat/f-globalisation": "0.2.0",
-    "@justeat/f-mega-modal": "3.0.0",
+    "@justeat/f-mega-modal": "3.0.2",
     "@justeat/f-vue-icons": "1.13.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/molecules/f-searchbox/src/components/Form.vue
+++ b/packages/components/molecules/f-searchbox/src/components/Form.vue
@@ -57,7 +57,6 @@
 import { mapState, mapActions } from 'vuex';
 import debounce from 'lodash.debounce';
 import ErrorMessage from '@justeat/f-error-message';
-import '@justeat/f-error-message/dist/f-error-message.css';
 import FormSearchField from './formElements/FormSearchField.vue';
 import FormSearchButton from './formElements/FormSearchButton.vue';
 import FormSearchSuggestions from './formElements/FormSearchSuggestions.vue';

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchModalOverlay.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormFullAddressSearchModalOverlay.vue
@@ -52,9 +52,7 @@
 <script>
 import { mapState, mapActions } from 'vuex';
 import FullAddressOverlaySearch from '@justeat/f-mega-modal';
-import '@justeat/f-mega-modal/dist/f-mega-modal.css';
 import CancelButton from '@justeat/f-button';
-import '@justeat/f-button/dist/f-button.css';
 import FullAddressSearchSuggestions from './FormFullAddressSearchSuggestions.vue';
 import LoadingIndicator from '../FormStates/FormLoadingIndicator.vue';
 import { ON_FULL_ADDRESS_MODAL_CLOSED } from '../../event-types';

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchButton.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchButton.vue
@@ -21,7 +21,6 @@
 
 <script>
 import SearchButton from '@justeat/f-button';
-import '@justeat/f-button/dist/f-button.css';
 import { EyeglassIcon } from '@justeat/f-vue-icons';
 
 export default {

--- a/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchField.vue
+++ b/packages/components/molecules/f-searchbox/src/components/formElements/FormSearchField.vue
@@ -65,7 +65,6 @@
 import { mapActions, mapState } from 'vuex';
 import { CrossIcon } from '@justeat/f-vue-icons';
 import ClearButton from '@justeat/f-button';
-import '@justeat/f-button/dist/f-button.css';
 import FormSearchInnerFieldWrapper from './FormSearchInnerFieldWrapper.vue';
 import FormFullAddressSearchOverlay from './FormFullAddressSearchModalOverlay.vue';
 import LoadingIndicator from '../FormStates/FormLoadingIndicator.vue';

--- a/packages/components/molecules/f-searchbox/vue.config.js
+++ b/packages/components/molecules/f-searchbox/vue.config.js
@@ -1,5 +1,7 @@
 const path = require('path');
 
+const PeerDepsExternalsPlugin = require('peer-deps-externals-webpack-plugin');
+
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 
@@ -43,5 +45,10 @@ module.exports = {
     },
     pluginOptions: {
         lintStyleOnBuild: true
+    },
+    configureWebpack: {
+        plugins: [
+            new PeerDepsExternalsPlugin()
+        ]
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,14 +2220,6 @@
     "@justeat/f-services" "1.0.0"
     "@justeat/f-vue-icons" "2.5.0"
 
-"@justeat/f-form-field@4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-4.5.0.tgz#931d5d643090c2fce46ecf8302b3333013fb3d7d"
-  integrity sha512-EJLkg0vzxS+BE16mZ2Q2r7bB3jvZd8EFW8jB5GmACSqtsCe0iLLFSfY2cPlDx3oZ1nZMoRse/T2foCrjH5c7dg==
-  dependencies:
-    "@justeat/f-services" "1.0.0"
-    "@justeat/f-vue-icons" "2.5.0"
-
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-0.2.0.tgz#90ec559642c165b6325669c506c417abe09fa5dd"
@@ -2434,6 +2426,13 @@
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.1.0.tgz#e8a62dd2d03c2cf14ce1fa7d50540c2171b8fc38"
   integrity sha512-m2WfTJWR5Yako3hKEZ7SL3zDvZQA7VQ9hbUBnk02lxMYSKSqeHmLPICaLGtPXCIDBEuESFk2kscHSQc3GBxxmg==
+  dependencies:
+    "@justeat/f-services" "1.7.0"
+
+"@justeat/f-wdio-utils@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.4.0.tgz#6916a392777c88bc84e0d5a258e7e94c64ff7800"
+  integrity sha512-CQ69zuqvPGIAmDAF+EZM9dnBoIizBIMrl4L2tpvk27oRPKycQGgFIjfq1v/wTgVNwVXVJNCEG6zEKNjccSl+Ew==
   dependencies:
     "@justeat/f-services" "1.7.0"
 


### PR DESCRIPTION
### Added
- **Breaking Change**: Added `f-button`, `f-error-message` & `f-mega-modal` dependency to peer dependencies. Now `f-button`, `f-error-message` & `f-mega-modal` should be included as dependencies of the consuming component or application.

### Removed
- **Breaking Change**: Removed `f-button`, `f-error-message` & `f-mega-modal` styles import from the component. Make sure to import `f-button`, `f-error-message` & `f-mega-modal` styles in your application.

---

## UI Review Checks

- [x] README and/or UI Documentation has been updated