### PR TITLE
f-cookie-banner@v3.8.1 - Added data-test-id and selectors file for testing

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -4,8 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest – to be added to the next release
+v3.8.1
 ------------------------------
+*March 11, 2022*
+
+### Added
+- `data-test-id` to the cookie banner title for testing.
+- `f-cookie-banner-selectors.js` file and selectors for UI element assertions in tests.
+
 *February 23, 2022*
 
 ### Changed

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner – Cookie Banner",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
+++ b/packages/components/organisms/f-cookie-banner/src/components/CookieBanner.vue
@@ -23,6 +23,7 @@
                     data-test-id="cookieBannerContent">
                     <h2
                         id="cookieConsentTitle"
+                        data-test-id="cookieConsentTitle"
                         ref="cookieBannerHeading"
                         tabindex="0"
                         :class="$style['c-cookieBanner-title']"

--- a/packages/components/organisms/f-cookie-banner/test-utils/component-objects/f-cookie-banner-selectors.js
+++ b/packages/components/organisms/f-cookie-banner/test-utils/component-objects/f-cookie-banner-selectors.js
@@ -1,0 +1,5 @@
+exports.COOKIE_BANNER_COMPONENT = '[data-test-id="cookieConsentBanner"]';
+exports.COOKIE_BANNER_TITLE = '[data-test-id="cookieConsentTitle"]';
+exports.COOKIE_BANNER_LINK = '[data-test-id="link-component"]';
+exports.ACCEPT_ALL_COOKIES_BUTTON = '[data-test-id="accept-all-cookies-button"]';
+exports.ACCEPT_NECESSARY_COOKIES_BUTTON = '[data-test-id="accept-necessary-cookies-button"]';


### PR DESCRIPTION
v3.8.1
------------------------------
*March 11, 2022*

### Added
- `data-test-id` to the cookie banner title for testing.
- `f-cookie-banner-selectors.js` file and selectors for UI element assertions in tests.