### PR TITLE
f-header@9.0.0 - add atom deps to peer deps

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v8.1.0
+------------------------------
+*December 13, 2021*
+
+### Added
+- **Breaking Change**: Added `f-button` and `f-popover` dependencies to peer dependencies. Now `f-button` and `f-popover` should be included as a dependency of the consuming component or application.
+
+### Removed
+- **Breaking Change**: Removed `f-button` and `f-popover` styles import from the component. Make sure to import `f-button` and `f-popover` styles in your application.
+
+
 v8.0.0
 ------------------------------
 *December 9, 2021*

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v8.1.0
+v9.0.0
 ------------------------------
 *December 13, 2021*
 

--- a/packages/components/organisms/f-header/README.md
+++ b/packages/components/organisms/f-header/README.md
@@ -13,7 +13,7 @@ Global Header Component for Vue.js.
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-header.svg)](https://badge.fury.io/js/%40justeat%2Ff-header)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-header/badge.svg)](https://coveralls.io/github/justeat/f-header)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-header/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-header?targetFile=package.json)
+[![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/4bc223d1/f-header)
 
 
 ## Usage

--- a/packages/components/organisms/f-header/README.md
+++ b/packages/components/organisms/f-header/README.md
@@ -59,6 +59,13 @@ export default {
 }
 ```
 
+The package also has dependencies that need to be installed by consuming components/applications:
+
+| Dependency | Command to install | Styles to include |
+| ----- | ----- | ----- |
+| f-button | `yarn add @justeat/f-button` | `import '@justeat/f-button/dist/f-button.css';` |
+| f-popover | `yarn add @justeat/f-popover` | `import '@justeat/f-popover/dist/f-popover.css';` |
+
 
 ## Configuration
 

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -45,7 +45,9 @@
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
-    "@justeat/f-trak": ">=0.6.0"
+    "@justeat/f-trak": ">=0.6.0",
+    "@justeat/f-button": "3.x",
+    "@justeat/f-popover": "2.x"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.12.13",

--- a/packages/components/organisms/f-header/src/components/CountrySelector.vue
+++ b/packages/components/organisms/f-header/src/components/CountrySelector.vue
@@ -53,8 +53,6 @@
 
 <script>
 import VPopover from '@justeat/f-popover';
-import '@justeat/f-popover/dist/f-popover.css';
-
 import CountrySelectorPanel from './CountrySelectorPanel.vue';
 import FlagIcon from './FlagIcon.vue';
 

--- a/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
+++ b/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
@@ -58,7 +58,6 @@
 import FButton from '@justeat/f-button';
 import { ArrowIcon } from '@justeat/f-vue-icons';
 import FlagIcon from './FlagIcon.vue';
-import '@justeat/f-button/dist/f-button.css';
 import { countries } from '../tenants';
 
 export default {

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -265,7 +265,6 @@
 import { MopedIcon, GiftIcon, ProfileIcon } from '@justeat/f-vue-icons';
 import { axiosServices, windowServices } from '@justeat/f-services';
 import VPopover from '@justeat/f-popover';
-import '@justeat/f-popover/dist/f-popover.css';
 
 // Internal
 import CountrySelector from './CountrySelector.vue';

--- a/packages/components/organisms/f-header/stories/header.stories.js
+++ b/packages/components/organisms/f-header/stories/header.stories.js
@@ -1,3 +1,6 @@
+import '@justeat/f-popover/dist/f-popover.css';
+import '@justeat/f-button/dist/f-button.css'; // these styles are imported to fix visual regression tests
+
 import { withA11y } from '@storybook/addon-a11y';
 import VueHeader from '../src/components/Header.vue';
 

--- a/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
+++ b/packages/components/organisms/f-header/test-utils/component-objects/f-header.component.js
@@ -6,6 +6,7 @@ const {
     NAVIGATION
 } = require('./f-header.selectors');
 
+
 module.exports = class Header extends Page {
     constructor() {
         super('organism', 'header-component');

--- a/packages/components/organisms/f-header/vue.config.js
+++ b/packages/components/organisms/f-header/vue.config.js
@@ -1,5 +1,7 @@
 const path = require('path');
 
+const PeerDepsExternalsPlugin = require('peer-deps-externals-webpack-plugin');
+
 const rootDir = path.join(__dirname, '..', '..');
 const sassOptions = require('../../../../config/sassOptions')(rootDir);
 const responseLoggedIn = require('./src/components/_tests/__mocks__/api.account.details.json');
@@ -36,5 +38,10 @@ module.exports = {
     },
     pluginOptions: {
         lintStyleOnBuild: true
+    },
+    configureWebpack: {
+        plugins: [
+            new PeerDepsExternalsPlugin()
+        ]
     }
 };


### PR DESCRIPTION
### Added
- **Breaking Change**: Added `f-button` and `f-popover` dependencies to peer dependencies. Now `f-button` and `f-popover` should be included as a dependency of the consuming component or application.

### Removed
- **Breaking Change**: Removed `f-button` and `f-popover` styles import from the component. Make sure to import `f-button` and `f-popover` styles in your application.