### PR TITLE
f-contact-preferences@0.14.0 - Amending styles to match the designs.

### DIFF
--- a/packages/components/pages/f-contact-preferences/CHANGELOG.md
+++ b/packages/components/pages/f-contact-preferences/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.14.0
+------------------------------
+*January 26, 2022*
+
+### Changed
+- Styles to match the designs.
+
+
 v0.13.0
 ------------------------------
 *January 21, 2022*

--- a/packages/components/pages/f-contact-preferences/package.json
+++ b/packages/components/pages/f-contact-preferences/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-contact-preferences",
   "description": "Fozzie Contact Preferences - Fozzie user contact preferences form component",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "main": "dist/f-contact-preferences.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [
@@ -57,13 +57,13 @@
     "@justeat/browserslist-config-fozzie": ">=1.2.0",
     "vuex": ">=3.5.1"
   },
-  "devDependencies": {    
+  "devDependencies": {
     "@justeat/f-vue-icons": "3.3.0",
     "@justeat/f-button": "3.2.0",
-    "@justeat/f-card": "3.4.0",
-    "@justeat/f-card-with-content": "1.0.0",    
+    "@justeat/f-card": "3.5.0",
+    "@justeat/f-card-with-content": "1.0.0",
     "@justeat/f-alert": "4.1.0",
-    "@justeat/f-form-field": "4.5.0",    
+    "@justeat/f-form-field": "4.5.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",

--- a/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
+++ b/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
@@ -324,11 +324,6 @@ export default {
     margin: spacing(x2) 0 spacing(x4);
 }
 
-.c-formField-label,
-.c-formField-label-description {
-    margin-bottom: 0;
-}
-
 .c-contactPreferences-subtitle {
     @include font-size(heading-s);
 }

--- a/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
+++ b/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
@@ -321,7 +321,7 @@ export default {
     flex-flow: column;
     border: none;
     padding: 0;
-    margin: spacing(x2) 0 spacing(x4);
+    margin: spacing(x2) 0 spacing(x3);
 }
 
 .c-formField-label,

--- a/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
+++ b/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
@@ -321,7 +321,7 @@ export default {
     flex-flow: column;
     border: none;
     padding: 0;
-    margin: spacing(x2) 0 spacing(x3);
+    margin: spacing(x2) 0 spacing(x4);
 }
 
 .c-formField-label,
@@ -352,6 +352,6 @@ export default {
 }
 
 .c-contactPreferences-alert {
-    margin: 0 0 spacing(x4);
+    margin: -(spacing()) 0 spacing(x4); // Negative top margin needed to offset the fieldset's bottom margin.
 }
 </style>

--- a/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
+++ b/packages/components/pages/f-contact-preferences/src/components/ContactPreferences.vue
@@ -5,6 +5,7 @@
         <card-component
             v-if="!shouldShowLoadErrorCard"
             :card-heading="$t('heading')"
+            card-heading-size="beta"
             has-inner-spacing-large
             :card-size-custom="'medium'"
             has-outline>
@@ -22,8 +23,7 @@
                             :class="$style['c-contactPreferences-formField']"
                             input-type="checkbox"
                             is-grouped
-                            :label-text=" $t(`${key}.email`)"
-                            :label-description="getEmailDescription(key)"
+                            :label-text="getLabelText(key, 'email')"
                             :disabled="!isEmailEnabled"
                             :data-test-id="`contact-preferences-${key}-email-checkbox`"
                             :name="`contact-preferences-${key}-email`"
@@ -35,8 +35,7 @@
                             :class="$style['c-contactPreferences-formField']"
                             input-type="checkbox"
                             is-grouped
-                            :label-text=" $t(`${key}.sms`)"
-                            :label-description="getSmsDescription(key)"
+                            :label-text="getLabelText(key, 'sms')"
                             :disabled="!isSmsEnabled"
                             :data-test-id="`contact-preferences-${key}-sms-checkbox`"
                             :name="`contact-preferences-${key}-sms`"
@@ -203,23 +202,26 @@ export default {
         },
 
         /**
-        * Returns translation string if it exists
+        * Returns label text for a given key and field.
         * @param {string} key - The key of the preference that needs changing
+        * @param {string} field - The field of the preference that needs changing
         */
-        getEmailDescription (key) {
-            if (!this.$te(`${key}.emailDescription`)) return '';
+        getLabelText (key, field) {
+            const label = this.$t(`${key}.${field}`);
+            const description = this.getDescription(key, `${field}Description`);
 
-            return `(${this.$t(`${key}.emailDescription`)})`;
+            return `${label} ${description}`;
         },
 
         /**
-        * Returns translation string if it exists
+        * Returns translation for a description if it exists
         * @param {string} key - The key of the preference that needs changing
+        * @param {string} field - The field of the preference that needs changing
         */
-        getSmsDescription (key) {
-            if (!this.$te(`${key}.smsDescription`)) return '';
+        getDescription (key, field) {
+            if (!this.$te(`${key}.${field}`)) return '';
 
-            return `(${this.$t(`${key}.smsDescription`)})`;
+            return `(${this.$t(`${key}.${field}`)})`;
         },
 
         /**
@@ -313,21 +315,18 @@ export default {
 };
 </script>
 
-<style lang="scss">
-.c-formField-label,
-.c-formField-label-description {
-    margin-bottom: 0;
-}
-</style>
-
 <style lang="scss" module>
-
 .c-contactPreferences-fieldset {
     display: flex;
     flex-flow: column;
     border: none;
     padding: 0;
-    margin: spacing(x2) 0;
+    margin: spacing(x2) 0 spacing(x4);
+}
+
+.c-formField-label,
+.c-formField-label-description {
+    margin-bottom: 0;
 }
 
 .c-contactPreferences-subtitle {
@@ -337,6 +336,7 @@ export default {
 .c-contactPreferences {
     .c-contactPreferences-formField {
         margin-top: 0;
+
         .c-contactPreferences-formField + & {
             margin-bottom: spacing(x2);
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2208,6 +2208,13 @@
   dependencies:
     "@justeat/f-services" "0.13.0"
 
+"@justeat/f-card@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-card/-/f-card-3.4.0.tgz#8786fa1d97c50228d40ddeb7c44570bc0f2bd599"
+  integrity sha512-lzOld5dn8867Orjixj1A2qA9X8jrt+waKKuKyb59fomigJ+EnhP6XVeMhZixuu7aVee480EAXT2liklCA2eaxw==
+  dependencies:
+    "@justeat/f-services" "0.13.0"
+
 "@justeat/f-content-cards@6.0.0-beta.2":
   version "6.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-6.0.0-beta.2.tgz#1b77d0d33ad0b8b41d26d78029c848e8444d20b5"


### PR DESCRIPTION
v0.14.0
------------------------------
*January 26, 2022*

### Changed
- Styles to match the designs.

_Note: the main heading is smaller than requested. This is known and it's because fozzie's heading sizes are not exactly matching the designs provided. There's an ongoing conversation about this with the design team and should be amended in fozzie shortly._

**Images:**
![image](https://user-images.githubusercontent.com/10439518/151325735-2868cfc1-9eef-423a-9b4a-e010969e4d71.png)

![image](https://user-images.githubusercontent.com/10439518/151325914-5790834c-ba4f-4a9f-9459-603d216669bc.png)

