### PR TITLE
f-restaurant-card@v0.29.5 - Removed gap and added margin for Safari support

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.29.5
+------------------------------
+*April 22, 2022*
+### Fixed
+- Removed `gap` property and replaced with margin for Safari support
+
 v0.29.4
 ------------------------------
 *April 8, 2022*

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "0.29.4",
+  "version": "0.29.5",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
@@ -489,7 +489,7 @@ export default {
             grid-template-columns: 1fr 1fr;
             grid-auto-flow: dense;
             grid-auto-rows: min-content;
-            gap: 0 spacing(c);
+            grid-gap: 0 spacing(c);
             overflow-wrap: break-word;
             align-items: flex-start;
 

--- a/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/RestaurantCard.vue
@@ -445,7 +445,6 @@ export default {
 
 .c-restaurantCard-ratingContainer {
     display: flex;
-    gap: spacing(b);
     align-items: center;
     margin-right: spacing(b);
 }

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/RestaurantRating.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantRating/RestaurantRating.vue
@@ -171,6 +171,7 @@ export default {
     padding: 0;
     margin: 0;
     white-space: nowrap;
+    margin-right: spacing(b);
 }
 
 .c-restaurantCard-rating-iconWrapper {

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTag.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTag.vue
@@ -67,6 +67,7 @@ export default {
 
     &.c-restaurantTag--isLarge.c-restaurantTag--isUppercase.c-restaurantTag--positive {
         margin-bottom: 0;
+        margin-right: spacing(b);
     }
 }
 

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTags.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTags.vue
@@ -41,11 +41,10 @@ export default {
     display: flex;
     flex-flow: row wrap;
     align-items: center;
-    gap: spacing(a);
 }
 
 .c-restaurantTags-tag {
     list-style-type: none;
-    margin: 0;
+    margin: 0 spacing(a) spacing(a) 0;
 }
 </style>


### PR DESCRIPTION
---

### Fixed
- Removed `gap` property and replaced with margin for Safari support

---

## UI Review Checks
- [X] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [X] Chrome (latest)
- [X] Safari 15.3/ 14.1/ 13.1
- [X] Mobile Safari


Before
![Screenshot 2022-04-22 at 15 28 33](https://user-images.githubusercontent.com/4212434/164744165-8b29e77b-3fec-4e48-9e9b-50037fed98de.png)

After (storybook in browserstack)

![Screenshot 2022-04-25 at 09 44 34](https://user-images.githubusercontent.com/4212434/165053604-774d8da8-e8fd-4b83-9723-ebbebccc9c99.png)


