### PR TITLE
f-image-tile@v0.10.2 - Updated margin between image and text

### DIFF
--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.10.2
+------------------------------
+*March 8, 2022*
+
+### Updated
+- Margin between text and image
+
 v0.10.1
 ------------------------------
 *February 28, 2022*

--- a/packages/components/atoms/f-image-tile/package.json
+++ b/packages/components/atoms/f-image-tile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-image-tile",
   "description": "Fozzie Image Tile - An interactive tile component containing an image, text and link.",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "main": "dist/f-image-tile.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -249,7 +249,7 @@ $image-tile-text-transform: translate3d(5px, 0, 0);
 }
 
 .c-imageTile-textContainer {
-    margin-top: spacing(d);
+    margin-top: spacing(b);
     display: flex;
     max-width: 100%;
 


### PR DESCRIPTION


---

### Updated
- Margin between text and image

---

## UI Review Checks

- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [X] Chrome (latest)

Before
![Screenshot 2022-03-08 at 11 08 32](https://user-images.githubusercontent.com/4212434/157226895-7ca76816-189d-4f18-ab60-dae3f4d273cc.png)

After
![Screenshot 2022-03-08 at 11 08 14](https://user-images.githubusercontent.com/4212434/157226948-bbd77672-a6c7-4eb1-8707-7d5e4bcff75e.png)


