### PR TITLE
f-restaurant-card@v0.29.1 - Fixed moved margin to parent

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.29.1
+------------------------------
+*March 25, 2022*
+### Fixed
+- Moved margin declaration to parent `c-deliveryTimeMeta` 
+
 v0.29.0
 ------------------------------
 *March 24, 2022*

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue
@@ -71,7 +71,7 @@ export default {
 </script>
 
 <style lang="scss" module>
-.c-deliveryTimeMeta-iconText {
+.c-deliveryTimeMeta {
     margin-right: spacing(b);
 }
 </style>


### PR DESCRIPTION
---

### Fixed
- Moved margin declaration to parent `c-deliveryTimeMeta` 

---

## UI Review Checks
- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested
- [X] Chrome (latest)


Before
![Screenshot 2022-03-25 at 16 01 37](https://user-images.githubusercontent.com/4212434/160157751-7436069e-780e-48b9-8848-7ec519513d10.png)


After
![Screenshot 2022-03-25 at 16 01 22](https://user-images.githubusercontent.com/4212434/160157772-d0e32e14-6aed-4969-8ed9-a0608e161568.png)

