### PR TITLE
f-account-info - small changes to enable contract tests #trivial

### DIFF
--- a/packages/components/pages/f-account-info/CHANGELOG.md
+++ b/packages/components/pages/f-account-info/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.14.2
+------------------------------
+*January 17, 2022*
+
+### Added
+-  `src/services` and `src/constants.js` to `dist` in package.json
+
+### Changed
+- private functions to public in `Consumer.api`for testing access
+
 
 v0.14.1
 ------------------------------

--- a/packages/components/pages/f-account-info/CHANGELOG.md
+++ b/packages/components/pages/f-account-info/CHANGELOG.md
@@ -10,9 +10,6 @@ v0.14.2
 ### Added
 -  `src/services` and `src/constants.js` to `dist` in package.json
 
-### Changed
-- private functions to public in `Consumer.api`for testing access
-
 
 v0.14.1
 ------------------------------

--- a/packages/components/pages/f-account-info/package.json
+++ b/packages/components/pages/f-account-info/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-account-info",
   "description": "Fozzie Account Info - The account information page",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "main": "dist/f-account-info.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [

--- a/packages/components/pages/f-account-info/package.json
+++ b/packages/components/pages/f-account-info/package.json
@@ -6,7 +6,9 @@
   "maxBundleSize": "100kB",
   "files": [
     "dist",
-    "test-utils"
+    "test-utils",
+    "src/services",
+    "src/constants.js"
   ],
   "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/components/pages/f-account-info",
   "contributors": [

--- a/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
+++ b/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
@@ -7,10 +7,14 @@ import {
 } from '../../constants';
 
 export default class ConsumerApi {
+    #httpClient;
+    #cookies;
+    #baseUrl;
+
     constructor ({ httpClient, cookies, baseUrl } = {}) {
-        this.httpClient = httpClient;
-        this.cookies = cookies;
-        this.baseUrl = baseUrl;
+        this.#httpClient = httpClient;
+        this.#cookies = cookies;
+        this.#baseUrl = baseUrl;
     }
 
     async getConsumerDetails (authToken, conversationId = this.setConversationId()) {
@@ -19,7 +23,7 @@ export default class ConsumerApi {
             Authorization: authToken ? `Bearer ${authToken}` : ''
         };
 
-        const response = await this.httpClient.get(`${this.baseUrl}/${CONSUMER_DETAILS_URL}`, headers);
+        const response = await this.#httpClient.get(`${this.#baseUrl}/${CONSUMER_DETAILS_URL}`, headers);
 
         return response;
     }
@@ -30,7 +34,7 @@ export default class ConsumerApi {
             Authorization: authToken ? `Bearer ${authToken}` : ''
         };
 
-        const response = await this.httpClient.get(`${this.baseUrl}/${CONSUMER_ADDRESSES_URL}`, headers);
+        const response = await this.#httpClient.get(`${this.#baseUrl}/${CONSUMER_ADDRESSES_URL}`, headers);
 
         return response;
     }
@@ -38,7 +42,7 @@ export default class ConsumerApi {
     setConversationId = conversationId => {
         const cid = conversationId || uuid();
 
-        this.cookies.set(CONVERSATION_ID_NAME, cid);
+        this.#cookies.set(CONVERSATION_ID_NAME, cid);
 
         return cid;
     };

--- a/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
+++ b/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
@@ -7,14 +7,10 @@ import {
 } from '../../constants';
 
 export default class ConsumerApi {
-    #httpClient;
-    #cookies;
-    #baseUrl;
-
     constructor ({ httpClient, cookies, baseUrl } = {}) {
-        this.#httpClient = httpClient;
-        this.#cookies = cookies;
-        this.#baseUrl = baseUrl;
+        this.httpClient = httpClient;
+        this.cookies = cookies;
+        this.baseUrl = baseUrl;
     }
 
     async getConsumerDetails (authToken, conversationId = this.setConversationId()) {
@@ -23,7 +19,7 @@ export default class ConsumerApi {
             Authorization: authToken ? `Bearer ${authToken}` : ''
         };
 
-        const response = await this.#httpClient.get(`${this.#baseUrl}/${CONSUMER_DETAILS_URL}`, headers);
+        const response = await this.httpClient.get(`${this.baseUrl}/${CONSUMER_DETAILS_URL}`, headers);
 
         return response;
     }
@@ -34,7 +30,7 @@ export default class ConsumerApi {
             Authorization: authToken ? `Bearer ${authToken}` : ''
         };
 
-        const response = await this.#httpClient.get(`${this.#baseUrl}/${CONSUMER_ADDRESSES_URL}`, headers);
+        const response = await this.httpClient.get(`${this.baseUrl}/${CONSUMER_ADDRESSES_URL}`, headers);
 
         return response;
     }
@@ -42,7 +38,7 @@ export default class ConsumerApi {
     setConversationId = conversationId => {
         const cid = conversationId || uuid();
 
-        this.#cookies.set(CONVERSATION_ID_NAME, cid);
+        this.cookies.set(CONVERSATION_ID_NAME, cid);
 
         return cid;
     };

--- a/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
+++ b/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
@@ -36,7 +36,7 @@ export default class ConsumerApi {
     }
 
     setConversationId = conversationId => {
-        const cid = conversationId || uuid(); 
+        const cid = conversationId || uuid();
 
         this.cookies.set(CONVERSATION_ID_NAME, cid);
 

--- a/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
+++ b/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
@@ -36,7 +36,7 @@ export default class ConsumerApi {
     }
 
     setConversationId = conversationId => {
-        const cid = conversationId || uuid();
+        const cid = conversationId || uuid(); 
 
         this.cookies.set(CONVERSATION_ID_NAME, cid);
 


### PR DESCRIPTION
Small PR to enable contract tests - 

### Added
-  `src/services` and `src/constants.js` to `dist` in package.json