### PR TITLE
generator-component@2.6.0 - remove theme.css fozzie import

### DIFF
--- a/packages/tools/generator-component/CHANGELOG.md
+++ b/packages/tools/generator-component/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v2.6.0
+------------------------------
+*December 22, 2021*
+
+### Removed
+- $theme variable as it is not needed anymore.
+
+
 v2.5.0
 ------------------------------
 *December 7, 2021*

--- a/packages/tools/generator-component/generators/app/templates/src/assets/scss/common.scss
+++ b/packages/tools/generator-component/generators/app/templates/src/assets/scss/common.scss
@@ -1,6 +1,1 @@
-// Set $theme variable so that fozzie doesn't complain when vars are imported below
-// n.b. This variables isn't actually used (unless there are theme specific vars from fozzie)
-// Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
-$theme: 'jet' !default;
-
 @import  '~@justeat/fozzie/src/scss/fozzie';

--- a/packages/tools/generator-component/package.json
+++ b/packages/tools/generator-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/generator-component",
   "description": "Generator Component – A generator for Fozzie components",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "files": [
     "generators"
   ],


### PR DESCRIPTION
### Removed
- $theme variable as it is not needed anymore.