### PR TITLE
f-offers@v1.6.0 🖌 Fixes UK-specific translation strings

### DIFF
--- a/packages/components/pages/f-offers/CHANGELOG.md
+++ b/packages/components/pages/f-offers/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.6.0
+------------------------------
+*January 6, 2022*
+
+### Changed
+- Fixed UK-specific copy-pasted strings in IE, AU and NZ.
+
+
 v1.5.0
 ------------------------------
 *November 4, 2021*

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-offers",
   "description": "Fozzie Offers - displays offers to the customers",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "dist/f-offers.umd.min.js",
   "maxBundleSize": "140kB",
   "files": [

--- a/packages/components/pages/f-offers/src/tenants/en-AU.js
+++ b/packages/components/pages/f-offers/src/tenants/en-AU.js
@@ -22,7 +22,7 @@ const messages = {
     unauthenticated: {
         header: {
             title: 'Great local takeaways',
-            subtitle: 'Order for delivery or collection from the UK’s best selection of independent restaurants.'
+            subtitle: 'Order for delivery or collection from Australia’s best selection of independent restaurants.'
         },
         title: 'Log in to see your offers',
         subtitle: 'Tasty deals might be waiting',

--- a/packages/components/pages/f-offers/src/tenants/en-IE.js
+++ b/packages/components/pages/f-offers/src/tenants/en-IE.js
@@ -22,7 +22,7 @@ const messages = {
     unauthenticated: {
         header: {
             title: 'Great local takeaways',
-            subtitle: 'Order for delivery or collection from the UK’s best selection of independent restaurants.'
+            subtitle: 'Order for delivery or collection from Ireland’s best selection of independent restaurants.'
         },
         title: 'Log in to see your offers',
         subtitle: 'Tasty deals might be waiting',

--- a/packages/components/pages/f-offers/src/tenants/en-NZ.js
+++ b/packages/components/pages/f-offers/src/tenants/en-NZ.js
@@ -22,7 +22,7 @@ const messages = {
     unauthenticated: {
         header: {
             title: 'Great local takeaways',
-            subtitle: 'Order for delivery or collection from the UK’s best selection of independent restaurants.'
+            subtitle: 'Order for delivery or collection from New Zealand’s best selection of independent restaurants.'
         },
         title: 'Log in to see your offers',
         subtitle: 'Tasty deals might be waiting',


### PR DESCRIPTION
### Changed
- Fixed UK-specific copy-pasted strings in IE, AU and NZ.