### PR TITLE
f-restaurant-card@v0.29.4 - Fix minor design issues

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.29.4
 ------------------------------
-*April 1, 2022*
+*April 8, 2022*
 ### Fixed
 - Margin Spacing on Restaurant Dishes
 - Image tag spacing to match logo spacing

--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.29.4
+------------------------------
+*April 1, 2022*
+### Fixed
+- Margin Spacing on Restaurant Dishes
+- Image tag spacing to match logo spacing
+
 v0.29.3
 ------------------------------
 *April 1, 2022*

--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -7,8 +7,9 @@ v0.29.4
 ------------------------------
 *April 8, 2022*
 ### Fixed
-- Margin Spacing on Restaurant Dishes
+- Text vertical alignment on restaurant dishes
 - Image tag spacing to match logo spacing
+- Gap between restaurant tags
 - Prevent ratings count from wrapping
 
 v0.29.3

--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -9,6 +9,7 @@ v0.29.4
 ### Fixed
 - Margin Spacing on Restaurant Dishes
 - Image tag spacing to match logo spacing
+- Prevent ratings count from wrapping
 
 v0.29.3
 ------------------------------

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
@@ -426,7 +426,7 @@ export default {
 }
 
 .c-restaurantCard-imageTags {
-    bottom: spacing(c);
+    bottom: spacing(d);
     left: spacing(d);
     position: absolute;
     margin-bottom: 0;

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
@@ -426,7 +426,7 @@ export default {
 }
 
 .c-restaurantCard-imageTags {
-    bottom: spacing(b);
+    bottom: spacing(c);
     left: spacing(d);
     position: absolute;
     margin-bottom: 0;

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantDishes/RestaurantDish.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantDishes/RestaurantDish.vue
@@ -9,6 +9,7 @@
                 {{ name }}
             </span>
             <span
+                v-if="calories || portion"
                 :class="[$style['c-restaurantCard-dish-nutritionalInfo']]">
                 <span
                     v-if="calories"

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/RestaurantRating.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/RestaurantRating.vue
@@ -170,6 +170,7 @@ export default {
     align-items: center;
     padding: 0;
     margin: 0;
+    white-space: nowrap;
 }
 
 .c-restaurantCard-rating-iconWrapper {

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTag.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTag.vue
@@ -56,7 +56,6 @@ export default {
 .c-restaurantTag {
     display: block;
     padding: 0 spacing(a);
-    margin-bottom: spacing(a);
     border-radius: $radius-rounded-a;
     @include font-size($font-paragraph-03);
     color: $color-content-default;

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTags.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTags.vue
@@ -41,7 +41,7 @@ export default {
     display: flex;
     flex-flow: row wrap;
     align-items: center;
-    gap: 0 spacing(a);
+    gap: spacing(a);
 }
 
 .c-restaurantTags-tag {


### PR DESCRIPTION
Fixed minor design issues raised during mob testing.

### Fixed
- Centre Restaurant dish names when calories data is not present
- Image tag spacing to match logo spacing
- Prevent ratings count from wrapping

![image](https://user-images.githubusercontent.com/68010631/162472973-71ef1947-74d3-4932-844d-b4dd30594057.png)
---

### Ratings Wrapping
This issue happens typically on restaurants with a lot of data and users on the lower size of the restaurant list view
#### Before
![image](https://user-images.githubusercontent.com/68010631/162480549-62fe7cae-8b9c-487f-9536-de512fbf6476.png)

#### After
![image](https://user-images.githubusercontent.com/68010631/162480590-8121200f-aa19-4304-9abd-d3c5c2d6f4e4.png)

---
_(Fixed issues raised in ticket **SEARCH-2698**)_