### PR TITLE
#trivial - component tests for account-info

### DIFF
--- a/packages/components/pages/f-account-info/CHANGELOG.md
+++ b/packages/components/pages/f-account-info/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Latest – to be added to the next release
 ------------------------------
 ### Added
-- component tests into `f-account-info.component.spec`
-- test ids into `DeleteAccount.vue` and `EmailAddressField.vue`
-- `vuelidate` and `f-services` package into `package.json` 
+- component tests in `f-account-info.component.spec`
+- test ids in `DeleteAccount.vue` and `EmailAddressField.vue`
+- `vuelidate` and `f-services` package in `package.json` 
 
 ### Changed
 - component test ids in `AccountInfo.vue`

--- a/packages/components/pages/f-account-info/CHANGELOG.md
+++ b/packages/components/pages/f-account-info/CHANGELOG.md
@@ -4,6 +4,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest – to be added to the next release
+------------------------------
+### Added
+- component tests into `f-account-info.component.spec`
+- elements and functions into `f-account-info.component.js`
+- test ids into `DeleteAccount.vue` and `EmailAddressField.vue`
+- `vuelidate` and `f-services` package into `package.json` 
+
+### Changed
+- component test ids in `AccountInfo.vue`
+- test filenames from `accountInfo` to `account-info`
+
+
 v0.14.0
 ------------------------------
 *December 17, 2021*

--- a/packages/components/pages/f-account-info/CHANGELOG.md
+++ b/packages/components/pages/f-account-info/CHANGELOG.md
@@ -8,7 +8,6 @@ Latest – to be added to the next release
 ------------------------------
 ### Added
 - component tests into `f-account-info.component.spec`
-- elements and functions into `f-account-info.component.js`
 - test ids into `DeleteAccount.vue` and `EmailAddressField.vue`
 - `vuelidate` and `f-services` package into `package.json` 
 

--- a/packages/components/pages/f-account-info/package.json
+++ b/packages/components/pages/f-account-info/package.json
@@ -48,7 +48,9 @@
     "@justeat/f-card-with-content": "1.0.0",
     "@justeat/f-form-field": "4.5.0",
     "@justeat/f-globalisation": "1.0.0",
-    "@justeat/f-vue-icons": "3.3.0"
+    "@justeat/f-vue-icons": "3.3.0",
+    "@justeat/f-services": "1.13.0",
+    "vuelidate": "0.7.6"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0",

--- a/packages/components/pages/f-account-info/src/components/AccountInfo.vue
+++ b/packages/components/pages/f-account-info/src/components/AccountInfo.vue
@@ -18,7 +18,7 @@
                 @submit.prevent="onFormSubmit">
                 <form-field
                     :value="consumer.firstName"
-                    data-test-id="account-info-consumer-firstName"
+                    name="account-info-consumer-firstName"
                     maxlength="50"
                     :label-text="$t('consumer.firstNameLabel')"
                     :placeholder="$t('consumer.firstNamePlaceholder')"
@@ -27,10 +27,14 @@
                     <template
                         v-if="$v.consumer.firstName.$invalid"
                         #error>
-                        <f-error-message v-show="!$v.consumer.firstName.required && $v.consumer.firstName.$dirty">
+                        <f-error-message
+                            v-show="!$v.consumer.firstName.required && $v.consumer.firstName.$dirty"
+                            data-test-id="consumer-firstName-empty-error">
                             {{ $t('validation.firstNameRequired') }}
                         </f-error-message>
-                        <f-error-message v-show="!$v.consumer.firstName.isValidName">
+                        <f-error-message
+                            v-show="!$v.consumer.firstName.isValidName"
+                            data-test-id="consumer-firstName-invalid-error">
                             {{ $t('validation.firstNameInvalid') }}
                         </f-error-message>
                     </template>
@@ -38,7 +42,7 @@
 
                 <form-field
                     :value="consumer.lastName"
-                    data-test-id="account-info-consumer-lastName"
+                    name="account-info-consumer-lastName"
                     maxlength="50"
                     :label-text="$t('consumer.lastNameLabel')"
                     :placeholder="$t('consumer.lastNamePlaceholder')"
@@ -47,10 +51,14 @@
                     <template
                         v-if="$v.consumer.lastName.$invalid"
                         #error>
-                        <f-error-message v-show="!$v.consumer.lastName.required && $v.consumer.lastName.$dirty">
+                        <f-error-message
+                            v-show="!$v.consumer.lastName.required && $v.consumer.lastName.$dirty"
+                            data-test-id="consumer-lastName-empty-error">
                             {{ $t('validation.lastNameRequired') }}
                         </f-error-message>
-                        <f-error-message v-show="!$v.consumer.lastName.isValidName">
+                        <f-error-message
+                            v-show="!$v.consumer.lastName.isValidName"
+                            data-test-id="consumer-lastName-invalid-error">
                             {{ $t('validation.lastNameInvalid') }}
                         </f-error-message>
                     </template>
@@ -58,7 +66,7 @@
 
                 <form-field
                     :value="consumer.phoneNumber"
-                    data-test-id="account-info-consumer-phoneNumber"
+                    name="account-info-consumer-phoneNumber"
                     maxlength="16"
                     :label-text="$t('consumer.phoneNumberLabel')"
                     :placeholder="$t('consumer.phoneNumberPlaceholder')"
@@ -67,10 +75,14 @@
                     <template
                         v-if="$v.consumer.phoneNumber.$invalid"
                         #error>
-                        <f-error-message v-show="!$v.consumer.phoneNumber.required && $v.consumer.phoneNumber.$dirty">
+                        <f-error-message
+                            v-show="!$v.consumer.phoneNumber.required && $v.consumer.phoneNumber.$dirty"
+                            data-test-id="consumer-phoneNumber-empty-error">
                             {{ $t('validation.phoneNumberRequired') }}
                         </f-error-message>
-                        <f-error-message v-show="!$v.consumer.phoneNumber.isValidPhoneNumber && $v.consumer.phoneNumber.required && $v.consumer.phoneNumber.$dirty">
+                        <f-error-message
+                            v-show="!$v.consumer.phoneNumber.isValidPhoneNumber && $v.consumer.phoneNumber.required && $v.consumer.phoneNumber.$dirty"
+                            data-test-id="consumer-phoneNumber-invalid-error">
                             {{ $t('validation.phoneNumberInvalid') }}
                         </f-error-message>
                     </template>
@@ -83,7 +95,7 @@
 
                 <form-field
                     :value="consumer.line1"
-                    data-test-id="account-info-consumer-line1"
+                    name="account-info-consumer-line1"
                     maxlength="50"
                     :label-text="$t('consumer.addressLabel')"
                     :placeholder="$t('consumer.line1Placeholder')"
@@ -92,7 +104,9 @@
                     <template
                         v-if="$v.consumer.line1.$invalid"
                         #error>
-                        <f-error-message v-show="!$v.consumer.line1.required && $v.consumer.line1.$dirty">
+                        <f-error-message
+                            v-show="!$v.consumer.line1.required && $v.consumer.line1.$dirty"
+                            data-test-id="consumer-address-line1-empty-error">
                             {{ $t('validation.line1Required') }}
                         </f-error-message>
                     </template>
@@ -100,21 +114,21 @@
 
                 <form-field
                     :value="consumer.line2"
-                    data-test-id="account-info-consumer-line2"
+                    name="account-info-consumer-line2"
                     maxlength="50"
                     :placeholder="$t('consumer.line2Placeholder')"
                     @input="onEditConsumer('line2', $event, true)" />
 
                 <form-field
                     :value="consumer.line3"
-                    data-test-id="account-info-consumer-line3"
+                    name="account-info-consumer-line3"
                     maxlength="50"
                     :placeholder="$t('consumer.line3Placeholder')"
                     @input="onEditConsumer('line3', $event, true)" />
 
                 <form-field
                     :value="consumer.locality"
-                    data-test-id="account-info-consumer-locality"
+                    name="account-info-consumer-locality"
                     maxlength="50"
                     :label-text="$t('consumer.localityLabel')"
                     :placeholder="$t('consumer.localityPlaceholder')"
@@ -123,7 +137,9 @@
                     <template
                         v-if="$v.consumer.locality.$invalid"
                         #error>
-                        <f-error-message v-show="!$v.consumer.locality.required && $v.consumer.locality.$dirty">
+                        <f-error-message
+                            v-show="!$v.consumer.locality.required && $v.consumer.locality.$dirty"
+                            data-test-id="consumer-city-empty-error">
                             {{ $t('validation.localityRequired') }}
                         </f-error-message>
                     </template>
@@ -131,7 +147,7 @@
 
                 <form-field
                     :value="consumer.postcode"
-                    data-test-id="account-info-consumer-postcode"
+                    name="account-info-consumer-postcode"
                     maxlength="50"
                     :label-text="$t('consumer.postcodeLabel')"
                     :placeholder="$t('consumer.postcodePlaceholder')"
@@ -140,10 +156,14 @@
                     <template
                         v-if="$v.consumer.postcode.$invalid"
                         #error>
-                        <f-error-message v-show="!$v.consumer.postcode.required && $v.consumer.postcode.$dirty">
+                        <f-error-message
+                            v-show="!$v.consumer.postcode.required && $v.consumer.postcode.$dirty"
+                            data-test-id="consumer-postcode-empty-error">
                             {{ $t('validation.postcodeRequired') }}
                         </f-error-message>
-                        <f-error-message v-show="!$v.consumer.postcode.isValidPostcode && $v.consumer.postcode.required">
+                        <f-error-message
+                            v-show="!$v.consumer.postcode.isValidPostcode && $v.consumer.postcode.required"
+                            data-test-id="consumer-postcode-invalid-error">
                             {{ $t('validation.postcodeInvalid') }}
                         </f-error-message>
                     </template>
@@ -151,7 +171,7 @@
 
                 <f-button
                     :class="[$style['c-accountInfo-submitButton']]"
-                    data-test-id="account-info-submit-button"
+                    data-test-id="account-info-save-changes-button"
                     button-type="primary"
                     button-size="large"
                     is-full-width
@@ -163,7 +183,7 @@
 
             <f-button
                 :class="[$style['c-accountInfo-changePasswordButton']]"
-                data-test-id="account-info-submit-button"
+                data-test-id="account-info-change-password-button"
                 button-type="secondary"
                 href="/change-password?returnurl=/account/info"
                 button-size="large"

--- a/packages/components/pages/f-account-info/src/components/DeleteAccount.vue
+++ b/packages/components/pages/f-account-info/src/components/DeleteAccount.vue
@@ -5,6 +5,7 @@
         <p>{{ $t('deleteAccountMessage') }}</p>
 
         <f-link
+            id="delete-account"
             is-distinct
             href="/account/deactivate"
             target="_blank">

--- a/packages/components/pages/f-account-info/src/components/DeleteAccount.vue
+++ b/packages/components/pages/f-account-info/src/components/DeleteAccount.vue
@@ -5,7 +5,7 @@
         <p>{{ $t('deleteAccountMessage') }}</p>
 
         <f-link
-            id="delete-account"
+            name="account-info-delete-account-link"
             is-distinct
             href="/account/deactivate"
             target="_blank">

--- a/packages/components/pages/f-account-info/src/components/EmailAddressField.vue
+++ b/packages/components/pages/f-account-info/src/components/EmailAddressField.vue
@@ -9,7 +9,7 @@
             :value="emailAddress" />
 
         <f-link
-            name="account-info-change-email-link"
+            name="account-info-change-emailAddress-link"
             is-distinct
             :class="$style['c-accountInfo-customerCareLink']"
             href="/help/article/203097431/how-do-i-manage-my-account"

--- a/packages/components/pages/f-account-info/src/components/EmailAddressField.vue
+++ b/packages/components/pages/f-account-info/src/components/EmailAddressField.vue
@@ -9,7 +9,7 @@
             :value="emailAddress" />
 
         <f-link
-            id="change-email-address-link"
+            name="account-info-change-email-link"
             is-distinct
             :class="$style['c-accountInfo-customerCareLink']"
             href="/help/article/203097431/how-do-i-manage-my-account"

--- a/packages/components/pages/f-account-info/src/components/EmailAddressField.vue
+++ b/packages/components/pages/f-account-info/src/components/EmailAddressField.vue
@@ -3,11 +3,13 @@
         <form-field
             :label-text="$t('consumer.emailAddressLabel')"
             disabled
+            name="account-info-consumer-emailAddress"
             :placeholder="$t('consumer.emailAddressPlaceholder')"
             class="u-spacingBottom--large"
             :value="emailAddress" />
 
         <f-link
+            id="change-email-address-link"
             is-distinct
             :class="$style['c-accountInfo-customerCareLink']"
             href="/help/article/203097431/how-do-i-manage-my-account"

--- a/packages/components/pages/f-account-info/src/components/_tests/AccountInfo.test.js
+++ b/packages/components/pages/f-account-info/src/components/_tests/AccountInfo.test.js
@@ -263,7 +263,7 @@ describe('AccountInfo', () => {
                 ])('should call the Mutation correctly when changing the consumer textbox `%s` to the value `%s`', async (field, newValue) => {
                     // Arrange
                     wrapper = await mountAccountInfo();
-                    const element = wrapper.find(`[data-test-id="account-info-consumer-${field}"]`);
+                    const element = wrapper.find(`[name="account-info-consumer-${field}"]`);
 
                     // Act
                     element.vm.$emit('input', newValue);
@@ -282,7 +282,7 @@ describe('AccountInfo', () => {
                     // Arrange
                     wrapper = await mountAccountInfo();
                     await wrapper.setData({ hasFormUpdate: false });
-                    const element = wrapper.find('[data-test-id="account-info-consumer-firstName"]');
+                    const element = wrapper.find('[name="account-info-consumer-firstName"]');
 
                     // Act
                     element.vm.$emit('input', 'harry');
@@ -302,7 +302,7 @@ describe('AccountInfo', () => {
                         // Arrange
                         wrapper = await mountAccountInfo();
 
-                        const element = wrapper.find(`[data-test-id="account-info-consumer-${field}"]`);
+                        const element = wrapper.find(`[name="account-info-consumer-${field}"]`);
 
                         // Act
                         element.vm.$emit('input', 'Nice Road');
@@ -321,7 +321,7 @@ describe('AccountInfo', () => {
                         // Arrange
                         wrapper = await mountAccountInfo();
 
-                        const element = wrapper.find(`[data-test-id="account-info-consumer-${field}"]`);
+                        const element = wrapper.find(`[name="account-info-consumer-${field}"]`);
 
                         // Act
                         element.vm.$emit('input', 'Harry Potter');

--- a/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info-selectors.js
+++ b/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info-selectors.js
@@ -1,5 +1,5 @@
 exports.COMPONENT = '[data-test-id="account-info"]';
-exports.CHANGE_EMAIL_ADDRESS_LINK = '[name="account-info-change-email-link"]';
+exports.CHANGE_EMAIL_ADDRESS_LINK = '[name="account-info-change-emailAddress-link"]';
 exports.SAVE_CHANGES_BUTTON = '[data-test-id="account-info-save-changes-button"]';
 exports.CHANGE_PASSWORD_BUTTON = '[data-test-id="account-info-change-password-button"]';
 exports.DELETE_ACCOUNT_LINK = '[name="account-info-delete-account-link"]';

--- a/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info-selectors.js
+++ b/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info-selectors.js
@@ -1,8 +1,8 @@
 exports.COMPONENT = '[data-test-id="account-info"]';
-exports.CHANGE_EMAIL_ADDRESS_LINK = '[id="change-email-address-link"]';
-exports.SAVE_CHANGES = '[data-test-id="account-info-save-changes-button"]';
-exports.CHANGE_PASSWORD = '[data-test-id="account-info-change-password-button"]';
-exports.DELETE_ACCOUNT = '[id="delete-account"]';
+exports.CHANGE_EMAIL_ADDRESS_LINK = '[name="account-info-change-email-link"]';
+exports.SAVE_CHANGES_BUTTON = '[data-test-id="account-info-save-changes-button"]';
+exports.CHANGE_PASSWORD_BUTTON = '[data-test-id="account-info-change-password-button"]';
+exports.DELETE_ACCOUNT_LINK = '[name="account-info-delete-account-link"]';
 
 
 exports.FIELDS = {

--- a/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info-selectors.js
+++ b/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info-selectors.js
@@ -17,7 +17,7 @@ exports.FIELDS = {
         invalidError: '[data-test-id="consumer-lastName-invalid-error"]'
     },
     emailAddress: {
-        input: '[data-test-id="formfield-account-info-consumer-emailAddress"]'
+        input: '[data-test-id="formfield-account-info-consumer-emailAddress-input"]'
     },
     phoneNumber: {
         input: '[data-test-id="formfield-account-info-consumer-phoneNumber-input"]',

--- a/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info.component.js
+++ b/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info.component.js
@@ -14,10 +14,26 @@ module.exports = class AccountInfo extends Page {
     }
 
     get component () { return $(COMPONENT); }
-    get changeEmailAddressLink () { return $(CHANGE_EMAIL_ADDRESS_LINK); }
-    get saveChangesButton () { return $(SAVE_CHANGES_BUTTON); }
-    get changePasswordButton () { return $(CHANGE_PASSWORD_BUTTON); }
-    get deleteAccountLink () { return $(DELETE_ACCOUNT_LINK); }
+
+    LinksAndButtons = {
+        changeEmailAddressLink: {
+            get cta () { return $(CHANGE_EMAIL_ADDRESS_LINK); }
+        },
+        saveChangesButton: {
+            get cta () { return $(SAVE_CHANGES_BUTTON); }
+        },
+        changePasswordButton: {
+            get cta () { return $(CHANGE_PASSWORD_BUTTON); }
+        },
+        deleteAccountLink: {
+            get cta () { return $(DELETE_ACCOUNT_LINK); }
+        }
+    }
+
+    // get changeEmailAddressLink () { return $(CHANGE_EMAIL_ADDRESS_LINK); }
+    // get saveChangesButton () { return $(SAVE_CHANGES_BUTTON); }
+    // get changePasswordButton () { return $(CHANGE_PASSWORD_BUTTON); }
+    // get deleteAccountLink () { return $(DELETE_ACCOUNT_LINK); }
 
     fields = {
         firstName: {
@@ -112,23 +128,11 @@ module.exports = class AccountInfo extends Page {
         return this.fields[fieldName].invalidError.isDisplayed();
     }
 
-    emailAddressLinkCanBeClicked () {
-        return this.changeEmailAddressLink.isClickable();
-    }
-
-    saveChangesButtonCanBeClicked () {
-        return this.saveChangesButton.isClickable();
-    }
-
-    changePasswordButtonCanBeClicked () {
-        return this.changePasswordButton.isClickable();
-    }
-
-    deleteAccountLinkCanBeClicked () {
-        return this.deleteAccountLink.isClickable();
+    canBeClicked (callToActionName) {
+        return this.LinksAndButtons[callToActionName].cta.isClickable();
     }
 
     isDisabled (field) {
-        return this.fields[field].input.isEnabled();
+        return !this.fields[field].input.isEnabled();
     }
 };

--- a/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info.component.js
+++ b/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info.component.js
@@ -2,11 +2,11 @@ const Page = require('@justeat/f-wdio-utils/src/page.object');
 const {
     COMPONENT,
     CHANGE_EMAIL_ADDRESS_LINK,
-    SAVE_CHANGES,
-    CHANGE_PASSWORD,
-    DELETE_ACCOUNT,
+    SAVE_CHANGES_BUTTON,
+    CHANGE_PASSWORD_BUTTON,
+    DELETE_ACCOUNT_LINK,
     FIELDS
-} = require('./f-accountInfo-selectors');
+} = require('./f-account-info-selectors');
 
 module.exports = class AccountInfo extends Page {
     constructor () {
@@ -15,9 +15,9 @@ module.exports = class AccountInfo extends Page {
 
     get component () { return $(COMPONENT); }
     get changeEmailAddressLink () { return $(CHANGE_EMAIL_ADDRESS_LINK); }
-    get saveChangesButton () { return $(SAVE_CHANGES); }
-    get changePasswordButton () { return $(CHANGE_PASSWORD); }
-    get deleteAccountLink () { return $(DELETE_ACCOUNT); }
+    get saveChangesButton () { return $(SAVE_CHANGES_BUTTON); }
+    get changePasswordButton () { return $(CHANGE_PASSWORD_BUTTON); }
+    get deleteAccountLink () { return $(DELETE_ACCOUNT_LINK); }
 
     fields = {
         firstName: {

--- a/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info.component.js
+++ b/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info.component.js
@@ -74,10 +74,6 @@ module.exports = class AccountInfo extends Page {
         super.load(this.component);
     }
 
-    click (field) {
-        this.fields[field].input.click();
-    }
-
     waitForComponent () {
         super.waitForComponent(this.component);
     }

--- a/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info.component.js
+++ b/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info.component.js
@@ -30,11 +30,6 @@ module.exports = class AccountInfo extends Page {
         }
     }
 
-    // get changeEmailAddressLink () { return $(CHANGE_EMAIL_ADDRESS_LINK); }
-    // get saveChangesButton () { return $(SAVE_CHANGES_BUTTON); }
-    // get changePasswordButton () { return $(CHANGE_PASSWORD_BUTTON); }
-    // get deleteAccountLink () { return $(DELETE_ACCOUNT_LINK); }
-
     fields = {
         firstName: {
             get input () { return $(FIELDS.firstName.input); },

--- a/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info.component.js
+++ b/packages/components/pages/f-account-info/test-utils/component-objects/f-account-info.component.js
@@ -100,6 +100,10 @@ module.exports = class AccountInfo extends Page {
         this.fields[field].input.setValue(customerInput[field].input);
     }
 
+    clickOutOfInputField () {
+        this.component.click();
+    }
+
     isEmptyErrorMessageDisplayed (fieldName) {
         return this.fields[fieldName].emptyError.isDisplayed();
     }

--- a/packages/components/pages/f-account-info/test-utils/component-objects/f-accountInfo-selectors.js
+++ b/packages/components/pages/f-account-info/test-utils/component-objects/f-accountInfo-selectors.js
@@ -1,2 +1,46 @@
-// eslint-disable-next-line import/prefer-default-export
-export const COMPONENT = '[data-test-id="account-info"]';
+exports.COMPONENT = '[data-test-id="account-info"]';
+exports.CHANGE_EMAIL_ADDRESS_LINK = '[id="change-email-address-link"]';
+exports.SAVE_CHANGES = '[data-test-id="account-info-save-changes-button"]';
+exports.CHANGE_PASSWORD = '[data-test-id="account-info-change-password-button"]';
+exports.DELETE_ACCOUNT = '[id="delete-account"]';
+
+
+exports.FIELDS = {
+    firstName: {
+        input: '[data-test-id="formfield-account-info-consumer-firstName-input"]',
+        emptyError: '[data-test-id="consumer-firstName-empty-error"]',
+        invalidError: '[data-test-id="consumer-firstName-invalid-error"]'
+    },
+    lastName: {
+        input: '[data-test-id="formfield-account-info-consumer-lastName-input"]',
+        emptyError: '[data-test-id="consumer-lastName-empty-error"]',
+        invalidError: '[data-test-id="consumer-lastName-invalid-error"]'
+    },
+    emailAddress: {
+        input: '[data-test-id="formfield-account-info-consumer-emailAddress"]'
+    },
+    phoneNumber: {
+        input: '[data-test-id="formfield-account-info-consumer-phoneNumber-input"]',
+        emptyError: '[data-test-id="consumer-phoneNumber-empty-error"]',
+        invalidError: '[data-test-id="consumer-phoneNumber-invalid-error"]'
+    },
+    addressLine1: {
+        input: '[data-test-id="formfield-account-info-consumer-line1-input"]',
+        emptyError: '[data-test-id="consumer-address-line1-empty-error"]'
+    },
+    addressLine2: {
+        input: '[data-test-id="formfield-account-info-consumer-line2-input"]'
+    },
+    addressLine3: {
+        input: '[data-test-id="formfield-account-info-consumer-line3-input"]'
+    },
+    city: {
+        input: '[data-test-id="formfield-account-info-consumer-locality-input"]',
+        emptyError: '[data-test-id="consumer-city-empty-error"]'
+    },
+    postcode: {
+        input: '[data-test-id="formfield-account-info-consumer-postcode-input"]',
+        emptyError: '[data-test-id="consumer-postcode-empty-error"]',
+        invalidError: '[data-test-id="consumer-postcode-invalid-error"]'
+    }
+};

--- a/packages/components/pages/f-account-info/test-utils/component-objects/f-accountInfo.component.js
+++ b/packages/components/pages/f-account-info/test-utils/component-objects/f-accountInfo.component.js
@@ -1,5 +1,12 @@
 const Page = require('@justeat/f-wdio-utils/src/page.object');
-const { COMPONENT } = require('./f-accountInfo-selectors');
+const {
+    COMPONENT,
+    CHANGE_EMAIL_ADDRESS_LINK,
+    SAVE_CHANGES,
+    CHANGE_PASSWORD,
+    DELETE_ACCOUNT,
+    FIELDS
+} = require('./f-accountInfo-selectors');
 
 module.exports = class AccountInfo extends Page {
     constructor () {
@@ -7,9 +14,57 @@ module.exports = class AccountInfo extends Page {
     }
 
     get component () { return $(COMPONENT); }
+    get changeEmailAddressLink () { return $(CHANGE_EMAIL_ADDRESS_LINK); }
+    get saveChangesButton () { return $(SAVE_CHANGES); }
+    get changePasswordButton () { return $(CHANGE_PASSWORD); }
+    get deleteAccountLink () { return $(DELETE_ACCOUNT); }
+
+    fields = {
+        firstName: {
+            get input () { return $(FIELDS.firstName.input); },
+            get emptyError () { return $(FIELDS.firstName.emptyError); },
+            get invalidError () { return $(FIELDS.firstName.invalidError); }
+        },
+        lastName: {
+            get input () { return $(FIELDS.lastName.input); },
+            get emptyError () { return $(FIELDS.lastName.emptyError); },
+            get invalidError () { return $(FIELDS.lastName.invalidError); }
+        },
+        emailAddress: {
+            get input () { return $(FIELDS.emailAddress.input); }
+        },
+        phoneNumber: {
+            get input () { return $(FIELDS.phoneNumber.input); },
+            get emptyError () { return $(FIELDS.phoneNumber.emptyError); },
+            get invalidError () { return $(FIELDS.phoneNumber.invalidError); }
+        },
+        addressLine1: {
+            get input () { return $(FIELDS.addressLine1.input); },
+            get emptyError () { return $(FIELDS.addressLine1.emptyError); }
+        },
+        addressLine2: {
+            get input () { return $(FIELDS.addressLine2.input); }
+        },
+        addressLine3: {
+            get input () { return $(FIELDS.addressLine3.input); }
+        },
+        city: {
+            get input () { return $(FIELDS.city.input); },
+            get emptyError () { return $(FIELDS.city.emptyError); }
+        },
+        postcode: {
+            get input () { return $(FIELDS.postcode.input); },
+            get emptyError () { return $(FIELDS.postcode.emptyError); },
+            get invalidError () { return $(FIELDS.postcode.invalidError); }
+        }
+    }
 
     load () {
         super.load(this.component);
+    }
+
+    click (field) {
+        this.fields[field].input.click();
     }
 
     waitForComponent () {
@@ -18,5 +73,58 @@ module.exports = class AccountInfo extends Page {
 
     isComponentDisplayed () {
         return this.component.isDisplayed();
+    }
+
+    /**
+    * @description
+    * Select all the text in the field and then performs a backspace to clear the field
+    *
+    * @param {String} fieldName The name of the field input it is clearing
+    */
+    clearBlurField (fieldName) {
+        // Determines the OS
+        const CONTROL = process.platform === 'darwin' ? 'Command' : '\uE009';
+        const el = this.fields[fieldName].input;
+        el.click();
+        el.keys([CONTROL, 'a']);
+        el.keys(['Backspace']);
+    }
+
+    /**
+    * @description
+    * Inputs customer details into the account-info component.
+    *
+    * @param {Object} customerInput customer input details
+    */
+    populateAccountForm (field, customerInput) {
+        this.fields[field].input.setValue(customerInput[field].input);
+    }
+
+    isEmptyErrorMessageDisplayed (fieldName) {
+        return this.fields[fieldName].emptyError.isDisplayed();
+    }
+
+    isInvalidErrorMessageDisplayed (fieldName) {
+        return this.fields[fieldName].invalidError.isDisplayed();
+    }
+
+    emailAddressLinkCanBeClicked () {
+        return this.changeEmailAddressLink.isClickable();
+    }
+
+    saveChangesButtonCanBeClicked () {
+        return this.saveChangesButton.isClickable();
+    }
+
+    changePasswordButtonCanBeClicked () {
+        return this.changePasswordButton.isClickable();
+    }
+
+    deleteAccountLinkCanBeClicked () {
+        return this.deleteAccountLink.isClickable();
+    }
+
+    isDisabled (field) {
+        return this.fields[field].input.isEnabled();
     }
 };

--- a/packages/components/pages/f-account-info/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/pages/f-account-info/test/accessibility/axe-accessibility.spec.js
@@ -1,6 +1,6 @@
 import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper';
 
-const AccountInfo = require('../../test-utils/component-objects/f-accountInfo.component');
+const AccountInfo = require('../../test-utils/component-objects/f-account-info.component');
 
 const accountInfo = new AccountInfo();
 

--- a/packages/components/pages/f-account-info/test/component/f-account-info.component.spec.js
+++ b/packages/components/pages/f-account-info/test/component/f-account-info.component.spec.js
@@ -18,7 +18,7 @@ describe('f-account-info component tests', () => {
         expect(accountInfo.isComponentDisplayed()).toBe(true);
     });
 
-    it('should detect that the email formfield is disabled and uneditable', () => {
+    it('should show that the email formfield is disabled', () => {
         // Assert
         expect(accountInfo.isDisabled('emailAddress')).toBe(true);
     });
@@ -31,19 +31,19 @@ describe('f-account-info component tests', () => {
         expect(accountInfo.changePasswordButtonCanBeClicked()).toBe(true);
     });
 
-    // to be migrated over to visual regression
+    // to be skipped once migrated into visual regression
 
     forEach(['firstName', 'lastName', 'phoneNumber', 'addressLine1', 'city', 'postcode'])
     .it('should display an error message immediately when %s input has been deleted', field => {
         // Act
         accountInfo.clearBlurField(field);
-        accountInfo.component.click();
+        accountInfo.clickOutOfInputField();
 
         // Assert
         expect(accountInfo.isEmptyErrorMessageDisplayed(field)).toBe(true);
     });
 
-    it('should display the illegal first name error message immediately on change', () => {
+    it('should display the illegal first name error message immediately on click', () => {
         // Arrange
         const customerInput = {
             firstName: {
@@ -54,13 +54,13 @@ describe('f-account-info component tests', () => {
         // Act
         accountInfo.clearBlurField('firstName');
         accountInfo.populateAccountForm('firstName', customerInput);
-        accountInfo.component.click();
+        accountInfo.clickOutOfInputField();
 
         // Assert
         expect(accountInfo.isInvalidErrorMessageDisplayed('firstName')).toBe(true);
     });
 
-    it('should display the illegal phone number error message immediately on change', () => {
+    it('should display the illegal phone number error message immediately on click', () => {
         // Arrange
         const customerInput = {
             phoneNumber: {
@@ -71,13 +71,13 @@ describe('f-account-info component tests', () => {
         // Act
         accountInfo.clearBlurField('phoneNumber');
         accountInfo.populateAccountForm('phoneNumber', customerInput);
-        accountInfo.component.click();
+        accountInfo.clickOutOfInputField();
 
         // Assert
         expect(accountInfo.isInvalidErrorMessageDisplayed('phoneNumber')).toBe(true);
     });
 
-    it('should display invalid postcode error message immediately on change', () => {
+    it('should display invalid postcode error message immediately on click', () => {
         // Arrange
         const customerInput = {
             postcode: {
@@ -88,7 +88,7 @@ describe('f-account-info component tests', () => {
         // Act
         accountInfo.clearBlurField('postcode');
         accountInfo.populateAccountForm('postcode', customerInput);
-        accountInfo.component.click();
+        accountInfo.clickOutOfInputField();
 
         // Assert
         expect(accountInfo.isInvalidErrorMessageDisplayed('postcode')).toBe(true);

--- a/packages/components/pages/f-account-info/test/component/f-account-info.component.spec.js
+++ b/packages/components/pages/f-account-info/test/component/f-account-info.component.spec.js
@@ -23,12 +23,10 @@ describe('f-account-info component tests', () => {
         expect(accountInfo.isDisabled('emailAddress')).toBe(true);
     });
 
-    it('should check if all call to actions are clickable', () => {
+    forEach(['changeEmailAddressLink', 'saveChangesButton', 'changePasswordButton', 'deleteAccountLink'])
+    .it('should check if all call to actions are clickable', cta => {
         // Assert
-        expect(accountInfo.deleteAccountLinkCanBeClicked()).toBe(true);
-        expect(accountInfo.emailAddressLinkCanBeClicked()).toBe(true);
-        expect(accountInfo.saveChangesButtonCanBeClicked()).toBe(true);
-        expect(accountInfo.changePasswordButtonCanBeClicked()).toBe(true);
+        expect(accountInfo.canBeClicked(cta)).toBe(true);
     });
 
     // to be skipped once migrated into visual regression
@@ -58,6 +56,23 @@ describe('f-account-info component tests', () => {
 
         // Assert
         expect(accountInfo.isInvalidErrorMessageDisplayed('firstName')).toBe(true);
+    });
+
+    it('should display the illegal last name error message immediately on click', () => {
+        // Arrange
+        const customerInput = {
+            lastName: {
+                input: '123'
+            }
+        };
+
+        // Act
+        accountInfo.clearBlurField('lastName');
+        accountInfo.populateAccountForm('lastName', customerInput);
+        accountInfo.clickOutOfInputField();
+
+        // Assert
+        expect(accountInfo.isInvalidErrorMessageDisplayed('lastName')).toBe(true);
     });
 
     it('should display the illegal phone number error message immediately on click', () => {

--- a/packages/components/pages/f-account-info/test/component/f-account-info.component.spec.js
+++ b/packages/components/pages/f-account-info/test/component/f-account-info.component.spec.js
@@ -1,6 +1,6 @@
 import forEach from 'mocha-each';
 
-const AccountInfo = require('../../test-utils/component-objects/f-accountInfo.component');
+const AccountInfo = require('../../test-utils/component-objects/f-account-info.component');
 
 let accountInfo;
 

--- a/packages/components/pages/f-account-info/test/component/f-accountInfo.component.spec.js
+++ b/packages/components/pages/f-account-info/test/component/f-accountInfo.component.spec.js
@@ -1,3 +1,5 @@
+import forEach from 'mocha-each';
+
 const AccountInfo = require('../../test-utils/component-objects/f-accountInfo.component');
 
 let accountInfo;
@@ -14,5 +16,81 @@ describe('f-account-info component tests', () => {
     it('should display the f-account-info component', () => {
         // Assert
         expect(accountInfo.isComponentDisplayed()).toBe(true);
+    });
+
+    it('should detect that the email formfield is disabled and uneditable', () => {
+        // Assert
+        expect(accountInfo.isDisabled('emailAddress')).toBe(true);
+    });
+
+    it('should check if all call to actions are clickable', () => {
+        // Assert
+        expect(accountInfo.deleteAccountLinkCanBeClicked()).toBe(true);
+        expect(accountInfo.emailAddressLinkCanBeClicked()).toBe(true);
+        expect(accountInfo.saveChangesButtonCanBeClicked()).toBe(true);
+        expect(accountInfo.changePasswordButtonCanBeClicked()).toBe(true);
+    });
+
+    // to be migrated over to visual regression
+
+    forEach(['firstName', 'lastName', 'phoneNumber', 'addressLine1', 'city', 'postcode'])
+    .it('should display an error message immediately when %s input has been deleted', field => {
+        // Act
+        accountInfo.clearBlurField(field);
+        accountInfo.component.click();
+
+        // Assert
+        expect(accountInfo.isEmptyErrorMessageDisplayed(field)).toBe(true);
+    });
+
+    it('should display the illegal first name error message immediately on change', () => {
+        // Arrange
+        const customerInput = {
+            firstName: {
+                input: '123'
+            }
+        };
+
+        // Act
+        accountInfo.clearBlurField('firstName');
+        accountInfo.populateAccountForm('firstName', customerInput);
+        accountInfo.component.click();
+
+        // Assert
+        expect(accountInfo.isInvalidErrorMessageDisplayed('firstName')).toBe(true);
+    });
+
+    it('should display the illegal phone number error message immediately on change', () => {
+        // Arrange
+        const customerInput = {
+            phoneNumber: {
+                input: '123'
+            }
+        };
+
+        // Act
+        accountInfo.clearBlurField('phoneNumber');
+        accountInfo.populateAccountForm('phoneNumber', customerInput);
+        accountInfo.component.click();
+
+        // Assert
+        expect(accountInfo.isInvalidErrorMessageDisplayed('phoneNumber')).toBe(true);
+    });
+
+    it('should display invalid postcode error message immediately on change', () => {
+        // Arrange
+        const customerInput = {
+            postcode: {
+                input: '123'
+            }
+        };
+
+        // Act
+        accountInfo.clearBlurField('postcode');
+        accountInfo.populateAccountForm('postcode', customerInput);
+        accountInfo.component.click();
+
+        // Assert
+        expect(accountInfo.isInvalidErrorMessageDisplayed('postcode')).toBe(true);
     });
 });


### PR DESCRIPTION
### Added
- component tests in `f-account-info.component.spec`
- test ids in `DeleteAccount.vue` and `EmailAddressField.vue`
- `vuelidate` and `f-services` package in `package.json`  - to resolve current issue on storybook prod - https://vue.pie.design/?path=/story/components-pages--account-info-component

### Changed
- data-test-ids in `AccountInfo.vue`  - the `formfield` component needs a `name` element to override the `data-test-id` it already has - https://github.com/justeat/fozzie-components/blob/master/packages/components/atoms/f-form-field/src/components/FormField.vue 
- test filenames from `accountInfo` to `account-info`