### PR TITLE
f-contact-preferences@0.11.0 - Add info and error logging

### DIFF
--- a/packages/components/pages/f-contact-preferences/CHANGELOG.md
+++ b/packages/components/pages/f-contact-preferences/CHANGELOG.md
@@ -12,9 +12,12 @@ v0.11.0
 - `info` and `error` logs to preferences fetch and save requests
 - Unit tests
 
+### Changed
+- Move store module registration from `created` to `beforeCreate`.
+
 ### Removed
-- Unused variable from story helper
 - Mounted hook which was duplicating the `initialise()` call
+- Unused variable from story helper
 
 
 v0.10.0

--- a/packages/components/pages/f-contact-preferences/CHANGELOG.md
+++ b/packages/components/pages/f-contact-preferences/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.11.0
 ------------------------------
-*December 14, 2021*
+*December 16, 2021*
 
 ### Added
 - `info` and `error` logs to preferences fetch and save requests
@@ -14,6 +14,7 @@ v0.11.0
 
 ### Removed
 - Unused variable from story helper
+- Mounted hook which was duplicating the `initialise()` call
 
 
 v0.10.0

--- a/packages/components/pages/f-contact-preferences/CHANGELOG.md
+++ b/packages/components/pages/f-contact-preferences/CHANGELOG.md
@@ -4,9 +4,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.11.0
+------------------------------
+*December 14, 2021*
+
+### Added
+- `info` and `error` logs to preferences fetch and save requests
+- Unit tests
+
+### Removed
+- Unused variable from story helper
+
+
 v0.10.0
 ------------------------------
-*December 02, 2021*
+*December 2, 2021*
 
 ### Changed
 - Generic checkboxes to use `f-form-field`

--- a/packages/components/pages/f-contact-preferences/package.json
+++ b/packages/components/pages/f-contact-preferences/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-contact-preferences",
   "description": "Fozzie Contact Preferences - Fozzie user contact preferences form component",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "main": "dist/f-contact-preferences.umd.min.js",
   "maxBundleSize": "50kB",
   "files": [

--- a/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
+++ b/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
@@ -170,8 +170,6 @@ export default {
             'editPreference'
         ]),
 
-
-
         /**
         * Returns translation string if it exists
         * @param {string} key - The key of the preference that needs changing
@@ -231,8 +229,10 @@ export default {
         async initialise () {
             try {
                 await this.loadPreferences({ api: this.contactPreferencesApi, authToken: this.authToken });
+                this.$log.info('Account preferences fetched successfully', ['account-pages', 'contact-preferences']);
                 this.isFormDirty = false;
             } catch (error) {
+                this.$log.error('Error fetching account preferences', error, ['account-pages', 'contact-preferences']);
                 this.handleErrorState(new GetPreferencesError(error.message, error?.response?.status));
             } finally {
                 this.$nextTick(() => {
@@ -260,8 +260,10 @@ export default {
 
             try {
                 await this.savePreferences({ api: this.contactPreferencesApi, authToken: this.authToken });
+                this.$log.info('Account preferences saved successfully', ['account-pages', 'contact-preferences']);
                 this.isFormDirty = false;
             } catch (error) {
+                this.$log.error('Error saving account preferences', error, ['account-pages', 'contact-preferences']);
                 this.handleErrorState(new GetPreferencesError(error.message, error?.response?.status));
             } finally {
                 this.setSubmittingState(false);
@@ -309,4 +311,3 @@ export default {
     }
 }
 </style>
-

--- a/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
+++ b/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
@@ -151,7 +151,7 @@ export default {
         }
     },
 
-    created () {
+    beforeCreate () {
         if (!this.$store.hasModule('fContactPreferencesModule')) {
             this.$store.registerModule('fContactPreferencesModule', fContactPreferencesModule);
         }

--- a/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
+++ b/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
@@ -142,7 +142,7 @@ export default {
 
     watch: {
         isAuthFinished: {
-            immediate: true,
+            immediate: true, // this prevents the need to call initialise() on mounted
             async handler (value) {
                 if (value) {
                     await this.initialise();

--- a/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
+++ b/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
@@ -157,12 +157,6 @@ export default {
         }
     },
 
-    async mounted () {
-        if (this.isAuthFinished) {
-            await this.initialise();
-        }
-    },
-
     methods: {
         ...mapActions('fContactPreferencesModule', [
             'loadPreferences',

--- a/packages/components/pages/f-contact-preferences/src/components/_tests/ContactPreferences.test.js
+++ b/packages/components/pages/f-contact-preferences/src/components/_tests/ContactPreferences.test.js
@@ -56,9 +56,10 @@ const mountContactPreferences = async ({
     state = storeState,
     mocks = sutMocks,
     propsData = sutProps,
-    data = dataDefaults
+    data = dataDefaults,
+    storeOverride = null
 } = {}) => {
-    const store = createStore({ state, actions });
+    const store = storeOverride || createStore({ state, actions });
 
     initialiseSpy = jest.spyOn(ContactPreferences.methods, 'initialise');
 
@@ -106,7 +107,7 @@ describe('ContactPreferences Component', () => {
     describe('when creating the component', () => {
         it('should register the Store Module', async () => {
             // Arrange & Act
-            wrapper = await mountContactPreferences();
+            wrapper = await mountContactPreferences({ storeOverride: new Vuex.Store() });
 
             // Assert
             expect(wrapper.vm.$store.state.fContactPreferencesModule).toBeDefined();

--- a/packages/components/pages/f-contact-preferences/src/components/_tests/ContactPreferences.test.js
+++ b/packages/components/pages/f-contact-preferences/src/components/_tests/ContactPreferences.test.js
@@ -180,6 +180,10 @@ describe('ContactPreferences Component', () => {
 
             // Assert
             expect(logMocks.info).toHaveBeenCalledTimes(1);
+            expect(logMocks.info).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.arrayContaining(['account-pages', 'contact-preferences'])
+            );
         });
 
         it('should log an error if loading preferences throws an error', async () => {
@@ -196,6 +200,11 @@ describe('ContactPreferences Component', () => {
 
             // Assert
             expect(logMocks.error).toHaveBeenCalledTimes(1);
+            expect(logMocks.error).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.any(Error),
+                expect.arrayContaining(['account-pages', 'contact-preferences'])
+            );
         });
 
         it('should not call initialise method if the authorisation has not completed', async () => {
@@ -297,6 +306,10 @@ describe('ContactPreferences Component', () => {
 
             // Assert
             expect(logMocks.info).toHaveBeenCalledTimes(1);
+            expect(logMocks.info).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.arrayContaining(['account-pages', 'contact-preferences'])
+            );
         });
 
         it('should not call the save action if no changes', async () => {
@@ -345,6 +358,11 @@ describe('ContactPreferences Component', () => {
 
             // Arrange
             expect(logMocks.error).toHaveBeenCalledTimes(1);
+            expect(logMocks.error).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.any(Error),
+                expect.arrayContaining(['account-pages', 'contact-preferences'])
+            );
         });
     });
 });

--- a/packages/components/pages/f-contact-preferences/stories/story.helper.js
+++ b/packages/components/pages/f-contact-preferences/stories/story.helper.js
@@ -25,41 +25,6 @@ export const apiStateOptions = {
     }
 };
 
-const apiStateDefinitions1 = {
-    getContactPreferencesDefault: {
-        url: '/consumer/preferences',
-        method: httpVerbs.get,
-        responseStatus: httpStatusCodes.ok,
-        requestData: null,
-        responseData: getConsumerPreferences,
-        state: apiStates.none
-    },
-    postContactPreferencesNewsEmail: {
-        url: '/consumer/preferences',
-        method: httpVerbs.post,
-        responseStatus: httpStatusCodes.ok,
-        requestData: null,
-        responseData: getConsumerPreferences,
-        state: apiStates.none
-    },
-    getContactPreferencesUnknownApiFailure: {
-        url: '/consumer/preferences',
-        method: httpVerbs.get,
-        responseStatus: httpStatusCodes.ok,
-        requestData: null,
-        responseData: getConsumerPreferences,
-        state: apiStates.apiPostFailed
-    },
-    postContactPreferencesUnknownApiFailure: {
-        url: '/consumer/preferences',
-        method: httpVerbs.post,
-        responseStatus: httpStatusCodes.internalServerError,
-        requestData: null,
-        responseData: getConsumerPreferences,
-        state: apiStates.apiPostFailed
-    }
-};
-
 const apiStateDefinitions = {
     none: { // Good GET and good POST
         state: apiStates.none,


### PR DESCRIPTION
### Added
- `info` and `error` logs to preferences fetch and save requests
- Unit tests

### Removed
- Unused variable from story helper (integrated changes from #1543)

---

## UI Review Checks
- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
