### PR TITLE
f-offers@1.8.0 and f-loyalty@1.7.0 - f-content-cards dependency update

### DIFF
--- a/packages/components/pages/f-loyalty/CHANGELOG.md
+++ b/packages/components/pages/f-loyalty/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.7.0
+------------------------------
+*February 25, 2022*
+
+### Changed
+- Updated f-content-cards to the latest which uses a new $log interface.
+
+
 v1.6.1
 ------------------------------
 *February 17, 2022*

--- a/packages/components/pages/f-loyalty/package.json
+++ b/packages/components/pages/f-loyalty/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-loyalty",
   "description": "Fozzie Loyalty - provides a way for customers to collect loyalty stamps for restaurants",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "main": "dist/f-loyalty.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [
@@ -59,7 +59,7 @@
     "@braze/web-sdk": "3.3.0",
     "@justeat/f-breadcrumbs": "3.1.0",
     "@justeat/f-button": "3.2.0",
-    "@justeat/f-content-cards": "7.0.0",
+    "@justeat/f-content-cards": "7.4.0",
     "@justeat/f-media-element": "2.0.0",
     "@justeat/f-tabs": "2.0.0",
     "@justeat/f-trak": "0.7.1",

--- a/packages/components/pages/f-offers/CHANGELOG.md
+++ b/packages/components/pages/f-offers/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.8.0
+------------------------------
+*February 25, 2022*
+
+### Changed
+- Updated f-content-cards to the latest which uses a new $log interface.
+
+
 v1.7.0
 ------------------------------
 *February 17, 2022*

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -3,7 +3,7 @@
   "description": "Fozzie Offers - displays offers to the customers",
   "version": "1.8.0",
   "main": "dist/f-offers.umd.min.js",
-  "maxBundleSize": "140kB",
+  "maxBundleSize": "150kB",
   "files": [
     "dist",
     "test-utils"

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-offers",
   "description": "Fozzie Offers - displays offers to the customers",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "main": "dist/f-offers.umd.min.js",
   "maxBundleSize": "140kB",
   "files": [
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@braze/web-sdk": "3.3.0",
-    "@justeat/f-content-cards": "6.0.0-beta.2",
+    "@justeat/f-content-cards": "7.4.0",
     "@justeat/f-button": "3.0.2",
     "@justeat/f-media-element": "2.0.0",
     "@justeat/f-searchbox": "6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,24 +2292,6 @@
   dependencies:
     "@justeat/f-services" "0.13.0"
 
-"@justeat/f-content-cards@6.0.0-beta.2":
-  version "6.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-6.0.0-beta.2.tgz#1b77d0d33ad0b8b41d26d78029c848e8444d20b5"
-  integrity sha512-+Z1YqCpYMAZIZzZl7Bb+NAApKGvjNwypsAWcFlmqXpQgnmYV0C5CxJZo2z7VDXaQ7J7IZiTDH62YpvXJt1kP5A==
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "7.12.13"
-    "@justeat/f-services" "1.0.1"
-    core-js "3.6.5"
-
-"@justeat/f-content-cards@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-7.0.0.tgz#486e3cc1e6e8196a0d8a7efb026c55d18237a5a2"
-  integrity sha512-FuKy9jC+6//idD/ZJQ2Of/se/g0BtzuETyloKuSxHrF9XocqT7GVrGGr9vJm6whoglqrLcBq48dpuq7us03OjA==
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "7.12.13"
-    "@justeat/f-services" "1.0.1"
-    core-js "3.6.5"
-
 "@justeat/f-dom@0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-dom/-/f-dom-0.4.0.tgz#3e838a2dd06d4d5281c17f5fb9f66d7485fd759a"


### PR DESCRIPTION
### Changed
- Updated f-content-cards to the latest which uses a new $log interface.