### PR TITLE
f-filter-pill@v0.6.0 - Screen reader improvements

### DIFF
--- a/packages/components/atoms/f-filter-pill/CHANGELOG.md
+++ b/packages/components/atoms/f-filter-pill/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.6.0
+------------------------------
+*March 24, 2022*
+
+### Added
+- `screenReaderMessage` prop for screen-reader friendly copy
+
+### Changed
+- Added `aria-hidden` attributes to the elements rendering `displayText` and `displayNumber`
+
 v0.5.0
 ------------------------------
 *March 16, 2022*

--- a/packages/components/atoms/f-filter-pill/package.json
+++ b/packages/components/atoms/f-filter-pill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-filter-pill",
   "description": "Fozzie Filter Pill - An interactive component for filter toggles.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "dist/f-filter-pill.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
+++ b/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
@@ -45,13 +45,13 @@
                 <span
                     :class="$style['c-filterPill-text']"
                     data-test-id="filter-pill-text"
-                    :aria-hidden="screenReaderMessage ? true : null">
+                    :aria-hidden="!!screenReaderMessage">
                     {{ displayText }}
                 </span>
                 <span
                     :class="$style['c-filterPill-number']"
                     data-test-id="filter-pill-number"
-                    :aria-hidden="screenReaderMessage ? true : null">
+                    :aria-hidden="!!screenReaderMessage">
                     {{ displayNumber }}
                 </span>
             </label>

--- a/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
+++ b/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
@@ -45,13 +45,13 @@
                 <span
                     :class="$style['c-filterPill-text']"
                     data-test-id="filter-pill-text"
-                    aria-hidden="true">
+                    :aria-hidden="screenReaderMessage ? true : null">
                     {{ displayText }}
                 </span>
                 <span
                     :class="$style['c-filterPill-number']"
                     data-test-id="filter-pill-number"
-                    aria-hidden="true">
+                    :aria-hidden="screenReaderMessage ? true : null">
                     {{ displayNumber }}
                 </span>
             </label>

--- a/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
+++ b/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
@@ -36,14 +36,22 @@
                 data-test-id="filter-pill-label"
                 :tabindex="-1">
                 <tick-icon :class="$style['c-filterPill-icon']" />
+                <p
+                    v-if="screenReaderMessage"
+                    data-test-id="filter-pill-sr-msg"
+                    class="is-visuallyHidden">
+                    {{ screenReaderMessage }}
+                </p>
                 <span
                     :class="$style['c-filterPill-text']"
-                    data-test-id="filter-pill-text">
+                    data-test-id="filter-pill-text"
+                    aria-hidden="true">
                     {{ displayText }}
                 </span>
                 <span
                     :class="$style['c-filterPill-number']"
-                    data-test-id="filter-pill-number">
+                    data-test-id="filter-pill-number"
+                    aria-hidden="true">
                     {{ displayNumber }}
                 </span>
             </label>
@@ -91,6 +99,10 @@ export default {
         isLoading: {
             type: Boolean,
             default: false
+        },
+        screenReaderMessage: {
+            type: String,
+            default: null
         }
     },
     data () {

--- a/packages/components/atoms/f-filter-pill/src/components/_tests/FilterPill.test.js
+++ b/packages/components/atoms/f-filter-pill/src/components/_tests/FilterPill.test.js
@@ -137,6 +137,40 @@ describe('FilterPill', () => {
                 expect(element.text()).toBe(propsData.screenReaderMessage);
                 expect(element.classes().includes('is-visuallyHidden')).toBe(true);
             });
+
+            it('should apply `aria-hidden` attributes to the `displayText` and `displayNumber` if provided', () => {
+                // Arrange
+                const propsData = { screenReaderMessage: 'A screen reader message' };
+
+                // Act
+                const wrapper = shallowMount(FilterPill, {
+                    propsData
+                });
+
+                const displayTextElement = wrapper.find('[data-test-id="filter-pill-text"]');
+                const displayNumberElement = wrapper.find('[data-test-id="filter-pill-number"]');
+
+                // Assert
+                expect(displayTextElement.attributes()['aria-hidden']).toStrictEqual('true');
+                expect(displayNumberElement.attributes()['aria-hidden']).toStrictEqual('true');
+            });
+
+            it('should not apply `aria-hidden` attributes to the `displayText` and `displayNumber` if not provided', () => {
+                // Arrange
+                const propsData = { screenReaderMessage: null };
+
+                // Act
+                const wrapper = shallowMount(FilterPill, {
+                    propsData
+                });
+
+                const displayTextElement = wrapper.find('[data-test-id="filter-pill-text"]');
+                const displayNumberElement = wrapper.find('[data-test-id="filter-pill-number"]');
+
+                // Assert
+                expect(displayTextElement.attributes()['aria-hidden']).toBe(undefined);
+                expect(displayNumberElement.attributes()['aria-hidden']).toBe(undefined);
+            });
         });
     });
 

--- a/packages/components/atoms/f-filter-pill/src/components/_tests/FilterPill.test.js
+++ b/packages/components/atoms/f-filter-pill/src/components/_tests/FilterPill.test.js
@@ -120,6 +120,24 @@ describe('FilterPill', () => {
                 expect(element.text()).toBe(propsData.displayNumber.toString());
             });
         });
+
+        describe('screenReaderMessage :: ', () => {
+            it('Should render the screen reader message in a visually hidden element', () => {
+                // Arrange
+                const propsData = { screenReaderMessage: 'A screen reader message' };
+
+                // Act
+                const wrapper = shallowMount(FilterPill, {
+                    propsData
+                });
+
+                const element = wrapper.find('[data-test-id="filter-pill-sr-msg"]');
+
+                // Assert
+                expect(element.text()).toBe(propsData.screenReaderMessage);
+                expect(element.classes().includes('is-visuallyHidden')).toBe(true);
+            });
+        });
     });
 
     describe('methods :: ', () => {

--- a/packages/components/atoms/f-filter-pill/stories/FilterPill.stories.js
+++ b/packages/components/atoms/f-filter-pill/stories/FilterPill.stories.js
@@ -52,6 +52,11 @@ FilterPillComponent.argTypes = {
         control: { type: 'boolean' },
         description: 'Indicates whether or not to display a loading state',
         defaultValue: false
+    },
+    screenReaderMessage: {
+        control: { type: 'text' },
+        description: 'An optional message to read on screen readers',
+        defaultValue: 'Low Delivery Fee, 15 restaurants'
     }
 };
 


### PR DESCRIPTION
v0.6.0
------------------------------
*March 24, 2022*

### Added
- `screenReaderMessage` prop for screen-reader friendly copy

### Changed
- Added `aria-hidden` attributes to the elements rendering `displayText` and `displayNumber`