### PR TITLE
f-restaurant-card@v0.26.0 - Optional performance tracking

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,9 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.26.0
+------------------------------
+*March 03, 2022*
+### Added
+- Performance tracking prop
+- Calls to performance tracking on `mounted` lifecycle hook for the Card container and delivery meta components
+
 v0.25.0
 ------------------------------
-*Februrary 22, 2022*
+*March 02, 2022*
 ### Added
 - Skeleton loader styling and animations
 ### Changed

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
@@ -192,7 +192,8 @@ export default {
     },
     provide () {
         return {
-            isListItem: this.isListItem
+            isListItem: this.isListItem,
+            performanceTracker: this.performanceTracker
         };
     },
     props: {
@@ -268,6 +269,11 @@ export default {
         errorBoundary: {
             type: Object,
             default: () => RenderlessSlotWrapper // by default returns a renderless component that will just render it's slot and not bloat markup
+        },
+        // An optional library for tracking rendering performance
+        performanceTracker: {
+            type: Object,
+            default: null
         }
     },
     computed: {
@@ -293,6 +299,13 @@ export default {
         },
         hasCuisines () {
             return !!this.cuisines?.length;
+        }
+    },
+    mounted () {
+        if (this.performanceTracker) {
+            this.$nextTick(() => {
+                this.performanceTracker.time('tier-1');
+            });
         }
     },
     methods: {

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
@@ -343,6 +343,7 @@ export default {
     mounted () {
         if (this.performanceTracker) {
             this.$nextTick(() => {
+                // Hard coding temporarily. We can eventually configure this
                 this.performanceTracker.time('tier-1');
             });
         }

--- a/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/_tests/RestaurantCard.test.js
@@ -385,4 +385,24 @@ describe('RestaurantCard', () => {
             expect(emittedEvent.length).toBe(1);
         });
     });
+
+    describe('performance tracking', () => {
+        it('calls the performance tracker with `tier-1` after rendering if prop value exists', async () => {
+            // arrange
+            const performanceTrackerMock = {
+                time: jest.fn()
+            };
+
+            const propsData = {
+                performanceTracker: performanceTrackerMock
+            };
+
+            // act
+            await mount(RestaurantCard, { propsData });
+
+            // assert
+            expect(performanceTrackerMock.time).toHaveBeenCalledTimes(1);
+            expect(performanceTrackerMock.time).toHaveBeenCalledWith('tier-1');
+        });
+    });
 });

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue
@@ -39,6 +39,11 @@ export default {
         MapPinIcon,
         ClockSmallIcon
     },
+    inject: {
+        performanceTracker: {
+            default: null
+        }
+    },
     props: {
         address: {
             type: String,
@@ -51,6 +56,13 @@ export default {
         eta: {
             type: String,
             default: null
+        }
+    },
+    mounted () {
+        if (this.performanceTracker) {
+            this.$nextTick(() => {
+                this.performanceTracker.time('tier-3');
+            });
         }
     }
 };

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue
@@ -61,6 +61,7 @@ export default {
     mounted () {
         if (this.performanceTracker) {
             this.$nextTick(() => {
+                // Hard coding temporarily. We can eventually configure this
                 this.performanceTracker.time('tier-3');
             });
         }

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/_tests/DeliveryTimeMeta.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/_tests/DeliveryTimeMeta.test.js
@@ -1,5 +1,5 @@
 import { shallowMount, mount, config } from '@vue/test-utils';
-import sut from '../DeliveryTimeMeta.vue';
+import DeliveryTimeMeta from '../DeliveryTimeMeta.vue';
 
 
 describe('DeliveryTimeMeta', () => {
@@ -17,7 +17,7 @@ describe('DeliveryTimeMeta', () => {
         };
 
         // act
-        const wrapper = shallowMount(sut, { propsData });
+        const wrapper = shallowMount(DeliveryTimeMeta, { propsData });
 
         // assert
         expect(wrapper.exists()).toBe(true);
@@ -31,7 +31,7 @@ describe('DeliveryTimeMeta', () => {
         };
 
         // act
-        const wrapper = mount(sut, { propsData });
+        const wrapper = mount(DeliveryTimeMeta, { propsData });
 
         const visibleText = wrapper.text();
         const etaExists = wrapper.find(etaSelector).exists();
@@ -49,7 +49,7 @@ describe('DeliveryTimeMeta', () => {
         };
 
         // act
-        const wrapper = mount(sut, { propsData });
+        const wrapper = mount(DeliveryTimeMeta, { propsData });
 
         const visibleText = wrapper.text();
         const distanceExists = wrapper.find(locationSelector).exists();
@@ -66,7 +66,7 @@ describe('DeliveryTimeMeta', () => {
         };
 
         // act
-        const wrapper = mount(sut, { propsData });
+        const wrapper = mount(DeliveryTimeMeta, { propsData });
 
         const visibleText = wrapper.text();
         const addressExists = wrapper.find(locationSelector).exists();
@@ -84,7 +84,7 @@ describe('DeliveryTimeMeta', () => {
             };
 
             // act
-            const wrapper = mount(sut, { propsData });
+            const wrapper = mount(DeliveryTimeMeta, { propsData });
 
             const etaText = wrapper.text();
             const etaIconExists = wrapper.find(etaIconSelector).exists();
@@ -101,7 +101,7 @@ describe('DeliveryTimeMeta', () => {
             };
 
             // act
-            const wrapper = mount(sut, { propsData });
+            const wrapper = mount(DeliveryTimeMeta, { propsData });
 
             const distanceText = wrapper.text();
             const distanceIconExists = wrapper.find(distanceIconSelector).exists();
@@ -118,7 +118,7 @@ describe('DeliveryTimeMeta', () => {
             };
 
             // act
-            const wrapper = mount(sut, { propsData });
+            const wrapper = mount(DeliveryTimeMeta, { propsData });
 
             const addressText = wrapper.text();
             const addressIconExists = wrapper.find(addressIconSelector).exists();
@@ -145,7 +145,7 @@ describe('DeliveryTimeMeta', () => {
             };
 
             // act
-            const wrapper = mount(sut, { propsData });
+            const wrapper = mount(DeliveryTimeMeta, { propsData });
 
             const etaText = wrapper.text();
             const etaIconExists = wrapper.find(etaIconSelector).exists();
@@ -162,7 +162,7 @@ describe('DeliveryTimeMeta', () => {
             };
 
             // act
-            const wrapper = mount(sut, { propsData });
+            const wrapper = mount(DeliveryTimeMeta, { propsData });
 
             const distanceText = wrapper.text();
             const distanceIconExists = wrapper.find(distanceIconSelector).exists();
@@ -179,7 +179,7 @@ describe('DeliveryTimeMeta', () => {
             };
 
             // act
-            const wrapper = mount(sut, { propsData });
+            const wrapper = mount(DeliveryTimeMeta, { propsData });
 
             const addressText = wrapper.text();
             const addressIconExists = wrapper.find(addressIconSelector).exists();
@@ -187,6 +187,37 @@ describe('DeliveryTimeMeta', () => {
             // assert
             expect(addressText).toBeTruthy();
             expect(addressIconExists).toBe(true);
+        });
+    });
+
+    describe('performance tracking', () => {
+        const performanceTrackerMock = {
+            time: jest.fn()
+        };
+
+        beforeEach(() => {
+            jest.resetAllMocks();
+            config.provide = {
+                performanceTracker: performanceTrackerMock
+            };
+        });
+
+        afterEach(() => {
+            config.provide = {};
+        });
+
+        it('calls the performance tracker with `tier-3` after rendering if prop value exists', async () => {
+            // arrange
+            const propsData = {
+                performanceTracker: performanceTrackerMock
+            };
+
+            // act
+            await mount(DeliveryTimeMeta, { propsData });
+
+            // assert
+            expect(performanceTrackerMock.time).toHaveBeenCalledTimes(1);
+            expect(performanceTrackerMock.time).toHaveBeenCalledWith('tier-3');
         });
     });
 });


### PR DESCRIPTION
v0.26.0
------------------------------
*March 03, 2022*
### Added
- Performance tracking prop
- Calls to performance tracking on `mounted` lifecycle hook for the Card container and delivery meta components

### Example of tracking output in SearchWeb:
<img width="401" alt="Screenshot 2022-03-03 at 11 31 34" src="https://user-images.githubusercontent.com/16766185/156556442-500e70f2-ceed-4a1e-bd40-31699cd205b3.png">
