### PR TITLE
f-image-tile@v0.10.0 - Changes to support SSR & replacing storybook default values with args

### DIFF
--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.9.3
+------------------------------
+*February 24, 2022*
+
+### Changed
+        
+- Moved `isToggleSelected` assignement into created lifecycle method for SSR
+
+
 v0.9.2
 ------------------------------
 *February 23, 2022*

--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -3,13 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v0.9.3
+v0.10.0
 ------------------------------
-*February 24, 2022*
+*February 25, 2022*
 
 ### Changed
         
 - Moved `isToggleSelected` assignement into created lifecycle method for SSR
+- Updated stories to use args instead of default value
+- Added label style for `isLink`
 
 
 v0.9.2

--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -9,7 +9,7 @@ v0.10.0
 
 ### Changed
         
-- Moved `isToggleSelected` assignement into created lifecycle method for SSR
+- Moved `isToggleSelected` assignment into created lifecycle method for SSR
 - Updated stories to use args instead of default value
 - Added label style for `isLink`
 

--- a/packages/components/atoms/f-image-tile/package.json
+++ b/packages/components/atoms/f-image-tile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-image-tile",
   "description": "Fozzie Image Tile - An interactive tile component containing an image, text and link.",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "main": "dist/f-image-tile.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-image-tile/package.json
+++ b/packages/components/atoms/f-image-tile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-image-tile",
   "description": "Fozzie Image Tile - An interactive tile component containing an image, text and link.",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "main": "dist/f-image-tile.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -27,7 +27,10 @@
             :tabindex="!isLink ? 0 : -1"
             @change="toggleFilter">
         <label
-            :class="$style['c-imageTile-label']"
+            :class="[
+                $style['c-imageTile-label'], {
+                    [$style['c-imageTile-label--link']]: isLink
+                }]"
             :for="`imageTileToggle-${tileId}`"
             data-test-id="image-tile-label"
             :tabindex="!isLink ? -1 : false">
@@ -221,6 +224,10 @@ $image-tile-text-transform: translate3d(5px, 0, 0);
     &:focus {
         outline: none; // Prevents Safari doubling focus styles.
     }
+}
+
+.c-imageTile-label--link {
+    pointer-events: none;
 }
 
 .c-imageTile-imageContainer {

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -126,7 +126,7 @@ export default {
             }
         }
     },
-    mounted () {
+    created () {
         this.isToggleSelected = this.isSelected;
     },
     methods: {

--- a/packages/components/atoms/f-image-tile/src/components/_tests/ImageTile.test.js
+++ b/packages/components/atoms/f-image-tile/src/components/_tests/ImageTile.test.js
@@ -175,6 +175,24 @@ describe('ImageTile', () => {
         });
     });
 
+    describe('created :: ', () => {
+        it.each([
+            [true, true],
+            [false, false]
+        ])('should update `isToggleSelected` %s when set to %s', (expectedValue, isSelected) => {
+            // Arrange
+            const propsData = { isSelected };
+
+            // Act
+            const wrapper = shallowMount(ImageTile, {
+                propsData
+            });
+
+            // Assert
+            expect(wrapper.vm.isToggleSelected).toBe(expectedValue);
+        });
+    });
+
     describe('methods :: ', () => {
         describe('toggleFilter :: ', () => {
             it('should update `isToggleSelected` value and $emit toggle event when called', async () => {

--- a/packages/components/atoms/f-image-tile/stories/ImageTile.stories.js
+++ b/packages/components/atoms/f-image-tile/stories/ImageTile.stories.js
@@ -36,47 +36,50 @@ export const ImageTileComponent = (args, { argTypes }) => ({
             `
 });
 
+ImageTileComponent.args = {
+    href: '/Chicken',
+    tileId: 'Chicken',
+    displayText: 'Chicken',
+    imgSrc: ImageTileCuisine,
+    isSelected: false,
+    isLink: false,
+    altText: '',
+    fallbackImage: ImageTileWallpaper
+};
+
 ImageTileComponent.argTypes = {
     href: {
         control: { type: 'text' },
-        description: 'Anchor link path',
-        defaultValue: '/Chicken'
+        description: 'Anchor link path'
     },
     tileId: {
         control: { type: 'text' },
-        description: 'Image tile filter id',
-        defaultValue: 'Chicken'
+        description: 'Image tile filter id'
     },
     displayText: {
         control: { type: 'text' },
-        description: 'Component display text',
-        defaultValue: 'Chicken'
+        description: 'Component display text'
     },
     imgSrc: {
         control: { type: 'select' },
         options: [ImageTileCuisine, null, fakeImage],
-        description: 'Cuisine image link',
-        defaultValue: ImageTileCuisine
+        description: 'Cuisine image link'
     },
     isSelected: {
         control: { type: 'boolean' },
-        description: 'Marks the filter as selected',
-        defaultValue: false
+        description: 'Marks the filter as selected'
     },
     isLink: {
         control: { type: 'boolean' },
-        description: 'Component acts as a link, rather than default toggle',
-        defaultValue: false
+        description: 'Component acts as a link, rather than default toggle'
     },
     altText: {
         control: { type: 'text' },
-        description: 'Image alt text',
-        defaultValue: ''
+        description: 'Image alt text'
     },
     fallbackImage: {
         control: { type: 'text' },
-        description: 'Fallback image url',
-        defaultValue: ImageTileWallpaper
+        description: 'Fallback image url'
     }
 };
 


### PR DESCRIPTION
---

### Changed
        
- Moved `isToggleSelected` assignment into created lifecycle method for SSR
- Updated stories to use args instead of default value
- Added label style for `isLink`

---

No visual changes. 
![Screenshot 2022-02-25 at 11 04 16](https://user-images.githubusercontent.com/4212434/155704812-a2d5df2e-3942-4cf0-9600-d1c72bbc2e4a.png)


## UI Review Checks
- [X] Unit tests have been [created]
- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [X] Chrome (latest)
- [X] Firefox
- [X] Safari

