### PR TITLE
f-filter-pill@v0.4.0 - Add `a` tag to the component for the SEO reasons

### DIFF
--- a/packages/components/atoms/f-filter-pill/CHANGELOG.md
+++ b/packages/components/atoms/f-filter-pill/CHANGELOG.md
@@ -3,13 +3,20 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.4.0
+------------------------------
+*March 15, 2022*
+
+### Added
+- `a` tag for the SEO reasons
+
 v0.3.1
 ------------------------------
 *March 14, 2022*
 
 ### Added
 - Checked Attribute to Filter Pill
-  
+
 v0.3.0
 ------------------------------
 *March 10, 2022*

--- a/packages/components/atoms/f-filter-pill/package.json
+++ b/packages/components/atoms/f-filter-pill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-filter-pill",
   "description": "Fozzie Filter Pill - An interactive component for filter toggles.",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "main": "dist/f-filter-pill.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
+++ b/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
@@ -8,7 +8,7 @@
         data-test-id="filter-item">
         <a
             :class="$style['c-filterPill-link']"
-            :href="toggleValue"
+            :href="href"
             tabindex="-1"
             aria-hidden="true"
             data-test-id="filter-pill-link">
@@ -60,6 +60,10 @@ export default {
             default: null
         },
         toggleValue: {
+            type: String,
+            default: null
+        },
+        href: {
             type: String,
             default: null
         },

--- a/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
+++ b/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
@@ -6,6 +6,16 @@
                 [$style['c-filterPill--disabled']]: isToggleDisabled
             }]"
         data-test-id="filter-item">
+        <a
+            :class="$style['c-filterPill-link']"
+            :href="toggleValue"
+            tabindex="-1"
+            aria-hidden="true"
+            data-test-id="filter-pill-link">
+            <span class="is-visuallyHidden">
+                {{ displayText }}
+            </span>
+        </a>
         <input
             :id="`filterPillToggle-${inputId}`"
             type="checkbox"
@@ -130,6 +140,10 @@ $filter-pill-ease: ease-in-out;
 
 .c-filterPill--selected {
     box-shadow: 0 0 0 2px $color-focus;
+}
+
+.c-filterPill-link {
+    pointer-events: none;
 }
 
 .c-filterPill-label {

--- a/packages/components/atoms/f-filter-pill/src/components/_tests/FilterPill.test.js
+++ b/packages/components/atoms/f-filter-pill/src/components/_tests/FilterPill.test.js
@@ -52,7 +52,6 @@ describe('FilterPill', () => {
                 });
 
                 const link = wrapper.find('[data-test-id="filter-pill-link"]');
-                console.log(link);
 
                 // Assert
                 expect(link.attributes('href')).toBe(propsData.href);

--- a/packages/components/atoms/f-filter-pill/src/components/_tests/FilterPill.test.js
+++ b/packages/components/atoms/f-filter-pill/src/components/_tests/FilterPill.test.js
@@ -41,6 +41,24 @@ describe('FilterPill', () => {
             });
         });
 
+        describe('href :: ', () => {
+            it('should have filter `href` value', () => {
+                // Arrange
+                const propsData = { href: '/area/cf10-cardiff/?refine=low_delivery_fee' };
+
+                // Act
+                const wrapper = shallowMount(FilterPill, {
+                    propsData
+                });
+
+                const link = wrapper.find('[data-test-id="filter-pill-link"]');
+                console.log(link);
+
+                // Assert
+                expect(link.attributes('href')).toBe(propsData.href);
+            });
+        });
+
         describe('isSelected :: ', () => {
             it.each([
                 [true, true],

--- a/packages/components/atoms/f-filter-pill/stories/FilterPill.stories.js
+++ b/packages/components/atoms/f-filter-pill/stories/FilterPill.stories.js
@@ -12,6 +12,7 @@ export const FilterPillComponent = (args, { argTypes }) => ({
     template: `<filter-pill
                     :input-id='inputId'
                     :toggle-value='toggleValue'
+                    :href='href'
                     :is-selected='isSelected'
                     :is-disabled='isDisabled'
                     :display-text='displayText'
@@ -29,6 +30,11 @@ FilterPillComponent.argTypes = {
         control: { type: 'text' },
         description: 'Filter pill toggle value',
         defaultValue: 'low_delivery_fee'
+    },
+    href: {
+        control: { type: 'text' },
+        description: 'Filter pill href value',
+        defaultValue: '/area/cf10-cardiff/?refine=low_delivery_fee'
     },
     isSelected: {
         control: { type: 'boolean' },

--- a/packages/components/atoms/f-filter-pill/stories/FilterPill.stories.js
+++ b/packages/components/atoms/f-filter-pill/stories/FilterPill.stories.js
@@ -11,6 +11,7 @@ export const FilterPillComponent = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
     template: `<filter-pill
                     :input-id='inputId'
+                    :toggle-value='toggleValue'
                     :is-selected='isSelected'
                     :is-disabled='isDisabled'
                     :display-text='displayText'


### PR DESCRIPTION
The presence of a URL is currently required by SearchWeb SEO to be consumable by web crawlers.

No visual changes.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Safari
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)
