### PR TITLE
f-header@9.4.0 - f-vue-icons package version bump

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v9.4.0
+------------------------------
+*January 28, 2021*
+
+### Updated
+- f-vue-icons to the latest (3.4.0) to fix jet logo rendering.
+
+
 v9.3.0
 ------------------------------
 *January 20, 2021*

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header - Globalised Header Component",
-  "version": "9.3.0",
+  "version": "9.4.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [
@@ -60,7 +60,7 @@
     "@babel/plugin-proposal-class-properties": "7.12.13",
     "@justeat/f-button": "3.0.2",
     "@justeat/f-popover": "2.0.0",
-    "@justeat/f-vue-icons": "3.3.0",
+    "@justeat/f-vue-icons": "3.4.0",
     "@justeat/f-wdio-utils": "0.5.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",


### PR DESCRIPTION
### Updated
- f-vue-icons to the latest (3.4.0) to fix jet logo rendering.