### PR TITLE
f-offers@1.10.0 - Bump f-searchbox

### DIFF
--- a/packages/components/pages/f-offers/CHANGELOG.md
+++ b/packages/components/pages/f-offers/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.10.0
+------------------------------
+*April 07, 2022*
+
+### Changed
+- `f-searchbox` to stop alerts when `ZERO_RESULTS` appear.
+
 
 v1.9.0
 ------------------------------

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-offers",
   "description": "Fozzie Offers - displays offers to the customers",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "main": "dist/f-offers.umd.min.js",
   "maxBundleSize": "150kB",
   "files": [
@@ -64,7 +64,7 @@
     "@justeat/f-content-cards": "7.4.0",
     "@justeat/f-button": "3.0.2",
     "@justeat/f-media-element": "2.0.0",
-    "@justeat/f-searchbox": "6.3.0",
+    "@justeat/f-searchbox": "6.7.0",
     "@justeat/f-trak": "0.7.1",
     "@justeat/f-mega-modal": "3.0.0",
     "@vue/cli-plugin-babel": "4.5.16",


### PR DESCRIPTION
https://github.com/justeat/f-searchbox/pull/290

### Changed
- `f-searchbox` to stop alerts when `ZERO_RESULTS` appear.