### PR TITLE
f-restaurant-card@0.16.1 - use new spacing values

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.16.1
+------------------------------
+*Februrary 03, 2022*
+### Changed
+- Use new `spacing()` values
+
 v0.16.0
 ------------------------------
 *Februrary 02, 2022*

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
@@ -96,7 +96,7 @@ export default {
         content: '\2022'; // round bullet character
         color: $color-content-subdued;
         line-height: 1;
-        margin: 0 spacing(x0.5);
+        margin: 0 spacing(a);
     }
 }
 </style>


### PR DESCRIPTION
v0.16.1
------------------------------
*Februrary 03, 2022*
### Changed
- Use new `spacing()` values