### PR TITLE
f-braze-adapter@v4.2.0  - url location substitution

### DIFF
--- a/packages/services/f-braze-adapter/CHANGELOG.md
+++ b/packages/services/f-braze-adapter/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.2.0
+------------------------------
+*February 08, 2022*
+
+### Added
+- urlLocationSubstitution filter to replace any URL placeholders
+- tests for new filter
+
+
 v4.1.0
 ------------------------------
 *January 18, 2022*

--- a/packages/services/f-braze-adapter/package.json
+++ b/packages/services/f-braze-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-braze-adapter",
   "description": "Fozzie Metadata Service",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "main": "dist/f-braze-adapter.umd.js",
   "module": "dist/f-braze-adapter.es.js",
   "files": [

--- a/packages/services/f-braze-adapter/src/services/BrazeConsumer.js
+++ b/packages/services/f-braze-adapter/src/services/BrazeConsumer.js
@@ -18,6 +18,7 @@ import dispatcherEventStream from './DispatcherEventStream';
 import { LOGGER } from './types/events';
 import { LOG_ERROR, LOG_INFO } from './types/logger';
 import locationFilter from './utils/locationFilter';
+import urlLocationSubstitution from './utils/urlLocationSubstitution';
 
 class BrazeConsumer {
     /**
@@ -111,7 +112,8 @@ class BrazeConsumer {
             cards => filterByEnabledCardTypes(cards, this.enabledCardTypes),
             cards => filterByBrands(cards, this.brands),
             filterByCurrentlyActive,
-            cards => locationFilter(cards, currentLocation)
+            cards => locationFilter(cards, currentLocation),
+            cards => urlLocationSubstitution(cards, currentLocation)
         ];
 
         this._cards = [];

--- a/packages/services/f-braze-adapter/src/services/_tests/BrazeConsumer.test.js
+++ b/packages/services/f-braze-adapter/src/services/_tests/BrazeConsumer.test.js
@@ -5,6 +5,7 @@ import transformCardData from '../utils/transformCardData';
 const mockCards = [
     {
         title: '51 Pegasi b',
+        url: 'https://just-eat.co.uk/search?location=$LOCATION&lat=$LAT&lon=$LON',
         extras: {
             updated: '2020-02-17T13:23:58.000Z',
             custom_card_type: 'Promotion_Card_1', // eslint-disable-line camelcase
@@ -13,6 +14,7 @@ const mockCards = [
     },
     {
         title: 'Wasp-17b',
+        url: 'https://just-eat.co.uk/search?location=$LOCATION&lat=$LAT&lon=$LON',
         extras: {
             updated: '2020-02-16T12:28:58.000Z',
             custom_card_type: 'Promotion_Card_2', // eslint-disable-line camelcase
@@ -21,6 +23,7 @@ const mockCards = [
     },
     {
         title: 'Wasp-19b',
+        url: 'https://just-eat.co.uk/search?location=$LOCATION&lat=$LAT&lon=$LON',
         extras: {
             updated: '2020-02-15T18:23:58.000Z',
             custom_card_type: 'Promotion_Card_3', // eslint-disable-line camelcase

--- a/packages/services/f-braze-adapter/src/services/_tests/BrazeConsumer.test.js
+++ b/packages/services/f-braze-adapter/src/services/_tests/BrazeConsumer.test.js
@@ -5,7 +5,6 @@ import transformCardData from '../utils/transformCardData';
 const mockCards = [
     {
         title: '51 Pegasi b',
-        url: 'https://just-eat.co.uk/search?location=$LOCATION&lat=$LAT&lon=$LON',
         extras: {
             updated: '2020-02-17T13:23:58.000Z',
             custom_card_type: 'Promotion_Card_1', // eslint-disable-line camelcase
@@ -14,7 +13,6 @@ const mockCards = [
     },
     {
         title: 'Wasp-17b',
-        url: 'https://just-eat.co.uk/search?location=$LOCATION&lat=$LAT&lon=$LON',
         extras: {
             updated: '2020-02-16T12:28:58.000Z',
             custom_card_type: 'Promotion_Card_2', // eslint-disable-line camelcase
@@ -23,7 +21,6 @@ const mockCards = [
     },
     {
         title: 'Wasp-19b',
-        url: 'https://just-eat.co.uk/search?location=$LOCATION&lat=$LAT&lon=$LON',
         extras: {
             updated: '2020-02-15T18:23:58.000Z',
             custom_card_type: 'Promotion_Card_3', // eslint-disable-line camelcase

--- a/packages/services/f-braze-adapter/src/services/utils/_tests/urlLocationSubstitution.test.js
+++ b/packages/services/f-braze-adapter/src/services/utils/_tests/urlLocationSubstitution.test.js
@@ -17,7 +17,7 @@ const MOCK_CARDS = [
 ];
 
 describe('urlLocationSubstitution', () => {
-    it('should substitute the $LOCATION marker when passed in card url', () => {
+    it('should substitute the $LOCATION$ marker when passed in card url', () => {
         // Arrange & act
         const [card] = urlLocationSubstitution(MOCK_CARDS, MOCK_CUSTOMER_LOCATION);
         const { url } = card;
@@ -26,7 +26,7 @@ describe('urlLocationSubstitution', () => {
         expect(url).toContain(MOCK_CUSTOMER_LOCATION.location);
     });
 
-    it('should substitute the $LON marker when passed in card url', () => {
+    it('should substitute the $LON$ marker when passed in card url', () => {
         // Arrange & act
         const [card] = urlLocationSubstitution(MOCK_CARDS, MOCK_CUSTOMER_LOCATION);
         const { url } = card;
@@ -35,7 +35,7 @@ describe('urlLocationSubstitution', () => {
         expect(url).toContain(MOCK_CUSTOMER_LOCATION.longitude);
     });
 
-    it('should substitute the $LAT marker when passed in card url', () => {
+    it('should substitute the $LAT$ marker when passed in card url', () => {
         // Arrange & act
         const [card] = urlLocationSubstitution(MOCK_CARDS, MOCK_CUSTOMER_LOCATION);
         const { url } = card;

--- a/packages/services/f-braze-adapter/src/services/utils/_tests/urlLocationSubstitution.test.js
+++ b/packages/services/f-braze-adapter/src/services/utils/_tests/urlLocationSubstitution.test.js
@@ -8,7 +8,7 @@ const MOCK_CUSTOMER_LOCATION = {
 const MOCK_CARDS = [
     {
         id: '1',
-        url: 'https://just-eat.co.uk/search?location=$LOCATION&lat=$LAT&lon=$LON'
+        url: 'https://just-eat.co.uk/search?location=$LOCATION$&lat=$LAT$&lon=$LON$'
     },
     {
         id: '2',

--- a/packages/services/f-braze-adapter/src/services/utils/_tests/urlLocationSubstitution.test.js
+++ b/packages/services/f-braze-adapter/src/services/utils/_tests/urlLocationSubstitution.test.js
@@ -1,0 +1,46 @@
+import urlLocationSubstitution from '../urlLocationSubstitution';
+
+const MOCK_CUSTOMER_LOCATION = {
+    location: 'BS1 3EQ',
+    longitude: '54.567',
+    latitude: '96.987'
+};
+const MOCK_CARDS = [
+    {
+        id: '1',
+        url: 'https://just-eat.co.uk/search?location=$LOCATION&lat=$LAT&lon=$LON'
+    },
+    {
+        id: '2',
+        url: 'https://just-eat.co.uk/search'
+    }
+];
+
+describe('urlLocationSubstitution', () => {
+    it('should substitute the $LOCATION marker when passed in card url', () => {
+        // Arrange & act
+        const [card] = urlLocationSubstitution(MOCK_CARDS, MOCK_CUSTOMER_LOCATION);
+        const { url } = card;
+
+        // Assert
+        expect(url).toContain(MOCK_CUSTOMER_LOCATION.location);
+    });
+
+    it('should substitute the $LON marker when passed in card url', () => {
+        // Arrange & act
+        const [card] = urlLocationSubstitution(MOCK_CARDS, MOCK_CUSTOMER_LOCATION);
+        const { url } = card;
+
+        // Assert
+        expect(url).toContain(MOCK_CUSTOMER_LOCATION.longitude);
+    });
+
+    it('should substitute the $LAT marker when passed in card url', () => {
+        // Arrange & act
+        const [card] = urlLocationSubstitution(MOCK_CARDS, MOCK_CUSTOMER_LOCATION);
+        const { url } = card;
+
+        // Assert
+        expect(url).toContain(MOCK_CUSTOMER_LOCATION.latitude);
+    });
+});

--- a/packages/services/f-braze-adapter/src/services/utils/urlLocationSubstitution.js
+++ b/packages/services/f-braze-adapter/src/services/utils/urlLocationSubstitution.js
@@ -8,7 +8,7 @@
  */
 const urlLocationSubstitution = (cards, { location, longitude, latitude }) => cards.map(card => ({
     ...card,
-    url: card.url.replace('$LOCATION', location).replace('$LAT', latitude).replace('$LON', longitude)
+    url: card?.url?.replace('$LOCATION', location).replace('$LAT', latitude).replace('$LON', longitude)
 }));
 
 export default urlLocationSubstitution;

--- a/packages/services/f-braze-adapter/src/services/utils/urlLocationSubstitution.js
+++ b/packages/services/f-braze-adapter/src/services/utils/urlLocationSubstitution.js
@@ -8,7 +8,7 @@
  */
 const urlLocationSubstitution = (cards, { location, longitude, latitude }) => cards.map(card => ({
     ...card,
-    url: card?.url?.replace('$LOCATION', location).replace('$LAT', latitude).replace('$LON', longitude)
+    url: card?.url?.replace('$LOCATION$', location).replace('$LAT$', latitude).replace('$LON$', longitude)
 }));
 
 export default urlLocationSubstitution;

--- a/packages/services/f-braze-adapter/src/services/utils/urlLocationSubstitution.js
+++ b/packages/services/f-braze-adapter/src/services/utils/urlLocationSubstitution.js
@@ -1,0 +1,14 @@
+/**
+ * Replaces any found location placeholders with users current location data
+ * @param cards
+ * @param location
+ * @param longitude
+ * @param latitude
+ * @returns {*}
+ */
+const urlLocationSubstitution = (cards, { location, longitude, latitude }) => cards.map(card => ({
+    ...card,
+    url: card.url.replace('$LOCATION', location).replace('$LAT', latitude).replace('$LON', longitude)
+}));
+
+export default urlLocationSubstitution;


### PR DESCRIPTION
PR adds a url placeholder replacement filter. It replaces `$LAT$`,`$LON$` and `$LOCATION$` placeholder values. I have added some unit tests to cover the filter. I have also updated the `BrazeConsumer` class to accept this new filter.
