### PR TITLE
f-restaurant-card@v0.27.0 - Show ratings without counts

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.27.0
+------------------------------
+*March 18, 2022*
+### Changed
+- Show ratings if count is missing
+- Split count and 'own rating' message elements to simplify template
+
 v0.26.0
 ------------------------------
 *March 03, 2022*

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/RestaurantRating.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/RestaurantRating.vue
@@ -54,18 +54,26 @@
                 {{ ratingsMax }}
             </data>
 
-            <!-- Number of ratings/Own rating message -->
-            <span aria-hidden="true">
+            <!-- Number of ratings -->
+            <span
+                v-if="count && !isOwnRating"
+                aria-hidden="true">
                 &#40;
                 <data
-                    v-if="!isOwnRating"
                     data-test-id="rating"
                     :class="[$style['c-restaurantCard-rating-count']]"
                     :value="count">
                     {{ count }}
                 </data>
+                &#41;
+            </span>
+
+            <!-- Own rating message -->
+            <span
+                v-else-if="isOwnRating"
+                aria-hidden="true">
+                &#40;
                 <span
-                    v-else
                     data-test-id="rating-own-rating-message"
                     :class="[$style['c-restaurantCard-rating-count']]">
                     {{ isOwnRatingMessage }}
@@ -145,7 +153,7 @@ export default {
     },
     computed: {
         noRatingsAvailable () {
-            return !this.count || !this.mean;
+            return !this.mean;
         },
         meanFormatted () {
             return Number.parseFloat(this.mean).toFixed(2);

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/RestaurantRating.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/RestaurantRating.vue
@@ -54,9 +54,22 @@
                 {{ ratingsMax }}
             </data>
 
+            <!-- Own rating message -->
+            <span
+                v-if="isOwnRating"
+                aria-hidden="true">
+                &#40;
+                <span
+                    data-test-id="rating-own-rating-message"
+                    :class="[$style['c-restaurantCard-rating-count']]">
+                    {{ isOwnRatingMessage }}
+                </span>
+                &#41;
+            </span>
+
             <!-- Number of ratings -->
             <span
-                v-if="count && !isOwnRating"
+                v-else-if="count"
                 aria-hidden="true">
                 &#40;
                 <data
@@ -65,19 +78,6 @@
                     :value="count">
                     {{ count }}
                 </data>
-                &#41;
-            </span>
-
-            <!-- Own rating message -->
-            <span
-                v-else-if="isOwnRating"
-                aria-hidden="true">
-                &#40;
-                <span
-                    data-test-id="rating-own-rating-message"
-                    :class="[$style['c-restaurantCard-rating-count']]">
-                    {{ isOwnRatingMessage }}
-                </span>
                 &#41;
             </span>
         </template>

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/_tests/RestaurantRating.test.js
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/_tests/RestaurantRating.test.js
@@ -29,17 +29,12 @@ describe('RestaurantRating component', () => {
         expect(screenReaderMessageElement.text()).toStrictEqual(screenReaderMessage);
     });
 
-    it.each([
-        'mean',
-        'count'
-    ])('does not render a summary ratings message for screenreaders if %p prop is missing', propToMiss => {
+    it('does not render a summary ratings message for screenreaders if `mean` prop is missing', () => {
         // arrange
         const screenReaderMessage = 'foo';
 
-        const propToAdd = propToMiss === 'mean' ? { count: 10 } : { mean: 5 };
-
         const propsData = {
-            ...propToAdd,
+            count: 10,
             accessibleMessage: screenReaderMessage
         };
 
@@ -110,16 +105,12 @@ describe('RestaurantRating component', () => {
             expect(ownRatingMessageElement.text()).toStrictEqual(isOwnRatingMessage);
         });
 
-        it.each([
-            'mean',
-            'count'
-        ])('shows an empty star and a no ratings message if %p is missing', propToMiss => {
+        it('shows an empty star and a no ratings message if `mean` is missing', () => {
             // arrange
             const notRatedMessage = 'Not rated yet';
-            const propToAdd = propToMiss === 'mean' ? { count: 10 } : { mean: 5 };
 
             const propsData = {
-                ...propToAdd,
+                count: 10,
                 isOwnRating,
                 isOwnRatingMessage: 'You',
                 notRatedMessage
@@ -184,16 +175,12 @@ describe('RestaurantRating component', () => {
             expect(countMessage.text()).toStrictEqual('250');
         });
 
-        it.each([
-            'mean',
-            'count'
-        ])('shows an empty star and a no ratings message if %p is missing', propToMiss => {
+        it('shows an empty star and a no ratings message if `mean` is missing', () => {
             // arrange
             const notRatedMessage = 'Not rated yet';
-            const propToAdd = propToMiss === 'mean' ? { count: 10 } : { mean: 5 };
 
             const propsData = {
-                ...propToAdd,
+                count: 10,
                 isOwnRating,
                 notRatedMessage
             };


### PR DESCRIPTION
v0.27.0
------------------------------
*March 18, 2022*

### Changed
- Show ratings if count is missing
- Split count and 'own rating' message elements to simplify template

<img width="365" alt="Screenshot 2022-03-18 at 09 58 26" src="https://user-images.githubusercontent.com/16766185/158982548-6bcd96e3-e90b-4007-b9cd-bd30a57d6e4f.png">

