### PR TITLE
f-filter-pill@0.3.1 - add checked attribute to filter pill

### DIFF
--- a/packages/components/atoms/f-filter-pill/CHANGELOG.md
+++ b/packages/components/atoms/f-filter-pill/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.3.0
+------------------------------
+*February 23, 2022*
+
+### Added
+- Checked Attribute to Filter Pill
+  
 v0.2.0
 ------------------------------
 *February 23, 2022*

--- a/packages/components/atoms/f-filter-pill/CHANGELOG.md
+++ b/packages/components/atoms/f-filter-pill/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v0.3.0
+v0.2.1
 ------------------------------
 *February 23, 2022*
 

--- a/packages/components/atoms/f-filter-pill/package.json
+++ b/packages/components/atoms/f-filter-pill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-filter-pill",
   "description": "Fozzie Filter Pill - An interactive component for filter toggles.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/f-filter-pill.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-filter-pill/package.json
+++ b/packages/components/atoms/f-filter-pill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-filter-pill",
   "description": "Fozzie Filter Pill - An interactive component for filter toggles.",
-  "version": "0.3.0",
+  "version": "0.2.1",
   "main": "dist/f-filter-pill.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
+++ b/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
@@ -12,6 +12,7 @@
             class="is-visuallyHidden"
             :class="$style['c-filterPill-checkbox']"
             data-test-id="filter-pill-input"
+            :checked="isToggleSelected"
             :tabindex="0"
             :disabled="isToggleDisabled"
             @change="toggleFilter">

--- a/packages/components/atoms/f-filter-pill/src/components/_tests/FilterPill.test.js
+++ b/packages/components/atoms/f-filter-pill/src/components/_tests/FilterPill.test.js
@@ -99,6 +99,38 @@ describe('FilterPill', () => {
             });
         });
 
+        describe('checked :: ', () => {
+            it('should have a true checked state when filter is selected', () => {
+                // Arrange
+                const propsData = { isSelected: true };
+
+                // Act
+                const wrapper = shallowMount(FilterPill, {
+                    propsData
+                });
+
+                const { checked } = wrapper.find('input').element;
+
+                // Assert
+                expect(checked).toBe(true);
+            });
+
+            it('should have a false checked state when filter is not selected', () => {
+                // Arrange
+                const propsData = { isSelected: false };
+
+                // Act
+                const wrapper = shallowMount(FilterPill, {
+                    propsData
+                });
+
+                const { checked } = wrapper.find('input').element;
+
+                // Assert
+                expect(checked).toBe(false);
+            });
+        });
+
         describe('displayText :: ', () => {
             it('should show filter text', () => {
                 // Arrange

--- a/packages/components/atoms/f-filter-pill/src/components/_tests/FilterPill.test.js
+++ b/packages/components/atoms/f-filter-pill/src/components/_tests/FilterPill.test.js
@@ -99,38 +99,6 @@ describe('FilterPill', () => {
             });
         });
 
-        describe('checked :: ', () => {
-            it('should have a true checked state when filter is selected', () => {
-                // Arrange
-                const propsData = { isSelected: true };
-
-                // Act
-                const wrapper = shallowMount(FilterPill, {
-                    propsData
-                });
-
-                const { checked } = wrapper.find('input').element;
-
-                // Assert
-                expect(checked).toBe(true);
-            });
-
-            it('should have a false checked state when filter is not selected', () => {
-                // Arrange
-                const propsData = { isSelected: false };
-
-                // Act
-                const wrapper = shallowMount(FilterPill, {
-                    propsData
-                });
-
-                const { checked } = wrapper.find('input').element;
-
-                // Assert
-                expect(checked).toBe(false);
-            });
-        });
-
         describe('displayText :: ', () => {
             it('should show filter text', () => {
                 // Arrange
@@ -181,6 +149,52 @@ describe('FilterPill', () => {
                 expect(wrapper.vm.isToggleSelected).toBe(true);
                 expect(spy).toHaveBeenCalledWith('toggle', wrapper.vm.toggleValue);
             });
+        });
+    });
+
+    describe('checked :: ', () => {
+        it('should have a true checked state when filter is selected', () => {
+            // Arrange
+            const propsData = { isSelected: true };
+
+            // Act
+            const wrapper = shallowMount(FilterPill, {
+                propsData
+            });
+
+            const { checked } = wrapper.find('input').element;
+
+            // Assert
+            expect(checked).toBe(true);
+        });
+
+        it('should have a false checked state when filter is not selected', () => {
+            // Arrange
+            const propsData = { isSelected: false };
+
+            // Act
+            const wrapper = shallowMount(FilterPill, {
+                propsData
+            });
+
+            const { checked } = wrapper.find('input').element;
+
+            // Assert
+            expect(checked).toBe(false);
+        });
+
+        it('should have a true checked state when filter is clicked', () => {
+            // Arrange & Act
+            const wrapper = shallowMount(FilterPill);
+
+            const inputEl = wrapper.find('input');
+
+            inputEl.trigger('click');
+
+            const { checked } = inputEl.element;
+
+            // Assert
+            expect(checked).toBe(true);
         });
     });
 });


### PR DESCRIPTION
Adds the missing checked attribute/property to the filter pill when the filter pill is selected indirectly i.e. checked through vueX or props.

## Browsers Tested

- [X] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)
