### PR TITLE
f-image-tile@v0.4.0 - Adding Text

### DIFF
--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -5,9 +5,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.4.0
 ------------------------------
-*January X, 2022*
+*January 26, 2022*
 
 ### Added
+- Styled and truncated text
+- Transitions accounting for prefers-reduced-motion
 
 
 v0.3.0

--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.4.0
+------------------------------
+*January X, 2022*
+
+### Added
+
+
 v0.3.0
 ------------------------------
 *January 19, 2022*

--- a/packages/components/atoms/f-image-tile/package.json
+++ b/packages/components/atoms/f-image-tile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-image-tile",
   "description": "Fozzie Image Tile - An interactive tile component containing an image, text and link.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "dist/f-image-tile.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-image-tile/src/assets/scss/common.scss
+++ b/packages/components/atoms/f-image-tile/src/assets/scss/common.scss
@@ -1,6 +1,1 @@
-// Set $theme variable so that fozzie doesn't complain when vars are imported below
-// n.b. This variables isn't actually used (unless there are theme specific vars from fozzie)
-// Instead, the theme is handled via a data-attribute on the component (via the `@mixin theme()` below)
-$theme: 'jet' !default;
-
 @import  '~@justeat/fozzie/src/scss/fozzie';

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -41,11 +41,9 @@
                     :role="isPresentationRole ? 'presentation' : false">
             </span>
             <span
-                :class="$style['c-imageTile-text-container']"
+                :class="$style['c-imageTile-textContainer']"
                 :aria-hidden="isLink">
-                <span :class="$style['c-imageTile-icon-container']">
-                    <tick-icon :class="$style['c-imageTile-icon']" />
-                </span>
+                <tick-icon :class="$style['c-imageTile-icon']" />
                 <span :class="$style['c-imageTile-text']">
                     {{ displayText }}
                 </span>
@@ -159,23 +157,13 @@ export default {
 
 $image-tile-background-opacity: 0.7;
 $image-tile-background-color: $color-interactive-brand;
+$image-tile-selected: $color-content-positive;
+$image-tile-transition-duration: 0.2s;
+$image-tile-ease: ease-in-out;
 
 
 .c-imageTile {
-    @include font-size(heading-m);
-
-    font-family: $font-family-base;
     position: relative;
-
-    &:hover {
-        cursor: pointer;
-    }
-
-    &:hover .c-imageTile-icon {
-        opacity: 1;
-        transform: rotate(0) scale(1);
-        width: 20px;
-    }
 }
 
 .c-imageTile-link {
@@ -198,12 +186,12 @@ $image-tile-background-color: $color-interactive-brand;
 }
 
 .c-imageTile-imageContainer {
-  display: block;
-  background-color: rgba($image-tile-background-color, $image-tile-background-opacity);
-  border-radius: $radius-rounded-b;
-  background-image: var(--bg-image);
-  padding-top: (3 / 5) * 100%; // 5:3 aspect ratio
-  position: relative;
+    background-color: rgba($image-tile-background-color, $image-tile-background-opacity);
+    border-radius: $radius-rounded-b;
+    background-image: var(--bg-image);
+    display: block;
+    padding-top: (3 / 5) * 100%; // 5:3 aspect ratio
+    position: relative;
 }
 
 .c-imageTile-image {
@@ -215,40 +203,62 @@ $image-tile-background-color: $color-interactive-brand;
     height: 100%;
 }
 
-.c-imageTile-text-container {
+.c-imageTile-textContainer {
+    margin-top: spacing();
     display: flex;
+    max-width: 100%;
 
     .c-imageTile--selected & {
-        color: #017A39;
+        color: $image-tile-selected;
     }
 }
 
 .c-imageTile-icon {
+    align-self: center;
     opacity: 0;
-    margin-right: spacing();
-    transform: rotate( -45deg ) scale(.5);
-    transition: transform .4s ease, opacity .4s ease;
+    transform: translate3d(-10px, 10px, 0);
+    width: 0;
+    will-change: transform, opacity;
 
-    .c-imageTile--selected & {
+    @media (prefers-reduced-motion: no-preference) {
+        transition: transform $image-tile-transition-duration $image-tile-ease,
+                    opacity $image-tile-transition-duration $image-tile-ease,
+                    width $image-tile-transition-duration $image-tile-ease;
+    }
+
+    .c-imageTile--selected &,
+    .c-imageTile:hover & {
         opacity: 1;
-        transform: rotate(0) scale(1);
-        width: 10px;
+        transform: translate3d(0, 10px, 0);
+        width: 15px;
     }
 
     .c-imageTile--selected & path {
-        fill: #017A39;
+        fill: $image-tile-selected;
     }
 }
 
 .c-imageTile-text {
     @include font-size(body-s);
+    display: block;
     font-family: $font-family-base;
     font-weight: $font-weight-regular;
-    flex: 1;
+    margin-right: spacing(2);
     overflow: hidden;
-    white-space: nowrap;
     text-overflow: ellipsis;
+    transform: translate3d(0px, 10px, 0);
+    white-space: nowrap;
     width: 100%;
+    will-change: transform;
+
+    @media (prefers-reduced-motion: no-preference) {
+        transition: transform $image-tile-transition-duration $image-tile-ease;
+    }
+
+    .c-imageTile--selected &,
+    .c-imageTile:hover & {
+        transform: translate3d(5px, 10px, 0);
+    }
 }
 
 </style>

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -270,7 +270,7 @@ $image-tile-text-transform: translate3d(5px, 0, 0);
     }
 
     @include media('>=mid') {
-        .c-imageTile:hover &  {
+        .c-imageTile:hover & {
             transform: $image-tile-text-transform;
         }
     }

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -1,6 +1,9 @@
 <template>
     <div
-        :class="$style['c-imageTile']"
+        :class="[
+            $style['c-imageTile'], {
+                [$style['c-imageTile--selected']]: isToggleSelected
+            }]"
         data-test-id="image-tile-component">
         <a
             :class="[
@@ -23,10 +26,7 @@
             data-test-id="image-tile-input"
             @change="toggleFilter">
         <label
-            :class="[
-                $style['c-imageTile-label'], {
-                    [$style['c-imageTile-label--selected']]: isToggleSelected
-                }]"
+            :class="$style['c-imageTile-label']"
             :for="`imageTileToggle-${tileId}`"
             data-test-id="image-tile-label">
             <span
@@ -40,18 +40,28 @@
                     :alt="altText"
                     :role="isPresentationRole ? 'presentation' : false">
             </span>
-            <span :aria-hidden="isLink">
-                {{ displayText }}
+            <span
+                :class="$style['c-imageTile-text-container']"
+                :aria-hidden="isLink">
+                <span :class="$style['c-imageTile-icon-container']">
+                    <tick-icon :class="$style['c-imageTile-icon']" />
+                </span>
+                <span :class="$style['c-imageTile-text']">
+                    {{ displayText }}
+                </span>
             </span>
         </label>
     </div>
 </template>
 
 <script>
+import { TickIcon } from '@justeat/f-vue-icons';
 
 export default {
     name: 'ImageTile',
-    components: {},
+    components: {
+        TickIcon
+    },
     props: {
         href: {
             type: String,
@@ -156,6 +166,16 @@ $image-tile-background-color: $color-interactive-brand;
 
     font-family: $font-family-base;
     position: relative;
+
+    &:hover {
+        cursor: pointer;
+    }
+
+    &:hover .c-imageTile-icon {
+        opacity: 1;
+        transform: rotate(0) scale(1);
+        width: 20px;
+    }
 }
 
 .c-imageTile-link {
@@ -177,10 +197,6 @@ $image-tile-background-color: $color-interactive-brand;
     flex-flow: column wrap;
 }
 
-.c-imageTile-label--selected {
-  border: 1px solid green;
-}
-
 .c-imageTile-imageContainer {
   display: block;
   background-color: rgba($image-tile-background-color, $image-tile-background-opacity);
@@ -197,6 +213,42 @@ $image-tile-background-color: $color-interactive-brand;
     left: 0;
     width: 100%;
     height: 100%;
+}
+
+.c-imageTile-text-container {
+    display: flex;
+
+    .c-imageTile--selected & {
+        color: #017A39;
+    }
+}
+
+.c-imageTile-icon {
+    opacity: 0;
+    margin-right: spacing();
+    transform: rotate( -45deg ) scale(.5);
+    transition: transform .4s ease, opacity .4s ease;
+
+    .c-imageTile--selected & {
+        opacity: 1;
+        transform: rotate(0) scale(1);
+        width: 10px;
+    }
+
+    .c-imageTile--selected & path {
+        fill: #017A39;
+    }
+}
+
+.c-imageTile-text {
+    @include font-size(body-s);
+    font-family: $font-family-base;
+    font-weight: $font-weight-regular;
+    flex: 1;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    width: 100%;
 }
 
 </style>

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -160,7 +160,13 @@ $image-tile-background-color: $color-interactive-brand;
 $image-tile-selected: $color-content-positive;
 $image-tile-transition-duration: 0.2s;
 $image-tile-ease: ease-in-out;
+$image-tile-text-transform: translate3d(5px, 0, 0);
 
+@mixin image-tile-icon-selected-transform() {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1) rotate(0);
+    width: 15px;
+}
 
 .c-imageTile {
     position: relative;
@@ -205,7 +211,7 @@ $image-tile-ease: ease-in-out;
 }
 
 .c-imageTile-textContainer {
-    margin-top: spacing();
+    margin-top: spacing(x2);
     display: flex;
     max-width: 100%;
 
@@ -227,15 +233,18 @@ $image-tile-ease: ease-in-out;
                     width $image-tile-transition-duration $image-tile-ease;
     }
 
-    .c-imageTile--selected &,
-    .c-imageTile:hover & {
-        opacity: 1;
-        transform: translate3d(0, 0, 0) scale(1) rotate(0);
-        width: 15px;
+    .c-imageTile--selected & {
+        @include image-tile-icon-selected-transform();
     }
 
     .c-imageTile--selected & path {
         fill: $image-tile-selected;
+    }
+
+    @include media('>=mid') {
+        .c-imageTile:hover & {
+            @include image-tile-icon-selected-transform();
+        }
     }
 }
 
@@ -256,9 +265,14 @@ $image-tile-ease: ease-in-out;
         transition: transform $image-tile-transition-duration $image-tile-ease;
     }
 
-    .c-imageTile--selected &,
-    .c-imageTile:hover & {
-        transform: translate3d(5px, 0, 0);
+    .c-imageTile--selected & {
+        transform: $image-tile-text-transform;
+    }
+
+    @include media('>=mid') {
+        .c-imageTile:hover &  {
+            transform: $image-tile-text-transform;
+        }
     }
 }
 

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -164,6 +164,7 @@ $image-tile-ease: ease-in-out;
 
 .c-imageTile {
     position: relative;
+    width: 100%;
 }
 
 .c-imageTile-link {
@@ -216,7 +217,7 @@ $image-tile-ease: ease-in-out;
 .c-imageTile-icon {
     align-self: center;
     opacity: 0;
-    transform: translate3d(-10px, 10px, 0);
+    transform: translate3d(-10px, 0, 0) scale(0.5) rotate(-60deg);
     width: 0;
     will-change: transform, opacity;
 
@@ -229,7 +230,7 @@ $image-tile-ease: ease-in-out;
     .c-imageTile--selected &,
     .c-imageTile:hover & {
         opacity: 1;
-        transform: translate3d(0, 10px, 0);
+        transform: translate3d(0, 0, 0) scale(1) rotate(0);
         width: 15px;
     }
 
@@ -243,10 +244,10 @@ $image-tile-ease: ease-in-out;
     display: block;
     font-family: $font-family-base;
     font-weight: $font-weight-regular;
-    margin-right: spacing(2);
+    margin-right: spacing(x2);
     overflow: hidden;
     text-overflow: ellipsis;
-    transform: translate3d(0px, 10px, 0);
+    transform: translate3d(0, 0, 0);
     white-space: nowrap;
     width: 100%;
     will-change: transform;
@@ -257,7 +258,7 @@ $image-tile-ease: ease-in-out;
 
     .c-imageTile--selected &,
     .c-imageTile:hover & {
-        transform: translate3d(5px, 10px, 0);
+        transform: translate3d(5px, 0, 0);
     }
 }
 

--- a/packages/components/atoms/f-image-tile/src/components/_tests/ImageTile.test.js
+++ b/packages/components/atoms/f-image-tile/src/components/_tests/ImageTile.test.js
@@ -62,58 +62,58 @@ describe('ImageTile', () => {
                 // Assert
                 expect(label.attributes('for')).toContain(propsData.tileId);
             });
+        });
 
-            describe('imgSrc :: ', () => {
-                it('should apply `imgSrc` to the image src', () => {
-                    // Arrange
-                    const propsData = { imgSrc: 'https://via.placeholder.com/150' };
+        describe('imgSrc :: ', () => {
+            it('should apply `imgSrc` to the image src', () => {
+                // Arrange
+                const propsData = { imgSrc: 'https://via.placeholder.com/150' };
 
-                    // Act
-                    const wrapper = shallowMount(ImageTile, {
-                        propsData
-                    });
-
-                    const image = wrapper.find('[data-test-id="image-tile-image"]');
-
-                    // Assert
-                    expect(image.attributes('src')).toContain(propsData.imgSrc);
+                // Act
+                const wrapper = shallowMount(ImageTile, {
+                    propsData
                 });
 
-                it('should not have an image if the `imgSrc` is empty', () => {
-                    // Arrange
-                    const propsData = { imgSrc: '' };
+                const image = wrapper.find('[data-test-id="image-tile-image"]');
 
-                    // Act
-                    const wrapper = shallowMount(ImageTile, {
-                        propsData
-                    });
-
-                    const image = wrapper.find('[data-test-id="image-tile-image"]');
-
-                    // Assert
-                    expect(image.exists()).toBe(false);
-                });
+                // Assert
+                expect(image.attributes('src')).toContain(propsData.imgSrc);
             });
 
-            describe('isSelected :: ', () => {
-                const isSelectedTrue = true;
-                const isSelectedFalse = false;
+            it('should not have an image if the `imgSrc` is empty', () => {
+                // Arrange
+                const propsData = { imgSrc: '' };
 
-                it.each([
-                    [true, isSelectedTrue],
-                    [false, isSelectedFalse]
-                ])('should update `isToggleSelected` %s when set to %s', (expectedValue, isSelected) => {
-                    // Arrange
-                    const propsData = { isSelected };
-
-                    // Act
-                    const wrapper = shallowMount(ImageTile, {
-                        propsData
-                    });
-
-                    // Assert
-                    expect(wrapper.vm.isToggleSelected).toBe(expectedValue);
+                // Act
+                const wrapper = shallowMount(ImageTile, {
+                    propsData
                 });
+
+                const image = wrapper.find('[data-test-id="image-tile-image"]');
+
+                // Assert
+                expect(image.exists()).toBe(false);
+            });
+        });
+
+        describe('isSelected :: ', () => {
+            const isSelectedTrue = true;
+            const isSelectedFalse = false;
+
+            it.each([
+                [true, isSelectedTrue],
+                [false, isSelectedFalse]
+            ])('should update `isToggleSelected` %s when set to %s', (expectedValue, isSelected) => {
+                // Arrange
+                const propsData = { isSelected };
+
+                // Act
+                const wrapper = shallowMount(ImageTile, {
+                    propsData
+                });
+
+                // Assert
+                expect(wrapper.vm.isToggleSelected).toBe(expectedValue);
             });
         });
     });


### PR DESCRIPTION
This PR adds and styles the text for the f-image-tile component.

---

### Added
- Styled and truncated text
- Transitions accounting for prefers-reduced-motion

---

## UI Review Checks
![Screenshot 2022-01-25 at 15 08 53](https://user-images.githubusercontent.com/4212434/151131315-5d7bcf99-46c1-44ee-b7aa-20e146795c6e.png)
Hover
![Screenshot 2022-01-25 at 15 09 05](https://user-images.githubusercontent.com/4212434/151131325-cc76a24d-cef6-4869-b36c-93eb97361c96.png)
Selected

![Screenshot 2022-01-25 at 15 09 51](https://user-images.githubusercontent.com/4212434/151131330-1d5af6ca-16f1-4f36-893f-492782eb696a.png)
Truncated text
![Screenshot 2022-01-25 at 15 09 59](https://user-images.githubusercontent.com/4212434/151131334-b1c6000a-1326-4ba9-b151-c2c4a5f8b765.png)
Hovered Truncated text


- [X] README and/or UI Documentation has been [created|updated]
- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [X] Chrome (latest)
- [X] Firefox
- [X] Safari

------

This ticket only covers adding the image as part of the Fozzie component. It doesn't cover its integration into searchWeb. However I have included some WIP images of what this currently looks like when added to SearchWeb replacing the form__toggle component for context.

Additional screenshots

![Screenshot 2022-01-25 at 14 42 39](https://user-images.githubusercontent.com/4212434/151131462-baf090e2-d006-466f-bace-2140c431fa2a.png)

![Screenshot 2022-01-25 at 14 42 59](https://user-images.githubusercontent.com/4212434/151131473-01cfa97f-8cd9-4d57-a019-330a4e042133.png)


![Screenshot 2022-01-25 at 14 46 54](https://user-images.githubusercontent.com/4212434/151131481-cfb7cf88-c67b-427d-9011-8cd7a0db2ed3.png)

![Screenshot 2022-01-25 at 14 48 42](https://user-images.githubusercontent.com/4212434/151131487-50b2bf52-8e31-4868-b17e-b6723121fd3a.png)


