### PR TITLE
f-image-tile@v0.10.3 - Updated href & added checked attribute

### DIFF
--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.10.3
+------------------------------
+*March 10, 2022*
+
+### Added
+- checked attribute 
+
+### Updated
+- `href` always added to link
+- `isLink` test updated
+
 v0.10.2
 ------------------------------
 *March 8, 2022*

--- a/packages/components/atoms/f-image-tile/package.json
+++ b/packages/components/atoms/f-image-tile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-image-tile",
   "description": "Fozzie Image Tile - An interactive tile component containing an image, text and link.",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "main": "dist/f-image-tile.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -10,7 +10,7 @@
                 $style['c-imageTile-link'], {
                     [$style['c-imageTile-link--toggle']]: !isLink
                 }]"
-            :href="isLink ? href : '#'"
+            :href="href"
             :aria-hidden="!isLink"
             :tabindex="isLink ? false : -1"
             data-test-id="image-tile-link">
@@ -21,6 +21,7 @@
         <input
             :id="`imageTileToggle-${tileId}`"
             type="checkbox"
+            :checked="isToggleSelected"
             class="is-visuallyHidden"
             :class="$style['c-imageTile-checkbox']"
             data-test-id="image-tile-input"

--- a/packages/components/atoms/f-image-tile/src/components/_tests/ImageTile.test.js
+++ b/packages/components/atoms/f-image-tile/src/components/_tests/ImageTile.test.js
@@ -14,9 +14,9 @@ describe('ImageTile', () => {
             const isLinkFalse = false;
 
             it.each([
-                ['https://www.google.com', isLinkTrue],
-                ['#', isLinkFalse]
-            ])('should update `href` to %s when set to %s', (expectedValue, isLink) => {
+                ['https://www.google.com', undefined, isLinkTrue],
+                ['https://www.google.com', '-1', isLinkFalse]
+            ])('should pass `href` and update `tabindex` to expected values', (expectedValue, expectedTabindex, isLink) => {
                 // Arrange
                 const propsData = { isLink, href: 'https://www.google.com' };
 
@@ -29,6 +29,7 @@ describe('ImageTile', () => {
 
                 // Assert
                 expect(link.attributes('href')).toBe(expectedValue);
+                expect(link.attributes('tabindex')).toBe(expectedTabindex);
             });
         });
 


### PR DESCRIPTION
---

### Added
- checked attribute 

### Updated
- `href` always added to link
- `isLink` test updated

---

## UI Review Checks

No visual changes - difference below is due to the images on staging.
Before (staging with toggle on)
![Screenshot 2022-03-10 at 17 13 42](https://user-images.githubusercontent.com/4212434/157717983-ad662942-c645-4597-830a-2d7cc7d86345.png)


After (Storybook)
![Screenshot 2022-03-10 at 17 11 25](https://user-images.githubusercontent.com/4212434/157717539-6395f20e-8f89-42bf-8f04-d3b7cf589806.png)



- [X] README and/or UI Documentation has been [created|updated]
- [X] Unit tests have been [created|updated]
- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [X] Chrome (latest)
