### PR TITLE
fozzie-components@v5.8.7 - Updated axe core version and fixed reporting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v5.8.7
+------------------------------
+*January 17, 2022*
+
+### Updated
+- `axe-core` version to latest.
+
+### Fixed
+- `axe-helper.js` to create reports in the correct directory if tests fail locally.
+
 
 v5.8.6
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "5.8.6",
+  "version": "5.8.7",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",
@@ -75,7 +75,7 @@
     "@wdio/spec-reporter": "7.6.0",
     "@wdio/sync": "7.6.0",
     "allure-commandline": "2.13.0",
-    "axe-core": "4.1.1",
+    "axe-core": "4.3.5",
     "axe-reports": "1.1.11",
     "axios": "0.21.4",
     "babel-core": "7.0.0-bridge.0",

--- a/test/utils/axe-helper.js
+++ b/test/utils/axe-helper.js
@@ -2,6 +2,7 @@ const { source } = require('axe-core');
 const AxeReports = require('axe-reports');
 const { exec } = require('child_process');
 const fs = require('fs');
+const path = require('path');
 
 /**
  * Runs the WCAG accessibility tests on the curent page of the global browser
@@ -48,7 +49,7 @@ exports.processResults = (results, componentName) => {
     console.log('Creating .CSV artifact for Axe violations');
 
     const fileName = `${componentName}-a11y-violations`;
-    const localFilePath = `${__dirname}../../../test/results/axe-violations/${fileName}`;
+    const localFilePath = path.join(__dirname + `/../results/axe-violations/${fileName}`);
     // axe-reports can't create the CSV in CI due to permissions so we have to create the file ourselves.
     if (process.env.CIRCLECI) {
         const ciFileName = `/home/circleci/project/test/results/axe-violations/${fileName}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2428,6 +2428,13 @@
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
 
+"@justeat/f-vue-icons@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-3.3.0.tgz#1794f32c78b78394d267fc6090310e02a0227bfb"
+  integrity sha512-tUipy/GwDffsnpKx0hkKTTgrCTFNVId1og5ARxxrB9nZK/CQrT/e86oQN+3OAxWKEHZQmK4/7SYCg8tSDTohyQ==
+  dependencies:
+    babel-helper-vue-jsx-merge-props "2.0.3"
+
 "@justeat/f-wdio-utils@0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.4.0.tgz#6916a392777c88bc84e0d5a258e7e94c64ff7800"
@@ -6980,12 +6987,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axe-core@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.1.tgz#70a7855888e287f7add66002211a423937063eaf"
-  integrity sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==
-
-axe-core@^4.2.0:
+axe-core@4.3.5, axe-core@^4.2.0:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.5.tgz#78d6911ba317a8262bfee292aeafcc1e04b49cc5"
   integrity sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==


### PR DESCRIPTION
v5.8.7
------------------------------
*January 17, 2022*

### Updated
- `axe-core` version to latest.

### Fixed
- `axe-helper.js` to create reports in the correct directory if tests fail locally.