### PR TITLE
f-vue-icons@3.8.0 - Upgrade f-icons

### DIFF
--- a/packages/tools/f-vue-icons/CHANGELOG.md
+++ b/packages/tools/f-vue-icons/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v3.8.0
+------------------------------
+*March 01 2022*
+
+### Changed
+- `star-empty` icon - remove whitespace
+- `star-filled` icon - remove whitespace
+
 v3.7.0
 ------------------------------
 *February 17, 2022*

--- a/packages/tools/f-vue-icons/icons/StarEmptyIcon.js
+++ b/packages/tools/f-vue-icons/icons/StarEmptyIcon.js
@@ -9,7 +9,7 @@ export default {
     return h("svg", _mergeJSXProps([{
       attrs: {
         xmlns: "http://www.w3.org/2000/svg",
-        viewBox: "0 0 18 17"
+        viewBox: "0.5 0.64 17.06 16.42"
       },
       "class": "c-ficon c-ficon--star-empty"
     }, ctx.data]), [h("path", {

--- a/packages/tools/f-vue-icons/icons/StarFilledIcon.js
+++ b/packages/tools/f-vue-icons/icons/StarFilledIcon.js
@@ -9,13 +9,13 @@ export default {
     return h("svg", _mergeJSXProps([{
       attrs: {
         xmlns: "http://www.w3.org/2000/svg",
-        viewBox: "0 0 18 18"
+        viewBox: "-0.02 0.16 18.03 17.01"
       },
       "class": "c-ficon c-ficon--star-filled"
     }, ctx.data]), [h("defs", [h("path", {
       attrs: {
         id: "star-filled-a",
-        d: "M12 17.3l4.8 2.8a.7.7 0 001-.7L16.5 14l4.3-3.7a.7.7 0 00-.4-1.2l-5.6-.5-2.2-5.1a.7.7 0 00-1.2 0L9.2 8.6l-5.6.5a.7.7 0 00-.4 1.2L7.5 14l-1.3 5.4a.7.7 0 001 .7l4.8-2.8z"
+        d: "m12 17.3 4.8 2.8a.7.7 0 0 0 1-.7L16.5 14l4.3-3.7a.7.7 0 0 0-.4-1.2l-5.6-.5-2.2-5.1a.7.7 0 0 0-1.2 0L9.2 8.6l-5.6.5a.7.7 0 0 0-.4 1.2L7.5 14l-1.3 5.4a.7.7 0 0 0 1 .7l4.8-2.8z"
       }
     })]), h("use", {
       attrs: {

--- a/packages/tools/f-vue-icons/package.json
+++ b/packages/tools/f-vue-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-vue-icons",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "main": "dist/f-vue-icons.cjs.js",
   "maxBundleSize": "150kB",
   "cdn": "dist/f-vue-icons.min.js",
@@ -52,7 +52,7 @@
     "babel-helper-vue-jsx-merge-props": "2.0.3"
   },
   "devDependencies": {
-    "@justeat/f-icons": "4.8.0",
+    "@justeat/f-icons": "4.8.1",
     "@vue/cli-plugin-babel": "4.5.8",
     "@vue/cli-plugin-unit-jest": "4.5.8",
     "@vue/test-utils": "1.0.3",

--- a/packages/tools/f-vue-icons/src/components/StarEmptyIcon.js
+++ b/packages/tools/f-vue-icons/src/components/StarEmptyIcon.js
@@ -10,6 +10,6 @@ export default {
         const attrs = ctx.data.attrs || {};
         ctx.data.attrs = attrs;
 
-        return <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 17" class="c-ficon c-ficon--star-empty" {...ctx.data}><path fill="#CACACA" fill-rule="evenodd" d="M16.6 6l-4.8-.4L10 1.2a1 1 0 00-1.8 0L6 5.6 1.5 6a1 1 0 00-.6 1.8L4.5 11l-1.1 4.7a1 1 0 001.4 1L9 14.4l4.1 2.5a1 1 0 001.5-1.1l-1-4.7 3.6-3.2c.7-.6.3-1.7-.6-1.8zM9 12.4l-3.8 2.3 1-4.3L3 7.5l4.4-.4 1.7-4 1.7 4 4.4.4-3.3 2.9 1 4.3L9 12.4z"></path></svg>;
+        return <svg xmlns="http://www.w3.org/2000/svg" viewBox="0.5 0.64 17.06 16.42" class="c-ficon c-ficon--star-empty" {...ctx.data}><path fill="#CACACA" fill-rule="evenodd" d="M16.6 6l-4.8-.4L10 1.2a1 1 0 00-1.8 0L6 5.6 1.5 6a1 1 0 00-.6 1.8L4.5 11l-1.1 4.7a1 1 0 001.4 1L9 14.4l4.1 2.5a1 1 0 001.5-1.1l-1-4.7 3.6-3.2c.7-.6.3-1.7-.6-1.8zM9 12.4l-3.8 2.3 1-4.3L3 7.5l4.4-.4 1.7-4 1.7 4 4.4.4-3.3 2.9 1 4.3L9 12.4z"></path></svg>;
     }
 };

--- a/packages/tools/f-vue-icons/src/components/StarFilledIcon.js
+++ b/packages/tools/f-vue-icons/src/components/StarFilledIcon.js
@@ -10,6 +10,6 @@ export default {
         const attrs = ctx.data.attrs || {};
         ctx.data.attrs = attrs;
 
-        return <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="c-ficon c-ficon--star-filled" {...ctx.data}><defs><path id="star-filled-a" d="M12 17.3l4.8 2.8a.7.7 0 001-.7L16.5 14l4.3-3.7a.7.7 0 00-.4-1.2l-5.6-.5-2.2-5.1a.7.7 0 00-1.2 0L9.2 8.6l-5.6.5a.7.7 0 00-.4 1.2L7.5 14l-1.3 5.4a.7.7 0 001 .7l4.8-2.8z"></path></defs><use fill="#FF8000" fill-rule="evenodd" transform="translate(-3 -3)" href="#star-filled-a"></use></svg>;
+        return <svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.02 0.16 18.03 17.01" class="c-ficon c-ficon--star-filled" {...ctx.data}><defs><path id="star-filled-a" d="m12 17.3 4.8 2.8a.7.7 0 0 0 1-.7L16.5 14l4.3-3.7a.7.7 0 0 0-.4-1.2l-5.6-.5-2.2-5.1a.7.7 0 0 0-1.2 0L9.2 8.6l-5.6.5a.7.7 0 0 0-.4 1.2L7.5 14l-1.3 5.4a.7.7 0 0 0 1 .7l4.8-2.8z"></path></defs><use fill="#FF8000" fill-rule="evenodd" transform="translate(-3 -3)" href="#star-filled-a"></use></svg>;
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2353,10 +2353,10 @@
     axios "0.21.1"
     axios-mock-adapter "1.19.0"
 
-"@justeat/f-icons@4.8.0":
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-4.8.0.tgz#25afd9d64be61666c6ce368aa688d899cc1ce13b"
-  integrity sha512-OpxsfEw1c8QcXQH6CdKGnynHpQMV0a0lVlRsDhFB5R1g+wtnA+F0OYMmZzlS8bMN1/HGYYsSLPUwOEjTCuhDZw==
+"@justeat/f-icons@4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-4.8.1.tgz#7bfbf725abece12fc469ee134fe6e7cb871f9594"
+  integrity sha512-Je6V1XsO2AZ2xZXq53/NdeZa83xDqHuntX22EcxmGul5OOQH4+DfQhe7cOa4AVWCW2tH4cBamVvYNBTGpYawpg==
 
 "@justeat/f-link@2.0.0":
   version "2.0.0"


### PR DESCRIPTION
v3.8.0
------------------------------
*March 01 2022*

### Changed
- `star-empty` icon - remove whitespace
- `star-filled` icon - remove whitespace