### PR TITLE
f-image-tile@v0.5.1 - Update tabindex value

### DIFF
--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.5.1
+------------------------------
+*January 31, 2022*
+
+### Updated
+- Updated tabindex value on input 
 
 v0.5.0
 ------------------------------

--- a/packages/components/atoms/f-image-tile/package.json
+++ b/packages/components/atoms/f-image-tile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-image-tile",
   "description": "Fozzie Image Tile - An interactive tile component containing an image, text and link.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "dist/f-image-tile.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -24,7 +24,7 @@
             class="is-visuallyHidden"
             :class="$style['c-imageTile-checkbox']"
             data-test-id="image-tile-input"
-            :tabindex="!isLink ? 0 : false"
+            :tabindex="!isLink ? 0 : -1"
             @change="toggleFilter">
         <label
             :class="$style['c-imageTile-label']"


### PR DESCRIPTION
---

### Updated
- Updated tabindex value on input 

This component can have two purposes either a toggle or a link.
I have updated the input in the link state to be non focusable to improve the screen reader experience and make sure only the link gains focus.

---

## UI Review Checks

- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [X] Chrome (latest)
