### PR TITLE
fozzie-components@v5.7.0 – Adding storybook:serve-visualregression #globalconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v5.7.0
+------------------------------
+*December 15, 2021*
+
+### Added
+- Added storybook serve npm script to only spin up storybook for packages that have visual regression tests.
+
+
 v5.6.0
 ------------------------------
 *November 26, 2021*

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "storybook:build-changed": "cross-env-shell CHANGED_ONLY=true lerna run storybook:build --include-dependencies --stream",
     "storybook:serve": "lerna run storybook:serve --stream",
     "storybook:serve-changed": "cross-env-shell CHANGED_ONLY=true lerna run storybook:serve --stream",
+    "storybook:serve-visualregression": "cross-env-shell VISUAL_REGRESSION=true lerna run storybook:serve --stream",
     "storybook:serve-static": "lerna run storybook:serve-static --stream",
     "storybook:deploy": "lerna run storybook:deploy",
     "test": "cross-env-shell \"lerna run $LERNA_ARGS test --stream\"",

--- a/packages/storybook/config/storybook/story.config.js
+++ b/packages/storybook/config/storybook/story.config.js
@@ -22,6 +22,24 @@ const getChangedPackageStories = () => {
     return storyPaths;
 };
 
+const getPackagesWithVisualRegression = () => {
+    let packageJsonMatches;
+    try {
+        packageJsonMatches = execSync('grep --include=\package.json --exclude-dir={node_modules,.yalc} -rnw "../../packages/components" -e "test:visual"');
+    } catch (error) {
+        console.info('No components found that have visual regression tests.');
+        process.exit(0);
+    }
+
+    const visualRegressionPackagePaths = packageJsonMatches.toString().match(/^(.)*(?=package.json)/gm);
+
+    const storyPaths = [];
+
+    visualRegressionPackagePaths.forEach(path => storyPaths.push(`../../${path}stories/*.stories.@(js|mdx)`));
+
+    return storyPaths;
+};
+
 const getStoryFiles = () => {
     // Executed if Storybook is running in VS Code via the launch.json command.
     if (process.env.VS_DEBUGGER) {
@@ -31,6 +49,10 @@ const getStoryFiles = () => {
     // Executed if the storybook:serve-changed script is executed by CircleCI.
     if (process.env.CHANGED_ONLY) {
         return getChangedPackageStories();
+    }
+
+    if (process.env.VISUAL_REGRESSION) {
+        return getPackagesWithVisualRegression();
     }
 
     // Executed if the storybook:serve script is executed.


### PR DESCRIPTION
### Added
- Added storybook serve npm script to only spin up storybook for packages that have visual regression tests.