### PR TITLE
#trivial - Remove dup method in favour of package import.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v7.1.0
+------------------------------
+*March 9, 2022*
+
+### Added
+- `f-wido-utils` version bump.
+
+### Removed
+- Reference to `getAccessibilityTestResults` from `axe-helper` file.
+
+### Changed
+- References within mono-repo to take wrapper method `getAxeResults` instead.
+
+
 v7.0.1
 ------------------------------
 *March 1, 2022*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",
@@ -58,6 +58,7 @@
     "@justeat/browserslist-config-fozzie": "1.2.0",
     "@justeat/eslint-config-fozzie": "5.1.0",
     "@justeat/fozzie": "8.0.0",
+    "@justeat/f-wdio-utils": "0.8.1",
     "@justeat/stylelint-config-fozzie": "2.2.0",
     "@percy/cli": "1.0.0-beta.73",
     "@percy/webdriverio": "2.0.0",

--- a/packages/components/atoms/f-button/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-button/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const ActionButton = require('../../test-utils/component-objects/f-button--action.component');
 const LinkButton = require('../../test-utils/component-objects/f-button--link.component');
@@ -13,7 +13,7 @@ describe('Accessibility tests', () => {
 
         // Act
         button.load();
-        const axeResults = getAccessibilityTestResults('f-button - action');
+        const axeResults = getAxeResults('f-button - action');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);
@@ -25,7 +25,7 @@ describe('Accessibility tests', () => {
 
         // Act
         button.load();
-        const axeResults = getAccessibilityTestResults('f-button - link');
+        const axeResults = getAxeResults('f-button - link');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);
@@ -37,7 +37,7 @@ describe('Accessibility tests', () => {
 
         // Act
         button.load();
-        const axeResults = getAccessibilityTestResults('f-button - icon');
+        const axeResults = getAxeResults('f-button - icon');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-card/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-card/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const Card = require('../../test-utils/component-objects/f-card.component');
 
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-card component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-card');
+        const axeResults = getAxeResults('f-card');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-error-message/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-error-message/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const ErrorMessage = require('../../test-utils/component-objects/f-error-message.component');
 
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-error-message component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-error-message');
+        const axeResults = getAxeResults('f-error-message');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-filter-pill/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-filter-pill/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const FilterPill = require('../../test-utils/component-objects/f-filter-pill.component');
 
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-filter-pill component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-filter-pill');
+        const axeResults = getAxeResults('f-filter-pill');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-form-field/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-form-field/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const FormField = require('../../test-utils/component-objects/f-form-field.component');
 
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-formField component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-form-field');
+        const axeResults = getAxeResults('f-form-field');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-image-tile/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-image-tile/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const ImageTile = require('../../test-utils/component-objects/f-image-tile.component');
 
@@ -10,7 +10,7 @@ describe('Accessibility tests', () => {
     });
     it('a11y - should test f-image-tile component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-image-tile');
+        const axeResults = getAxeResults('f-image-tile');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-link/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-link/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const Link = require('../../test-utils/component-objects/f-link.component');
 
@@ -10,7 +10,7 @@ describe('Accessibility tests', () => {
     });
     it('a11y - should test f-link component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-link');
+        const axeResults = getAxeResults('f-link');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-popover/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-popover/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const Popover = require('../../test-utils/component-objects/f-popover.component');
 
@@ -10,7 +10,7 @@ describe('Accessibility tests', () => {
     });
     it('a11y - should test f-popover component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-popover');
+        const axeResults = getAxeResults('f-popover');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-spinner/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-spinner/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const Spinner = require('../../test-utils/component-objects/f-spinner.component');
 
@@ -13,7 +13,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-spinner component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-spinner');
+        const axeResults = getAxeResults('f-spinner');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/molecules/f-alert/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/molecules/f-alert/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 const Alert = require('../../test-utils/component-objects/f-alert.component');
 
 const alert = new Alert();
@@ -10,7 +10,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-alert component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-alert');
+        const axeResults = getAxeResults('f-alert');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/molecules/f-breadcrumbs/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/molecules/f-breadcrumbs/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 const Breadcrumbs = require('../../test-utils/component-objects/f-breadcrumbs.component');
 
 const breadcrumbs = new Breadcrumbs();
@@ -9,7 +9,7 @@ describe('Accessibility tests', () => {
     });
     it('a11y - should test f-breadcrumbs component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-breadcrumbs');
+        const axeResults = getAxeResults('f-breadcrumbs');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/molecules/f-card-with-content/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/molecules/f-card-with-content/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const CardWithContent = require('../../test-utils/component-objects/f-card-with-content.component');
 
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-card-with-content component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-card-with-content');
+        const axeResults = getAxeResults('f-card-with-content');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/molecules/f-media-element/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/molecules/f-media-element/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const MediaElement = require('../../test-utils/component-objects/f-media-element.component');
 
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-media-element component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-media-element');
+        const axeResults = getAxeResults('f-media-element');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/molecules/f-mega-modal/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/molecules/f-mega-modal/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const MegaModal = require('../../test-utils/component-objects/f-mega-modal.component');
 
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-mega-modal component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-mega-modal');
+        const axeResults = getAxeResults('f-mega-modal');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/molecules/f-navigation-links/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/molecules/f-navigation-links/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const NavigationLinks = require('../../test-utils/component-objects/f-navigation-links.component');
 
@@ -13,7 +13,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-navigation-links component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-navigation-links');
+        const axeResults = getAxeResults('f-navigation-links');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/molecules/f-promotions-showcase/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/molecules/f-promotions-showcase/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const PromotionsShowcase = require('../../test-utils/component-objects/f-promotions-showcase.component');
 
@@ -10,7 +10,7 @@ describe('Accessibility tests', () => {
     });
     it('a11y - should test f-promotions-showcase component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-promotions-showcase');
+        const axeResults = getAxeResults('f-promotions-showcase');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/molecules/f-restaurant-card/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/molecules/f-restaurant-card/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const RestaurantCard = require('../../test-utils/component-objects/f-restaurant-card.component');
 
@@ -10,7 +10,7 @@ describe('Accessibility tests', () => {
     });
     it('a11y - should test f-restaurant-card component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-restaurant-card');
+        const axeResults = getAxeResults('f-restaurant-card');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/molecules/f-searchbox/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/molecules/f-searchbox/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const Searchbox = require('../../test-utils/component-objects/f-searchbox.component');
 
@@ -10,7 +10,7 @@ describe('Accessibility tests', () => {
     });
     it('a11y - should test f-searchbox component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-searchbox');
+        const axeResults = getAxeResults('f-searchbox');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/molecules/f-skeleton-loader/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/molecules/f-skeleton-loader/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const SkeletonLoader = require('../../test-utils/component-objects/f-skeleton-loader.component');
 
@@ -10,7 +10,7 @@ describe('Accessibility tests', () => {
     });
     it('a11y - should test f-skeleton-loader component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-skeleton-loader');
+        const axeResults = getAxeResults('f-skeleton-loader');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/molecules/f-tabs/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/molecules/f-tabs/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const Tabs = require('../../test-utils/component-objects/f-tabs.component');
 
@@ -10,7 +10,7 @@ describe('Accessibility tests', () => {
     });
     it('a11y - should test f-tabs component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-tabs');
+        const axeResults = getAxeResults('f-tabs');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/molecules/f-user-message/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/molecules/f-user-message/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const UserMessage = require('../../test-utils/component-objects/f-user-message.component');
 
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-user-message component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-user-message');
+        const axeResults = getAxeResults('f-user-message');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/organisms/f-content-cards/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-content-cards/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const HomePromotionCard1 = require('../../test-utils/component-objects/f-content-cards-home-promotion-card1.component');
 const HomePromotionCard2 = require('../../test-utils/component-objects/f-content-cards-home-promotion-card2.component');
@@ -15,7 +15,7 @@ describe('Accessibility tests', () => {
     it('a11y - should test f-content-card component WCAG compliance', () => {
         // Act
         card1.load();
-        const axeResults = getAccessibilityTestResults('f-content-card-home-promotion-1');
+        const axeResults = getAxeResults('f-content-card-home-promotion-1');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);
@@ -24,7 +24,7 @@ describe('Accessibility tests', () => {
     it('a11y - should test f-content-card component WCAG compliance', () => {
         // Act
         card2.load();
-        const axeResults = getAccessibilityTestResults('f-content-card-home-promotion-2');
+        const axeResults = getAxeResults('f-content-card-home-promotion-2');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/organisms/f-cookie-banner/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const LegacyCookieBanner = require('../../test-utils/component-objects/f-cookie-banner-legacy.component');
 
@@ -15,7 +15,7 @@ describe('Legacy Accessibility tests', () => {
 
         // Act
         legacyCookieBanner.load();
-        const axeResults = getAccessibilityTestResults('f-cookie-banner');
+        const axeResults = getAxeResults('f-cookie-banner');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);
@@ -27,7 +27,7 @@ describe('Legacy Accessibility tests', () => {
 
         // Act
         cookieConsentBanner.load();
-        const axeResults = getAccessibilityTestResults('f-cookie-banner');
+        const axeResults = getAxeResults('f-cookie-banner');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/organisms/f-footer/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-footer/test/accessibility/axe-accessibility.spec.js
@@ -1,6 +1,6 @@
 import forEach from 'mocha-each';
 
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 const Footer = require('../../test-utils/component-objects/f-footer.component');
 
 let footer;
@@ -17,7 +17,7 @@ describe('Accessibility tests', () => {
 
             // Act
             footer.load();
-            const axeResults = getAccessibilityTestResults('f-footer');
+            const axeResults = getAxeResults('f-footer');
 
             // Assert
             expect(axeResults.violations.length).toBe(0);
@@ -30,7 +30,7 @@ describe('Accessibility tests', () => {
 
             // Act
             footer.load();
-            const axeResults = getAccessibilityTestResults('f-footer');
+            const axeResults = getAxeResults('f-footer');
 
             // Assert
             expect(axeResults.violations.length).toBe(0);

--- a/packages/components/organisms/f-form/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-form/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const Form = require('../../test-utils/component-objects/f-form.component');
 
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-form component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-form');
+        const axeResults = getAxeResults('f-form');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/organisms/f-header/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-header/test/accessibility/axe-accessibility.spec.js
@@ -1,6 +1,6 @@
 import forEach from 'mocha-each';
 
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 const Header = require('../../test-utils/component-objects/f-header.component');
 
 const header = new Header();
@@ -13,7 +13,7 @@ describe('Accessibility tests', () => {
 
             // Act
             header.load();
-            const axeResults = getAccessibilityTestResults('f-header');
+            const axeResults = getAxeResults('f-header');
 
             // Assert
             expect(axeResults.violations.length).toBe(0);

--- a/packages/components/organisms/f-status-banner/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-status-banner/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const StatusBanner = require('../../test-utils/component-objects/f-status-banner.component');
 
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
     });
     it('a11y - should test f-status-banner component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-status-banner');
+        const axeResults = getAxeResults('f-status-banner');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/pages/f-account-info/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/pages/f-account-info/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const AccountInfo = require('../../test-utils/component-objects/f-account-info.component');
 
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-account-info component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-account-info');
+        const axeResults = getAxeResults('f-account-info');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/pages/f-checkout/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/pages/f-checkout/test/accessibility/axe-accessibility.spec.js
@@ -1,7 +1,7 @@
 import forEach from 'mocha-each';
 import argumentStringBuilder from '../../test-utils/component-objects/argumentStringBuilder';
 
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const Checkout = require('../../test-utils/component-objects/f-checkout.component');
 
@@ -19,7 +19,7 @@ describe('Accessibility tests', () => {
 
         // Act
         checkout.load();
-        const axeResults = getAccessibilityTestResults('f-checkout-delivery');
+        const axeResults = getAxeResults('f-checkout-delivery');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);
@@ -32,7 +32,7 @@ describe('Accessibility tests', () => {
 
         // Act
         checkout.load();
-        const axeResults = getAccessibilityTestResults('f-checkout-collection');
+        const axeResults = getAxeResults('f-checkout-collection');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);
@@ -45,7 +45,7 @@ describe('Accessibility tests', () => {
 
         // Act
         checkout.load();
-        const axeResults = getAccessibilityTestResults('f-checkout-guest');
+        const axeResults = getAxeResults('f-checkout-guest');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);
@@ -57,7 +57,7 @@ describe('Accessibility tests', () => {
         checkout.withQuery('args', args);
         // Act
         checkout.loadError();
-        const axeResults = getAccessibilityTestResults('f-checkout-error-page');
+        const axeResults = getAxeResults('f-checkout-error-page');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/pages/f-contact-preferences/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/pages/f-contact-preferences/test/accessibility/axe-accessibility.spec.js
@@ -1,5 +1,5 @@
 import forEach from 'mocha-each';
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const ContactPreferences = require('../../test-utils/component-objects/f-contactPreferences.component');
 
@@ -19,7 +19,7 @@ describe('Accessibility tests', () => {
 
         // Act
         contactPreferences.load();
-        const axeResults = getAccessibilityTestResults('f-contact-preferences');
+        const axeResults = getAxeResults('f-contact-preferences');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);
@@ -35,7 +35,7 @@ describe('Accessibility tests', () => {
         contactPreferences.load();
         contactPreferences.clickNewsEmailCheckbox();
         contactPreferences.clickSubmitButton();
-        const axeResults = getAccessibilityTestResults('f-contact-preferences - save error alert');
+        const axeResults = getAxeResults('f-contact-preferences - save error alert');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);
@@ -49,7 +49,7 @@ describe('Accessibility tests', () => {
 
         // Act
         contactPreferences.loadError();
-        const axeResults = getAccessibilityTestResults('f-contact-preferences - load error page');
+        const axeResults = getAxeResults('f-contact-preferences - load error page');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/pages/f-loyalty/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/pages/f-loyalty/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const Loyalty = require('../../test-utils/component-objects/f-loyalty.component');
 
@@ -10,7 +10,7 @@ describe('Accessibility tests', () => {
     });
     xit('a11y - should test f-loyalty component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-loyalty');
+        const axeResults = getAxeResults('f-loyalty');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/pages/f-offers/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/pages/f-offers/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const Offers = require('../../test-utils/component-objects/f-offers.component');
 
@@ -10,7 +10,7 @@ describe('Accessibility tests', () => {
     });
     it('a11y - should test f-offers component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-offers');
+        const axeResults = getAxeResults('f-offers');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/pages/f-registration/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/pages/f-registration/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 const Registration = require('../../test-utils/component-objects/f-registration.component');
 
 const registration = new Registration();
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-registration component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-registration');
+        const axeResults = getAxeResults('f-registration');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/pages/f-takeawaypay-activation/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/pages/f-takeawaypay-activation/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-const { getAccessibilityTestResults } = require('../../../../../../test/utils/axe-helper');
+const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
 
 const TakeawaypayActivation = require('../../test-utils/component-objects/f-takeawaypayActivation.component');
 const { AUTHENTICATION_JWT } = require('../../test-utils/constants/f-takeawaypayActivation');
@@ -15,7 +15,7 @@ describe('Accessibility tests', () => {
         takeawayPayComponent.load();
 
         // Act
-        const axeResults = getAccessibilityTestResults('f-takeawaypayActivation-unauthenticated');
+        const axeResults = getAxeResults('f-takeawaypayActivation-unauthenticated');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);
@@ -32,7 +32,7 @@ describe('Accessibility tests', () => {
         takeawayPayComponent.load('loggedIn');
 
         // Act
-        const axeResults = getAccessibilityTestResults('f-takeawaypayActivation-authenticated');
+        const axeResults = getAxeResults('f-takeawaypayActivation-authenticated');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);
@@ -51,7 +51,7 @@ describe('Accessibility tests', () => {
         takeawayPayComponent.waitForActivationSuccessComponent();
 
         // Act
-        const axeResults = getAccessibilityTestResults('f-takeawaypayActivation-successfulActivation');
+        const axeResults = getAxeResults('f-takeawaypayActivation-successfulActivation');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);
@@ -68,7 +68,7 @@ describe('Accessibility tests', () => {
         takeawayPayComponent.load('error');
 
         // Act
-        const axeResults = getAccessibilityTestResults('f-takeawaypayActivation-error');
+        const axeResults = getAxeResults('f-takeawaypayActivation-error');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/tools/generator-component/generators/app/templates/test/accessibility/axe-accessibility.spec.js
+++ b/packages/tools/generator-component/generators/app/templates/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import { getAccessibilityTestResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
+import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
 
 const <%= name.filename %> = require('../../test-utils/component-objects/f-<%= name.default %>.component');
 
@@ -11,7 +11,7 @@ describe('Accessibility tests', () => {
 
     it('a11y - should test f-<%= name.default %> component WCAG compliance', () => {
         // Act
-        const axeResults = getAccessibilityTestResults('f-<%= name.default %>');
+        const axeResults = getAxeResults('f-<%= name.default %>');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/test/utils/axe-helper.js
+++ b/test/utils/axe-helper.js
@@ -1,41 +1,21 @@
-const { source } = require('axe-core');
 const AxeReports = require('axe-reports');
 const { exec } = require('child_process');
 const fs = require('fs');
-const path = require('path');
+const Page = require('@justeat/f-wdio-utils/src/page.object');
 const { getTestConfiguration } = require('../../test/configuration/configuration-helper');
 const configuration = getTestConfiguration();
 
 /**
- * Runs the WCAG accessibility tests on the curent page of the global browser
+ * Wrapper for our Page.object `getAccessibilityTestResults` method so we
+ * can invoke and process the results from the `processResults` call.
+ *
+ * @param componentName
  */
-exports.getAccessibilityTestResults = (componentName) => {
-    browser.execute(source);
+exports.getAxeResults = (componentName) => {
+    const newPageInstance = new Page();
+    const results = newPageInstance.getAccessibilityTestResults();
 
-    // https://github.com/dequelabs/axe-core/blob/develop/doc/API.md
-
-    const results = browser.executeAsync(done => {
-        const options = {
-            runOnly: {
-                type: 'tag',
-                values: ['wcag21a', 'wcag21aa', 'wcag143', 'cat.color', 'cat.aria']
-            },
-            rules: {
-				'duplicate-id': { enabled: false },
-                'bypass': { enabled: false }
-			}
-        };
-
-        axe.run(document, options, (err, results) => {
-            if (err) throw err;
-            done(results);
-
-            return results;
-        });
-    });
-
-    if(results.violations.length > 0)
-    {
+    if (results.violations.length > 0) {
         exports.processResults(results, componentName);
     }
 


### PR DESCRIPTION
### Added
- `f-wido-utils` version bump.

### Removed
- Reference to `getAccessibilityTestResults` from `axe-helper` file.

### Changed
- References within mono-repo to take wrapper method `getAxeResults` instead.