### PR TITLE
f-breadcrumbs@v3.2.0 - Add nav landmark to breadcrumb list.

### DIFF
--- a/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
+++ b/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
@@ -3,12 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-Latest (to be added to next release)
+v3.2.0
 ------------------------------
-*February 4, 2022*
+*March 15, 2022*
 
 ### Changed
 - Upgraded to ESLint v8
+
+### Added
+- `nav` landmark & `aria-label`.
+- Tests to cover change.
 
 
 v3.1.0

--- a/packages/components/molecules/f-breadcrumbs/package.json
+++ b/packages/components/molecules/f-breadcrumbs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-breadcrumbs",
   "description": "Fozzie Bread Crumbs – Provides clickable paths back to previous pages",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "main": "dist/f-breadcrumbs.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/molecules/f-breadcrumbs/src/components/BreadCrumbs.vue
+++ b/packages/components/molecules/f-breadcrumbs/src/components/BreadCrumbs.vue
@@ -1,5 +1,6 @@
 <template>
-    <div
+    <nav
+        aria-label="breadcrumbs"
         data-test-id="breadcrumbs-component"
         :class="$style['c-breadcrumbs']">
         <ul
@@ -39,7 +40,7 @@
                 </li>
             </template>
         </ul>
-    </div>
+    </nav>
 </template>
 
 <script>

--- a/packages/components/molecules/f-breadcrumbs/src/components/tests/Breadcrumbs.test.js
+++ b/packages/components/molecules/f-breadcrumbs/src/components/tests/Breadcrumbs.test.js
@@ -13,6 +13,17 @@ describe('BreadCrumbs', () => {
         expect(wrapper.exists()).toBe(true);
     });
 
+    it('should contain `aria-label` with content `breadcrumbs`', () => {
+        // Arrange
+        const wrapper = shallowMount(BreadCrumbs);
+
+        // Act
+        const result = wrapper.find("[data-test-id='breadcrumbs-component']");
+
+        // Assert
+        expect(result.attributes('aria-label')).toBe('breadcrumbs');
+    });
+
     describe('props::', () => {
         describe('`links`', () => {
             it('should render a link when a url is supplied', () => {


### PR DESCRIPTION
### Changed
- Upgraded to ESLint v8

### Added
- `nav` landmark & `aria-label`.
- Tests to cover change.

## UI Review Checks

- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

