### PR TITLE
f-header@9.10.0 - Updated header f-popover package ver

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v9.10.0
+------------------------------
+*March 30, 2022*
+
+### Changed
+- Version of `f-popover`
+
 
 v9.9.0
 ------------------------------

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header - Globalised Header Component",
-  "version": "9.9.0",
+  "version": "9.10.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.12.13",
     "@justeat/f-button": "3.3.0",
-    "@justeat/f-popover": "2.2.0",
+    "@justeat/f-popover": "2.3.0",
     "@justeat/f-vue-icons": "3.4.0",
     "@justeat/f-wdio-utils": "0.5.0",
     "@vue/cli-plugin-babel": "4.5.16",


### PR DESCRIPTION
v9.10.0
------------------------------
*March 30, 2022*

### Changed
- Version of `f-popover`