### PR TITLE
f-restaurant-card@v0.29.2 - Amended alignment of restaurant card content

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.29.3
+------------------------------
+*April 1, 2022*
+### Fixed
+- Alignment of restaurant card content
+
 v0.29.2
 ------------------------------
 *March 31, 2022*

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
@@ -489,12 +489,13 @@ export default {
             display: grid;
             grid-template-columns: 1fr 1fr;
             grid-auto-flow: dense;
+            grid-auto-rows: min-content;
             gap: 0 spacing(c);
             overflow-wrap: break-word;
+            align-items: flex-start;
 
             > * {
                 grid-column: 2;
-                margin: 0;
             }
         }
 
@@ -514,7 +515,7 @@ export default {
         }
 
         .c-restaurantCard-name {
-            margin-bottom: spacing(a);
+            margin-bottom: spacing(b);
         }
 
         .c-restaurantCard-tags {


### PR DESCRIPTION
---

### Fixed
- Alignment of restaurant card content

---

Before
![Screenshot 2022-04-01 at 16 28 23](https://user-images.githubusercontent.com/4212434/161294800-13f6ee7b-e3b5-4070-8e60-7203255f0577.png)


After

![Screenshot 2022-04-01 at 16 25 58](https://user-images.githubusercontent.com/4212434/161294126-5d37905e-a90c-44c0-a94e-5ba3d4d3cc03.png)


## UI Review Checks
- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested
- [X] Chrome (latest)
