### PR TITLE
f-restaurant-card@v0.17.0 - disabled restaurant message

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -10,7 +10,8 @@ v0.17.0
 - new `disabledMessage` prop that is rendered when a restaurant is disabled
 - unit tests to test `disabledMessage` rendering logic
 ### Changed
-- rename `disabled` prop to `isDisabled`
+- remove `disabled` prop
+- remove any disabled check business logic from component
 - add new color support to `IconText` component
 - simplify SCSS color theme logic in `IconText` component using a mixin
 - update storybook with the new prop changes

--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -13,6 +13,7 @@ v0.17.0
 - rename `disabled` prop to `isDisabled`
 - add new color support to `IconText` component
 - simplify SCSS color theme logic in `IconText` component using a mixin
+- update storybook with the new prop changes
 
 
 v0.16.1

--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.17.0
+------------------------------
+*Februrary 07, 2022*
+### Added
+- new `disabledMessage` prop that is rendered when a restaurant is disabled
+- unit tests to test `disabledMessage` rendering logic
+### Changed
+- rename `disabled` prop to `isDisabled`
+- add new color support to `IconText` component
+- simplify SCSS color theme logic in `IconText` component using a mixin
+
+
 v0.16.1
 ------------------------------
 *Februrary 03, 2022*

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -12,7 +12,7 @@
         <!-- background image -->
         <restaurant-image
             :class="[$style['c-restaurantCard-img']]"
-            :img-url="imgUrl">
+            :img-url="imageUrl">
             <!-- Logo image -->
             <restaurant-logo
                 v-if="logoUrl"
@@ -129,6 +129,16 @@
                 is-bold>
                 <offer-icon />
             </icon-text>
+
+            <!-- Disabled Message -->
+            <icon-text
+                v-if="isDisabled && disabledMessage"
+                data-test-id="restaurant-disabled"
+                :text="disabledMessage"
+                color="colorSupportError"
+                hide-icon-in-tile-view>
+                <clock-small-icon />
+            </icon-text>
         </div>
 
         <!-- Dishes -->
@@ -146,7 +156,7 @@
 </template>
 
 <script>
-import { OfferIcon, LegendIcon } from '@justeat/f-vue-icons';
+import { OfferIcon, LegendIcon, ClockSmallIcon } from '@justeat/f-vue-icons';
 import ErrorBoundaryMixin from '../assets/vue/mixins/errorBoundary.mixin';
 import RestaurantImage from './subcomponents/RestaurantImage/RestaurantImage.vue';
 import RestaurantLogo from './subcomponents/RestaurantLogo/RestaurantLogo.vue';
@@ -175,6 +185,7 @@ export default {
         IconText,
         OfferIcon,
         LegendIcon,
+        ClockSmallIcon,
         RestaurantFees,
         RestaurantAvailability,
         RenderlessSlotWrapper
@@ -206,10 +217,6 @@ export default {
         imgUrl: {
             type: String,
             default: null
-        },
-        disabled: {
-            type: Boolean,
-            default: false
         },
         isListItem: {
             type: Boolean,
@@ -259,6 +266,14 @@ export default {
         availability: {
             type: Object,
             default: null
+        },
+        isDisabled: {
+            type: Boolean,
+            default: false
+        },
+        disabledMessage: {
+            type: String,
+            default: null
         }
     },
     computed: {
@@ -281,6 +296,11 @@ export default {
         },
         hasFees () {
             return !!this.fees?.deliveryFeeText || !!this.fees?.minOrderText;
+        },
+        imageUrl () {
+            return this.isDisabled
+                ? null
+                : this.imgUrl;
         }
     }
 };

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -12,7 +12,7 @@
         <!-- background image -->
         <restaurant-image
             :class="[$style['c-restaurantCard-img']]"
-            :img-url="imageUrl">
+            :img-url="imgUrl">
             <!-- Logo image -->
             <restaurant-logo
                 v-if="logoUrl"
@@ -296,11 +296,6 @@ export default {
         },
         hasFees () {
             return !!this.fees?.deliveryFeeText || !!this.fees?.minOrderText;
-        },
-        imageUrl () {
-            return this.isDisabled
-                ? null
-                : this.imgUrl;
         }
     }
 };

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.v1.vue
@@ -132,7 +132,7 @@
 
             <!-- Disabled Message -->
             <icon-text
-                v-if="isDisabled && disabledMessage"
+                v-if="disabledMessage"
                 data-test-id="restaurant-disabled"
                 :text="disabledMessage"
                 color="colorSupportError"
@@ -144,7 +144,7 @@
         <!-- Dishes -->
         <component
             :is="errorBoundary"
-            v-if="!disabled && hasDishes"
+            v-if="hasDishes"
             :tier="3">
             <restaurant-dishes
                 data-test-id="restaurant-dishes"
@@ -266,10 +266,6 @@ export default {
         availability: {
             type: Object,
             default: null
-        },
-        isDisabled: {
-            type: Boolean,
-            default: false
         },
         disabledMessage: {
             type: String,

--- a/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.v1.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.v1.test.js
@@ -298,4 +298,56 @@ describe('RestaurantCard.v1', () => {
             expect(wrapper.find('[data-test-id="restaurant-fees"]').exists()).toBe(true);
         });
     });
+
+    describe('Disabled Message', () => {
+        it('displays a disabled message if one is provided and `isDisabled` is true', () => {
+            // arrange
+            const propsData = {
+                isDisabled: true,
+                disabledMessage: 'foo bar baz'
+            };
+
+            // act
+            const wrapper = mount(RestaurantCardV1, { propsData });
+
+            // assert
+            expect(wrapper.find('[data-test-id="restaurant-disabled"]').exists()).toBe(true);
+        });
+
+        it.each([
+            null,
+            undefined,
+            ''
+        ])('does not display a disabled message if none exists', disabledMessage => {
+            // arrange
+            const propsData = {
+                isDisabled: true,
+                disabledMessage
+            };
+
+            // act
+            const wrapper = mount(RestaurantCardV1, { propsData });
+
+            // assert
+            expect(wrapper.find('[data-test-id="restaurant-disabled"]').exists()).toBe(false);
+        });
+
+        it.each([
+            false,
+            null,
+            undefined
+        ])('does not display a disabled message if `isDisabled` is falsey', isDisabled => {
+            // arrange
+            const propsData = {
+                isDisabled,
+                disabledMessage: 'foo bar baz'
+            };
+
+            // act
+            const wrapper = mount(RestaurantCardV1, { propsData });
+
+            // assert
+            expect(wrapper.find('[data-test-id="restaurant-disabled"]').exists()).toBe(false);
+        });
+    });
 });

--- a/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.v1.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.v1.test.js
@@ -300,10 +300,9 @@ describe('RestaurantCard.v1', () => {
     });
 
     describe('Disabled Message', () => {
-        it('displays a disabled message if one is provided and `isDisabled` is true', () => {
+        it('displays a disabled message if one is provided', () => {
             // arrange
             const propsData = {
-                isDisabled: true,
                 disabledMessage: 'foo bar baz'
             };
 
@@ -321,26 +320,7 @@ describe('RestaurantCard.v1', () => {
         ])('does not display a disabled message if none exists', disabledMessage => {
             // arrange
             const propsData = {
-                isDisabled: true,
                 disabledMessage
-            };
-
-            // act
-            const wrapper = mount(RestaurantCardV1, { propsData });
-
-            // assert
-            expect(wrapper.find('[data-test-id="restaurant-disabled"]').exists()).toBe(false);
-        });
-
-        it.each([
-            false,
-            null,
-            undefined
-        ])('does not display a disabled message if `isDisabled` is falsey', isDisabled => {
-            // arrange
-            const propsData = {
-                isDisabled,
-                disabledMessage: 'foo bar baz'
             };
 
             // act

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/IconText.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/IconText.vue
@@ -65,6 +65,13 @@ export default {
 </script>
 
 <style lang="scss" module>
+@mixin themedColor($color) {
+    color: $color;
+    path {
+        fill: $color;
+    }
+}
+
 .c-restaurantCard-iconText {
     @include font-size();
     margin: spacing() 0;
@@ -94,15 +101,14 @@ export default {
 }
 
 .c-restaurantCard-iconText--colorSupportPositive {
-    color: $color-support-positive;
-    path {
-        fill: $color-support-positive;
-    }
+    @include themedColor($color-support-positive);
 }
+
 .c-restaurantCard-iconText--colorSupportInfo {
-    color: $color-support-info;
-    path {
-        fill: $color-support-info;
-    }
+    @include themedColor($color-support-info);
+}
+
+.c-restaurantCard-iconText--colorSupportError {
+    @include themedColor($color-support-error);
 }
 </style>

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
@@ -76,7 +76,6 @@ RestaurantCardComponent.args = {
             availabilityTranslatedName: 'Pre-order',
             availabilityMessage: 'Opening at 13:20'
         },
-        isDisabled: false,
         disabledMessage: 'Not taking orders at the moment'
     },
 

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
@@ -23,7 +23,6 @@ RestaurantCardComponent.args = {
     data: {
         id: '00000',
         name: 'McDonald\'s® - Clapham Junction',
-        disabled: false,
         logoUrl: restaurantLogo,
         imgUrl: restaurantImage,
         isListItem: true,
@@ -76,7 +75,9 @@ RestaurantCardComponent.args = {
             availabilityType: availabilityTypes.PREORDER,
             availabilityTranslatedName: 'Pre-order',
             availabilityMessage: 'Opening at 13:20'
-        }
+        },
+        isDisabled: false,
+        disabledMessage: 'Not taking orders at the moment'
     },
 
     flags: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2247,6 +2247,17 @@
   dependencies:
     "@justeat/f-services" "1.0.0"
 
+"@justeat/f-braze-adapter@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-braze-adapter/-/f-braze-adapter-4.0.0.tgz#343be7a2210d457868cdbb7c594270295bcf8280"
+  integrity sha512-mvaon/eXd7AnNlHI7qjUvkztltcKCOe+e+pTZineZfWnisLvCtNynoQZy8AmdHD5a9buNaGnX6vk0c9kCO6CEw==
+  dependencies:
+    date-fns "2.16.1"
+    lodash.findindex "4.6.0"
+    lodash.orderby "4.6.0"
+    lodash.startswith "4.2.1"
+    lodash.uniq "4.5.0"
+
 "@justeat/f-button@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-3.0.2.tgz#9560d0caf56ae0801208ddd0c27cb50d670d54a8"
@@ -2327,6 +2338,14 @@
     "@justeat/f-services" "1.0.0"
     "@justeat/f-vue-icons" "2.5.0"
 
+"@justeat/f-form-field@4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-4.6.0.tgz#eb70e7aebba7fb2bddb80be012e3f7b0dee069f8"
+  integrity sha512-/lj9c1W06hTHX+//qmScJZhHTkkKC2kZrQ4bWQvdF9cB1Ph07kldpDt+uUBtS5FJl/8szE9kSjplK29MtsSDjQ==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+    "@justeat/f-vue-icons" "2.5.0"
+
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-0.2.0.tgz#90ec559642c165b6325669c506c417abe09fa5dd"
@@ -2373,13 +2392,6 @@
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-navigation-links/-/f-navigation-links-0.3.0.tgz#73475aec7110f8be32b58e2d5250f62ba92295a8"
   integrity sha512-qcImxIiXRY57/54Piu/i9zZ6k7mRsnxHHcdnuPJvGAxbWDPNJIcWgJL07tMEedLVeZ+OM3Pg9KEkC983Hrc8vg==
-
-"@justeat/f-popover@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-popover/-/f-popover-2.0.0.tgz#2f7c337a56a209aec96b009aacf4dfc646e3bdc3"
-  integrity sha512-64EtGfhMk2YFkJ8LB+Q7XhjyQp83RRMS84Xout1nkQg0E5iBzGs+7G5JLUT6fSspZOxqpsuGjwQinbcIwajj3w==
-  dependencies:
-    "@justeat/f-services" "1.7.0"
 
 "@justeat/f-searchbox@6.0.0":
   version "6.0.0"


### PR DESCRIPTION
v0.17.0
------------------------------
*Februrary 07, 2022*
### Added
- new `disabledMessage` prop that is rendered when a restaurant is disabled
- unit tests to test `disabledMessage` rendering logic
### Changed
- remove `disabled` prop
- remove any disabled check business logic from component
- add new color support to `IconText` component
- simplify SCSS color theme logic in `IconText` component using a mixin
- update storybook with the new prop changes

## UI Review Checks
<img width="250" alt="Screenshot 2022-02-07 at 12 45 52" src="https://user-images.githubusercontent.com/16766185/152790657-c583b6e7-c8a2-4559-9f94-b1e644ee2ea1.png">
Example in SearchWeb
<img width="698" alt="Screenshot 2022-02-07 at 12 52 22" src="https://user-images.githubusercontent.com/16766185/152791599-822a0f4c-2b73-49de-af17-870a5af89402.png">

- [X] Unit tests have been [created|updated]

## Browsers Tested

- [X] Chrome (latest)
