### PR TITLE
f-promotions-showcase@v0.5.0 - style changes to match figma designs

### DIFF
--- a/packages/components/molecules/f-promotions-showcase/CHANGELOG.md
+++ b/packages/components/molecules/f-promotions-showcase/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.5.0
+------------------------------
+*February 15, 2021*
+
+### Changed
+- Updating styles to match the design icing changes
+
+
 v0.4.0
 ------------------------------
 *February 11, 2022*

--- a/packages/components/molecules/f-promotions-showcase/package.json
+++ b/packages/components/molecules/f-promotions-showcase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-promotions-showcase",
   "description": "Fozzie Promotions Showcase - A place for promotional messages to be displayed",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/f-promotions-showcase.umd.min.js",
   "maxBundleSize": "4kB",
   "files": [

--- a/packages/components/molecules/f-promotions-showcase/src/components/PromotionsShowcase.vue
+++ b/packages/components/molecules/f-promotions-showcase/src/components/PromotionsShowcase.vue
@@ -31,7 +31,9 @@
                 <div
                     :class="$style['c-promotionsShowcase-itemElement']"
                     data-test-id="promotionsShowcase-itemElement">
-                    <h4 data-test-id="promotionsShowcase-itemTitle">
+                    <h4
+                        :class="$style['c-promotionsShowcase-itemTitle']"
+                        data-test-id="promotionsShowcase-itemTitle">
                         {{ item.title }}
                     </h4>
                     <p
@@ -119,8 +121,8 @@ export default {
 }
 
 .c-promotionsShowcase-inner {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: repeat(1, minmax(0, 1fr));
     justify-content: center;
     background-color: $color-container-default;
 
@@ -129,7 +131,7 @@ export default {
     border-radius: $radius-rounded-c;
 
     @include media('>=wide') {
-        flex-direction: row;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
 
@@ -158,9 +160,13 @@ export default {
     }
 }
 
+.c-promotionsShowcase-itemTitle {
+    @include font-size(heading-s, true, 'narrow');
+}
+
 .c-promotionsShowcase-itemElement {
     & + & {
-        margin-left: spacing(d);
+        margin-left: spacing(b);
     }
 }
 
@@ -181,16 +187,12 @@ export default {
 
 .c-promotionsShowcase-itemElement--styleLink {
     color: $color-content-link;
-    font-weight: $font-weight-bold;
-
-    .c-promotionsShowcase-item:hover & {
-        text-decoration: underline;
-    }
+    text-decoration: underline;
 }
 
 .c-promotionsShowcase-itemElement--styleEmphasized {
     text-decoration: underline;
-    font-weight: $font-weight-bold;
+    color: $color-content-link;
 }
 
 .c-promotionsShowcase-itemIllustrationContainer {


### PR DESCRIPTION
PR adds style changes to the showcase component for MenuWeb. It brings it in line with icing related designs.

Main points

- Changed left margin after icon to be spacing `b`
- Changed headings to be `h4`
- Changed link to be styled like icing designs
- Changed font size on titles to be `heading-s` `narrow`
- Changed column layout on larger screen sizes adding `css grid`

## UI Review Checks

![Screenshot 2022-02-15 at 09 46 35](https://user-images.githubusercontent.com/15876339/154037488-7ee2a6e0-eddc-44b8-833b-6cb65bf31146.png)
![Screenshot 2022-02-15 at 09 44 22](https://user-images.githubusercontent.com/15876339/154037500-ada96e89-ae60-4f33-890f-184108f351d2.png)
![Screenshot 2022-02-15 at 09 46 21](https://user-images.githubusercontent.com/15876339/154037516-60a42487-b3a3-4d64-a521-e79c6e8dac17.png)
![Screenshot 2022-02-15 at 09 44 08](https://user-images.githubusercontent.com/15876339/154037522-752776a4-01b0-47a2-92df-282469f79387.png)
![Screenshot 2022-02-15 at 09 46 07](https://user-images.githubusercontent.com/15876339/154037527-7ea8da35-4361-460f-af3d-b66ebba942f3.png)
![Screenshot 2022-02-15 at 09 43 42](https://user-images.githubusercontent.com/15876339/154037578-46b51fb9-3342-4f8e-9501-67f1cce4ec2f.png)

## Browsers Tested

- [x] Chrome (latest)
- [x] Mobile (Please list device/browser – Ideally one iPhone model and one Android)
