### PR TITLE
f-header@9.1.0 - jet logo

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -11,6 +11,12 @@ v9.1.0
 ### Added
 - Jet logo support via `useJetLogo` prop.
 
+### Updated
+- f-vue-icons to the latest (3.3.0).
+
+### Removed
+- Arrow button size override from mobile country selector as with the latest version of f-vue-icons arrow doesn't have a transparent spacing around it.
+
 
 v9.0.0
 ------------------------------

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v9.1.0
+------------------------------
+*December 14, 2021*
+
+### Added
+- Jet logo support via `useJetLogo` prop.
+
+
 v9.0.0
 ------------------------------
 *December 13, 2021*

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -9,7 +9,7 @@ v9.1.0
 *December 14, 2021*
 
 ### Added
-- Jet logo support via `useJetLogo` prop.
+- Jet logo support via `shouldUseJetLogo` prop.
 
 ### Updated
 - f-vue-icons to the latest (3.3.0).

--- a/packages/components/organisms/f-header/README.md
+++ b/packages/components/organisms/f-header/README.md
@@ -92,7 +92,7 @@ The props that can be defined are as follows:
 | userInfoUrl               | `String`      | `/api/account/details` | URL to call to retrieve the userInfo (when `userInfoProp` isn't set). |
 | showCountrySelector       | `Boolean`     | `false` | Defines whether the country selector should be shown in the navigation. |
 | showSkipLink              | `Boolean`     | `true`  | Set to false if you need to remove skip-to-main-content link from the header. |
-| useJetLogo                | `Boolean`     | `false`  | Set to true if you want to show Jet logo in the header. |
+| shouldUseJetLogo                | `Boolean`     | `false`  | Set to true if you want to show Jet logo in the header. |
 **Important:** if you're adding a new property to show/hide something on the navigation bar, you probably want to check the `hasNavigationLinks` computed property, since you might have to update it.
 
 ### CSS styles

--- a/packages/components/organisms/f-header/README.md
+++ b/packages/components/organisms/f-header/README.md
@@ -92,7 +92,7 @@ The props that can be defined are as follows:
 | userInfoUrl               | `String`      | `/api/account/details` | URL to call to retrieve the userInfo (when `userInfoProp` isn't set). |
 | showCountrySelector       | `Boolean`     | `false` | Defines whether the country selector should be shown in the navigation. |
 | showSkipLink              | `Boolean`     | `true`  | Set to false if you need to remove skip-to-main-content link from the header. |
-
+| useJetLogo                | `Boolean`     | `false`  | Set to true if you want to show Jet logo in the header. |
 **Important:** if you're adding a new property to show/hide something on the navigation bar, you probably want to check the `hasNavigationLinks` computed property, since you might have to update it.
 
 ### CSS styles

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Globalised Header Component",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [
@@ -53,7 +53,7 @@
     "@babel/plugin-proposal-class-properties": "7.12.13",
     "@justeat/f-button": "3.0.2",
     "@justeat/f-popover": "2.0.0",
-    "@justeat/f-vue-icons": "2.4.0",
+    "@justeat/f-vue-icons": "3.3.0",
     "@justeat/f-wdio-utils": "0.4.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",

--- a/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
+++ b/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
@@ -146,8 +146,6 @@ $countrySelector-text-bg-hover : $color-container-subtle;
 
         svg.c-countrySelector-goBackIcon {
             transform: rotate(180deg);
-            width: 28px;
-            height: 28px;
         }
     }
 }

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -139,7 +139,7 @@ export default {
             default: false
         },
 
-        useJetLogo: {
+        shouldUseJetLogo: {
             type: Boolean,
             default: false
         }
@@ -158,7 +158,7 @@ export default {
 
     computed: {
         theme () {
-            if (this.useJetLogo) {
+            if (this.shouldUseJetLogo) {
                 return 'jet';
             }
             return globalisationServices.getTheme(this.locale);

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -137,6 +137,11 @@ export default {
         tallBelowMid: {
             type: Boolean,
             default: false
+        },
+
+        useJetLogo: {
+            type: Boolean,
+            default: false
         }
     },
 
@@ -153,6 +158,9 @@ export default {
 
     computed: {
         theme () {
+            if (this.useJetLogo) {
+                return 'jet';
+            }
             return globalisationServices.getTheme(this.locale);
         },
 

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -18,13 +18,15 @@
 <script>
 import {
     LogoJusteatIcon as JeLogo,
-    LogoMenulogIcon as MlLogo
+    LogoMenulogIcon as MlLogo,
+    LogoJetHorizontalIcon as JetLogo
 } from '@justeat/f-vue-icons';
 
 export default {
     components: {
         JeLogo,
-        MlLogo
+        MlLogo,
+        JetLogo
     },
     props: {
         theme: {
@@ -158,5 +160,14 @@ export default {
             & path {
                 fill: $header-logo-color--alt;
             }
+    }
+
+    .c-icon--jet {
+        width: auto;
+        height: 24px;
+
+        @include media('>mid') {
+            height: 36px;
+        }
     }
 </style>

--- a/packages/components/organisms/f-header/src/components/_tests/Header.test.js
+++ b/packages/components/organisms/f-header/src/components/_tests/Header.test.js
@@ -77,6 +77,21 @@ describe('Header', () => {
         // Assert
         expect(wrapper.attributes('data-theme')).toBe('je');
     });
+
+    it('should render jet themed component if shouldUseJetLogo prop is true even when there is no locale', () => {
+        // Arrange
+        const propsData = {
+            locale: '',
+            headerBackgroundTheme: 'transparent',
+            shouldUseJetLogo: true
+        };
+
+        // Act
+        const wrapper = shallowMount(Header, { propsData });
+
+        // Assert
+        expect(wrapper.attributes('data-theme')).toBe('jet');
+    });
 });
 
 describe('showDeliveryEnquiryWithContext', () => {

--- a/packages/components/organisms/f-header/src/components/_tests/Logo.test.js
+++ b/packages/components/organisms/f-header/src/components/_tests/Logo.test.js
@@ -47,6 +47,23 @@ describe('Logo', () => {
         expect(logo).toBeDefined();
     });
 
+    it('should render Jet logo if jet theme passed', () => {
+        // Arrange
+        const propsData = {
+            theme: 'jet',
+            headerBackgroundTheme: 'transparent',
+            companyName: 'Just Eat Takeaway.com',
+            isLogoDisabled: false
+        };
+
+        // Act
+        const wrapper = shallowMount(Logo, { propsData });
+        const logo = wrapper.find('[data-theme-logo="c-icon--jet"]');
+
+        // Assert
+        expect(logo).toBeDefined();
+    });
+
     it('should render an anchor tag around the logo if isLogoDisabled is false', () => {
         const $style = {
             disabled: 'disabled'

--- a/packages/components/organisms/f-header/stories/header.stories.js
+++ b/packages/components/organisms/f-header/stories/header.stories.js
@@ -36,7 +36,7 @@ export const HeaderComponent = (args, { argTypes }) => ({
             :key="locale"
             :show-skip-link="showSkipLink"
             :tall-below-mid="tallBelowMid"
-            :use-jet-logo="useJetLogo" />`
+            :should-use-jet-logo="shouldUseJetLogo" />`
 });
 
 HeaderComponent.storyName = 'f-header';
@@ -53,7 +53,7 @@ HeaderComponent.args = {
     showDeliveryEnquiry: false,
     logoLinkDisabled: false,
     tallBelowMid: false,
-    useJetLogo: false
+    shouldUseJetLogo: false
 };
 
 HeaderComponent.argTypes = {
@@ -78,7 +78,7 @@ HeaderComponent.argTypes = {
         description: 'Configure the user details; set to `false` (in RAW mode) to simulate a logged out user'
     },
 
-    useJetLogo: {
+    shouldUseJetLogo: {
         control: { type: 'boolean' },
         description: 'If set to true the header shows the Jet logo'
     },

--- a/packages/components/organisms/f-header/stories/header.stories.js
+++ b/packages/components/organisms/f-header/stories/header.stories.js
@@ -35,7 +35,8 @@ export const HeaderComponent = (args, { argTypes }) => ({
             :custom-nav-links="customNavLinks"
             :key="locale"
             :show-skip-link="showSkipLink"
-            :tall-below-mid="tallBelowMid" />`
+            :tall-below-mid="tallBelowMid"
+            :use-jet-logo="useJetLogo" />`
 });
 
 HeaderComponent.storyName = 'f-header';
@@ -51,7 +52,8 @@ HeaderComponent.args = {
     showOffersLink: false,
     showDeliveryEnquiry: false,
     logoLinkDisabled: false,
-    tallBelowMid: false
+    tallBelowMid: false,
+    useJetLogo: false
 };
 
 HeaderComponent.argTypes = {
@@ -74,6 +76,11 @@ HeaderComponent.argTypes = {
     userInfoProp: {
         control: { type: 'object' },
         description: 'Configure the user details; set to `false` (in RAW mode) to simulate a logged out user'
+    },
+
+    useJetLogo: {
+        control: { type: 'boolean' },
+        description: 'If set to true the header shows the Jet logo'
     },
 
     // Not currently possible to set complex values (i.e., arrays) for controls via query strings.


### PR DESCRIPTION
### Added
- Jet logo support via `useJetLogo` prop.

### Updated
- f-vue-icons to the latest (3.3.0).

### Removed
- Arrow button size override from mobile country selector as with the latest version of f-vue-icons arrow doesn't have a transparent spacing around it.