### PR TITLE
f-header@v9.8.0 - small changes to match latest design

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -6,12 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v9.8.0
 ------------------------------
-*March 22, 2022*
+*March 23, 2022*
 
 ### Changed
 - corner radius when navigation is closed on mobile view
 - horizontal navigation when using a tablet
 - padding and bottom-border in account popover
+- padding of header container above mid
 
 
 v9.7.0

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -11,7 +11,7 @@ v9.8.0
 ### Changed
 - corner radius when navigation is closed on mobile view
 - horizontal navigation when using a tablet
-- padding and border in account popover
+- padding and bottom-border in account popover
 
 
 v9.7.0

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -11,7 +11,7 @@ v9.8.0
 ### Changed
 - corner radius when navigation is closed on mobile view
 - horizontal navigation when using a tablet
-- padding in account popover
+- padding and border in account popover
 
 
 v9.7.0

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -9,8 +9,9 @@ v9.8.0
 *March 22, 2022*
 
 ### Changed
-- extra small padding changes
-- navigation fix when using a tablet
+- corner radius when navigation is closed on mobile view
+- horizontal navigation when using a tablet
+- padding in account popover
 
 
 v9.7.0

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v9.8.0
+------------------------------
+*March 22, 2022*
+
+### Changed
+- extra small padding changes
+- navigation fix when using a tablet
+
+
 v9.7.0
 ------------------------------
 *March 16, 2022*

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header - Globalised Header Component",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-header/src/assets/scss/navigation.scss
+++ b/packages/components/organisms/f-header/src/assets/scss/navigation.scss
@@ -206,7 +206,6 @@ $nav-toggleIcon-space              : 5px;
     @include media('>mid') {
         margin-top: spacing(c);
     }
-    
     // tooltip arrow
     &:before {
         right: 4%;

--- a/packages/components/organisms/f-header/src/assets/scss/navigation.scss
+++ b/packages/components/organisms/f-header/src/assets/scss/navigation.scss
@@ -141,7 +141,7 @@ $nav-toggleIcon-space              : 5px;
 
     &:focus ~ .c-nav-toggle {
         background-color: $nav-trigger-focus-bg;
-        box-shadow: 0 0 6px 0 $nav-trigger-focus-color;
+        box-shadow: 0 3px 6px 0 $nav-trigger-focus-color;
 
         .c-header--transparent & {
             background-color: transparent;
@@ -194,20 +194,11 @@ $nav-toggleIcon-space              : 5px;
             transition: opacity $nav-popover-transition-duration ease-in-out,
                         z-index 0s linear;
         }
-
-        // tooltip arrow
-        &:before {
-            right: 10%;
-        }
     }
 }
 
 .c-nav-popover.c-nav-popover--countrySelector {
     @include media('>mid') {
-        margin-top: spacing(e);
-        // tooltip arrow
-        &:before {
-            right: 4%;
-        }
+        margin-top: spacing(c);
     }
 }

--- a/packages/components/organisms/f-header/src/assets/scss/navigation.scss
+++ b/packages/components/organisms/f-header/src/assets/scss/navigation.scss
@@ -194,11 +194,21 @@ $nav-toggleIcon-space              : 5px;
             transition: opacity $nav-popover-transition-duration ease-in-out,
                         z-index 0s linear;
         }
+
+        // tooltip arrow
+        &:before {
+            right: 10%;
+        }
     }
 }
 
 .c-nav-popover.c-nav-popover--countrySelector {
     @include media('>mid') {
         margin-top: spacing(c);
+    }
+    
+    // tooltip arrow
+    &:before {
+        right: 4%;
     }
 }

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -205,6 +205,7 @@ html:global(.is-navInView) {
             left: 0;
             width: 100%;
             z-index: zIndex(high);
+            border-radius: 0;
         }
     }
 }
@@ -215,6 +216,7 @@ html:global(.is-navInView) {
     position: relative;
     z-index: zIndex(mid);
     box-shadow: $header-box-shadow;
+    border-radius: 0 0 $radius-rounded-d $radius-rounded-d;
 
     // Styles for a sticky header on mobile
     @include media('<=mid') {
@@ -227,10 +229,6 @@ html:global(.is-navInView) {
         &.is-sticky-scrollingUp {
             top: 0;
         }
-    }
-
-    @include media('>mid') {
-        border-radius: 0 0 $radius-rounded-d $radius-rounded-d;
     }
 }
 

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -283,6 +283,11 @@ html:global(.is-navInView) {
         min-height: $header-height--narrow;
 
         @include media('>mid') {
+            padding-left: #{$layout-margin}px;
+            padding-right: #{$layout-margin}px;
+        }
+
+        @include media('<wide') {
             padding-left: #{$layout-margin--mid}px;
             padding-right: #{$layout-margin--mid}px;
         }

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -25,7 +25,6 @@
 
             <navigation
                 :copy="copy"
-                :is-jet-logo-theme="shouldUseJetLogo"
                 :custom-nav-links="customNavLinks"
                 :show-delivery-enquiry="showDeliveryEnquiryWithContent"
                 :show-offers-link="showOffersLinkWithContent"
@@ -282,8 +281,7 @@ html:global(.is-navInView) {
         position: relative;
         min-height: $header-height--narrow;
 
-        // tablet size or less
-        @media screen and (max-width: 834px) {
+        @include media('>mid') {
             padding-left: #{$layout-margin--mid}px;
             padding-right: #{$layout-margin--mid}px;
         }

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -21,6 +21,7 @@
                 :is-logo-disabled="isLogoLinkDisabled"
                 :logo-gtm-label="copy.logo.gtm"
                 :header-background-theme="headerBackgroundTheme"
+                :resize-logo="showDeliveryEnquiryWithContent && showCountrySelector"
                 :is-open="mobileNavIsOpen" />
 
             <navigation

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -21,7 +21,7 @@
                 :is-logo-disabled="isLogoLinkDisabled"
                 :logo-gtm-label="copy.logo.gtm"
                 :header-background-theme="headerBackgroundTheme"
-                :resize-logo="showDeliveryEnquiryWithContent && showCountrySelector"
+                :should-resize-logo="showDeliveryEnquiryWithContent && showCountrySelector"
                 :is-open="mobileNavIsOpen" />
 
             <navigation

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -25,6 +25,7 @@
 
             <navigation
                 :copy="copy"
+                :is-jet-logo-theme="shouldUseJetLogo"
                 :custom-nav-links="customNavLinks"
                 :show-delivery-enquiry="showDeliveryEnquiryWithContent"
                 :show-offers-link="showOffersLinkWithContent"
@@ -283,7 +284,8 @@ html:global(.is-navInView) {
         position: relative;
         min-height: $header-height--narrow;
 
-        @include media('<wide') {
+        // tablet size or less
+        @media screen and (max-width: 834px) {
             padding-left: #{$layout-margin--mid}px;
             padding-right: #{$layout-margin--mid}px;
         }

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -7,6 +7,7 @@
             :is="iconComponent"
             :class="[
                 $style['c-logo-img'],
+                { [$style['c-logo-img--jet']]: theme === 'jet' },
                 { [$style['c-logo-img--alt']]: isAltLogo }
             ]"
             :data-theme-logo="iconComponent"
@@ -112,8 +113,19 @@ export default {
         margin-left: -10.5px; //half of hamburger menu width
 
         @include media('>mid') {
-            height: 40px;
             margin-left: 0;
+            height: 40px;
+        }
+    }
+
+    .c-logo-img--jet {
+        @include media('>mid') {
+            @include media('<wide') {
+                height: 32px;
+            }
+            @include media('>wide') {
+                height: 40px;
+            }
         }
     }
 

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -130,7 +130,7 @@ export default {
             }
 
             // tablet
-            @media screen and (max-width:833px){
+            @media screen and (max-width: 833px) {
                 height: 25px;
                 margin-top: spacing(b);
             }

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -7,7 +7,7 @@
             :is="iconComponent"
             :class="[
                 $style['c-logo-img'],
-                { [$style['c-logo-img--jet']]: theme === 'jet' && resizeLogo },
+                { [$style['c-logo-img--jet']]: theme === 'jet' && shouldResizeLogo },
                 { [$style['c-logo-img--alt']]: isAltLogo }
             ]"
             :data-theme-logo="iconComponent"
@@ -54,7 +54,7 @@ export default {
             type: Boolean,
             default: false
         },
-        resizeLogo: {
+        shouldResizeLogo: {
             type: Boolean,
             default: false
         }

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -122,7 +122,7 @@ export default {
         }
     }
 
-    // shrinks long JET logo (for tablet screen) when long delivery link is displayed
+    // resizes takeaway logo for tablets if delivery link and country selector are also visible
     .c-logo-img--jet {
         @include media('>mid') {
             @include media('<wide') {

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -7,7 +7,7 @@
             :is="iconComponent"
             :class="[
                 $style['c-logo-img'],
-                { [$style['c-logo-img--jet']]: theme === 'jet' },
+                { [$style['c-logo-img--jet']]: theme === 'jet' && resizeLogo },
                 { [$style['c-logo-img--alt']]: isAltLogo }
             ]"
             :data-theme-logo="iconComponent"
@@ -51,6 +51,10 @@ export default {
             default: 'white'
         },
         isOpen: {
+            type: Boolean,
+            default: false
+        },
+        resizeLogo: {
             type: Boolean,
             default: false
         }
@@ -118,11 +122,19 @@ export default {
         }
     }
 
+    // shrinks long JET logo (for tablet screen) when long delivery link is displayed
     .c-logo-img--jet {
         @include media('>mid') {
             @include media('<wide') {
-                height: 32px;
+                height: 35px;
             }
+
+            // tablet
+            @media screen and (max-width:833px){
+                height: 25px;
+                margin-top: spacing(b);
+            }
+
             @include media('>wide') {
                 height: 40px;
             }

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -139,11 +139,12 @@
                 </li>
 
                 <li
-                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
-                             $style['has-sublist'], {
-                                 'is-hidden': !userInfo || !showLoginInfo,
-                                 [$style['is-open']]: userMenuIsOpen
-                             }]"
+                    :class="[
+                        $style['c-nav-list-item--horizontallyAlignedAboveMid'],
+                        $style['has-sublist'], {
+                            'is-hidden': !userInfo || !showLoginInfo,
+                            [$style['is-open']]: userMenuIsOpen
+                        }]"
                     data-test-id="user-info-icon"
                     v-on="isBelowMid ? null : { mouseover: openUserMenu, mouseleave: closeUserMenu }"
                     @keyup.esc="closeUserMenu">

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -669,6 +669,10 @@ export default {
         margin-top: spacing(d);
         margin-bottom: spacing(d);
     }
+
+    @include media('>wide') {
+        margin-left: spacing(c);
+    }
 }
 
 .c-nav-list-btn {

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -470,8 +470,7 @@ export default {
             if (this.showCountrySelector) {
                 this.closeCountrySelector();
             }
-
-            if (this.isBelowMid && this.navIsOpen) {
+            if (this.isBelowMid) {
                 // This is added to remove the ability to scroll the page content when the mobile navigation is open
                 this.handleMobileNavState();
 
@@ -577,13 +576,11 @@ export default {
         },
 
         handleMobileNavState () {
-            if (this.isBelowMid) {
-                this.$emit('onMobileNavToggle', this.navIsOpen);
+            this.$emit('onMobileNavToggle', this.navIsOpen);
 
-                if (typeof document !== 'undefined') {
-                    document.documentElement.classList.toggle('is-navInView', this.navIsOpen);
-                    document.documentElement.classList.toggle('is-navInView--noPad', this.navIsOpen && this.headerBackgroundTheme === 'transparent');
-                }
+            if (typeof document !== 'undefined') {
+                document.documentElement.classList.toggle('is-navInView', this.navIsOpen);
+                document.documentElement.classList.toggle('is-navInView--noPad', this.navIsOpen && this.headerBackgroundTheme === 'transparent');
             }
         },
 

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -92,8 +92,7 @@
 
                 <li
                     v-if="showOffersLink"
-                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
-                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]">
+                    :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
                     <nav-link
                         :text="copy.offers.text"
                         :tabindex="tabIndex"
@@ -115,8 +114,7 @@
 
                 <li
                     v-if="showDeliveryEnquiry"
-                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
-                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]">
+                    :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
                     <nav-link
                         :text="copy.deliveryEnquiry.text"
                         :tabindex="tabIndex"
@@ -145,8 +143,7 @@
                              $style['has-sublist'], {
                                  'is-hidden': !userInfo || !showLoginInfo,
                                  [$style['is-open']]: userMenuIsOpen
-                             },
-                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]"
+                             }]"
                     data-test-id="user-info-icon"
                     v-on="isBelowMid ? null : { mouseover: openUserMenu, mouseleave: closeUserMenu }"
                     @keyup.esc="closeUserMenu">
@@ -201,8 +198,7 @@
 
                 <li
                     v-if="!userInfo && showLoginInfo"
-                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
-                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]">
+                    :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
                     <nav-link
                         :text="copy.accountLogin.text"
                         :tabindex="tabIndex"
@@ -218,8 +214,7 @@
 
                 <li
                     v-if="userInfo && isBelowMid && showLoginInfo"
-                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
-                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]">
+                    :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
                     <nav-link
                         v-if="userInfo && isBelowMid && showLoginInfo"
                         :text="copy.accountLogout.text"
@@ -236,8 +231,7 @@
 
                 <li
                     v-if="showHelpLink"
-                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
-                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]">
+                    :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
                     <nav-link
                         :text="copy.help.text"
                         :tabindex="tabIndex"
@@ -252,8 +246,7 @@
 
                 <li
                     v-if="showCountrySelector"
-                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
-                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]">
+                    :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
                     <country-selector
                         :is-below-mid="isBelowMid"
                         :copy="copy.countrySelector"
@@ -342,11 +335,6 @@ export default {
         isOrderCountSupported: {
             type: Boolean,
             default: true
-        },
-
-        isJetLogoTheme: {
-            type: Boolean,
-            default: false
         },
 
         headerBackgroundTheme: {
@@ -680,16 +668,6 @@ export default {
         margin-top: spacing(d);
         margin-bottom: spacing(d);
     }
-}
-
-.c-nav-list-jetLogoTheme {
-    // for tablets - keeps navigation all inline when larger JET logo is used
-    @media (min-width:834px) and (max-width:900px) {
-        float: left;
-        padding: spacing(b) spacing(b);
-        margin-top: spacing(e);
-        margin-bottom: spacing(d);
-  }
 }
 
 .c-nav-list-btn {

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -92,7 +92,8 @@
 
                 <li
                     v-if="showOffersLink"
-                    :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
+                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
+                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]">
                     <nav-link
                         :text="copy.offers.text"
                         :tabindex="tabIndex"
@@ -114,7 +115,8 @@
 
                 <li
                     v-if="showDeliveryEnquiry"
-                    :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
+                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
+                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]">
                     <nav-link
                         :text="copy.deliveryEnquiry.text"
                         :tabindex="tabIndex"
@@ -139,12 +141,12 @@
                 </li>
 
                 <li
-                    :class="[
-                        $style['c-nav-list-item--horizontallyAlignedAboveMid'],
-                        $style['has-sublist'], {
-                            'is-hidden': !userInfo || !showLoginInfo,
-                            [$style['is-open']]: userMenuIsOpen
-                        }]"
+                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
+                             $style['has-sublist'], {
+                                 'is-hidden': !userInfo || !showLoginInfo,
+                                 [$style['is-open']]: userMenuIsOpen
+                             },
+                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]"
                     data-test-id="user-info-icon"
                     v-on="isBelowMid ? null : { mouseover: openUserMenu, mouseleave: closeUserMenu }"
                     @keyup.esc="closeUserMenu">
@@ -199,7 +201,8 @@
 
                 <li
                     v-if="!userInfo && showLoginInfo"
-                    :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
+                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
+                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]">
                     <nav-link
                         :text="copy.accountLogin.text"
                         :tabindex="tabIndex"
@@ -215,7 +218,8 @@
 
                 <li
                     v-if="userInfo && isBelowMid && showLoginInfo"
-                    :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
+                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
+                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]">
                     <nav-link
                         v-if="userInfo && isBelowMid && showLoginInfo"
                         :text="copy.accountLogout.text"
@@ -232,7 +236,8 @@
 
                 <li
                     v-if="showHelpLink"
-                    :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
+                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
+                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]">
                     <nav-link
                         :text="copy.help.text"
                         :tabindex="tabIndex"
@@ -247,7 +252,8 @@
 
                 <li
                     v-if="showCountrySelector"
-                    :class="$style['c-nav-list-item--horizontallyAlignedAboveMid']">
+                    :class="[$style['c-nav-list-item--horizontallyAlignedAboveMid'],
+                             { [$style['c-nav-list-jetLogoTheme']]: isJetLogoTheme }]">
                     <country-selector
                         :is-below-mid="isBelowMid"
                         :copy="copy.countrySelector"
@@ -336,6 +342,11 @@ export default {
         isOrderCountSupported: {
             type: Boolean,
             default: true
+        },
+
+        isJetLogoTheme: {
+            type: Boolean,
+            default: false
         },
 
         headerBackgroundTheme: {
@@ -668,8 +679,20 @@ export default {
 .c-nav-list-item--horizontallyAlignedAboveMid {
     @include media('>mid') {
         float: left;
-        padding: 28px 16px;
+        padding: spacing(c) spacing(c);
+        margin-top: spacing(d);
+        margin-bottom: spacing(d);
     }
+}
+
+.c-nav-list-jetLogoTheme {
+    // for tablets - keeps navigation all inline when larger JET logo is used
+    @media (min-width:834px) and (max-width:900px) {
+        float: left;
+        padding: spacing(b) spacing(b);
+        margin-top: spacing(e);
+        margin-bottom: spacing(d);
+  }
 }
 
 .c-nav-list-btn {

--- a/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
+++ b/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
@@ -1,7 +1,8 @@
 <template>
     <ul
         :aria-label="copy.navTitle"
-        :class="$style['c-nav-popoverList']">
+        :class="[$style['c-nav-popoverList'],
+                 $style['c-user-list']]">
         <li
             v-for="(link, index) in copy.navLinks"
             :key="index"
@@ -88,15 +89,18 @@ export default {
 <style lang="scss" module>
 @import '../assets/scss/navigation.scss';
 
+.c-user-list {
+    margin: spacing(b) 0;
+    padding: 0 !important;
+}
+
 .list-link {
     text-decoration: none;
 
     @include media('>mid') {
         display: block;
-        padding: spacing(c) spacing(d);
-        margin: 0;
+        padding: spacing(c) 0;
         height: auto;
-        border-bottom: 1px solid $color-border-default;
     }
 
     @include media('<=mid') {

--- a/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
+++ b/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
@@ -90,8 +90,10 @@ export default {
 @import '../assets/scss/navigation.scss';
 
 .c-user-list {
-    margin: spacing(b) 0;
-    padding: 0 !important;
+    @include media('>mid') {
+        margin: spacing(b) 0;
+        padding: 0 !important;
+    }
 }
 
 .list-link {

--- a/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
+++ b/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
@@ -92,7 +92,6 @@ export default {
 .c-user-list {
     @include media('>mid') {
         margin: spacing(b) 0;
-        padding: 0 !important;
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,6 +2258,13 @@
   dependencies:
     "@justeat/f-services" "1.0.0"
 
+"@justeat/f-breadcrumbs@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-breadcrumbs/-/f-breadcrumbs-3.2.0.tgz#3b3e95696a7a9dbe34f89edbab06fbd8e05765ac"
+  integrity sha512-6rAue/s5NiQMXaslaPkAF/+F6SmKWA1EYoen8XnjhmZHY56oIhCgkWkbWoLsxZxocDKjaiB/8+dMkxI93YItPA==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+
 "@justeat/f-button@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-3.0.2.tgz#9560d0caf56ae0801208ddd0c27cb50d670d54a8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,13 +2258,6 @@
   dependencies:
     "@justeat/f-services" "1.0.0"
 
-"@justeat/f-breadcrumbs@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-breadcrumbs/-/f-breadcrumbs-3.2.0.tgz#3b3e95696a7a9dbe34f89edbab06fbd8e05765ac"
-  integrity sha512-6rAue/s5NiQMXaslaPkAF/+F6SmKWA1EYoen8XnjhmZHY56oIhCgkWkbWoLsxZxocDKjaiB/8+dMkxI93YItPA==
-  dependencies:
-    "@justeat/f-services" "1.0.0"
-
 "@justeat/f-button@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-3.0.2.tgz#9560d0caf56ae0801208ddd0c27cb50d670d54a8"


### PR DESCRIPTION
### Changed
- horizontal navigation when using a tablet with long JET logo
- padding and bottom-border in account popover
- corner radius when navigation is closed on mobile view


| Current  | New           |
| ------------- |:-------------:|
| ![image](https://user-images.githubusercontent.com/49618712/159449961-4c37c44f-2553-458b-93bb-91b36f24c811.png)     | ![image](https://user-images.githubusercontent.com/49618712/159480565-560aa475-b024-4ac9-b2e9-6d9aabb87308.png) |
| ![image](https://user-images.githubusercontent.com/49618712/159465333-497d0d77-6b53-4b32-a2bf-3b345db9ada5.png) | ![image](https://user-images.githubusercontent.com/49618712/159465182-ea1134f8-ed42-4019-bfdc-bbdd89c97188.png)    |
| ![image](https://user-images.githubusercontent.com/49618712/159466036-5322d4d9-8a1a-4741-bb84-bb1a4a1d8ae8.png) | ![image](https://user-images.githubusercontent.com/49618712/159466753-20d80790-bbde-4843-a38a-dd8f4d63fede.png) |

As changes are minor, these will be checked with design via storybook after PR has been merged
