### PR TITLE
f-footer@7.2.1 – Fix footer country select list z-index

### DIFF
--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v7.2.1
+------------------------------
+*April 14, 2022*
+
+### Removed
+- Set `.c-countrySelector-list` z-index set to high, due to it appearing under page header on certain smaller screens.
+
+
 v7.2.0
 ------------------------------
 *April 01, 2022*

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "main": "dist/f-footer.umd.min.js",
   "maxBundleSize": "80kB",
   "files": [

--- a/packages/components/organisms/f-footer/src/components/CountrySelector.vue
+++ b/packages/components/organisms/f-footer/src/components/CountrySelector.vue
@@ -217,6 +217,7 @@ $countrySelector-btn-font-size: 'body-s';
     background-color: $footer-bgLight;
     box-shadow: $elevation-02;
     list-style: none;
+    z-index: zIndex(high);
 
     & > li:before {
         content: none;


### PR DESCRIPTION
Footer Country select popover appears under the page header on certain screen and page sizes
---------

## Changed

 - Added high zIndex style to Country selector list. 

<img width="491" alt="Screenshot 2022-04-12 at 15 21 30" src="https://user-images.githubusercontent.com/26770126/163405889-089a819d-f77d-4b8e-8bdb-3139bc912e15.png">


## Browsers Tested

- [x] Chrome (latest)
- [x] Mobile (Please list device/browser – Ideally one iPhone model and one Android)
