### PR TITLE
fozzie-components@v5.9.0 - Danger checks to their own CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ jobs:
       - install_node_dependencies
       - run: # Run PR Checks
          name: Run PR Checks
-         command: yarn danger ci --fail-on-errors=true
+         command: yarn danger ci --failOnErrors
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,7 +519,7 @@ workflows:
             branches:
               ignore: ['gh-pages']
           requires:
-            - install
+            - danger-checks
       - bundlewatch:
           name: bundlewatch
           context: web-core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ jobs:
       - install_node_dependencies
       - run: # Run PR Checks
          name: Run PR Checks
-         command: yarn danger ci --fail-on-errors
+         command: yarn danger ci --fail-on-errors=true
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ jobs:
       - install_node_dependencies
       - run: # Run PR Checks
          name: Run PR Checks
-         command: yarn danger ci
+         command: yarn danger ci --fail-on-errors
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,6 +391,17 @@ jobs:
       - slack_notify_fail
       - slack_notify_success
 
+  danger-checks:
+    executor: node
+    steps:
+      - attach_workspace:
+          at: .
+      - run: # Run PR Checks
+         name: Run PR Checks
+         command: yarn danger ci
+      - slack_notify_fail
+      - slack_notify_success
+
   build:
     executor: node
     environment:
@@ -507,6 +518,14 @@ workflows:
           filters:
             branches:
               ignore: [ 'gh-pages' ]
+      - danger-checks:
+          name: danger-checks
+          context: web-core
+          filters:
+            branches:
+              ignore: ['gh-pages']
+          requires:
+            - install
       - build:
           name: build
           context: web-core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,9 +381,6 @@ jobs:
       - checkout
       - restore_cache_dist_directories
       - install_node_dependencies
-      - run: # Run PR Checks
-         name: Run PR Checks
-         command: yarn danger ci --failOnErrors
       - persist_to_workspace:
           root: .
           paths:
@@ -398,7 +395,7 @@ jobs:
           at: .
       - run: # Run PR Checks
          name: Run PR Checks
-         command: yarn danger ci
+         command: yarn danger ci --failOnErrors
       - slack_notify_fail
       - slack_notify_success
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v5.10.0
+------------------------------
+*January 19, 2022*
+
+### Updated
+- `.circleci/config.yml` to put danger checks in their own workflow.
+
+
 v5.9.0
 ------------------------------
 *January 18, 2022*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",


### PR DESCRIPTION
This PR adds the Danger checks to their own CircleCI job, allowing it to be re-run in isolation if violations are found.

PR that fails danger checks.
![Screenshot 2022-01-20 at 11 20 48](https://user-images.githubusercontent.com/14013357/150329386-43af4944-7375-4be6-b7b7-ca3490cf7e91.png)


After updating PR title and rerunning the `danger-checks` job.
![Screenshot 2022-01-20 at 11 23 05](https://user-images.githubusercontent.com/14013357/150329637-38d96c08-eac4-4afb-979c-c4aed65378b9.png)

