### PR TITLE
f-navigation-links@v1.1.0 - Add aria label and nav landmark.

### DIFF
--- a/packages/components/molecules/f-navigation-links/CHANGELOG.md
+++ b/packages/components/molecules/f-navigation-links/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.1.0
+------------------------------
+*March 15, 2022*
+
+### Added
+- `aria-label` and `nav` landmark to navigation.
+- Tests to cover changes.
+
 
 v1.0.0
 ------------------------------

--- a/packages/components/molecules/f-navigation-links/package.json
+++ b/packages/components/molecules/f-navigation-links/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-navigation-links",
   "description": "Fozzie Navigation Links - A component to display a collection of supplied links",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/f-navigation-links.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/molecules/f-navigation-links/src/components/NavigationLinks.vue
+++ b/packages/components/molecules/f-navigation-links/src/components/NavigationLinks.vue
@@ -1,25 +1,28 @@
 <template>
-    <ul
-        v-if="filterLinks.length"
-        :class="$style['c-navigationLinks']"
+    <nav
+        aria-label="navigation"
         data-test-id="navigationLinks">
-        <li
-            v-for="({
-                id, href, to, name
-            }, i) in filterLinks"
-            :key="i"
-            :class="$style['c-navigationLinks-item']">
-            <v-link
-                :data-test-id="id"
-                :has-text-decoration="false"
-                link-class="c-navigationLinks-link"
-                v-bind="{
-                    ...(href ? { href } : to ? { to } : {})
-                }">
-                {{ name }}
-            </v-link>
-        </li>
-    </ul>
+        <ul
+            v-if="filterLinks.length"
+            :class="$style['c-navigationLinks']">
+            <li
+                v-for="({
+                    id, href, to, name
+                }, i) in filterLinks"
+                :key="i"
+                :class="$style['c-navigationLinks-item']">
+                <v-link
+                    :data-test-id="id"
+                    :has-text-decoration="false"
+                    link-class="c-navigationLinks-link"
+                    v-bind="{
+                        ...(href ? { href } : to ? { to } : {})
+                    }">
+                    {{ name }}
+                </v-link>
+            </li>
+        </ul>
+    </nav>
 </template>
 
 <script>

--- a/packages/components/molecules/f-navigation-links/src/components/_tests/NavigationLinks.test.js
+++ b/packages/components/molecules/f-navigation-links/src/components/_tests/NavigationLinks.test.js
@@ -147,6 +147,14 @@ describe('NavigationLinks', () => {
         expect(link.exists()).toBeFalsy();
     });
 
+    it('should contain `aria-label` with content `navigation`', () => {
+        const wrapper = shallowMount(NavigationLinks);
+
+        const links = wrapper.find('[data-test-id="navigationLinks"]');
+
+        expect(links.attributes('aria-label')).toBe('navigation');
+    });
+
     describe('computed ::', () => {
         describe('filterLinks ::', () => {
             it('should filter props.links if link does not have `to` or `href` property', () => {

--- a/packages/components/molecules/f-navigation-links/src/components/_tests/NavigationLinks.test.js
+++ b/packages/components/molecules/f-navigation-links/src/components/_tests/NavigationLinks.test.js
@@ -50,25 +50,34 @@ const propsData = {
 
 describe('NavigationLinks', () => {
     it('should be defined', () => {
+        // Arrange & Act
         const wrapper = shallowMount(NavigationLinks, { propsData });
 
+        // Assert
         expect(wrapper.exists()).toBe(true);
     });
 
     it('should not fail if no `links` prop supplied', () => {
+        // Arrange & Act
         const wrapper = shallowMount(NavigationLinks);
 
+        // Assert
         expect(wrapper.html).toMatchSnapshot();
     });
 
     it('should display the list elements correctly for each `link` supplied', () => {
+        // Arrange
         const wrapper = shallowMount(NavigationLinks, { propsData });
 
+        // Act
         const links = wrapper.find('[data-test-id="navigationLinks"]');
+
+        // Assert
         expect(links).toMatchSnapshot();
     });
 
     it('should pass to attribute to `<v-link>` when present', () => {
+        // Arrange
         const expected = '/account/info';
         const wrapper = shallowMount(NavigationLinks, {
             propsData: {
@@ -81,12 +90,15 @@ describe('NavigationLinks', () => {
             }
         });
 
+        // Act
         const link = wrapper.find('[data-test-id="link1"]');
 
+        // Assert
         expect(link.attributes('to')).toEqual(expected);
     });
 
     it('should pass href attribute to `<v-link>` when present', () => {
+        // Arrange
         const expected = '/account/info';
         const wrapper = shallowMount(NavigationLinks, {
             propsData: {
@@ -99,12 +111,15 @@ describe('NavigationLinks', () => {
             }
         });
 
+        // Act
         const link = wrapper.find('[data-test-id="link1"]');
 
+        // Assert
         expect(link.attributes('href')).toEqual(expected);
     });
 
     it('should pass href attribute to `<v-link>` when both `to` and `href` present in links data', () => {
+        // Arrange
         const expected = '/account/info';
         const wrapper = shallowMount(NavigationLinks, {
             propsData: {
@@ -118,13 +133,16 @@ describe('NavigationLinks', () => {
             }
         });
 
+        // Act
         const link = wrapper.find('[data-test-id="link1"]');
 
+        // Assert
         expect(link.attributes('href')).toEqual(expected);
         expect(link.attributes('to')).toBeUndefined();
     });
 
     it('should skip link item if both `to` and `href` missing in props.links object', () => {
+        // Arrange
         const wrapper = shallowMount(NavigationLinks, {
             propsData: {
                 links: [
@@ -140,24 +158,30 @@ describe('NavigationLinks', () => {
             }
         });
 
+        // Act
         const links = wrapper.find('[data-test-id="navigationLinks"]');
         const link = wrapper.find('[data-test-id="link1"]');
 
+        // Assert
         expect(links.findAll('li').length).toEqual(1);
         expect(link.exists()).toBeFalsy();
     });
 
     it('should contain `aria-label` with content `navigation`', () => {
+        // Arrange
         const wrapper = shallowMount(NavigationLinks);
 
+        // Act
         const links = wrapper.find('[data-test-id="navigationLinks"]');
 
+        // Assert
         expect(links.attributes('aria-label')).toBe('navigation');
     });
 
     describe('computed ::', () => {
         describe('filterLinks ::', () => {
             it('should filter props.links if link does not have `to` or `href` property', () => {
+                // Arrange
                 const wrapper = shallowMount(NavigationLinks, {
                     propsData: {
                         links: [
@@ -178,7 +202,10 @@ describe('NavigationLinks', () => {
                     }
                 });
 
+                // Act
                 const result = wrapper.vm.filterLinks;
+
+                // Assert
                 expect(result.length).toEqual(2);
                 expect(result.find(x => x.id === 'link1')).toBeUndefined();
             });

--- a/packages/components/molecules/f-navigation-links/src/components/_tests/__snapshots__/NavigationLinks.test.js.snap
+++ b/packages/components/molecules/f-navigation-links/src/components/_tests/__snapshots__/NavigationLinks.test.js.snap
@@ -1,48 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NavigationLinks should display the list elements correctly for each \`link\` supplied 1`] = `
-<ul data-test-id="navigationLinks" class="c-navigationLinks">
-  <li class="c-navigationLinks-item">
-    <v-link-stub data-test-id="link1" link-class="c-navigationLinks-link" to="/account/info">
-      Your account
-    </v-link-stub>
-  </li>
-  <li class="c-navigationLinks-item">
-    <v-link-stub data-test-id="link2" link-class="c-navigationLinks-link" to="/order-history">
-      Your orders
-    </v-link-stub>
-  </li>
-  <li class="c-navigationLinks-item">
-    <v-link-stub data-test-id="link3" link-class="c-navigationLinks-link" to="/account/paymentoptions">
-      Your saved cards
-    </v-link-stub>
-  </li>
-  <li class="c-navigationLinks-item">
-    <v-link-stub data-test-id="link4" link-class="c-navigationLinks-link" to="/member/addressbook">
-      Your address book
-    </v-link-stub>
-  </li>
-  <li class="c-navigationLinks-item">
-    <v-link-stub data-test-id="link5" link-class="c-navigationLinks-link" to="/account/credit">
-      Redeem a voucher
-    </v-link-stub>
-  </li>
-  <li class="c-navigationLinks-item">
-    <v-link-stub data-test-id="link6" link-class="c-navigationLinks-link" to="/giftcards/redeem">
-      Redeem a gift card
-    </v-link-stub>
-  </li>
-  <li class="c-navigationLinks-item">
-    <v-link-stub data-test-id="link7" link-class="c-navigationLinks-link" to="/account/preferences">
-      Contact preferences
-    </v-link-stub>
-  </li>
-  <li class="c-navigationLinks-item">
-    <v-link-stub data-test-id="link8" link-class="c-navigationLinks-link" href="/anchor-link">
-      Anchor link
-    </v-link-stub>
-  </li>
-</ul>
+<nav aria-label="navigation" data-test-id="navigationLinks">
+  <ul class="c-navigationLinks">
+    <li class="c-navigationLinks-item">
+      <v-link-stub data-test-id="link1" link-class="c-navigationLinks-link" to="/account/info">
+        Your account
+      </v-link-stub>
+    </li>
+    <li class="c-navigationLinks-item">
+      <v-link-stub data-test-id="link2" link-class="c-navigationLinks-link" to="/order-history">
+        Your orders
+      </v-link-stub>
+    </li>
+    <li class="c-navigationLinks-item">
+      <v-link-stub data-test-id="link3" link-class="c-navigationLinks-link" to="/account/paymentoptions">
+        Your saved cards
+      </v-link-stub>
+    </li>
+    <li class="c-navigationLinks-item">
+      <v-link-stub data-test-id="link4" link-class="c-navigationLinks-link" to="/member/addressbook">
+        Your address book
+      </v-link-stub>
+    </li>
+    <li class="c-navigationLinks-item">
+      <v-link-stub data-test-id="link5" link-class="c-navigationLinks-link" to="/account/credit">
+        Redeem a voucher
+      </v-link-stub>
+    </li>
+    <li class="c-navigationLinks-item">
+      <v-link-stub data-test-id="link6" link-class="c-navigationLinks-link" to="/giftcards/redeem">
+        Redeem a gift card
+      </v-link-stub>
+    </li>
+    <li class="c-navigationLinks-item">
+      <v-link-stub data-test-id="link7" link-class="c-navigationLinks-link" to="/account/preferences">
+        Contact preferences
+      </v-link-stub>
+    </li>
+    <li class="c-navigationLinks-item">
+      <v-link-stub data-test-id="link8" link-class="c-navigationLinks-link" href="/anchor-link">
+        Anchor link
+      </v-link-stub>
+    </li>
+  </ul>
+</nav>
 `;
 
 exports[`NavigationLinks should not fail if no \`links\` prop supplied 1`] = `[Function]`;


### PR DESCRIPTION
### Added
- `aria-label` and `nav` landmark to navigation.
- Tests to cover changes.

## UI Review Checks

- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
