### PR TITLE
f-checkout@v3.15.4 - Update f-alert

### DIFF
--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -3,13 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.15.4
+------------------------------
+*January 27, 2022*
+
+### Changed
+- Bump `f-alert` version.
+
+
 v3.15.3
 ------------------------------
 *January 21, 2022*
 
 ### Changed
 - Passed tenant to `getCustomer` call
-  
+
 
 v3.15.2
 ------------------------------
@@ -40,7 +48,7 @@ v3.14.0
 
 ### Fixed
 - Logic for closest postcode
-  
+
 
 v3.13.3
 ------------------------------

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.12.13",
-    "@justeat/f-alert": "3.0.2",
+    "@justeat/f-alert": "4.1.0",
     "@justeat/f-button": "3.0.2",
     "@justeat/f-card": "3.0.0",
     "@justeat/f-card-with-content": "0.2.1",

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "3.15.3",
+  "version": "3.15.4",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "120kB",
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2184,13 +2184,6 @@
     eslint-config-airbnb-base "14.1.0"
     eslint-plugin-vue "6.2.2"
 
-"@justeat/f-alert@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@justeat/f-alert/-/f-alert-3.0.2.tgz#a4028e76146d3875f1c8452791e559cf915a5472"
-  integrity sha512-ppwaCHbr/vhqhWk9gAymVuW3GFNFeR3jG4jeHL3TjVI12FQfPhMjvhPnwbWd72FzBVsnFPbQAeg1+iBjBOgKRg==
-  dependencies:
-    "@justeat/f-services" "1.0.0"
-
 "@justeat/f-button@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-3.0.2.tgz#9560d0caf56ae0801208ddd0c27cb50d670d54a8"


### PR DESCRIPTION
### Changed
- Bump `f-alert` version.