### PR TITLE
f-feature-management@v0.9.0 - Replace old logger interface with new one

### DIFF
--- a/packages/services/f-feature-management/CHANGELOG.md
+++ b/packages/services/f-feature-management/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.9.0
+------------------------------
+*March 17, 2022*
+
+### Changed
+ - Replace old deprecated logger with new interface
+
+
 v0.8.0
 ------------------------------
 *March 3, 2022*
@@ -14,21 +22,21 @@ v0.7.2
 ------------------------------
 *February 21, 2022*
 
-### Changed 
+### Changed
  - Fix import of config JSON action import for features store module
 
 v0.7.1
 ------------------------------
 *November 23, 2021*
 
-### Changed 
+### Changed
  - Enable namespacing for store
 
 v0.7.0
 ------------------------------
 *November 18, 2021*
 
-### Changed 
+### Changed
  - Improved error logging
 
 v0.6.0

--- a/packages/services/f-feature-management/README.md
+++ b/packages/services/f-feature-management/README.md
@@ -1,18 +1,18 @@
 # Feature Management
 
-This service allows querying of feature flags as configured using the Feature 
+This service allows querying of feature flags as configured using the Feature
 Management service via an injectable Nuxt plugin
 
 ## Usage
 
-To create an instance of the service: 
+To create an instance of the service:
 
 ```javascript
 const featuresService = new FeaturesService(store, {
     httpClient: $axios, // nuxt-axios plugin instance or compliant http client
     cookies: $cookies, // cookie-universal-nuxt plugin or compliant cookie store
     analytics: $gtm, // @justeat/f-analytics instance
-    logger: $logger // See below
+    log: $log // See below
 });
 ```
 
@@ -41,7 +41,7 @@ The following configuration should be available in the store:
 }
 ```
 
-The service accesses this configuration from the store at the following 
+The service accesses this configuration from the store at the following
 location:
 
 ```javascript
@@ -50,15 +50,14 @@ store.state.configuration.settings.featureManagement
 
 ## Logging
 
-The logger must provide the following interface:
+The log class must provide the following interface:
 
 ```javascript
 
-class Logger {
-
+class Log {
   info (message, tags, payload = {}) { ... }
 
-   warn (message, tags, payload = {}) { ... }
+  warn (message, tags, payload = {}) { ... }
 
   error (message, exception, tags, payload = {}) { ... }
 }

--- a/packages/services/f-feature-management/package.json
+++ b/packages/services/f-feature-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-feature-management",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Service for querying feature values provided by Feature Management",
   "main": "dist/f-feature-management.umd.js",
   "module": "dist/f-feature-management.es.js",

--- a/packages/services/f-feature-management/test/vue/features.service.test.js
+++ b/packages/services/f-feature-management/test/vue/features.service.test.js
@@ -35,15 +35,15 @@ const mockCookies = {};
 
 const mockAnalytics = {};
 
-const mockLogger = {
-    logInfo: jest.fn()
+const mockLog = {
+    info: jest.fn()
 };
 
 const createSUT = () => new FeaturesService(mockStore, {
     httpClient: mockHttpClient,
     cookies: mockCookies,
     analytics: mockAnalytics,
-    logger: mockLogger
+    log: mockLog
 });
 
 describe('Feature Service tests', () => {


### PR DESCRIPTION
- We need to replace the old logger interface here so that we can delete it from the consuming website.
- Feature Management is one of the few places not yet using the new interface.
- We changed to a newer interface in November and are replacing the older one throughout.
- Reach out if you want more info as I can't post specifics in this repo.