### PR TITLE
f-restaurant-card@v0.18.0 - aria-label support for tags

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.18.0
+------------------------------
+*Februrary 11, 2022*
+### Changed
+- added aria-label support to `RestaurantTag` component
+- updated storybook with new aria label prop
+
 v0.17.0
 ------------------------------
 *Februrary 07, 2022*

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTag.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTag.vue
@@ -7,6 +7,7 @@
             [$style['c-restaurantTag--isUppercase']]: isUppercase
         }"
         :title="text"
+        :aria-label="ariaLabel"
         data-test-id="restaurant-tag">
         {{ text }}
     </span>
@@ -38,6 +39,10 @@ export default {
         isUppercase: {
             type: Boolean,
             default: false
+        },
+        ariaLabel: {
+            type: String,
+            default: null
         }
     }
 };

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/_tests/RestaurantTag.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/_tests/RestaurantTag.test.js
@@ -32,4 +32,36 @@ describe('RestaurantTag component', () => {
         // assert
         expect(wrapper.attributes('title')).toMatch(expectedTitle);
     });
+
+    it('sets an "aria-label" attribute to the text prop value', () => {
+        // arrange
+        const expectedAriaLabelText = 'foo';
+        const propsData = {
+            text: 'bar',
+            textColor: '#fff',
+            backgroundColor: '#222',
+            ariaLabel: expectedAriaLabelText
+        };
+
+        // act
+        const wrapper = shallowMount(RestaurantTag, { propsData });
+
+        // assert
+        expect(wrapper.attributes('aria-label')).toMatch(expectedAriaLabelText);
+    });
+
+    it('does not set an "aria-label" attribute if no prop is provided', () => {
+        // arrange
+        const propsData = {
+            text: 'bar',
+            textColor: '#fff',
+            backgroundColor: '#222'
+        };
+
+        // act
+        const wrapper = shallowMount(RestaurantTag, { propsData });
+
+        // assert
+        expect(wrapper.attributes('aria-label')).toBe(undefined);
+    });
 });

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
@@ -25,7 +25,7 @@ RestaurantCardComponent.args = {
         url: 'some-restaurant/12345',
         cuisines: ['Mexican', 'Burgers', 'Chinese'],
         tags: {
-            imageTags: [{ text: 'Promoted', colorScheme: 'dark' }, { text: 'StampCards', colorScheme: 'warm' }],
+            imageTags: [{ text: 'Promoted', colorScheme: 'dark' }, { text: 'StampCards', colorScheme: 'warm', ariaLabel: 'Stampcard Partner' }],
             contentTags: [{ text: 'BTA Winner' }, { text: 'Michelin Star' }, { text: 'Tried & Tasted' }, { text: 'New Ownership' }, { text: 'Delivered by Menulog' }, { text: 'A very very very super long unrealistic but necessary to test tag that hopefully never happens' }]
         },
         newTagText: 'new',

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantTag.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantTag.stories.js
@@ -22,7 +22,8 @@ export const RestaurantTagComponent = (args, { argTypes }) => ({
 RestaurantTagComponent.args = {
     text: 'Promoted',
     textColour: tagColourSchemes.promoted.text,
-    backgroundColour: tagColourSchemes.promoted.background
+    backgroundColour: tagColourSchemes.promoted.background,
+    ariaLabel: 'Foo bar'
 };
 
 RestaurantTagComponent.storyName = 'restaurant-tag';


### PR DESCRIPTION
v0.18.0
------------------------------
*Februrary 11, 2022*
### Changed
- added aria-label support to `RestaurantTag` component
- updated storybook with new aria label prop