### PR TITLE
f-content-cards@v8.0.0-alpha.7 - Adding Promotion Card One

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v8.0.0-alpha.7
+------------------------------
+*April 20, 2022*
+
+### Added
+- Promotion card one and story file
+
+
 v8.0.0-alpha.6
 ------------------------------
 *April 11, 2022*

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "8.0.0-alpha.6",
+  "version": "8.0.0-alpha.7",
   "main": "dist/f-content-cards.umd.min.js",
   "maxBundleSize": "75kB",
   "files": [

--- a/packages/components/organisms/f-content-cards/src/components/cards/PromotionCardOne.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cards/PromotionCardOne.vue
@@ -1,0 +1,53 @@
+<template>
+    <content-card-container
+        #default="{
+            card: {
+                title, subtitle, image, icon, ctaText, url
+            }
+        }"
+        :is-clickable="false"
+        :card="card">
+        <content-card-image
+            :restaurant-logo-url="icon"
+            :background-image-url="image" />
+        <content-card-body
+            :title="title"
+            :subtitle="subtitle"
+        >
+            <template #footer>
+                <f-button
+                    :href="url"
+                    isFullWidth
+                    type="primary">
+                    {{ ctaText }}
+                </f-button>
+            </template>
+        </content-card-body>
+    </content-card-container>
+</template>
+
+<script>
+import FButton from '@justeat/f-button';
+import ContentCardContainer from '../templates/ContentCardContainer.vue';
+import ContentCardImage from '../templates/ContentCardImage.vue';
+import ContentCardBody from '../templates/ContentCardBody.vue';
+
+export default {
+    components: {
+        ContentCardContainer,
+        ContentCardImage,
+        ContentCardBody,
+        FButton
+    },
+    props: {
+        card: {
+            type: Object,
+            default: () => ({})
+        }
+    }
+};
+</script>
+
+<style scoped>
+
+</style>

--- a/packages/components/organisms/f-content-cards/src/components/cards/_tests/PromotionCardOne.test.js
+++ b/packages/components/organisms/f-content-cards/src/components/cards/_tests/PromotionCardOne.test.js
@@ -1,0 +1,76 @@
+import { mount } from '@vue/test-utils';
+import PromotionCardOne from '../PromotionCardOne.vue';
+
+const MOCK_CARD = {
+    image: 'https://example.com/image.jpg',
+    icon: 'https://example.com/logo.jpg',
+    title: '__TEST_TITLE__',
+    subtitle: '__TEST_SUBTITLE__',
+    ctaText: '__TEST_CTA_TEXT__',
+    url: 'https://example.com'
+};
+
+describe('PromotionCardOne.vue', () => {
+    let wrapper;
+
+    beforeEach(() => {
+        // Arrange
+        wrapper = mount(PromotionCardOne, {
+            provide: {
+                emitCardView: jest.fn(),
+                emitCardClick: jest.fn()
+            },
+            propsData: {
+                card: MOCK_CARD
+            }
+        });
+    });
+
+    it('should display the cards image when card is passed to prop', () => {
+        // Act
+        const image = wrapper.find('[data-test-id="content-card-background-image"]');
+
+        // Assert
+        expect(image.attributes('src')).toEqual(MOCK_CARD.image);
+    });
+
+    it('should display the restaurant logo when card is passed to prop', () => {
+        // Act
+        const logo = wrapper.find('[data-test-id="content-card-restaurant-logo"]');
+
+        // Assert
+        expect(logo.attributes('src')).toEqual(MOCK_CARD.icon);
+    });
+
+    it('should display the title when card is passed to prop', () => {
+        // Act
+        const title = wrapper.find('[data-test-id="content-card-title"]');
+
+        // Assert
+        expect(title.text()).toEqual(MOCK_CARD.title);
+    });
+
+    it('should display the subtitle when card is passed to prop', () => {
+        // Act
+        const subtitle = wrapper.find('[data-test-id="content-card-subtitle"]');
+
+        // Assert
+        expect(subtitle.text()).toEqual(MOCK_CARD.subtitle);
+    });
+
+    it('should display the cta text when card is passed to prop', () => {
+        // Act
+        const ctaText = wrapper.find('[data-test-id="link-button-component"]');
+
+        // Assert
+        expect(ctaText.text()).toEqual(MOCK_CARD.ctaText);
+    });
+
+    it('should link to the url when card is passed to the prop', () => {
+        // Act
+        const link = wrapper.find('[data-test-id="link-button-component"]');
+
+        // Assert
+        expect(link.attributes('href')).toEqual(MOCK_CARD.url);
+    });
+});

--- a/packages/components/organisms/f-content-cards/stories/new/PromotionCardOne.stories.js
+++ b/packages/components/organisms/f-content-cards/stories/new/PromotionCardOne.stories.js
@@ -1,0 +1,107 @@
+import { withA11y } from '@storybook/addon-a11y';
+import PromotionCardOne from '../../src/components/cards/PromotionCardOne.vue';
+import jeBackground from '../images/je-marketing.jpg';
+import jeIcon from '../images/je-icon.png';
+
+export default {
+    title: 'Components/Molecules/f-content-cards/new',
+    decorators: [withA11y]
+};
+
+function cardGenerator (type, title, image, icon, description, cta) {
+    return {
+        type,
+        id: 'NWU1NTJjMWU2YThkNjM0ODllYzE3OGI5XyRfY2M9ZDg1MzM1ODktM2IyMC0xZmJkLWYwMzEtMTE5MjNjYjhiMjcyJm12PTVlNTUyYzFlNmE4ZDYzNDg5ZWMxNzhiZCZwaT1jbXA=',
+        viewed: false,
+        title,
+        imageUrl: null,
+        subtitle: description,
+        description: ['Optional small T&C copy so it doesnt take up too much space making the card massive.'],
+        created: null,
+        updated: '2020-02-25T14:21:15.000Z',
+        categories: [],
+        expiresAt: '2020-03-25T23:55:00.000Z',
+        url: 'https://www.just-eat.co.uk/area/s637jj',
+        linkText: 'www.just-eat.co.uk',
+        aspectRatio: 1,
+        order: '1',
+        image,
+        ctaText: cta,
+        icon,
+        pinned: false,
+        dismissible: true,
+        dismissed: false,
+        clicked: false,
+        Ra: null,
+        Rf: null
+    };
+}
+
+function provide () {
+    return {
+        emitCardView () { },
+        emitCardClick () { }
+    };
+}
+
+export const PromotionCardOneComponent = (args, { argTypes }) => ({
+    components: {
+        PromotionCardOne
+    },
+
+    props: Object.keys(argTypes),
+
+    provide,
+
+    computed: {
+        card () {
+            return cardGenerator(
+                'Promotion_Card_1',
+                this.title,
+                this.image,
+                this.icon,
+                this.description,
+                this.cta
+            );
+        }
+    },
+
+    template: '<promotion-card-one :card="card" />'
+});
+
+const args = {
+    title: 'StampCards are here',
+    description: 'Earn money off your favourite restaurants wih our StampCard programme. Earn 5 stamps for a tasty discount.',
+    image: jeBackground,
+    icon: jeIcon,
+    cta: 'View StampCards'
+};
+
+const argTypes = {
+    title: {
+        control: { type: 'text' },
+        description: 'Changes text of card title'
+    },
+    description: {
+        control: { type: 'text' },
+        description: 'Changes text of card subtitle'
+    },
+    image: {
+        control: { type: 'text' },
+        description: 'Changes text of card mage'
+    },
+    icon: {
+        control: { type: 'text' },
+        description: 'Changes text of card icon'
+    },
+    cta: {
+        control: { type: 'text' },
+        description: 'Changes text of card cta'
+    }
+};
+
+PromotionCardOneComponent.storyName = 'promotion-card-one';
+PromotionCardOneComponent.args = args;
+PromotionCardOneComponent.argTypes = argTypes;
+
+


### PR DESCRIPTION
PR adds a new promotion card one, alongside story file plus unit tests.

## UI Review Checks

![Screenshot 2022-04-20 at 13 50 01](https://user-images.githubusercontent.com/15876339/164235784-1183d994-a251-4a42-991e-0e6fcb6034d9.png)

- [x] Unit tests have been [created|updated]

## Browsers Tested

- [x] Chrome (latest)
