### PR TITLE
f-checkout@3.14.0 - Fix getAddressClosestToPostcode logic

### DIFF
--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.14.0
+------------------------------
+*January 14, 2022*
+
+### Fixed
+- Logic for closest postcode
+  
+
 v3.13.3
 ------------------------------
 *January 13, 2022*

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "3.13.3",
+  "version": "3.14.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "120kB",
   "files": [

--- a/packages/components/pages/f-checkout/src/services/addressService.js
+++ b/packages/components/pages/f-checkout/src/services/addressService.js
@@ -44,14 +44,16 @@ function getDefaultAddress (addresses) {
     return !addresses ? null : addresses.find(a => a && a.IsDefault);
 }
 
+const formatPostcode = postcode => postcode.replace(/ /g, '').replace(/-/g, '');
+
 function getAddressClosestToPostcode (postcode, addresses) {
     if (!postcode) {
         return getDefaultAddress(addresses);
     }
 
-    let formattedPostcode = postcode.replace(/ /g, '').replace(/-/g, '');
+    let formattedPostcode = formatPostcode(postcode);
 
-    let address = addresses.find(a => a.ZipCode === formattedPostcode);
+    let address = addresses.find(a => formatPostcode(a.ZipCode) === formattedPostcode);
 
     if (isFullPostCode(formattedPostcode)) {
         formattedPostcode = formattedPostcode.slice(0, formattedPostcode.length - 3);

--- a/packages/components/pages/f-checkout/src/services/addressService.js
+++ b/packages/components/pages/f-checkout/src/services/addressService.js
@@ -44,7 +44,7 @@ function getDefaultAddress (addresses) {
     return !addresses ? null : addresses.find(a => a && a.IsDefault);
 }
 
-const formatPostcode = postcode => postcode.replace(/ /g, '').replace(/-/g, '');
+const formatPostcode = postcode => postcode.replace(/\s/g, '').replace(/-/g, '');
 
 function getAddressClosestToPostcode (postcode, addresses) {
     if (!postcode) {


### PR DESCRIPTION
The logic inside `getAddressClosestToPostcode` would format the postcode which exists in the `je-location` cookie by removing the whitespace, and then would compare it to a postcode returned in the list of addresses from the API. These postcodes returned from the API often had spaces so there would rarely ever be an address found in this line 
```
let address = addresses.find(a => a.ZipCode === formattedPostcode);
```

Now there will be. 🙂 