### PR TITLE
f-header@v9.10.1 – Fix for user icon showing when fozzie utility classes not present

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v9.10.1
+------------------------------
+*April 7, 2022*
+
+### Fixed
+- User Profile Icon changed to using v-if rather than `is-hidden` class to hide it.
+- `showCountrySelector` added to `hasNavigationLinks` property so that it appears if only that prop is set to `true`.
+
+
 v9.10.0
 ------------------------------
 *March 30, 2022*

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header - Globalised Header Component",
-  "version": "9.10.0",
+  "version": "9.10.1",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -139,10 +139,10 @@
                 </li>
 
                 <li
+                    v-if="userInfo && showLoginInfo"
                     :class="[
                         $style['c-nav-list-item--horizontallyAlignedAboveMid'],
                         $style['has-sublist'], {
-                            'is-hidden': !userInfo || !showLoginInfo,
                             [$style['is-open']]: userMenuIsOpen
                         }]"
                     data-test-id="user-info-icon"
@@ -424,6 +424,7 @@ export default {
                 this.showHelpLink ||
                 this.showDeliveryEnquiry ||
                 this.showLoginInfo ||
+                this.showCountrySelector ||
                 this.customNavLinks.length > 0;
         },
 

--- a/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
+++ b/packages/components/organisms/f-header/src/components/_tests/Navigation.test.js
@@ -137,6 +137,7 @@ describe('Navigation', () => {
                 'showOffersLink',
                 'showHelpLink',
                 'showDeliveryEnquiry',
+                'showCountrySelector',
                 'showLoginLink'
             ])('should return true if `%s` is true', navLink => {
                 // Arrange & Act
@@ -185,6 +186,7 @@ describe('Navigation', () => {
                         showOffersLink: false,
                         showHelpLink: false,
                         showDeliveryEnquiry: false,
+                        showCountrySelector: false,
                         customNavLinks: []
                     }
                 });
@@ -781,7 +783,36 @@ describe('Navigation', () => {
                 });
 
                 // Assert
-                expect(wrapper.find('[data-test-id="user-info-icon"]').classes()).toContain('is-hidden');
+                expect(wrapper.find('[data-test-id="user-info-icon"]').exists()).toBe(false);
+            });
+
+            it('should show "user-info-icon" if `showLoginInfo: true` and the user is logged in and has nav link data', async () => {
+                // Arrange
+                wrapper = shallowMount(Navigation, {
+                    propsData: {
+                        ...defaultPropsData,
+                        showLoginInfo: true
+                    },
+                    computed: {
+                        hasNavigationLinks () {
+                            return true;
+                        }
+                    },
+                    mocks: {
+                        $style
+                    }
+                });
+
+                // Act
+                await wrapper.setData({
+                    ...defaultData,
+                    userInfo: {
+                        isAuthenticated: true
+                    }
+                });
+
+                // Assert
+                expect(wrapper.find('[data-test-id="user-info-icon"]').exists()).toBe(true);
             });
         });
 


### PR DESCRIPTION
### Fixed
- User Profile Icon changed to using v-if rather than `is-hidden` class to hide it.
- `showCountrySelector` added to `hasNavigationLinks` property so that it appears if only that prop is set to `true`.

---

## UI Review Checks

- [x] Unit tests have been [created|updated]

## Browsers Tested

- [x] Chrome (latest)
