### PR TITLE
f-account-info@v0.14.1 - Just a version bump

### DIFF
--- a/packages/components/pages/f-account-info/CHANGELOG.md
+++ b/packages/components/pages/f-account-info/CHANGELOG.md
@@ -4,8 +4,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest – to be added to the next release
+v0.14.1
 ------------------------------
+*January 13, 2022*
+
 ### Added
 - Visual tests
 - component tests in `f-account-info.component.spec`

--- a/packages/components/pages/f-account-info/package.json
+++ b/packages/components/pages/f-account-info/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-account-info",
   "description": "Fozzie Account Info - The account information page",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "main": "dist/f-account-info.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [


### PR DESCRIPTION
### Added
- visual tests
- component tests in `f-account-info.component.spec`
- test ids in `DeleteAccount.vue` and `EmailAddressField.vue`
- `vuelidate` and `f-services` package in `package.json`
### Changed
- component test ids in `AccountInfo.vue`
- test filenames from `accountInfo` to `account-info`