### PR TITLE
f-header@9.9.0 + f-footer@7.1.0 + f-spinner@0.4.0: Assorted accessibility updates

### DIFF
--- a/packages/components/atoms/f-spinner/CHANGELOG.md
+++ b/packages/components/atoms/f-spinner/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.4.0
+------------------------------
+*March 22, 2022*
+
+### Changed
+- Put spinner content inside `div` instead of `span` for accessibility.
+- Add storybook control to make spinner duration configurable.
+
+
 Latest (to be added to next release)
 ------------------------------
 *February 4, 2022*

--- a/packages/components/atoms/f-spinner/package.json
+++ b/packages/components/atoms/f-spinner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-spinner",
   "description": "Fozzie Spinner - loading indicator",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "dist/f-spinner.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-spinner/src/components/Spinner.vue
+++ b/packages/components/atoms/f-spinner/src/components/Spinner.vue
@@ -7,9 +7,9 @@
             role="alert"
             aria-live="polite" />
 
-        <span :class="{ ['is-hidden']: shouldShowSpinner }">
+        <div :class="{ ['is-hidden']: shouldShowSpinner }">
             <slot />
-        </span>
+        </div>
     </div>
 </template>
 

--- a/packages/components/atoms/f-spinner/stories/Spinner.stories.js
+++ b/packages/components/atoms/f-spinner/stories/Spinner.stories.js
@@ -7,10 +7,26 @@ export default {
     decorators: [withA11y]
 };
 
-export const VSpinnerComponent = () => ({
+export const VSpinnerComponent = (args, { argTypes }) => ({
     components: { VSpinner, TestComponent },
 
-    template: '<v-spinner><TestComponent /></v-spinner>'
+    props: Object.keys(argTypes),
+
+    template: `<v-spinner>
+        <TestComponent :duration="duration" />
+    </v-spinner>`
 });
 
 VSpinnerComponent.storyName = 'f-spinner';
+
+VSpinnerComponent.args = {
+    duration: 2000
+};
+
+VSpinnerComponent.argTypes = {
+    duration: {
+        control: { type: 'select' },
+        description: 'How long to show the spinner for before the test component loads. You can change this to restart the spinner.',
+        options: [1000, 2000, 5000, 10000, 30000, 60000]
+    }
+};

--- a/packages/components/atoms/f-spinner/stories/TestComponent.vue
+++ b/packages/components/atoms/f-spinner/stories/TestComponent.vue
@@ -8,10 +8,30 @@
 export default {
     name: 'TestComponent',
 
+    props: {
+        duration: {
+            type: Number,
+            required: true
+        }
+    },
+
+    watch: {
+        duration () {
+            this.$parent.$emit('start-spinner');
+            this.setSpinnerTimeout();
+        }
+    },
+
     mounted () {
-        setTimeout(() => {
-            this.$parent.$emit('stop-spinner');
-        }, 2000);
+        this.setSpinnerTimeout();
+    },
+
+    methods: {
+        setSpinnerTimeout () {
+            setTimeout(() => {
+                this.$parent.$emit('stop-spinner');
+            }, this.duration);
+        }
     }
 };
 </script>

--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -3,6 +3,19 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v7.1.0
+------------------------------
+*March 22, 2022*
+
+### Added
+- `lang` attribute for country selector links.
+- `outline-offset` to make to easier to see when app store links are focused.
+
+### Changed
+- Moved region from `ul` to containing element.
+
+
 v7.0.0
 ------------------------------
 *February 28, 2022*

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "main": "dist/f-footer.umd.min.js",
   "maxBundleSize": "80kB",
   "files": [

--- a/packages/components/organisms/f-footer/src/components/CountrySelector.vue
+++ b/packages/components/organisms/f-footer/src/components/CountrySelector.vue
@@ -3,6 +3,7 @@
         <div
             v-click-outside="hideCountryList"
             :class="$style['c-countrySelector']"
+            role="region"
             @keyup.esc="hideCountryList">
             <button
                 id="countrySelector-button"
@@ -48,8 +49,7 @@
                 v-show="showCountryList"
                 id="countrySelector-countries"
                 :class="$style['c-countrySelector-list']"
-                data-test-id="countrySelector-list"
-                role="region">
+                data-test-id="countrySelector-list">
                 <li
                     v-for="(country, i) in countries"
                     :key="`${i}_Country`"
@@ -67,7 +67,9 @@
                         <flag-icon
                             :country-code="country.key"
                             :class="$style['c-countrySelector-flag']" />
-                        <p data-test-id="countrySelector-list">
+                        <p
+                            data-test-id="countrySelector-list"
+                            :lang="country.lang">
                             {{ country.localisedName }}
                         </p>
                     </a>

--- a/packages/components/organisms/f-footer/src/components/IconList.vue
+++ b/packages/components/organisms/f-footer/src/components/IconList.vue
@@ -110,6 +110,7 @@ export default {
 
     a,
     svg {
+        outline-offset: spacing(a);
         display: block;
     }
 
@@ -128,7 +129,6 @@ export default {
 }
 
 .c-iconList--apps {
-
     .c-iconList-listItem {
         margin-right: spacing(d);
         margin-bottom: spacing(d);

--- a/packages/components/organisms/f-footer/src/components/_tests/CountrySelector.test.js
+++ b/packages/components/organisms/f-footer/src/components/_tests/CountrySelector.test.js
@@ -4,6 +4,7 @@ import CountrySelector from '../CountrySelector.vue';
 describe('CountrySelector', () => {
     let wrapper,
         button,
+        lang,
         list,
         localisedName,
         siteUrl;
@@ -11,6 +12,7 @@ describe('CountrySelector', () => {
     beforeEach(() => {
         localisedName = 'Denmark';
         siteUrl = 'https://www.just-eat.dk';
+        lang = 'da-DK';
 
         const propsData = {
             currentCountryName: 'United Kingdom',
@@ -18,6 +20,7 @@ describe('CountrySelector', () => {
             countries: [
                 {
                     key: 'dk',
+                    lang,
                     localisedName,
                     siteUrl
                 }
@@ -60,5 +63,10 @@ describe('CountrySelector', () => {
     it('should contain correct link', () => {
         const link = wrapper.find('[data-test-id="countrySelector-countryLink"]');
         expect(link.attributes('href')).toBe(siteUrl);
+    });
+
+    it('should contain `lang` attribute', () => {
+        const text = wrapper.find('[data-test-id="countrySelector-countryLink"]').find('p');
+        expect(text.attributes('lang')).toBe(lang);
     });
 });

--- a/packages/components/organisms/f-footer/src/components/_tests/CountrySelector.test.js
+++ b/packages/components/organisms/f-footer/src/components/_tests/CountrySelector.test.js
@@ -32,41 +32,58 @@ describe('CountrySelector', () => {
     });
 
     it('should be defined', () => {
+        // Assert
         expect(wrapper.exists()).toBe(true);
     });
 
     it('button should exist', () => {
+        // Assert
         expect(button.exists()).toBe(true);
     });
 
     it('list should not be displayed by default', () => {
+        // Assert
         expect(list.isVisible()).toBe(false);
     });
 
     it('list should be displayed when button is clicked', async () => {
+        // Act
         await button.trigger('click'); // wait for DOM to update as a result of click being triggered
 
+        // Assert
         expect(list.isVisible()).toBe(true);
     });
 
     it('list should not be displayed when button is clicked again', () => {
+        // Act
         button.trigger('click');
         button.trigger('click');
+
+        // Assert
         expect(list.isVisible()).toBe(false);
     });
 
     it('list should contain country from props', () => {
+        // Arrange & Act
         const country = wrapper.find(`[data-test-id="countrySelector-country-${wrapper.key}"]`);
+
+        // Assert
         expect(country.text()).toBe(localisedName);
     });
 
     it('should contain correct link', () => {
+        // Arrange & Act
         const link = wrapper.find('[data-test-id="countrySelector-countryLink"]');
+
+        // Assert
         expect(link.attributes('href')).toBe(siteUrl);
     });
 
     it('should contain `lang` attribute', () => {
+        // Arrange & Act
         const text = wrapper.find('[data-test-id="countrySelector-countryLink"]').find('p');
+
+        // Assert
         expect(text.attributes('lang')).toBe(lang);
     });
 });

--- a/packages/components/organisms/f-footer/src/tenants/countryList.js
+++ b/packages/components/organisms/f-footer/src/tenants/countryList.js
@@ -2,6 +2,7 @@ export default [
     {
         key: 'gb',
         dataTestKey: 'gb',
+        lang: 'en',
         localisedName: 'United Kingdom',
         siteUrl: 'https://www.just-eat.co.uk',
         gtm: 'click_country_gb'
@@ -9,6 +10,7 @@ export default [
     {
         key: 'au',
         dataTestKey: 'au',
+        lang: 'en',
         localisedName: 'Australia',
         siteUrl: 'https://www.menulog.com.au',
         gtm: 'click_country_au'
@@ -16,6 +18,7 @@ export default [
     {
         key: 'at',
         dataTestKey: 'at',
+        lang: 'de-AT',
         localisedName: 'Österreich',
         siteUrl: 'https://www.lieferando.at',
         gtm: 'click_country_at'
@@ -23,6 +26,7 @@ export default [
     {
         key: 'be',
         dataTestKey: 'be',
+        lang: 'nl-BE',
         localisedName: 'België',
         siteUrl: 'https://www.takeaway.com/be',
         gtm: 'click_country_be'
@@ -30,6 +34,7 @@ export default [
     {
         key: 'bg',
         dataTestKey: 'bg',
+        lang: 'en',
         localisedName: 'Bulgaria',
         siteUrl: 'https://www.takeaway.com/bg',
         gtm: 'click_country_bg'
@@ -37,6 +42,7 @@ export default [
     {
         key: 'ca',
         dataTestKey: 'ca_en',
+        lang: 'en',
         localisedName: 'Canada',
         siteUrl: 'https://www.skipthedishes.com',
         gtm: 'click_country_ca_en'
@@ -44,6 +50,7 @@ export default [
     {
         key: 'ca',
         dataTestKey: 'ca_fr',
+        lang: 'fr-CA',
         localisedName: 'Canada (FR)',
         siteUrl: 'https://www.skipthedishes.com/fr',
         gtm: 'click_country_ca_fr'
@@ -51,6 +58,7 @@ export default [
     {
         key: 'dk',
         dataTestKey: 'dk',
+        lang: 'da',
         localisedName: 'Danmark',
         siteUrl: 'https://www.just-eat.dk',
         gtm: 'click_country_dk'
@@ -58,6 +66,7 @@ export default [
     {
         key: 'fr',
         dataTestKey: 'jet_fr',
+        lang: 'fr',
         localisedName: 'France',
         siteUrl: 'https://www.just-eat.fr/',
         gtm: 'click_country_fr'
@@ -65,6 +74,7 @@ export default [
     {
         key: 'de',
         dataTestKey: 'de',
+        lang: 'de',
         localisedName: 'Deutschland',
         siteUrl: 'https://www.lieferando.de',
         gtm: 'click_country_de'
@@ -72,6 +82,7 @@ export default [
     {
         key: 'ie',
         dataTestKey: 'ie',
+        lang: 'en',
         localisedName: 'Ireland',
         siteUrl: 'https://www.just-eat.ie',
         gtm: 'click_country_ie'
@@ -79,6 +90,7 @@ export default [
     {
         key: 'il',
         dataTestKey: 'il',
+        lang: 'en',
         localisedName: 'Israel',
         siteUrl: 'https://www.10bis.co.il/next',
         gtm: 'click_country_il'
@@ -86,6 +98,7 @@ export default [
     {
         key: 'it',
         dataTestKey: 'it',
+        lang: 'it',
         localisedName: 'Italia',
         siteUrl: 'https://www.justeat.it',
         gtm: 'click_country_it'
@@ -93,6 +106,7 @@ export default [
     {
         key: 'lu',
         dataTestKey: 'lu',
+        lang: 'en',
         localisedName: 'Luxembourg',
         siteUrl: 'https://www.takeaway.com/lu',
         gtm: 'click_country_lu'
@@ -100,6 +114,7 @@ export default [
     {
         key: 'nl',
         dataTestKey: 'nl',
+        lang: 'nl',
         localisedName: 'Nederland',
         siteUrl: 'https://www.thuisbezorgd.nl',
         gtm: 'click_country_nl'
@@ -107,6 +122,7 @@ export default [
     {
         key: 'nz',
         dataTestKey: 'nz',
+        lang: 'en',
         localisedName: 'New Zealand',
         siteUrl: 'https://www.menulog.co.nz',
         gtm: 'click_country_nz'
@@ -114,6 +130,7 @@ export default [
     {
         key: 'no',
         dataTestKey: 'no',
+        lang: 'no',
         localisedName: 'Norge',
         siteUrl: 'https://www.just-eat.no',
         gtm: 'click_country_no'
@@ -121,6 +138,7 @@ export default [
     {
         key: 'pl',
         dataTestKey: 'pl',
+        lang: 'pl',
         localisedName: 'Polska',
         siteUrl: 'https://www.pyszne.pl',
         gtm: 'click_country_pl'
@@ -128,6 +146,7 @@ export default [
     {
         key: 'pt',
         dataTestKey: 'pt',
+        lang: 'pt',
         localisedName: 'Portugal',
         siteUrl: 'https://www.takeaway.com/pt',
         gtm: 'click_country_pt'
@@ -135,13 +154,15 @@ export default [
     {
         key: 'ro',
         dataTestKey: 'ro',
-        localisedName: 'Romania',
+        lang: 'ro',
+        localisedName: 'România',
         siteUrl: 'https://www.takeaway.com/ro',
         gtm: 'click_country_ro'
     },
     {
         key: 'es',
         dataTestKey: 'es',
+        lang: 'es',
         localisedName: 'España',
         siteUrl: 'https://www.just-eat.es',
         gtm: 'click_country_es'
@@ -149,6 +170,7 @@ export default [
     {
         key: 'ch',
         dataTestKey: 'ch_ch',
+        lang: 'de-CH',
         localisedName: 'Schweiz',
         siteUrl: 'https://www.eat.ch',
         gtm: 'click_country_ch'
@@ -156,6 +178,7 @@ export default [
     {
         key: 'ch',
         dataTestKey: 'ch_en',
+        lang: 'en',
         localisedName: 'Switzerland',
         siteUrl: 'https://www.eat.ch/en',
         gtm: 'click_country_ch_en'
@@ -163,6 +186,7 @@ export default [
     {
         key: 'ch',
         dataTestKey: 'ch_fr',
+        lang: 'fr-CH',
         localisedName: 'Suisse',
         siteUrl: 'https://www.eat.ch/fr',
         gtm: 'click_country_ch_fr'

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v9.8.0
+------------------------------
+*March 22, 2022*
+
+### Added
+- `lang` attribute to country selector links.
+
+
 v9.7.0
 ------------------------------
 *March 16, 2022*

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header - Globalised Header Component",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
+++ b/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
@@ -49,7 +49,8 @@
                         :class="$style['c-countrySelector-country-link']"
                         :has-border-bottom="false"
                         :is-country-link="true"
-                        :href="country.siteUrl">
+                        :href="country.siteUrl"
+                        :lang="country.lang">
                         <template #icon>
                             <flag-icon
                                 :country-code="country.flagKey"

--- a/packages/components/organisms/f-header/src/tenants/countryList.js
+++ b/packages/components/organisms/f-header/src/tenants/countryList.js
@@ -3,6 +3,7 @@ export default [
         key: 'gb',
         flagKey: 'gb',
         dataTestKey: 'gb',
+        lang: 'en',
         localisedName: 'United Kingdom',
         siteUrl: 'https://www.just-eat.co.uk',
         gtm: 'click_country_gb'
@@ -11,6 +12,7 @@ export default [
         key: 'au',
         flagKey: 'au',
         dataTestKey: 'au',
+        lang: 'en',
         localisedName: 'Australia',
         siteUrl: 'https://www.menulog.com.au',
         gtm: 'click_country_au'
@@ -19,6 +21,7 @@ export default [
         key: 'at',
         flagKey: 'at',
         dataTestKey: 'at',
+        lang: 'de-AT',
         localisedName: 'Österreich',
         siteUrl: 'https://www.lieferando.at',
         gtm: 'click_country_at'
@@ -27,6 +30,7 @@ export default [
         key: 'be',
         flagKey: 'be',
         dataTestKey: 'be',
+        lang: 'nl-BE',
         localisedName: 'België',
         siteUrl: 'https://www.takeaway.com/be',
         gtm: 'click_country_be'
@@ -35,6 +39,7 @@ export default [
         key: 'bg',
         flagKey: 'bg',
         dataTestKey: 'bg',
+        lang: 'en',
         localisedName: 'Bulgaria',
         siteUrl: 'https://www.takeaway.com/bg',
         gtm: 'click_country_bg'
@@ -43,6 +48,7 @@ export default [
         key: 'ca_en',
         flagKey: 'ca',
         dataTestKey: 'ca_en',
+        lang: 'en',
         localisedName: 'Canada',
         siteUrl: 'https://www.skipthedishes.com',
         gtm: 'click_country_ca_en'
@@ -51,6 +57,7 @@ export default [
         key: 'ca_fr',
         flagKey: 'ca',
         dataTestKey: 'ca_fr',
+        lang: 'fr-CA',
         localisedName: 'Canada (FR)',
         siteUrl: 'https://www.skipthedishes.com/fr',
         gtm: 'click_country_ca_fr'
@@ -59,6 +66,7 @@ export default [
         key: 'dk',
         flagKey: 'dk',
         dataTestKey: 'dk',
+        lang: 'da',
         localisedName: 'Danmark',
         siteUrl: 'https://www.just-eat.dk',
         gtm: 'click_country_dk'
@@ -67,6 +75,7 @@ export default [
         key: 'fr',
         flagKey: 'fr',
         dataTestKey: 'jet_fr',
+        lang: 'fr',
         localisedName: 'France',
         siteUrl: 'https://www.just-eat.fr',
         gtm: 'click_country_fr'
@@ -75,6 +84,7 @@ export default [
         key: 'de',
         flagKey: 'de',
         dataTestKey: 'de',
+        lang: 'de',
         localisedName: 'Deutschland',
         siteUrl: 'https://www.lieferando.de',
         gtm: 'click_country_de'
@@ -83,6 +93,7 @@ export default [
         key: 'ie',
         flagKey: 'ie',
         dataTestKey: 'ie',
+        lang: 'en',
         localisedName: 'Ireland',
         siteUrl: 'https://www.just-eat.ie',
         gtm: 'click_country_ie'
@@ -91,6 +102,7 @@ export default [
         key: 'il',
         flagKey: 'il',
         dataTestKey: 'il',
+        lang: 'en',
         localisedName: 'Israel',
         siteUrl: 'https://www.10bis.co.il/next',
         gtm: 'click_country_il'
@@ -99,6 +111,7 @@ export default [
         key: 'it',
         flagKey: 'it',
         dataTestKey: 'it',
+        lang: 'it',
         localisedName: 'Italia',
         siteUrl: 'https://www.justeat.it',
         gtm: 'click_country_it'
@@ -107,6 +120,7 @@ export default [
         key: 'lu',
         flagKey: 'lu',
         dataTestKey: 'lu',
+        lang: 'en',
         localisedName: 'Luxembourg',
         siteUrl: 'https://www.takeaway.com/lu',
         gtm: 'click_country_lu'
@@ -115,6 +129,7 @@ export default [
         key: 'nl',
         flagKey: 'nl',
         dataTestKey: 'nl',
+        lang: 'nl',
         localisedName: 'Nederland',
         siteUrl: 'https://www.thuisbezorgd.nl',
         gtm: 'click_country_nl'
@@ -123,6 +138,7 @@ export default [
         key: 'nz',
         flagKey: 'nz',
         dataTestKey: 'nz',
+        lang: 'en',
         localisedName: 'New Zealand',
         siteUrl: 'https://www.menulog.co.nz',
         gtm: 'click_country_nz'
@@ -131,6 +147,7 @@ export default [
         key: 'no',
         flagKey: 'no',
         dataTestKey: 'no',
+        lang: 'no',
         localisedName: 'Norge',
         siteUrl: 'https://www.just-eat.no',
         gtm: 'click_country_no'
@@ -139,6 +156,7 @@ export default [
         key: 'pl',
         flagKey: 'pl',
         dataTestKey: 'pl',
+        lang: 'pl',
         localisedName: 'Polska',
         siteUrl: 'https://www.pyszne.pl',
         gtm: 'click_country_pl'
@@ -147,6 +165,7 @@ export default [
         key: 'pt',
         flagKey: 'pt',
         dataTestKey: 'pt',
+        lang: 'pt',
         localisedName: 'Portugal',
         siteUrl: 'https://www.takeaway.com/pt',
         gtm: 'click_country_pt'
@@ -155,7 +174,8 @@ export default [
         key: 'ro',
         flagKey: 'ro',
         dataTestKey: 'ro',
-        localisedName: 'Romania',
+        lang: 'ro',
+        localisedName: 'România',
         siteUrl: 'https://www.takeaway.com/ro',
         gtm: 'click_country_ro'
     },
@@ -163,6 +183,7 @@ export default [
         key: 'es',
         flagKey: 'es',
         dataTestKey: 'es',
+        lang: 'es',
         localisedName: 'España',
         siteUrl: 'https://www.just-eat.es',
         gtm: 'click_country_es'
@@ -171,6 +192,7 @@ export default [
         key: 'ch_ch',
         flagKey: 'ch',
         dataTestKey: 'ch_ch',
+        lang: 'de-CH',
         localisedName: 'Schweiz',
         siteUrl: 'https://www.eat.ch',
         gtm: 'click_country_ch'
@@ -179,6 +201,7 @@ export default [
         key: 'ch_en',
         flagKey: 'ch',
         dataTestKey: 'ch_en',
+        lang: 'en',
         localisedName: 'Switzerland',
         siteUrl: 'https://www.eat.ch/en',
         gtm: 'click_country_ch_en'
@@ -187,6 +210,7 @@ export default [
         key: 'ch_fr',
         flagKey: 'ch',
         dataTestKey: 'ch_fr',
+        lang: 'fr-CH',
         localisedName: 'Suisse',
         siteUrl: 'https://www.eat.ch/fr',
         gtm: 'click_country_ch_fr'


### PR DESCRIPTION
## f-header

### Added
- `lang` attribute to country selector links.

---

## f-footer

### Added
- `lang` attribute for country selector links.
- `outline-offset` to make to easier to see when app store links are focused.

| Before | After |
| --- | --- |
| ![20220324T090245](https://user-images.githubusercontent.com/26894168/159880505-2b5cbe82-d6ec-406e-b6e9-5059410c3393.png) | ![20220324T090145](https://user-images.githubusercontent.com/26894168/159880406-0df350e4-b8ac-4865-9f83-a0dc8a93de7b.png) |

### Changed
- Moved region from `ul` to containing element.

---

## f-spinner

### Changed
- Put spinner content inside `div` instead of `span` for accessibility.
- Add storybook control to make spinner duration configurable.

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
