### PR TITLE
f-content-cards@v8.0.0-alpha.3 - Adding the container element

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v8.0.0-alpha.3
+------------------------------
+*March 29, 2022*
+
+### Added
+- Container component for new content cards template system.
+
 
 v8.0.0-alpha.2
 ------------------------------

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "8.0.0-alpha.2",
+  "version": "8.0.0-alpha.3",
   "main": "dist/f-content-cards.umd.min.js",
   "maxBundleSize": "75kB",
   "files": [

--- a/packages/components/organisms/f-content-cards/src/components/templates/ContentCardContainer.vue
+++ b/packages/components/organisms/f-content-cards/src/components/templates/ContentCardContainer.vue
@@ -1,0 +1,62 @@
+<template>
+    <component
+        :is="card.url && isClickable ? 'a' : 'div'"
+        :class="$style['c-card-container']"
+        :href="card.url"
+        :target="target.attribute"
+        :rel="target.rel"
+        :data-test-id="`content-card-container-${card.id}`"
+        @click="onClickContentCard">
+        <slot :card="card" />
+    </component>
+</template>
+
+<script>
+export default {
+    inject: [
+        'emitCardView',
+        'emitCardClick'
+    ],
+
+    props: {
+        card: {
+            type: Object,
+            default: () => ({})
+        },
+
+        isClickable: {
+            type: Boolean,
+            default: true
+        }
+    },
+
+    computed: {
+        target () {
+            return this.card.target || {};
+        }
+    },
+
+    mounted () {
+        this.onViewContentCard(); // TODO should only fire if in view
+    },
+
+    methods: {
+        onViewContentCard () {
+            this.emitCardView(this.card);
+        },
+
+        onClickContentCard () {
+            this.emitCardClick(this.card);
+        }
+    }
+};
+</script>
+
+<style lang="scss" module>
+.c-card-container {
+    max-width: 375px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+</style>

--- a/packages/components/organisms/f-content-cards/src/components/templates/_tests/ContentCardContainer.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/templates/_tests/ContentCardContainer.test.js
@@ -1,0 +1,60 @@
+import { shallowMount } from '@vue/test-utils';
+import ContentCardContainer from '../ContentCardContainer.vue';
+
+const MOCK_CARD = {
+    id: '__TEST_ID__',
+    url: 'https://example.com'
+};
+
+describe('ContentCardContainer.vue', () => {
+    let wrapper;
+    beforeEach(() => {
+        // Arrange
+        wrapper = shallowMount(ContentCardContainer, {
+            provide: {
+                emitCardView: jest.fn(),
+                emitCardClick: jest.fn()
+            },
+            propsData: {
+                card: MOCK_CARD,
+                isClickable: true
+            },
+            scopedSlots: {
+                default: '<p data-test-id="card-test-slot" slot-scope="cardData">{{cardData.card.id}}</p>'
+            }
+        });
+    });
+
+    it('should emit view content card event on mount', async () => {
+        // Act
+        await wrapper.vm.$nextTick();
+
+        // Assert
+        expect(wrapper.vm.emitCardView).toHaveBeenCalled();
+    });
+
+    it('should emit click event on click', async () => {
+        // Act
+        await wrapper.find('a').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        // Assert
+        expect(wrapper.vm.emitCardView).toHaveBeenCalled();
+    });
+
+    it('should set container as an `a` tag when `isClickable` is true and card has a url', async () => {
+        // Act
+        const tag = await wrapper.find('a');
+
+        // Assert
+        expect(tag.exists()).toBeTruthy();
+    });
+
+    it('should pass the card prop through to the slot via slot props', () => {
+        // Act
+        const slot = wrapper.find('[data-test-id="card-test-slot"]');
+
+        // Assert
+        expect(slot.text()).toEqual(MOCK_CARD.id);
+    });
+});


### PR DESCRIPTION
PR adds in the new container element / component for cards. Checking for card url and `isClickable` prop controlling base html tag. Unit tests have been created.

## UI Review Checks

![Screenshot 2022-03-29 at 08 58 07](https://user-images.githubusercontent.com/15876339/160562589-4907eb53-740d-45fe-8f67-25738a6b6866.png)

- [x] Unit tests have been created

## Browsers Tested

- [x] Chrome (latest)
