### PR TITLE
f-image-tile@v0.5.0 - Keyboard navigation

### DIFF
--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.5.0
 ------------------------------
-*January X, 2022*
+*January 28, 2022*
 
 ### Added
 - Focus styles for keyboard navigation

--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.5.0
+------------------------------
+*January X, 2022*
+
+### Added
+- Focus styles for keyboard navigation
+
 v0.4.0
 ------------------------------
 *January 26, 2022*

--- a/packages/components/atoms/f-image-tile/package.json
+++ b/packages/components/atoms/f-image-tile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-image-tile",
   "description": "Fozzie Image Tile - An interactive tile component containing an image, text and link.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/f-image-tile.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -202,7 +202,7 @@ $image-tile-text-transform: translate3d(5px, 0, 0);
     pointer-events: none;
 
     &:focus {
-        outline: none;
+        outline: none; // Focus styles not needed in toggle state.
     }
 }
 
@@ -211,7 +211,7 @@ $image-tile-text-transform: translate3d(5px, 0, 0);
     flex-flow: column wrap;
 
     &:focus {
-        outline: none;
+        outline: none; // Prevents Safari doubling focus styles.
     }
 }
 

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -24,11 +24,13 @@
             class="is-visuallyHidden"
             :class="$style['c-imageTile-checkbox']"
             data-test-id="image-tile-input"
+            :tabindex="!isLink ? 0 : false"
             @change="toggleFilter">
         <label
             :class="$style['c-imageTile-label']"
             :for="`imageTileToggle-${tileId}`"
-            data-test-id="image-tile-label">
+            data-test-id="image-tile-label"
+            :tabindex="!isLink ? -1 : false">
             <span
                 :class="$style['c-imageTile-imageContainer']"
                 :style="cssVars">
@@ -177,8 +179,7 @@ $image-tile-text-transform: translate3d(5px, 0, 0);
     position: relative;
     width: 100%;
 
-    &:focus-within,
-    &:focus-visible {
+    &:focus-within {
         @include image-tile-focus();
     }
 }
@@ -208,7 +209,10 @@ $image-tile-text-transform: translate3d(5px, 0, 0);
 .c-imageTile-label {
     display: flex;
     flex-flow: column wrap;
-    border-radius: $radius-rounded-b; // focus styles in safari
+
+    &:focus {
+        outline: none;
+    }
 }
 
 .c-imageTile-imageContainer {

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -168,9 +168,19 @@ $image-tile-text-transform: translate3d(5px, 0, 0);
     width: 15px;
 }
 
+@mixin image-tile-focus() {
+    outline: 2px solid $color-focus;
+    border-radius: $radius-rounded-b;
+}
+
 .c-imageTile {
     position: relative;
     width: 100%;
+
+    &:focus-within,
+    &:focus-visible {
+        @include image-tile-focus();
+    }
 }
 
 .c-imageTile-link {
@@ -179,17 +189,26 @@ $image-tile-text-transform: translate3d(5px, 0, 0);
     left: 0;
     right: 0;
     bottom: 0;
+
+    &:focus {
+        @include image-tile-focus();
+    }
 }
 
 .c-imageTile-link--toggle {
     display: block;
     position: static;
     pointer-events: none;
+
+    &:focus {
+        outline: none;
+    }
 }
 
 .c-imageTile-label {
     display: flex;
     flex-flow: column wrap;
+    border-radius: $radius-rounded-b; // focus styles in safari
 }
 
 .c-imageTile-imageContainer {
@@ -275,6 +294,5 @@ $image-tile-text-transform: translate3d(5px, 0, 0);
         }
     }
 }
-
 </style>
 


### PR DESCRIPTION


---

### Added
- Focus styles for keyboard navigation

---

This PR adds focus styles and tabindex for keyboard navigation

## UI Review Checks
![Screenshot 2022-01-28 at 12 07 24](https://user-images.githubusercontent.com/4212434/151544347-e980db77-1f8f-4752-b71b-9d302eff4190.png)
![Screenshot 2022-01-28 at 12 06 44](https://user-images.githubusercontent.com/4212434/151544505-67c3c9ab-c536-4367-bf25-a6d4de8772ca.png)


- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [X] Chrome (latest)
- [X] Firefox
- [X] Safari