### PR TITLE
f-content-cards@v8.0.0-alpha.2 - Adding Content card Body component

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v8.0.0-alpha.2
+------------------------------
+*March 23, 2022*
+
+### Added
+- Body component for new content cards template system.
+
+
 v8.0.0-alpha.1
 ------------------------------
 *March 15, 2022*

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "8.0.0-alpha.1",
+  "version": "8.0.0-alpha.2",
   "main": "dist/f-content-cards.umd.min.js",
   "maxBundleSize": "75kB",
   "files": [

--- a/packages/components/organisms/f-content-cards/src/components/templates/ContentCardBody.vue
+++ b/packages/components/organisms/f-content-cards/src/components/templates/ContentCardBody.vue
@@ -101,7 +101,7 @@ export default {
 .c-content-card-bodyWrapper {
     z-index: 10;
     width: 100%;
-    @include media('<=narrow'){
+    @include media('<=narrow') {
         padding: spacing(d);
     }
 }

--- a/packages/components/organisms/f-content-cards/src/components/templates/ContentCardBody.vue
+++ b/packages/components/organisms/f-content-cards/src/components/templates/ContentCardBody.vue
@@ -1,0 +1,108 @@
+<template>
+    <div :class="$style['c-content-card-bodyWrapper']">
+        <div :class="$style['c-content-card-body']">
+            <slot name="title">
+                <h3
+                    v-if="title"
+                    data-test-id="content-card-title"
+                    :class="$style['c-content-card-title']">
+                    {{ title }}
+                </h3>
+            </slot>
+            <slot name="subtitle">
+                <p
+                    v-if="subtitle"
+                    data-test-id="content-card-subtitle"
+                    :class="$style['c-content-card-subtitle']">
+                    {{ subtitle }}
+                </p>
+            </slot>
+            <slot name="description">
+                <template v-if="description">
+                    <p
+                        v-for="(text, index) in description"
+                        :key="index"
+                        data-test-id="content-card-description-item"
+                        :class="$style['c-content-card-description']">
+                        {{ text }}
+                    </p>
+                </template>
+            </slot>
+            <div :class="[$style['c-content-card-footer'], hasBorderFooter ? $style['c-content-card-footer--border'] : '']">
+                <slot name="footer" />
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        hasBorderFooter: {
+            type: Boolean,
+            default: false
+        },
+
+        title: {
+            type: String,
+            default: null
+        },
+
+        subtitle: {
+            type: String,
+            default: null
+        },
+
+        description: {
+            type: Array,
+            default: () => ([])
+        }
+    }
+};
+</script>
+
+<style lang="scss" module>
+.c-content-card-body {
+    margin-top: -(spacing(e));
+    width:100%;
+    background-color: #fff;
+    padding: spacing(d);
+    border-radius: 12px;
+    box-shadow: 0px 2px 2px rgba(27, 35, 36, 0.03), 0px 3px 1px -2px rgba(27, 35, 36, 0.07), 0px 1px 5px rgba(27, 35, 36, 0.06);
+}
+
+.c-content-card-title {
+    @include font-size(heading-s);
+    margin-bottom: spacing(b);
+    text-decoration: none;
+}
+
+.c-content-card-subtitle {
+    margin-top: 0;
+    margin-bottom: spacing(b);
+    text-decoration: none;
+}
+
+.c-content-card-description {
+    @include font-size(caption);
+    margin-top: 0;
+    margin-bottom: spacing(d);
+    text-decoration: none;
+}
+
+.c-content-card-footer {
+    padding-top: spacing(d);
+}
+
+.c-content-card-footer--border {
+    border-top: 1px solid $color-border-default;
+}
+
+.c-content-card-bodyWrapper {
+    z-index: 10;
+    width:100%;
+    @include media('<=narrow'){
+        padding: spacing(d);
+    }
+}
+</style>

--- a/packages/components/organisms/f-content-cards/src/components/templates/ContentCardBody.vue
+++ b/packages/components/organisms/f-content-cards/src/components/templates/ContentCardBody.vue
@@ -21,7 +21,7 @@
                 <template v-if="description">
                     <p
                         v-for="(text, index) in description"
-                        :key="index"
+                        :key="`description-${index}`"
                         data-test-id="content-card-description-item"
                         :class="$style['c-content-card-description']">
                         {{ text }}

--- a/packages/components/organisms/f-content-cards/src/components/templates/ContentCardBody.vue
+++ b/packages/components/organisms/f-content-cards/src/components/templates/ContentCardBody.vue
@@ -68,7 +68,7 @@ export default {
     background-color: #fff;
     padding: spacing(d);
     border-radius: 12px;
-    box-shadow: 0px 2px 2px rgba(27, 35, 36, 0.03), 0px 3px 1px -2px rgba(27, 35, 36, 0.07), 0px 1px 5px rgba(27, 35, 36, 0.06);
+    box-shadow: $elevation-box-shadow-01;
 }
 
 .c-content-card-title {

--- a/packages/components/organisms/f-content-cards/src/components/templates/ContentCardBody.vue
+++ b/packages/components/organisms/f-content-cards/src/components/templates/ContentCardBody.vue
@@ -64,7 +64,7 @@ export default {
 <style lang="scss" module>
 .c-content-card-body {
     margin-top: -(spacing(e));
-    width:100%;
+    width: 100%;
     background-color: #fff;
     padding: spacing(d);
     border-radius: 12px;
@@ -100,7 +100,7 @@ export default {
 
 .c-content-card-bodyWrapper {
     z-index: 10;
-    width:100%;
+    width: 100%;
     @include media('<=narrow'){
         padding: spacing(d);
     }

--- a/packages/components/organisms/f-content-cards/src/components/templates/ContentCardImage.vue
+++ b/packages/components/organisms/f-content-cards/src/components/templates/ContentCardImage.vue
@@ -15,7 +15,6 @@
 
 <script>
 export default {
-    name: 'ContentCardImage',
     props: {
         backgroundImageUrl: {
             type: String,

--- a/packages/components/organisms/f-content-cards/src/components/templates/_tests/ContentCardBody.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/templates/_tests/ContentCardBody.test.js
@@ -1,0 +1,165 @@
+import { shallowMount } from '@vue/test-utils';
+import Body from '../ContentCardBody.vue';
+
+const MOCK_TITLE = '__TEST_MOCK_TITLE__';
+const MOCK_SUB_TITLE = '__TEST_MOCK_SUB_TITLE__';
+const MOCK_DESCRIPTION = [
+    '__TEST_MOCK_DESCRIPTION_1__',
+    '__TEST_MOCK_DESCRIPTION_2__',
+    '__TEST_MOCK_DESCRIPTION_3__'
+];
+
+describe('Body.vue', () => {
+    describe('Title', () => {
+        it('should show the default h3 title when NO header is provided to the header slot', () => {
+            // Arrange
+            const wrapper = shallowMount(Body, {
+                propsData: {
+                    title: MOCK_TITLE
+                }
+            });
+
+            // Act
+            const titleElement = wrapper.find('[data-test-id="content-card-title"]');
+
+            // Assert
+            expect(titleElement.text()).toBe(MOCK_TITLE);
+        });
+
+        it('should show the contents provided to the header slot', () => {
+            // Arrange
+            const wrapper = shallowMount(Body, {
+                scopedSlots: {
+                    title: `<div data-test-id="content-card-header-slot-content">${MOCK_TITLE}</div>`
+                }
+            });
+
+            // Act
+            const slotContentElement = wrapper.find('[data-test-id="content-card-header-slot-content"]');
+
+            // Assert
+            expect(slotContentElement.exists()).toBe(true);
+            expect(slotContentElement.text()).toBe(MOCK_TITLE);
+        });
+
+        it('should not show header if NO slot of title is provided', () => {
+            // Arrange
+            const wrapper = shallowMount(Body);
+
+            // Act
+            const titleElement = wrapper.find('[data-test-id="content-card-title"]');
+            const slotContentElement = wrapper.find('[data-test-id="content-card-title-slot-content"]');
+
+            // Assert
+            expect(titleElement.exists()).toBe(false);
+            expect(slotContentElement.exists()).toBe(false);
+        });
+    });
+    describe('Subtitle', () => {
+        it('should show the default h4 tag with subtitle text when NO slot content is provided AND subtitle prop is set', () => {
+            // Arrange
+            const wrapper = shallowMount(Body, {
+                propsData: {
+                    subtitle: MOCK_SUB_TITLE
+                }
+            });
+
+            // Act
+            const subTitleElement = wrapper.find('[data-test-id="content-card-subtitle"]');
+
+            // Assert
+            expect(subTitleElement.text()).toBe(MOCK_SUB_TITLE);
+        });
+
+        it('should show the contents provided to the subtitle slot', () => {
+            // Arrange
+            const wrapper = shallowMount(Body, {
+                scopedSlots: {
+                    subtitle: `<div data-test-id="content-card-subtitle-slot-content">${MOCK_SUB_TITLE}</div>`
+                }
+            });
+
+            // Act
+            const slotContentElement = wrapper.find('[data-test-id="content-card-subtitle-slot-content"]');
+
+            // Assert
+            expect(slotContentElement.exists()).toBe(true);
+            expect(slotContentElement.text()).toBe(MOCK_SUB_TITLE);
+        });
+
+        it('should not show the subtitle if NO slot or subtitle prop is provided', () => {
+            // Arrange
+            const wrapper = shallowMount(Body);
+
+            // Act
+            const subtitleElement = wrapper.find('[data-test-id="content-card-subtitle"]');
+            const slotContentElement = wrapper.find('[data-test-id="content-card-subtitle-slot-content"]');
+
+            // Assert
+            expect(subtitleElement.exists()).toBe(false);
+            expect(slotContentElement.exists()).toBe(false);
+        });
+    });
+
+    describe('Description', () => {
+        it('should show the default p tag for each description item when no slot is provided', () => {
+            // Arrange
+            const wrapper = shallowMount(Body, {
+                propsData: {
+                    description: MOCK_DESCRIPTION
+                }
+            });
+
+            // Act
+            const descriptionItems = wrapper.findAll('[data-test-id="content-card-description-item"]');
+
+            // Assert
+            expect(descriptionItems.length).toBe(3);
+        });
+
+        it('should show the contents provided to the description slot', () => {
+            // Arrange
+            const wrapper = shallowMount(Body, {
+                scopedSlots: {
+                    description: '<div data-test-id="content-card-description-item-slot-content">TEST</div>'
+                }
+            });
+
+            // Act
+            const slotContentElement = wrapper.find('[data-test-id="content-card-description-item-slot-content"]');
+
+            // Assert
+            expect(slotContentElement.exists()).toBe(true);
+        });
+
+        it('should not show the description if NO slot or description prop is provided', () => {
+            // Arrange
+            const wrapper = shallowMount(Body);
+
+            // Act
+            const descriptionElement = wrapper.findAll('[data-test-id="content-card-description-item"]');
+            const slotContentElement = wrapper.find('[data-test-id="content-card-description-item-slot-content"]');
+
+            // Assert
+            expect(descriptionElement.length).toBe(0);
+            expect(slotContentElement.exists()).toBe(false);
+        });
+    });
+
+    describe('Footer', () => {
+        it('should display the contents of the footer slot', () => {
+            // Arrange
+            const wrapper = shallowMount(Body, {
+                scopedSlots: {
+                    footer: '<div data-test-id="content-card-footer-slot-content">Footer</div>'
+                }
+            });
+
+            // Act
+            const slotContentElement = wrapper.find('[data-test-id="content-card-footer-slot-content"]');
+
+            // Assert
+            expect(slotContentElement.exists()).toBe(true);
+        });
+    });
+});

--- a/packages/components/organisms/f-content-cards/src/components/templates/_tests/ContentCardImage.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/templates/_tests/ContentCardImage.test.js
@@ -1,5 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
-import Image from '../Image.vue';
+import Image from '../ContentCardImage.vue';
 
 const MOCK_BACKGROUND_IMG = 'https://example.com/image.jpg';
 const MOCK_LOGO_IMG = 'https://example.com/logo.jpg';


### PR DESCRIPTION
PR adds the body component of the new content card card templates, unit tests have been added. Also is a change to file names based on previous PR suggestions.

## UI Review Checks

![Screenshot 2022-03-21 at 15 52 29](https://user-images.githubusercontent.com/15876339/159732935-ab809c80-4906-449d-95d7-14a6c2543b18.png)

- [x] Unit tests have been created

## Browsers Tested

- [x] Chrome (latest)
