### PR TITLE
f-checkout@3.15.1 - Correct split notes disabled note key

### DIFF
--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v3.15.2
+v3.15.1
 ------------------------------
 *January 20, 2022*
 

--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v3.15.1
+v3.15.2
 ------------------------------
 *January 20, 2022*
 

--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.15.1
+------------------------------
+*January 20, 2022*
+
+### Fixed
+- Correct key for delivery note type when split notes is not enabled
+
 
 v3.15.0
 ------------------------------

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "3.15.2",
+  "version": "3.15.1",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "120kB",
   "files": [

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "120kB",
   "files": [

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "120kB",
   "files": [

--- a/packages/components/pages/f-checkout/src/store/checkout.module.js
+++ b/packages/components/pages/f-checkout/src/store/checkout.module.js
@@ -302,6 +302,7 @@ export default {
             const config = {
                 headers: {
                     'Content-Type': 'application/json',
+                    'Accept-Tenant': tenant,
                     'Accept-Language': language,
                     ...(state.authToken && {
                         Authorization: authHeader
@@ -326,6 +327,7 @@ export default {
          */
         getCustomer: async ({ commit, state, dispatch }, {
             url,
+            tenant,
             timeout
         }) => {
             if (!state.customer || state.customer.mobileNumber) {
@@ -336,6 +338,7 @@ export default {
             const config = {
                 headers: {
                     'Content-Type': 'application/json',
+                    'Accept-Tenant': tenant,
                     ...(state.authToken && {
                         Authorization: authHeader
                     })
@@ -627,7 +630,7 @@ export default {
     },
 
     getters: {
-        formattedNotes: state => (state.notesConfiguration.isSplitNotesEnabled ? state.notes : [{ type: 'delivery', value: state.notes.order?.note }]),
+        formattedNotes: state => (state.notesConfiguration.isSplitNotesEnabled ? state.notes : [{ type: 'delivery', note: state.notes.order?.note }]),
         shouldShowKitchenNotes: state => state.notesConfiguration[state.serviceType]?.kitchenNoteAccepted,
         noteTypeCourierOrOrder: state => (state.notesConfiguration[state.serviceType]?.courierNoteAccepted ? CHECKOUT_NOTE_TYPE_COURIER : CHECKOUT_NOTE_TYPE_ORDER),
         noteValue: state => (state.notesConfiguration[state.serviceType]?.courierNoteAccepted ? state.notes.courier?.note : state.notes.order?.note),

--- a/packages/components/pages/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/pages/f-checkout/src/store/tests/checkout.module.test.js
@@ -740,6 +740,7 @@ describe('CheckoutModule', () => {
                     headers: {
                         'Content-Type': 'application/json',
                         'Accept-Language': payload.language,
+                        'Accept-Tenant': payload.tenant,
                         Authorization: `Bearer ${state.authToken}`
                     },
                     timeout: payload.timeout
@@ -783,6 +784,7 @@ describe('CheckoutModule', () => {
                     const config = {
                         headers: {
                             'Content-Type': 'application/json',
+                            'Accept-Tenant': payload.tenant,
                             Authorization: `Bearer ${state.authToken}`
                         },
                         timeout: payload.timeout
@@ -1328,7 +1330,7 @@ describe('CheckoutModule', () => {
                 };
 
                 it('should return the formattedNotes as they are stored in state', () => {
-                    const expectedResult = [{ type: 'delivery', value: splitNotesDisabledState.notes.order.note }];
+                    const expectedResult = [{ type: 'delivery', note: splitNotesDisabledState.notes.order.note }];
 
                     // Act
                     const result = getters.formattedNotes(splitNotesDisabledState);


### PR DESCRIPTION
When split notes is disabled, we were using the key `value` when it should be `note`. This has now been corrected. 