### PR TITLE
f-checkout@3.14.0 - Update split notes logic 

### DIFF
--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v3.14.0
+------------------------------
+*January 12, 2022*
+
+### Fixed
+- Logic for deciding whether notes should be formatted for split notes
+
+
 v3.13.1
 ------------------------------
 *January 04, 2022*

--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v3.14.0
+v3.13.2
 ------------------------------
 *January 12, 2022*
 

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "3.13.1",
+  "version": "3.14.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "120kB",
   "files": [

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "3.14.0",
+  "version": "3.13.2",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "120kB",
   "files": [

--- a/packages/components/pages/f-checkout/src/components/Checkout.vue
+++ b/packages/components/pages/f-checkout/src/components/Checkout.vue
@@ -473,7 +473,9 @@ export default {
 
                 await this.lookupGeoLocation();
 
-                await this.handleUpdateCheckout(this.getMappedDataForUpdateCheckout());
+                const updateData = this.getMappedDataForUpdateCheckout();
+                console.log(updateData) //eslint-disable-line
+                await this.handleUpdateCheckout(updateData);
 
                 if (this.isFulfillable) {
                     await this.submitOrder();
@@ -858,7 +860,7 @@ export default {
             this.checkoutAnalyticsService.trackDialogEvent(event);
         },
 
-        async getMappedDataForUpdateCheckout () {
+        getMappedDataForUpdateCheckout () {
             return mapUpdateCheckoutRequest({
                 address: this.address,
                 customer: this.customer,

--- a/packages/components/pages/f-checkout/src/components/Checkout.vue
+++ b/packages/components/pages/f-checkout/src/components/Checkout.vue
@@ -472,10 +472,7 @@ export default {
                 }
 
                 await this.lookupGeoLocation();
-
-                const updateData = this.getMappedDataForUpdateCheckout();
-                console.log(updateData) //eslint-disable-line
-                await this.handleUpdateCheckout(updateData);
+                await this.handleUpdateCheckout(this.getMappedDataForUpdateCheckout());
 
                 if (this.isFulfillable) {
                     await this.submitOrder();

--- a/packages/components/pages/f-checkout/src/components/Notes.vue
+++ b/packages/components/pages/f-checkout/src/components/Notes.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="features.isSplitNotesEnabled">
+    <div v-if="notesConfiguration.isSplitNotesEnabled">
         <accordion
             :id="noteTypeCourierOrOrder"
             :title="$t(`userNote.${noteTypeCourierOrOrder}.${serviceType}.title`)">
@@ -71,6 +71,7 @@ export default {
     computed: {
         ...mapState(VUEX_CHECKOUT_MODULE, [
             'features',
+            'notesConfiguration',
             'serviceType'
         ]),
 

--- a/packages/components/pages/f-checkout/src/store/checkout.module.js
+++ b/packages/components/pages/f-checkout/src/store/checkout.module.js
@@ -626,7 +626,7 @@ export default {
     },
 
     getters: {
-        formattedNotes: state => (state.features.isSplitNotesEnabled ? state.notes : [{ type: 'delivery', value: state.notes.order?.note }]),
+        formattedNotes: state => (state.notesConfiguration.isSplitNotesEnabled ? state.notes : [{ type: 'delivery', value: state.notes.order?.note }]),
         shouldShowKitchenNotes: state => state.notesConfiguration[state.serviceType]?.kitchenNoteAccepted,
         noteTypeCourierOrOrder: state => (state.notesConfiguration[state.serviceType]?.courierNoteAccepted ? CHECKOUT_NOTE_TYPE_COURIER : CHECKOUT_NOTE_TYPE_ORDER),
         noteValue: state => (state.notesConfiguration[state.serviceType]?.courierNoteAccepted ? state.notes.courier?.note : state.notes.order?.note),

--- a/packages/components/pages/f-checkout/src/store/checkout.module.js
+++ b/packages/components/pages/f-checkout/src/store/checkout.module.js
@@ -234,9 +234,10 @@ export default {
          * @param {Object} context - Vuex context object, this is the standard first parameter for actions
          * @param {Object} payload - Parameter with the different configurations for the request.
          */
-        getNotesConfiguration: async ({ commit }, { url, timeout }) => {
+        getNotesConfiguration: async ({ commit, state }, { url, timeout }) => {
             const { data } = await checkoutApi.getNoteConfiguration(url, timeout);
-            commit(UPDATE_NOTES_CONFIGURATION, { ...data?.customerNotes?.serviceTypes, isSplitNotesEnabled: true });
+            const isSplitNotesEnabled = !data?.customerNotes?.serviceTypes[state.serviceType].orderNoteAccepted;
+            commit(UPDATE_NOTES_CONFIGURATION, { ...data?.customerNotes?.serviceTypes, isSplitNotesEnabled });
         },
 
 

--- a/packages/components/pages/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/pages/f-checkout/src/store/tests/checkout.module.test.js
@@ -1302,7 +1302,7 @@ describe('CheckoutModule', () => {
                 // Arrange
                 const splitNotesEnabledState = {
                     ...state,
-                    features: {
+                    notesConfiguration: {
                         isSplitNotesEnabled: true
                     },
                     notes: { courier: { note: 'Please do not knock' }, kitchen: { note: 'No ketchup please' } }
@@ -1321,7 +1321,7 @@ describe('CheckoutModule', () => {
                 // Arrange
                 const splitNotesDisabledState = {
                     ...state,
-                    features: {
+                    notesConfiguration: {
                         isSplitNotesEnabled: false
                     },
                     notes: { order: { note: 'Please do not knock' } }


### PR DESCRIPTION
Adapted the logic for split notes as currently it will format the notes based on whether split notes is enabled on the current environment, not the current restaurant. 