### PR TITLE
f-wdio-utils@v0.7.0 - Add method to get a11y results.

### DIFF
--- a/packages/services/f-wdio-utils/CHANGELOG.md
+++ b/packages/services/f-wdio-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.7.0
+------------------------------
+*March 02, 2022*
+
+### Added
+- `getAccessibilityTestResults`
+
+
 v0.6.0
 ------------------------------
 *January 24, 2022*

--- a/packages/services/f-wdio-utils/CHANGELOG.md
+++ b/packages/services/f-wdio-utils/CHANGELOG.md
@@ -8,7 +8,7 @@ v0.7.0
 *March 02, 2022*
 
 ### Added
-- `getAccessibilityTestResults`
+- `getAccessibilityTestResults` to `page.object.js` file.
 
 
 v0.6.0

--- a/packages/services/f-wdio-utils/package.json
+++ b/packages/services/f-wdio-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-wdio-utils",
   "description": "Fozzie Wdio Utils - webdriverIO page object",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "files": [
     "src/"
   ],

--- a/packages/services/f-wdio-utils/src/page.object.js
+++ b/packages/services/f-wdio-utils/src/page.object.js
@@ -87,6 +87,36 @@ class Page {
         });
         return tabOrderValue;
     }
+
+    /**
+     * Runs accessibility test results against a set of rules defined.
+     *
+     * @returns {ThenArg<ReturnType<BrowserCommandsType["executeAsync"]>>}
+     */
+    getAccessibilityTestResults = () => {
+        browser.execute(source);
+
+        // https://github.com/dequelabs/axe-core/blob/develop/doc/API.md
+
+        return browser.executeAsync(done => {
+            const options = {
+                runOnly: {
+                    type: 'tag',
+                    values: ['wcag21a', 'wcag21aa', 'wcag143', 'cat.color', 'cat.aria']
+                },
+                rules: {
+                    'duplicate-id': { enabled: false },
+                    // Ignoring as lang attribute is provided via a mixin, however Axe still fails.
+                    'html-has-lang': { enabled: false }
+                }
+            };
+
+            axe.run(document, options, (err, results) => {
+                if (err) throw err;
+                done(results);
+            });
+        });
+    };
 }
 
 module.exports = Page;


### PR DESCRIPTION
Adding this method to `f-wdio-utils` package so it can be imported to `coreweb` & back into `fozzie-components` therefore reducing code duplication.