### PR TITLE
f-restaurant-card@v0.16.0 - Preorder & Collection

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.16.0
+------------------------------
+*Februrary 02, 2022*
+
+### Added
+- New `RestaurantAvailability` component for displaying pre-order and collection info
+- Supporting unit tests
+- New blue colour variant to `IconText` class modifiers
+- Storybook file for the `RestaurantAvailability` component
+### Changed
+- Updated f-vue-icons to `3.5.0`
+- Use new clock-small icon on ETA
+- Directly target the SVG path elements in `IconText` colour modifiers to avoid default fills present in some icons
+- Simplified restaurant Storybook selector
+
 v0.15.0
 ------------------------------
 *January 31, 2022*

--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -17,6 +17,7 @@ v0.16.0
 - Use new clock-small icon on ETA
 - Directly target the SVG path elements in `IconText` colour modifiers to avoid default fills present in some icons
 - Simplified restaurant Storybook selector
+- Use pie design token aliases for `IconText` colours
 
 v0.15.0
 ------------------------------

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -46,17 +46,17 @@
   ],
   "dependencies": {
     "@justeat/f-services": "1.7.0",
-    "@justeat/f-vue-icons": "3.4.0"
+    "@justeat/f-vue-icons": "3.5.0"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"
   },
   "devDependencies": {
+    "@justeat/f-wdio-utils": "0.5.0",
     "@samhammer/vue-cli-plugin-stylelint": "2.0.1",
     "@vue/cli-plugin-babel": "4.4.6",
     "@vue/cli-plugin-eslint": "3.9.2",
     "@vue/cli-plugin-unit-jest": "4.4.6",
-    "@justeat/f-wdio-utils": "0.5.0",
     "@vue/test-utils": "1.0.3",
     "node-sass-magic-importer": "5.3.2"
   }

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -77,6 +77,15 @@
                     v-bind="rating" />
             </component>
 
+            <component
+                :is="errorBoundary"
+                v-if="availability"
+                :tier="3">
+                <restaurant-availability
+                    v-bind="availability"
+                    data-test-id="restaurant-availability" />
+            </component>
+
             <!-- Offline Icon -->
 
             <!-- Meta Items List -->
@@ -147,6 +156,7 @@ import RestaurantRating from './subcomponents/RestaurantRating/RestaurantRating.
 import DeliveryTimeMeta from './subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue';
 import IconText from './subcomponents/IconText.vue';
 import RestaurantFees from './subcomponents/RestaurantFees/RestaurantFees.vue';
+import RestaurantAvailability from './subcomponents/RestaurantAvailability/RestaurantAvailability.vue';
 import RenderlessSlotWrapper from './RenderlessSlotWrapper';
 
 export default {
@@ -164,6 +174,7 @@ export default {
         OfferIcon,
         LegendIcon,
         RestaurantFees,
+        RestaurantAvailability,
         RenderlessSlotWrapper
     },
     mixins: [ErrorBoundaryMixin],
@@ -237,6 +248,10 @@ export default {
         fees: {
             type: Object,
             default: () => {}
+        },
+        availability: {
+            type: Object,
+            default: null
         }
     },
     computed: {

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue
@@ -7,7 +7,7 @@
             :color="'green'"
             :hide-icon-in-tile-view="true"
             data-test-id="delivery-meta-eta">
-            <clock-icon data-test-id="delivery-meta-eta-icon" />
+            <clock-small-icon data-test-id="delivery-meta-eta-icon" />
         </icon-text>
 
         <icon-text
@@ -29,7 +29,7 @@
 </template>
 
 <script>
-import { MapPinIcon, ClockIcon } from '@justeat/f-vue-icons';
+import { MapPinIcon, ClockSmallIcon } from '@justeat/f-vue-icons';
 import IconText from '../IconText.vue';
 
 export default {
@@ -37,7 +37,7 @@ export default {
     components: {
         IconText,
         MapPinIcon,
-        ClockIcon
+        ClockSmallIcon
     },
     props: {
         address: {

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue
@@ -4,7 +4,7 @@
             v-if="eta"
             :text="eta"
             :is-bold="true"
-            :color="'green'"
+            :color="'colorSupportPositive'"
             :hide-icon-in-tile-view="true"
             data-test-id="delivery-meta-eta">
             <clock-small-icon data-test-id="delivery-meta-eta-icon" />

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/IconText.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/IconText.vue
@@ -86,6 +86,10 @@ export default {
     color: $color-green;
 }
 
+.c-restaurantCard-iconText-content--blue {
+    color: $color-blue;
+}
+
 .c-restaurantCard-iconText-icon {
     width: spacing(x2);
     height: spacing(x2);
@@ -99,6 +103,14 @@ export default {
 }
 
 .c-restaurantCard-iconText-icon--green {
-    fill: $color-green;
+    path {
+        fill: $color-green;
+    }
+}
+
+.c-restaurantCard-iconText-icon--blue {
+    path {
+        fill: $color-blue;
+    }
 }
 </style>

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/IconText.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/IconText.vue
@@ -82,12 +82,12 @@ export default {
     line-height: spacing(x2);
 }
 
-.c-restaurantCard-iconText-content--green {
-    color: $color-green;
+.c-restaurantCard-iconText-content--colorSupportPositive {
+    color: $color-support-positive;
 }
 
-.c-restaurantCard-iconText-content--blue {
-    color: $color-blue;
+.c-restaurantCard-iconText-content--colorSupportInfo {
+    color: $color-support-info;
 }
 
 .c-restaurantCard-iconText-icon {
@@ -102,15 +102,15 @@ export default {
     }
 }
 
-.c-restaurantCard-iconText-icon--green {
+.c-restaurantCard-iconText-icon--colorSupportPositive {
     path {
-        fill: $color-green;
+        fill: $color-support-positive;
     }
 }
 
-.c-restaurantCard-iconText-icon--blue {
+.c-restaurantCard-iconText-icon--colorSupportInfo {
     path {
-        fill: $color-blue;
+        fill: $color-support-info;
     }
 }
 </style>

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/IconText.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/IconText.vue
@@ -2,13 +2,13 @@
     <p
         :class="{
             [$style['c-restaurantCard-iconText']]: true,
+            [$style[`c-restaurantCard-iconText--${color}`]]: true,
             [$style['c-restaurantCard-iconText--bold']]: isBold
         }">
         <span
             v-if="showIcon"
             :class="{
                 [$style['c-restaurantCard-iconText-icon']]: true,
-                [$style[`c-restaurantCard-iconText-icon--${color}`]]: true,
                 [$style['c-restaurantCard-iconText-icon--hideOnMidBelow']]: hideIconInTileView
             }"
             data-test-id="icon-text-icon">
@@ -16,8 +16,7 @@
         </span>
         <span
             :class="{
-                [$style['c-restaurantCard-iconText-content']]: true,
-                [$style[`c-restaurantCard-iconText-content--${color}`]]: true
+                [$style['c-restaurantCard-iconText-content']]: true
             }"
             data-test-id="icon-text-visible-text">
             {{ text }}
@@ -82,14 +81,6 @@ export default {
     line-height: spacing(x2);
 }
 
-.c-restaurantCard-iconText-content--colorSupportPositive {
-    color: $color-support-positive;
-}
-
-.c-restaurantCard-iconText-content--colorSupportInfo {
-    color: $color-support-info;
-}
-
 .c-restaurantCard-iconText-icon {
     width: spacing(x2);
     height: spacing(x2);
@@ -102,13 +93,14 @@ export default {
     }
 }
 
-.c-restaurantCard-iconText-icon--colorSupportPositive {
+.c-restaurantCard-iconText--colorSupportPositive {
+    color: $color-support-positive;
     path {
         fill: $color-support-positive;
     }
 }
-
-.c-restaurantCard-iconText-icon--colorSupportInfo {
+.c-restaurantCard-iconText--colorSupportInfo {
+    color: $color-support-info;
     path {
         fill: $color-support-info;
     }

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
@@ -15,10 +15,10 @@
         </icon-text>
 
         <p
-            v-if="detailsMessage"
-            data-test-id="restaurant-availability-detailsMessage"
-            :class="[$style['c-restaurantCard-availability-detailsMessage']]">
-            {{ detailsMessage }}
+            v-if="message"
+            data-test-id="restaurant-availability-message"
+            :class="[$style['c-restaurantCard-availability-message']]">
+            {{ message }}
         </p>
     </div>
 </template>
@@ -58,7 +58,7 @@ export default {
             default: null
         },
         // The accompanying message for the availability type. i.e Opening times, delivering from...
-        detailsMessage: {
+        message: {
             type: String,
             default: null
         }
@@ -86,7 +86,7 @@ export default {
 }
 
 .c-restaurantCard-availability-iconText,
-.c-restaurantCard-availability-detailsMessage {
+.c-restaurantCard-availability-message {
     overflow-wrap: break-word;
     @include font-size($font-paragraph-02);
 }
@@ -100,7 +100,7 @@ export default {
     }
 }
 
-.c-restaurantCard-availability-detailsMessage {
+.c-restaurantCard-availability-message {
     margin-top: 0;
 }
 </style>

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
@@ -35,7 +35,7 @@ const availabilityTypeIcons = {
 };
 
 const iconColors = {
-    [availabilityTypes.PREORDER]: 'blue'
+    [availabilityTypes.PREORDER]: 'colorSupportInfo'
 };
 
 export default {

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
@@ -1,0 +1,107 @@
+<template>
+    <div :class="[$style['c-restaurantCard-availability']]">
+        <icon-text
+            v-if="availabilityTranslatedName"
+            :text="availabilityTranslatedName"
+            :color="iconColor"
+            hide-icon-in-tile-view
+            data-test-id="restaurant-availability-type"
+            :class="[$style['c-restaurantCard-availability-iconText']]">
+            <component
+                :is="icon"
+                v-if="icon"
+                aria-hidden="true"
+                data-test-id="restaurant-availability-icon" />
+        </icon-text>
+
+        <p
+            v-if="detailsMessage"
+            data-test-id="restaurant-availability-detailsMessage"
+            :class="[$style['c-restaurantCard-availability-detailsMessage']]">
+            {{ detailsMessage }}
+        </p>
+    </div>
+</template>
+
+<script>
+import { ClockSmallIcon, WalkingSmallIcon } from '@justeat/f-vue-icons';
+import isValidAvailabilityType from './propValidators/availabilityType.validator';
+import availabilityTypes from './availabilityTypes';
+
+import IconText from '../IconText.vue';
+
+const availabilityTypeIcons = {
+    [availabilityTypes.PREORDER]: ClockSmallIcon,
+    [availabilityTypes.COLLECTION]: WalkingSmallIcon
+};
+
+const iconColors = {
+    [availabilityTypes.PREORDER]: 'blue'
+};
+
+export default {
+    name: 'RestaurantAvailability',
+    components: {
+        IconText,
+        ClockSmallIcon,
+        WalkingSmallIcon
+    },
+    props: {
+        // The type of availability i.e. Pre-order, Collection
+        availabilityType: {
+            type: String,
+            default: null,
+            validator: isValidAvailabilityType
+        },
+        // The translated version of the availability type for the current tenant i.e. 'Pre-order', 'Preordina'
+        availabilityTranslatedName: {
+            type: String,
+            default: null
+        },
+        // The accompanying message for the availability type. i.e Opening times, delivering from...
+        detailsMessage: {
+            type: String,
+            default: null
+        }
+    },
+    computed: {
+        icon () {
+            return availabilityTypeIcons[this.availabilityType] || null;
+        },
+        iconColor () {
+            return iconColors[this.availabilityType] || null;
+        }
+    }
+};
+</script>
+
+<style lang="scss" module>
+.c-restaurantCard-availability {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+
+    svg {
+        height: 16px;
+    }
+}
+
+.c-restaurantCard-availability-iconText,
+.c-restaurantCard-availability-detailsMessage {
+    overflow-wrap: break-word;
+    @include font-size($font-paragraph-02);
+}
+
+.c-restaurantCard-availability-iconText {
+    &:after {
+        content: '\2022'; // round bullet character
+        color: $color-content-subdued;
+        line-height: 1;
+        margin: 0 spacing(x0.5);
+    }
+}
+
+.c-restaurantCard-availability-detailsMessage {
+    margin-top: 0;
+}
+</style>

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
@@ -27,7 +27,6 @@
 import { ClockSmallIcon, WalkingSmallIcon } from '@justeat/f-vue-icons';
 import isValidAvailabilityType from './propValidators/availabilityType.validator';
 import availabilityTypes from './availabilityTypes';
-
 import IconText from '../IconText.vue';
 
 const availabilityTypeIcons = {
@@ -47,7 +46,7 @@ export default {
         WalkingSmallIcon
     },
     props: {
-        // The type of availability i.e. Pre-order, Collection
+        // A string representation of pre-defined availability types: PREORDER, COLLECTION
         availabilityType: {
             type: String,
             default: null,

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
@@ -15,10 +15,10 @@
         </icon-text>
 
         <p
-            v-if="message"
+            v-if="availabilityMessage"
             data-test-id="restaurant-availability-message"
             :class="[$style['c-restaurantCard-availability-message']]">
-            {{ message }}
+            {{ availabilityMessage }}
         </p>
     </div>
 </template>
@@ -58,7 +58,7 @@ export default {
             default: null
         },
         // The accompanying message for the availability type. i.e Opening times, delivering from...
-        message: {
+        availabilityMessage: {
             type: String,
             default: null
         }

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
@@ -14,12 +14,12 @@
                 data-test-id="restaurant-availability-icon" />
         </icon-text>
 
-        <p
+        <span
             v-if="availabilityMessage"
             data-test-id="restaurant-availability-message"
             :class="[$style['c-restaurantCard-availability-message']]">
             {{ availabilityMessage }}
-        </p>
+        </span>
     </div>
 </template>
 
@@ -98,9 +98,5 @@ export default {
         line-height: 1;
         margin: 0 spacing(x0.5);
     }
-}
-
-.c-restaurantCard-availability-message {
-    margin-top: 0;
 }
 </style>

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/_tests/RestaurantAvailability.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/_tests/RestaurantAvailability.test.js
@@ -37,10 +37,10 @@ describe('RestaurantAvailability.vue', () => {
         expect(wrapper.find('[data-test-id="restaurant-availability-type"]').exists()).toBe(false);
     });
 
-    it('displays the `message` if provided', () => {
+    it('displays the `availabilityMessage` if provided', () => {
         // arrange
         const propsData = {
-            message: 'foo'
+            availabilityMessage: 'foo'
         };
 
         // act
@@ -48,10 +48,10 @@ describe('RestaurantAvailability.vue', () => {
         const renderedText = wrapper.find('[data-test-id="restaurant-availability-message"]').text();
 
         // assert
-        expect(renderedText).toStrictEqual(propsData.message);
+        expect(renderedText).toStrictEqual(propsData.availabilityMessage);
     });
 
-    it('does not display the `message` if not provided', () => {
+    it('does not display the `availabilityMessage` if not provided', () => {
         // arrange
         const propsData = {};
 

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/_tests/RestaurantAvailability.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/_tests/RestaurantAvailability.test.js
@@ -79,7 +79,7 @@ describe('RestaurantAvailability.vue', () => {
     });
 
     it.each([
-        ['blue', availabilityTypes.PREORDER],
+        ['colorSupportInfo', availabilityTypes.PREORDER],
         [null, availabilityTypes.COLLECTION]
     ])('sets the color as %p when the `availabilityType` is %p', (expectedColor, availabilityType) => {
         // arrange

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/_tests/RestaurantAvailability.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/_tests/RestaurantAvailability.test.js
@@ -37,21 +37,21 @@ describe('RestaurantAvailability.vue', () => {
         expect(wrapper.find('[data-test-id="restaurant-availability-type"]').exists()).toBe(false);
     });
 
-    it('displays the `detailsMessage` if provided', () => {
+    it('displays the `message` if provided', () => {
         // arrange
         const propsData = {
-            detailsMessage: 'foo'
+            message: 'foo'
         };
 
         // act
         const wrapper = mount(sut, { propsData });
-        const renderedText = wrapper.find('[data-test-id="restaurant-availability-detailsMessage"]').text();
+        const renderedText = wrapper.find('[data-test-id="restaurant-availability-message"]').text();
 
         // assert
-        expect(renderedText).toStrictEqual(propsData.detailsMessage);
+        expect(renderedText).toStrictEqual(propsData.message);
     });
 
-    it('does not display the `detailsMessage` if not provided', () => {
+    it('does not display the `message` if not provided', () => {
         // arrange
         const propsData = {};
 
@@ -59,7 +59,7 @@ describe('RestaurantAvailability.vue', () => {
         const wrapper = mount(sut, { propsData });
 
         // assert
-        expect(wrapper.find('[data-test-id="restaurant-availability-detailsMessage"]').exists()).toBe(false);
+        expect(wrapper.find('[data-test-id="restaurant-availability-message"]').exists()).toBe(false);
     });
 
     it.each([

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/_tests/RestaurantAvailability.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/_tests/RestaurantAvailability.test.js
@@ -1,0 +1,96 @@
+import { mount } from '@vue/test-utils';
+import { ClockSmallIcon, WalkingSmallIcon } from '@justeat/f-vue-icons';
+import availabilityTypes from '../availabilityTypes';
+import sut from '../RestaurantAvailability.vue';
+
+describe('RestaurantAvailability.vue', () => {
+    it('is defined', () => {
+        // act
+        const wrapper = mount(sut);
+
+        // assert
+        expect(wrapper.exists()).toBe(true);
+    });
+
+    it('displays the `availabilityTranslatedName` if provided', () => {
+        // arrange
+        const propsData = {
+            availabilityTranslatedName: 'foo'
+        };
+
+        // act
+        const wrapper = mount(sut, { propsData });
+        const renderedText = wrapper.find('[data-test-id="restaurant-availability-type"]').text();
+
+        // assert
+        expect(renderedText).toStrictEqual(propsData.availabilityTranslatedName);
+    });
+
+    it('does not display the `availabilityTranslatedName` if not provided', () => {
+        // arrange
+        const propsData = {};
+
+        // act
+        const wrapper = mount(sut, { propsData });
+
+        // assert
+        expect(wrapper.find('[data-test-id="restaurant-availability-type"]').exists()).toBe(false);
+    });
+
+    it('displays the `detailsMessage` if provided', () => {
+        // arrange
+        const propsData = {
+            detailsMessage: 'foo'
+        };
+
+        // act
+        const wrapper = mount(sut, { propsData });
+        const renderedText = wrapper.find('[data-test-id="restaurant-availability-detailsMessage"]').text();
+
+        // assert
+        expect(renderedText).toStrictEqual(propsData.detailsMessage);
+    });
+
+    it('does not display the `detailsMessage` if not provided', () => {
+        // arrange
+        const propsData = {};
+
+        // act
+        const wrapper = mount(sut, { propsData });
+
+        // assert
+        expect(wrapper.find('[data-test-id="restaurant-availability-detailsMessage"]').exists()).toBe(false);
+    });
+
+    it.each([
+        [ClockSmallIcon, availabilityTypes.PREORDER],
+        [WalkingSmallIcon, availabilityTypes.COLLECTION]
+    ])('uses the correct icon when the `availabilityType` is %p', (expectedIcon, availabilityType) => {
+        // arrange
+        const propsData = {
+            availabilityType
+        };
+
+        // act
+        const wrapper = mount(sut, { propsData });
+
+        // assert
+        expect(wrapper.vm.icon).toStrictEqual(expectedIcon);
+    });
+
+    it.each([
+        ['blue', availabilityTypes.PREORDER],
+        [null, availabilityTypes.COLLECTION]
+    ])('sets the color as %p when the `availabilityType` is %p', (expectedColor, availabilityType) => {
+        // arrange
+        const propsData = {
+            availabilityType
+        };
+
+        // act
+        const wrapper = mount(sut, { propsData });
+
+        // assert
+        expect(wrapper.vm.iconColor).toStrictEqual(expectedColor);
+    });
+});

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/availabilityTypes.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/availabilityTypes.js
@@ -1,0 +1,6 @@
+const availabilityTypes = {
+    PREORDER: 'PREORDER',
+    COLLECTION: 'COLLECTION'
+};
+
+export default availabilityTypes;

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/propValidators/_tests/availabilityType.validator.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/propValidators/_tests/availabilityType.validator.test.js
@@ -1,0 +1,26 @@
+import availabilityTypes from '../../availabilityTypes';
+import sut from '../availabilityType.validator';
+
+describe('availabilityType.validator', () => {
+    it.each([
+        availabilityTypes.PREORDER,
+        availabilityTypes.COLLECTION
+    ])('returns `true` if a type of %p is provided', availabilityType => {
+        // act
+        const result = sut(availabilityType);
+
+        // assert
+        expect(result).toBe(true);
+    });
+
+    it('returns `false` if an unrecognised availability type is provided', () => {
+        // arrange
+        const availabilityType = 'foo';
+
+        // act
+        const result = sut(availabilityType);
+
+        // assert
+        expect(result).toBe(false);
+    });
+});

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/propValidators/availabilityType.validator.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/propValidators/availabilityType.validator.js
@@ -1,0 +1,5 @@
+import availabilityTypes from '../availabilityTypes';
+
+const isValidAvailabilityType = value => !!availabilityTypes[value];
+
+export default isValidAvailabilityType;

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantAvailability.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantAvailability.stories.js
@@ -1,0 +1,26 @@
+// Uncomment the import below to add prop controls to your Story (and add `withKnobs` to the decorators array)
+// import {
+//     withKnobs, select, boolean
+// } from '@storybook/addon-knobs';
+import { withA11y } from '@storybook/addon-a11y';
+import RestaurantAvailability from '../src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue';
+import availabilityTypes from '../src/components/subcomponents/RestaurantAvailability/availabilityTypes';
+
+export default {
+    title: 'Components/Molecules/f-restaurant-card',
+    decorators: [withA11y]
+};
+
+export const RestaurantAvailabilityComponent = (args, { argTypes }) => ({
+    components: { RestaurantAvailability },
+    props: Object.keys(argTypes),
+    template:  '<restaurant-availability v-bind="$props" />'
+});
+
+RestaurantAvailabilityComponent.args = {
+    availabilityType: availabilityTypes.COLLECTION,
+    availabilityTranslatedName: 'Pre-order',
+    detailsMessage: 'Opening at 13:20'
+};
+
+RestaurantAvailabilityComponent.storyName = 'restaurant-availability';

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantAvailability.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantAvailability.stories.js
@@ -20,7 +20,7 @@ export const RestaurantAvailabilityComponent = (args, { argTypes }) => ({
 RestaurantAvailabilityComponent.args = {
     availabilityType: availabilityTypes.COLLECTION,
     availabilityTranslatedName: 'Pre-order',
-    detailsMessage: 'Opening at 13:20'
+    message: 'Opening at 13:20'
 };
 
 RestaurantAvailabilityComponent.storyName = 'restaurant-availability';

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantAvailability.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantAvailability.stories.js
@@ -20,7 +20,7 @@ export const RestaurantAvailabilityComponent = (args, { argTypes }) => ({
 RestaurantAvailabilityComponent.args = {
     availabilityType: availabilityTypes.COLLECTION,
     availabilityTranslatedName: 'Pre-order',
-    message: 'Opening at 13:20'
+    availabilityMessage: 'Opening at 13:20'
 };
 
 RestaurantAvailabilityComponent.storyName = 'restaurant-availability';

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
@@ -75,7 +75,7 @@ RestaurantCardComponent.args = {
         availability: {
             availabilityType: availabilityTypes.PREORDER,
             availabilityTranslatedName: 'Pre-order',
-            detailsMessage: 'Opening at 13:20'
+            message: 'Opening at 13:20'
         }
     },
 

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
@@ -6,6 +6,7 @@ import { withA11y } from '@storybook/addon-a11y';
 import RestaurantCard from '../src/components/RestaurantCard.vue';
 import restaurantLogo from './assets/images/mcdonalds-logo.gif';
 import restaurantImage from './assets/images/mcdonalds.webp';
+import availabilityTypes from '../src/components/subcomponents/RestaurantAvailability/availabilityTypes';
 
 export default {
     title: 'Components/Molecules/f-restaurant-card',
@@ -74,6 +75,11 @@ RestaurantCardComponent.args = {
         fees: {
             deliveryFeeText: '£2.50 delivery fee',
             minOrderText: 'No min. order'
+        },
+        availability: {
+            availabilityType: availabilityTypes.PREORDER,
+            availabilityTranslatedName: 'Pre-order',
+            detailsMessage: 'Opening at 13:20'
         }
     },
 

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
@@ -16,11 +16,7 @@ export default {
 export const RestaurantCardComponent = (args, { argTypes }) => ({
     components: { RestaurantCard },
     props: Object.keys(argTypes),
-    template:  `<restaurant-card v-bind="$props">
-                    <template v-slot:new-label>
-                        <p>Is New</p>
-                    </template>
-                </restaurant-card>`
+    template:  '<restaurant-card v-bind="$props"/>'
 });
 
 RestaurantCardComponent.args = {

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
@@ -75,7 +75,7 @@ RestaurantCardComponent.args = {
         availability: {
             availabilityType: availabilityTypes.PREORDER,
             availabilityTranslatedName: 'Pre-order',
-            message: 'Opening at 13:20'
+            availabilityMessage: 'Opening at 13:20'
         }
     },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2454,6 +2454,13 @@
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
 
+"@justeat/f-vue-icons@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-3.4.0.tgz#47743051d93e7a320d95bd2b7bd5e83580d60480"
+  integrity sha512-DK3uvkXqm7tjB0yDHdOaUVoOtKeBQb/WKAp0FnlnXCzl1YiOenNVggVcdqLLAmQn9GSZuhVK+aECCbDeohDjgQ==
+  dependencies:
+    babel-helper-vue-jsx-merge-props "2.0.3"
+
 "@justeat/f-wdio-utils@0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.4.0.tgz#6916a392777c88bc84e0d5a258e7e94c64ff7800"


### PR DESCRIPTION
v0.16.0
------------------------------
*Februrary 02, 2022*

### Added
- New `RestaurantAvailability` component for displaying pre-order and collection info
- Supporting unit tests
- New blue colour variant to `IconText` class modifiers
- Storybook file for the `RestaurantAvailability` component
### Changed
- Updated f-vue-icons to `3.5.0`
- Use new clock-small icon on ETA
- Directly target the SVG path elements in `IconText` colour modifiers to avoid default fills present in some icons
- Simplified restaurant Storybook selector

<img width="595" alt="Screenshot 2022-02-02 at 13 52 20" src="https://user-images.githubusercontent.com/16766185/152166803-2a3339ee-6132-42eb-8470-5cf23b9158b3.png">
<img width="608" alt="Screenshot 2022-02-02 at 13 51 25" src="https://user-images.githubusercontent.com/16766185/152166806-7d7c90cb-b380-453a-91b4-30bde00d9903.png">
