### PR TITLE
f-footer@6.2.0 - ES prensa link update

### DIFF
--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -4,12 +4,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v6.2.0
+------------------------------
+*February 1, 2022*
+
+### Changed
+- Link for ES Prensa to point to the prensa info page instead of email address.
+
+
 v6.1.0
 ------------------------------
 *January 11, 2022*
 
 ### Changed
-- Update ethics hotline links to point to new URL
+- Update ethics hotline links to point to new URL.
 
 
 v6.0.3

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "main": "dist/f-footer.umd.min.js",
   "maxBundleSize": "80kB",
   "files": [

--- a/packages/components/organisms/f-footer/src/tenants/es-ES.js
+++ b/packages/components/organisms/f-footer/src/tenants/es-ES.js
@@ -211,9 +211,7 @@ export default {
                     gtm: 'click_ethics_hotline'
                 },
                 {
-                    url: 'mailto:prensa@justeattakeaway.com',
-                    target: '_blank',
-                    rel: 'noopener',
+                    url: '/info/prensa',
                     text: 'Prensa',
                     gtm: 'click_prensa'
                 }


### PR DESCRIPTION
### Changed
- Link for ES Prensa to point to the prensa info page instead of email address.