### PR TITLE
f-breadcrumbs@3.2.1 - Package bump only.

### DIFF
--- a/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
+++ b/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.2.1
+------------------------------
+*March 18, 2022*
+
+### Changed
+- `package` version as previous bump does not seem to pull through changes.
+
+
 v3.2.0
 ------------------------------
 *March 15, 2022*

--- a/packages/components/molecules/f-breadcrumbs/package.json
+++ b/packages/components/molecules/f-breadcrumbs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-breadcrumbs",
   "description": "Fozzie Bread Crumbs – Provides clickable paths back to previous pages",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "main": "dist/f-breadcrumbs.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [


### PR DESCRIPTION
Not sure what happened with the previous version 3.2.0 but the markup changes I made [here](https://github.com/justeat/fozzie-components/blob/master/packages/components/molecules/f-breadcrumbs/src/components/BreadCrumbs.vue#L2) does not pull through ok, Unsure if the publish somehow went wrong (publish was automated from CI).