### PR TITLE
f-image-tile@v0.11.0 - Added unit tests for props

### DIFF
--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -5,10 +5,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.11.0
 ------------------------------
-*March 14, 2022*
+*March 11, 2022*
 
 ### Added
-- Unit tests for props: `href`, `displayText`, `altText` & `fallbackImage`
+- Unit tests for props: `href`, `displayText` & `altText`
 
 ### Changed
 `outline` to `box-shadow` to create rounded corners in safari

--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.11.0
+------------------------------
+*March 14, 2022*
+
+### Added
+- Unit tests for props: `href`, `displayText`, `altText` & `fallbackImage`
+
+### Changed
+`outline` to `box-shadow` to create rounded corners in safari
+
+
 v0.10.3
 ------------------------------
 *March 10, 2022*
@@ -10,7 +21,7 @@ v0.10.3
 ### Added
 - checked attribute 
 
-### Updated
+### Changed
 - `href` always added to link
 - `isLink` test updated
 
@@ -18,14 +29,14 @@ v0.10.2
 ------------------------------
 *March 8, 2022*
 
-### Updated
+### Changed
 - Margin between text and image
 
 v0.10.1
 ------------------------------
 *February 28, 2022*
 
-### Updated
+### Changed
 - Props and Events within `README.md`
 
 v0.10.0

--- a/packages/components/atoms/f-image-tile/package.json
+++ b/packages/components/atoms/f-image-tile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-image-tile",
   "description": "Fozzie Image Tile - An interactive tile component containing an image, text and link.",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "main": "dist/f-image-tile.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -183,8 +183,8 @@ $image-tile-text-transform: translate3d(5px, 0, 0);
 }
 
 @mixin image-tile-focus() {
-    outline: 2px solid $color-focus;
     border-radius: $radius-rounded-b;
+    box-shadow: 0 0 0 2px $color-focus;
 }
 
 .c-imageTile {

--- a/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
+++ b/packages/components/atoms/f-image-tile/src/components/ImageTile.vue
@@ -51,7 +51,9 @@
                 :class="$style['c-imageTile-textContainer']"
                 :aria-hidden="isLink">
                 <tick-icon :class="$style['c-imageTile-icon']" />
-                <span :class="$style['c-imageTile-text']">
+                <span
+                    :class="$style['c-imageTile-text']"
+                    data-test-id="image-tile-text">
                     {{ displayText }}
                 </span>
             </span>

--- a/packages/components/atoms/f-image-tile/src/components/_tests/ImageTile.test.js
+++ b/packages/components/atoms/f-image-tile/src/components/_tests/ImageTile.test.js
@@ -33,6 +33,18 @@ describe('ImageTile', () => {
             });
         });
 
+        xdescribe('href :: ', () => {
+        });
+
+        xdescribe('displayText :: ', () => {
+        });
+
+        xdescribe('altText :: ', () => {
+        });
+
+        xdescribe('fallbackImage :: ', () => {
+        });
+
         describe('tileId :: ', () => {
             it('should apply `tileId` to the input id', () => {
                 // Arrange

--- a/packages/components/atoms/f-image-tile/src/components/_tests/ImageTile.test.js
+++ b/packages/components/atoms/f-image-tile/src/components/_tests/ImageTile.test.js
@@ -33,16 +33,55 @@ describe('ImageTile', () => {
             });
         });
 
-        xdescribe('href :: ', () => {
+        describe('href :: ', () => {
+            it('should apply `href` to the link', () => {
+                // Arrange
+                const propsData = { href: 'https://www.google.com' };
+
+                // Act
+                const wrapper = shallowMount(ImageTile, {
+                    propsData
+                });
+
+                const link = wrapper.find('[data-test-id="image-tile-link"]');
+
+                // Assert
+                expect(link.attributes('href')).toBe(propsData.href);
+            });
         });
 
-        xdescribe('displayText :: ', () => {
+        describe('displayText :: ', () => {
+            it('should apply `displayText` to the image tile', () => {
+                // Arrange
+                const propsData = { displayText: 'Chicken' };
+
+                // Act
+                const wrapper = shallowMount(ImageTile, {
+                    propsData
+                });
+
+                const text = wrapper.find('[data-test-id="image-tile-text"]');
+
+                // Assert
+                expect(text.text()).toBe(propsData.displayText);
+            });
         });
 
-        xdescribe('altText :: ', () => {
-        });
+        describe('altText :: ', () => {
+            it('should apply `altText` to the image alt', () => {
+                // Arrange
+                const propsData = { imgSrc: 'https://via.placeholder.com/150', altText: '' };
 
-        xdescribe('fallbackImage :: ', () => {
+                // Act
+                const wrapper = shallowMount(ImageTile, {
+                    propsData
+                });
+
+                const image = wrapper.find('[data-test-id="image-tile-image"]');
+
+                // Assert
+                expect(image.attributes('alt')).toContain(propsData.altText);
+            });
         });
 
         describe('tileId :: ', () => {


### PR DESCRIPTION
---

### Added
- Unit tests for props: `href`, `displayText` & `altText`

### Changed
`outline` to `box-shadow` to create rounded corners in safari

---

## UI Review Checks

Before (safari)
![Screenshot 2022-03-11 at 13 15 45](https://user-images.githubusercontent.com/4212434/157873819-9eb45af9-3a2f-46d8-9452-a8e5194a0d3a.png)


After (safari)
![Screenshot 2022-03-11 at 13 14 55](https://user-images.githubusercontent.com/4212434/157873808-1c353a66-62db-4b02-989d-2aa7d9f0a628.png)


- [X] README and/or UI Documentation has been [created|updated]
- [X] Unit tests have been [created|updated]
- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [X] Chrome (latest)
- [X] Safari

