### PR TITLE
f-restaurant-card@0.22.0 - Sync more test ids with searchweb

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.22.0
+------------------------------
+*Februrary 17, 2022*
+### Changed
+- Sync a number of `data-test-id` attributes with the SearchWeb acceptance tests
+- Updated a number of unit tests to support the new test ids
+
 v0.21.0
 ------------------------------
 *Februrary 16, 2022*

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
@@ -127,7 +127,7 @@
             <!-- Disabled Message -->
             <icon-text
                 v-if="disabledMessage"
-                data-test-id="restaurant-disabled"
+                data-test-id="restaurant-offline"
                 :text="disabledMessage"
                 color="colorSupportError"
                 hide-icon-in-tile-view>

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
@@ -118,7 +118,7 @@
             <!-- Offer -->
             <icon-text
                 v-if="hasOffer"
-                data-test-id="restaurant-offer"
+                data-test-id="restaurant-discounts"
                 :text="offer"
                 is-bold>
                 <offer-icon />

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
@@ -80,8 +80,7 @@
                 v-if="availability"
                 :tier="3">
                 <restaurant-availability
-                    v-bind="availability"
-                    data-test-id="restaurant-availability" />
+                    v-bind="availability" />
             </component>
 
             <!-- Delivery Meta (etas, distance etc) -->

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
@@ -62,7 +62,6 @@
                 v-if="rating"
                 :tier="3">
                 <restaurant-rating
-                    data-test-id="restaurant-rating"
                     v-bind="rating" />
             </component>
 

--- a/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.test.js
@@ -311,7 +311,7 @@ describe('RestaurantCard', () => {
             const wrapper = mount(RestaurantCard, { propsData });
 
             // assert
-            expect(wrapper.find('[data-test-id="restaurant-disabled"]').exists()).toBe(true);
+            expect(wrapper.find('[data-test-id="restaurant-offline"]').exists()).toBe(true);
         });
 
         it.each([

--- a/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.test.js
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils';
 import RestaurantCard from '../RestaurantCard.vue';
 import { EVENT_CLICK_RESTAURANT_CARD } from '../../constants/custom-events';
+import RestaurantAvailability from '../subcomponents/RestaurantAvailability/RestaurantAvailability.vue';
 
 describe('RestaurantCard', () => {
     describe('Restaurant cuisines', () => {
@@ -329,6 +330,38 @@ describe('RestaurantCard', () => {
 
             // assert
             expect(wrapper.find('[data-test-id="restaurant-disabled"]').exists()).toBe(false);
+        });
+    });
+
+    describe('Restaurant availability', () => {
+        it('renders an availability component if data provided', () => {
+            // arrange
+            const propsData = {
+                availability: {
+                    availabilityType: 'COLLECTION',
+                    availabilityTranslatedName: 'Pre-order',
+                    availabilityMessage: 'Opening at 13:20'
+                }
+            };
+
+            // act
+            const wrapper = mount(RestaurantCard, { propsData });
+
+            // assert
+            expect(wrapper.findComponent(RestaurantAvailability).exists()).toBe(true);
+        });
+
+        it.each([
+            {},
+            {
+                availability: null
+            }
+        ])('does not render an availability component if availability prop is missing', propsData => {
+            // arrange & act
+            const wrapper = mount(RestaurantCard, { propsData });
+
+            // assert
+            expect(wrapper.findComponent(RestaurantAvailability).exists()).toBe(false);
         });
     });
 

--- a/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.test.js
@@ -153,7 +153,7 @@ describe('RestaurantCard', () => {
             const wrapper = mount(RestaurantCard, { propsData });
 
             // assert
-            expect(wrapper.find('[data-test-id="restaurant-offer"]').exists()).toBe(true);
+            expect(wrapper.find('[data-test-id="restaurant-discounts"]').exists()).toBe(true);
         });
 
         it.each([

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
@@ -1,5 +1,7 @@
 <template>
-    <div :class="[$style['c-restaurantCard-availability']]">
+    <div
+        :class="[$style['c-restaurantCard-availability']]"
+        data-test-id="restaurant-times">
         <icon-text
             v-if="availabilityTranslatedName"
             :text="availabilityTranslatedName"

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantImage/RestaurantImage.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantImage/RestaurantImage.vue
@@ -1,6 +1,7 @@
 <template>
     <div
         :class="[$style['c-restaurantCard-img']]"
+        data-test-id="restaurant-cuisine-image"
         :style="`${imgUrl ? `background-image: url(${imgUrl});` : null}`"
         role="presentation">
         <slot />

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/RestaurantRating.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/RestaurantRating.vue
@@ -16,7 +16,7 @@
         <!-- No ratings message -->
         <span
             v-if="noRatingsAvailable"
-            data-test-id="no-ratings-message"
+            data-test-id="restaurant-rating-none"
             :class="[$style['c-restaurantCard-rating-notRatedMsg']]">
             {{ notRatedMessage }}
         </span>
@@ -28,7 +28,7 @@
                  are still being discovered. Therefore this is subject to change
             -->
             <span
-                data-test-id="ratings-summary-message"
+                data-test-id="restaurant-rating"
                 class="is-visuallyHidden">
                 {{ accessibleMessage }}
             </span>
@@ -59,7 +59,7 @@
                 &#40;
                 <data
                     v-if="!isOwnRating"
-                    data-test-id="rating-count"
+                    data-test-id="rating"
                     :class="[$style['c-restaurantCard-rating-count']]"
                     :value="count">
                     {{ count }}

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/_tests/RestaurantRating.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/_tests/RestaurantRating.test.js
@@ -22,7 +22,7 @@ describe('RestaurantRating component', () => {
 
         // act
         const wrapper = mount(RestaurantRating, { propsData });
-        const screenReaderMessageElement = wrapper.find('[data-test-id="ratings-summary-message"]');
+        const screenReaderMessageElement = wrapper.find('[data-test-id="restaurant-rating"]');
 
         // assert
         expect(screenReaderMessageElement.exists()).toBe(true);
@@ -45,7 +45,7 @@ describe('RestaurantRating component', () => {
 
         // act
         const wrapper = mount(RestaurantRating, { propsData });
-        const screenReaderMessageElement = wrapper.find('[data-test-id="ratings-summary-message"]');
+        const screenReaderMessageElement = wrapper.find('[data-test-id="restaurant-rating]');
 
         // assert
         expect(screenReaderMessageElement.exists()).toBe(false);
@@ -94,7 +94,7 @@ describe('RestaurantRating component', () => {
             const filledStarElement = wrapper.find('[data-test-id="ratings-star-filled"]');
             const emptyStarElement = wrapper.find('[data-test-id="ratings-star-empty"]');
             const ownRatingMessageElement = wrapper.find('[data-test-id="rating-own-rating-message"]');
-            const noRatingsMessage = wrapper.find('[data-test-id="no-ratings-message"]');
+            const noRatingsMessage = wrapper.find('[data-test-id="restaurant-rating-none"]');
             const countMessage = wrapper.find('[data-test-id="rating-count"]');
 
             // assert
@@ -132,7 +132,7 @@ describe('RestaurantRating component', () => {
             const filledStarElement = wrapper.find('[data-test-id="ratings-star-filled"]');
             const ownRatingMessageElement = wrapper.find('[data-test-id="rating-own-rating-message"]');
             const emptyStarElement = wrapper.find('[data-test-id="ratings-star-empty"]');
-            const noRatingsMessage = wrapper.find('[data-test-id="no-ratings-message"]');
+            const noRatingsMessage = wrapper.find('[data-test-id="restaurant-rating-none"]');
             const countMessage = wrapper.find('[data-test-id="rating-count"]');
             const screenReaderMessageElement = wrapper.find('[data-test-id="ratings-summary-message"]');
 
@@ -168,8 +168,8 @@ describe('RestaurantRating component', () => {
             const filledStarElement = wrapper.find('[data-test-id="ratings-star-filled"]');
             const emptyStarElement = wrapper.find('[data-test-id="ratings-star-empty"]');
             const ownRatingMessageElement = wrapper.find('[data-test-id="rating-own-rating-message"]');
-            const noRatingsMessage = wrapper.find('[data-test-id="no-ratings-message"]');
-            const countMessage = wrapper.find('[data-test-id="rating-count"]');
+            const noRatingsMessage = wrapper.find('[data-test-id="restaurant-rating-none"]');
+            const countMessage = wrapper.find('[data-test-id="rating"]');
 
             // assert
             expect(emptyStarElement.exists()).toBe(false);
@@ -205,7 +205,7 @@ describe('RestaurantRating component', () => {
             const filledStarElement = wrapper.find('[data-test-id="ratings-star-filled"]');
             const ownRatingMessageElement = wrapper.find('[data-test-id="rating-own-rating-message"]');
             const emptyStarElement = wrapper.find('[data-test-id="ratings-star-empty"]');
-            const noRatingsMessage = wrapper.find('[data-test-id="no-ratings-message"]');
+            const noRatingsMessage = wrapper.find('[data-test-id="restaurant-rating-none"]');
             const countMessage = wrapper.find('[data-test-id="rating-count"]');
 
             // assert

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTag.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTag.vue
@@ -8,7 +8,7 @@
         }"
         :title="text"
         :aria-label="ariaLabel"
-        data-test-id="restaurant-tag">
+        data-test-id="restaurant-badge">
         {{ text }}
     </span>
 </template>


### PR DESCRIPTION
v0.22.0
------------------------------
*Februrary 17, 2022*
### Changed
- Sync a number of `data-test-id` attributes with the SearchWeb acceptance tests
- Updated a number of unit tests to support the new test ids

Note: Some of the test IDs could be named better, in my opinion. However the plan is to match the current implementation on SearchWeb, ensure everything passes then once this component is properly in use we can deprecate the old card and update these with nicer ID values.