### PR TITLE
f-restaurant-card@v0.29.0 - Remove eta clearfix when prop true

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.29.0
+------------------------------
+*March 24, 2022*
+### Added
+- new prop `inlineTileData` which, when enabled, prevents the ETA clearfix from being rendered (this is to assist with an experiment)
+
 v0.28.0
 ------------------------------
 *March 24, 2022*

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
@@ -112,7 +112,9 @@
                 </component>
 
                 <!-- This is a clearfix to force anything after cuisines to a new line (won't affect list-item mode) -->
-                <div :class="[$style['c-restaurantCard-clearfix']]" />
+                <div
+                    v-if="!inlineTileData"
+                    :class="[$style['c-restaurantCard-clearfix']]" />
 
                 <!-- Delivery Meta (etas, distance etc) -->
                 <component
@@ -315,6 +317,11 @@ export default {
         performanceTracker: {
             type: Object,
             default: null
+        },
+        // temporary prop to assist with an experiment
+        inlineTileData: {
+            type: Boolean,
+            default: false
         }
     },
     computed: {

--- a/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
+++ b/packages/components/molecules/f-restaurant-card/stories/RestaurantCard.stories.js
@@ -72,7 +72,8 @@ RestaurantCardComponent.args = {
         availabilityMessage: 'Opening at 13:20'
     },
     disabledMessage: 'Not taking orders at the moment',
-    isLoading: false
+    isLoading: false,
+    inlineTileData: false
 };
 
 RestaurantCardComponent.storyName = 'f-restaurant-card';


### PR DESCRIPTION
v0.29.0
------------------------------
*March 24, 2022*
### Added
- new prop `inlineTileData` which, when enabled, prevents the ETA clearfix from being rendered (this is to assist with an experiment)

### Prop false (no change)
<img width="341" alt="Screenshot 2022-03-25 at 10 54 07" src="https://user-images.githubusercontent.com/16766185/160108454-48e40ff1-4988-48f4-bdb9-f649c09340e1.png">

### Prop true
<img width="335" alt="Screenshot 2022-03-25 at 10 53 58" src="https://user-images.githubusercontent.com/16766185/160108447-cc8c9ac6-0600-42ff-b229-0645c10bd7a1.png">

