### PR TITLE
f-header@9.12.0 - small hover change to match design

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v9.12.0
+------------------------------
+*April 11, 2022*
+
+### Changed
+- CSS change to add hover to button
+
+
 v9.11.0
 ------------------------------
 *April 8, 2022*

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header - Globalised Header Component",
-  "version": "9.11.0",
+  "version": "9.12.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "40kB",
   "files": [

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -717,13 +717,10 @@ export default {
 }
 
 .c-nav-list-btn--hoverAboveMid {
-    &:hover {
-        background: $color-container-subtle;
-        border-radius: $nav-focus-borderRadius;
-    }
-    @include media('<=mid') {
+    @include media('>mid') {
         &:hover {
-            border-radius: 0;
+            background: $color-container-subtle;
+            border-radius: $nav-focus-borderRadius;
         }
     }
 }

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -158,7 +158,7 @@
                         :class="[
                             $style['c-nav-list-text'],
                             $style['c-nav-list-btn'],
-                            { [$style['c-nav-list-btn--hover']]: headerBackgroundTheme === 'white' }
+                            { [$style['c-nav-list-btn--hoverAboveMid']]: headerBackgroundTheme === 'white' }
                         ]"
                         @click.prevent="toggleUserMenu"
                         @keydown.space.prevent="toggleUserMenu">
@@ -702,6 +702,11 @@ export default {
         &:focus {
             border-radius: 0;
         }
+
+        &:hover {
+            background: $color-container-subtle;
+            border-radius: 0;
+        }
     }
 }
 
@@ -711,7 +716,7 @@ export default {
     }
 }
 
-.c-nav-list-btn--hover {
+.c-nav-list-btn--hoverAboveMid {
     &:hover {
         background: $color-container-subtle;
         border-radius: $nav-focus-borderRadius;


### PR DESCRIPTION
### Changed

- CSS small fix to add hover fade to `user-info-button` when header theme is `orange` or `transparent` in storybook (already works for white theme) & view is below mid

| Current | New |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/49618712/162700415-b1fd5a32-26fa-4c46-b902-32faf43acea4.png)|![image](https://user-images.githubusercontent.com/49618712/162700927-cecb3379-24cf-4c14-a3f0-6a0e28b95cf4.png)|





