### PR TITLE
f-takeawaypay-activation@v2.10.0 - fixing logging to be on the new logger instance

### DIFF
--- a/packages/components/pages/f-takeawaypay-activation/CHANGELOG.md
+++ b/packages/components/pages/f-takeawaypay-activation/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v2.10.0
+------------------------------
+*February 22, 2022*
+
+### Changed
+- Updated the logger to be using new $log interface so CoreWeb tests work
+
+
 v2.9.0
 ------------------------------
 *January 14, 2022*

--- a/packages/components/pages/f-takeawaypay-activation/package.json
+++ b/packages/components/pages/f-takeawaypay-activation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-takeawaypay-activation",
   "description": "Fozzie TakeawayPay Activation - Handles Takeaway Pay activation for users",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "main": "dist/f-takeawaypay-activation.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/pages/f-takeawaypay-activation/src/components/ActivationLoggedIn.vue
+++ b/packages/components/pages/f-takeawaypay-activation/src/components/ActivationLoggedIn.vue
@@ -116,7 +116,7 @@ export default {
     methods: {
         async activate () {
             this.activationInProgress = true;
-            const activationSuccessful = await TakeawaypayActivationServiceApi.activate(this.activateUrl, this.employeeId, this.authToken, this.consumerId, this.$store, this.$logger);
+            const activationSuccessful = await TakeawaypayActivationServiceApi.activate(this.activateUrl, this.employeeId, this.authToken, this.consumerId, this.$log);
             this.$emit('activation-result', activationSuccessful);
             this.activationInProgress = false;
         }

--- a/packages/components/pages/f-takeawaypay-activation/src/components/TakeawaypayActivation.vue
+++ b/packages/components/pages/f-takeawaypay-activation/src/components/TakeawaypayActivation.vue
@@ -166,7 +166,7 @@ export default {
     methods: {
         async initialize () {
             this.shouldShowSpinner = true;
-            const available = await TakeawaypayActivationServiceApi.isActivationAvailable(this.getActivationStatusUrl, this.employeeId, this.$store, this.$logger);
+            const available = await TakeawaypayActivationServiceApi.isActivationAvailable(this.getActivationStatusUrl, this.employeeId, this.$log);
 
             if (available) {
                 this.determineActivationState();

--- a/packages/components/pages/f-takeawaypay-activation/src/components/_tests/ActivationLoggedIn.test.js
+++ b/packages/components/pages/f-takeawaypay-activation/src/components/_tests/ActivationLoggedIn.test.js
@@ -2,7 +2,7 @@ import Vuex from 'vuex';
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import { VueI18n } from '@justeat/f-globalisation';
 import ActivationLoggedIn from '../ActivationLoggedIn.vue';
-import { i18n, $logger } from './helpers/setup';
+import { i18n, $log } from './helpers/setup';
 
 const localVue = createLocalVue();
 localVue.use(VueI18n);
@@ -60,7 +60,7 @@ describe('ActivationLoggedIn', () => {
                 localVue,
                 propsData,
                 mocks: {
-                    $logger
+                    $log
                 }
             });
 

--- a/packages/components/pages/f-takeawaypay-activation/src/components/_tests/helpers/setup.js
+++ b/packages/components/pages/f-takeawaypay-activation/src/components/_tests/helpers/setup.js
@@ -7,13 +7,13 @@ const i18n = {
     }
 };
 
-const $logger = {
-    logInfo: jest.fn(),
-    logWarn: jest.fn(),
-    logError: jest.fn()
+const $log = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
 };
 
 export {
     i18n,
-    $logger
+    $log
 };

--- a/packages/components/pages/f-takeawaypay-activation/src/services/TakeawaypayActivationServiceApi.js
+++ b/packages/components/pages/f-takeawaypay-activation/src/services/TakeawaypayActivationServiceApi.js
@@ -12,7 +12,7 @@ const activateLogData = (employeeId, consumerId) => ({
 });
 
 export default {
-    async isActivationAvailable (url, employeeId, store, logger) {
+    async isActivationAvailable (url, employeeId, logger) {
         try {
             const config = {
                 headers: {
@@ -26,8 +26,7 @@ export default {
             logInvoker({
                 message: 'TakeawayPay account linking fetched availability',
                 data: availabilityLogData(employeeId, data.available),
-                logMethod: logger.logInfo,
-                store
+                logMethod: logger.info
             });
 
             return data.available;
@@ -35,15 +34,14 @@ export default {
             logInvoker({
                 message: 'TakeawayPay account linking not available',
                 data: availabilityLogData(employeeId),
-                logMethod: logger.logWarn,
-                error,
-                store
+                logMethod: logger.warn,
+                error
             });
             return false;
         }
     },
 
-    async activate (url, employeeId, authToken, consumerId, store, logger) {
+    async activate (url, employeeId, authToken, consumerId, logger) {
         try {
             const authHeader = authToken && `Bearer ${authToken}`;
 
@@ -71,8 +69,7 @@ export default {
                 logInvoker({
                     message: 'TakeawayPay account linking succeeded',
                     data: activateLogData(employeeId, consumerId),
-                    logMethod: logger.logInfo,
-                    store
+                    logMethod: logger.info
                 });
                 return true;
             }
@@ -82,9 +79,8 @@ export default {
             logInvoker({
                 message: 'TakeawayPay account linking failed',
                 data: activateLogData(employeeId, consumerId),
-                logMethod: logger.logError,
-                error,
-                store
+                logMethod: logger.error,
+                error
             });
             return false;
         }


### PR DESCRIPTION
Tests in CoreWeb are failing due to the new `$log` being used and this package not being updated to support this new interface. This PR changes the code and tests to fix this.