### PR TITLE
f-restaurant-card@v0.13.0 - delivery fee and minimum order

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,19 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.13.0
+------------------------------
+*January 17, 2022*
+
+### Added
+- RestaurantFees component to display delivery fee and minimum order
+- RestaurantFees unit tests
+- Default background colour to restaurant card image
+### Changed
+- Changed restaurant image role from "img" to "presentation"
+- Added RestaurantFees data to storybook
+- Updated f-vue-icons dependency for new cash small icon
+
 v0.12.0
 ------------------------------
 *December 20, 2021*

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "@justeat/f-services": "1.7.0",
-    "@justeat/f-vue-icons": "3.3.0"
+    "@justeat/f-vue-icons": "3.4.0"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -100,7 +100,8 @@
 
             <restaurant-fees
                 v-if="hasFees"
-                v-bind="fees" />
+                v-bind="fees"
+                data-test-id="restaurant-fees" />
 
             <!-- Tags -->
             <div>

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -98,6 +98,10 @@
             </component>
             <!-- END ERROR BOUNDARY -->
 
+            <restaurant-fees
+                v-if="hasFees"
+                v-bind="fees" />
+
             <!-- Tags -->
             <div>
                 <!-- misc tags -->
@@ -154,6 +158,7 @@ import RestaurantTag from './subcomponents/RestaurantTags/RestaurantTag.vue';
 import RestaurantRating from './subcomponents/RestaurantRating/RestaurantRating.vue';
 import DeliveryTimeMeta from './subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue';
 import IconText from './subcomponents/IconText.vue';
+import RestaurantFees from './subcomponents/RestaurantFees/RestaurantFees.vue';
 
 export default {
     name: 'RestaurantCardV1',
@@ -168,7 +173,8 @@ export default {
         DeliveryTimeMeta,
         IconText,
         OfferIcon,
-        LegendIcon
+        LegendIcon,
+        RestaurantFees
     },
     mixins: [ErrorBoundaryMixin],
     // NOTE: These are merely some placeholder props and not indicative of the props we will end up using
@@ -237,6 +243,10 @@ export default {
         isPremier: {
             type: Boolean,
             default: false
+        },
+        fees: {
+            type: Object,
+            default: () => {}
         }
     },
     computed: {
@@ -256,6 +266,9 @@ export default {
         },
         hasDishes () {
             return !!this.dishes?.length;
+        },
+        hasFees () {
+            return !!this.fees?.deliveryFeeText || !!this.fees?.minOrderText;
         }
     },
     provide () {

--- a/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.v1.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.v1.test.js
@@ -349,4 +349,49 @@ describe('RestaurantCard.v1', () => {
             expect(wrapper.find('[data-test-id="restaurant-dishes"]').exists()).toBe(false);
         });
     });
+
+    describe('Restaurant Fees', () => {
+        it.each([
+            { fees: null },
+            { fees: undefined },
+            { fees: {} },
+            {}
+        ])('does not render if no fees state exists', propsData => {
+            // act
+            const wrapper = mount(RestaurantCardV1, { propsData });
+
+            // assert
+            expect(wrapper.find('[data-test-id="restaurant-fees"]').exists()).toBe(false);
+        });
+
+        it('renders if there is a delivery fee', () => {
+            // arrange
+            const propsData = {
+                fees: {
+                    deliveryFeeText: 'foo'
+                }
+            };
+
+            // act
+            const wrapper = mount(RestaurantCardV1, { propsData });
+
+            // assert
+            expect(wrapper.find('[data-test-id="restaurant-fees"]').exists()).toBe(true);
+        });
+
+        it('renders if there is a minimum order', () => {
+            // arrange
+            const propsData = {
+                fees: {
+                    minOrderText: 'foo'
+                }
+            };
+
+            // act
+            const wrapper = mount(RestaurantCardV1, { propsData });
+
+            // assert
+            expect(wrapper.find('[data-test-id="restaurant-fees"]').exists()).toBe(true);
+        });
+    });
 });

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
@@ -44,6 +44,7 @@ export default {
 .c-restaurantCard-fees {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
 }
 
 .c-restaurantCard-fees-item {

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
@@ -55,7 +55,7 @@ export default {
         content: '\2022'; // round bullet character
         color: $color-content-subdued;
         line-height: 1;
-        margin: 0 spacing(x0.5);;
+        margin: 0 spacing(x0.5);
     }
 
     &:last-of-type {

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
@@ -1,0 +1,81 @@
+<template>
+    <div :class="[$style['c-restaurantCard-fees']]">
+        <icon-text
+            v-if="deliveryFeeText"
+            :class="[$style['c-restaurantCard-fees-item']]"
+            :text="deliveryFeeText"
+            :hide-icon-in-tile-view="true"
+            data-test-id="restaurant-fees-delivery">
+            <cash-icon data-test-id="restaurant-fees-delivery-icon" />
+        </icon-text>
+
+        <icon-text
+            v-if="minOrderText"
+            :class="[$style['c-restaurantCard-fees-item']]"
+            :text="minOrderText"
+            data-test-id="restaurant-fees-min-order" />
+    </div>
+</template>
+
+<script>
+import { CashIcon } from '@justeat/f-vue-icons';
+import IconText from '../IconText.vue';
+
+export default {
+    name: 'RestaurantFees',
+    components: {
+        IconText,
+        CashIcon
+    },
+    props: {
+        deliveryFeeText: {
+            type: String,
+            default: null
+        },
+        minOrderText: {
+            type: String,
+            default: null
+        }
+    }
+};
+</script>
+
+<style lang="scss" module>
+.c-restaurantCard-fees {
+    display: flex;
+    align-items: center;
+}
+
+.c-restaurantCard-fees-item {
+    position: relative;
+    padding-right: spacing();
+    margin-right: spacing(x0.5);
+    white-space: nowrap;
+    font-size: $font-body-s-paragraph * 1px;
+
+    &:before {
+        display: none;
+    }
+
+    &:after {
+        content: '\2022';
+        color: $color-content-subdued;
+        position: absolute;
+        right: 0;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+    }
+
+    &:last-of-type {
+        padding-right: 0;
+        margin-right: 0;
+
+        &:after {
+            display: none;
+        }
+    }
+}
+</style>

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
@@ -6,7 +6,7 @@
             :text="deliveryFeeText"
             :hide-icon-in-tile-view="true"
             data-test-id="restaurant-fees-delivery">
-            <cash-icon data-test-id="restaurant-fees-delivery-icon" />
+            <cash-small-icon data-test-id="restaurant-fees-delivery-icon" />
         </icon-text>
 
         <icon-text
@@ -18,14 +18,14 @@
 </template>
 
 <script>
-import { CashIcon } from '@justeat/f-vue-icons';
+import { CashSmallIcon } from '@justeat/f-vue-icons';
 import IconText from '../IconText.vue';
 
 export default {
     name: 'RestaurantFees',
     components: {
         IconText,
-        CashIcon
+        CashSmallIcon
     },
     props: {
         deliveryFeeText: {

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
@@ -48,32 +48,17 @@ export default {
 }
 
 .c-restaurantCard-fees-item {
-    position: relative;
-    padding-right: spacing();
-    margin-right: spacing(x0.5);
     white-space: nowrap;
-    @include font-size($font-body-s-paragraph);
-
-    &:before {
-        display: none;
-    }
+    margin: spacing(x0.5) 0;
 
     &:after {
         content: '\2022'; // round bullet character
         color: $color-content-subdued;
-        position: absolute;
-        right: 0;
-        height: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-direction: column;
+        line-height: 1;
+        margin: 0 spacing(x0.5);;
     }
 
     &:last-of-type {
-        padding-right: 0;
-        margin-right: 0;
-
         &:after {
             display: none;
         }

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
@@ -52,14 +52,14 @@ export default {
     padding-right: spacing();
     margin-right: spacing(x0.5);
     white-space: nowrap;
-    font-size: $font-body-s-paragraph * 1px;
+    @include font-size($font-body-s-paragraph);
 
     &:before {
         display: none;
     }
 
     &:after {
-        content: '\2022';
+        content: '\2022'; // round bullet character
         color: $color-content-subdued;
         position: absolute;
         right: 0;

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/_tests/RestaurantFees.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/_tests/RestaurantFees.test.js
@@ -1,0 +1,132 @@
+import { mount } from '@vue/test-utils';
+import sut from '../RestaurantFees.vue';
+
+describe('RestaurantFees.vue', () => {
+    it('is defined', () => {
+        // act
+        const wrapper = mount(sut);
+
+        // assert
+        expect(wrapper.exists()).toBe(true);
+    });
+
+    it('displays delivery fee if one exists', () => {
+        // arrange
+        const propsData = {
+            deliveryFeeText: 'foo'
+        };
+
+        // act
+        const wrapper = mount(sut, { propsData });
+
+        // assert
+        expect(wrapper.find('[data-test-id="restaurant-fees-delivery"]').exists()).toBe(true);
+    });
+
+    it('displays `deliveryFeeText` text', () => {
+        // arrange
+        const propsData = {
+            deliveryFeeText: 'foo'
+        };
+
+        // act
+        const wrapper = mount(sut, { propsData });
+
+        // assert
+        expect(wrapper.find('[data-test-id="restaurant-fees-delivery"]').text()).toStrictEqual(propsData.deliveryFeeText);
+    });
+
+    it('does not display delivery fee if none exists', () => {
+        // arrange
+        const propsData = {
+            minOrderText: 'foo'
+        };
+
+        // act
+        const wrapper = mount(sut, { propsData });
+
+        // assert
+        expect(wrapper.find('[data-test-id="restaurant-fees-delivery"]').exists()).toBe(false);
+    });
+
+    it('displays minimum order if one exists', () => {
+        // arrange
+        const propsData = {
+            minOrderText: 'foo'
+        };
+
+        // act
+        const wrapper = mount(sut, { propsData });
+
+        // assert
+        expect(wrapper.find('[data-test-id="restaurant-fees-min-order"]').exists()).toBe(true);
+    });
+
+    it('displays `minOrderText` text', () => {
+        // arrange
+        const propsData = {
+            minOrderText: 'foo'
+        };
+
+        // act
+        const wrapper = mount(sut, { propsData });
+
+        // assert
+        expect(wrapper.find('[data-test-id="restaurant-fees-min-order"]').text()).toStrictEqual(propsData.minOrderText);
+    });
+
+    it('does not display minimum order if none exists', () => {
+        // arrange
+        const propsData = {
+            deliveryFeeText: 'foo'
+        };
+
+        // act
+        const wrapper = mount(sut, { propsData });
+
+        // assert
+        expect(wrapper.find('[data-test-id="restaurant-fees-min-order"]').exists()).toBe(false);
+    });
+
+    it('displays both delivery fee and minimum order if both exist', () => {
+        // arrange
+        const propsData = {
+            deliveryFeeText: 'foo',
+            minOrderText: 'bar'
+        };
+
+        // act
+        const wrapper = mount(sut, { propsData });
+
+        // assert
+        expect(wrapper.find('[data-test-id="restaurant-fees-delivery"]').exists()).toBe(true);
+        expect(wrapper.find('[data-test-id="restaurant-fees-min-order"]').exists()).toBe(true);
+    });
+
+    it('displays both `deliveryFeeText` and `minOrderText` text', () => {
+        // arrange
+        const propsData = {
+            deliveryFeeText: 'foo',
+            minOrderText: 'bar'
+        };
+
+        // act
+        const wrapper = mount(sut, { propsData });
+
+        // assert
+        expect(wrapper.find('[data-test-id="restaurant-fees-delivery"]').text()).toStrictEqual(propsData.deliveryFeeText);
+        expect(wrapper.find('[data-test-id="restaurant-fees-min-order"]').text()).toStrictEqual(propsData.minOrderText);
+    });
+
+    it('does not display anything if no delivery fee or minimum order exists', () => {
+        // arrange
+        const propsData = {};
+
+        // act
+        const wrapper = mount(sut, { propsData });
+
+        // assert
+        expect(wrapper.find('[data-test-id="restaurant-fees-delivery"]').exists()).toBe(false);
+        expect(wrapper.find('[data-test-id="restaurant-fees-min-order"]').exists()).toBe(false);
+    });
+});

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantImage/RestaurantImage.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantImage/RestaurantImage.vue
@@ -2,7 +2,7 @@
     <div
         :class="[$style['c-restaurantCard-img']]"
         :style="`background-image: url(${imgUrl});`"
-        role="img">
+        role="presentation">
         <slot />
     </div>
 </template>

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantImage/RestaurantImage.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantImage/RestaurantImage.vue
@@ -23,6 +23,7 @@ export default {
 $img-borderRadius : $radius-rounded-c;
 
 .c-restaurantCard-img {
+  background-color: $color-grey-30;
   background-size: cover;
   background-position: center;
   border-radius: $img-borderRadius;

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
@@ -70,7 +70,11 @@ RestaurantCardComponent.args = {
             }
         ],
         offer: '30% off when you spend £20 - some really really long offer that hopefully never happens but we need to protect against just in case',
-        isPremier: true
+        isPremier: true,
+        fees: {
+            deliveryFeeText: '£2.50 delivery fee',
+            minOrderText: 'No min. order'
+        }
     },
 
     flags: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2221,14 +2221,6 @@
     "@justeat/f-services" "1.0.0"
     "@justeat/f-vue-icons" "2.5.0"
 
-"@justeat/f-form-field@4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-4.5.0.tgz#931d5d643090c2fce46ecf8302b3333013fb3d7d"
-  integrity sha512-EJLkg0vzxS+BE16mZ2Q2r7bB3jvZd8EFW8jB5GmACSqtsCe0iLLFSfY2cPlDx3oZ1nZMoRse/T2foCrjH5c7dg==
-  dependencies:
-    "@justeat/f-services" "1.0.0"
-    "@justeat/f-vue-icons" "2.5.0"
-
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-0.2.0.tgz#90ec559642c165b6325669c506c417abe09fa5dd"
@@ -2433,6 +2425,13 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-3.0.0.tgz#25207d9c706c530a7fda0a7bc121134295c1bad0"
   integrity sha512-8mgBcRuciU4MnqabZkhd+F6awuFAIHRbQnUh4ZQc3cgdZC+eIgPgyrLLURg5HNJOXhi6ojhqAFUqJNb1Rc1ZMQ==
+  dependencies:
+    babel-helper-vue-jsx-merge-props "2.0.3"
+
+"@justeat/f-vue-icons@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-3.4.0.tgz#47743051d93e7a320d95bd2b7bd5e83580d60480"
+  integrity sha512-DK3uvkXqm7tjB0yDHdOaUVoOtKeBQb/WKAp0FnlnXCzl1YiOenNVggVcdqLLAmQn9GSZuhVK+aECCbDeohDjgQ==
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
 


### PR DESCRIPTION
v0.13.0
------------------------------
*January 17, 2022*

### Added
- RestaurantFees component to display delivery fee and minimum order
- RestaurantFees unit tests
- Default background colour to restaurant card image
### Changed
- Changed restaurant image role from "img" to "presentation"
- Added RestaurantFees data to storybook
- Updated f-vue-icons dependency for new cash small icon


<img width="261" alt="Screenshot 2022-01-17 at 14 03 39" src="https://user-images.githubusercontent.com/16766185/149782710-2a50417c-96ba-4cc0-826f-16663fba1167.png">