### PR TITLE
f-footer@v7.3.0 - Update iOS App download links in f-footer

### DIFF
--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v7.3.0
+------------------------------
+*April 25, 2022*
+
+### Changed
+- Footer to use correct iOS app download links.
+
+
 v7.2.1
 ------------------------------
 *April 14, 2022*

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "main": "dist/f-footer.umd.min.js",
   "maxBundleSize": "80kB",
   "files": [

--- a/packages/components/organisms/f-footer/src/tenants/en-GB.js
+++ b/packages/components/organisms/f-footer/src/tenants/en-GB.js
@@ -4,7 +4,7 @@ export default {
     downloadOurApps: 'Download our apps',
     appStoreIcons: [
         {
-            url: 'https://app.adjust.com/oc511o_1455tm?utm_medium=internal&campaign=footer',
+            url: 'https://app.adjust.com/oc511o?utm_medium=internal&campaign=footer-uk',
             name: 'ios',
             alt: 'Download on the App Store',
             gtm: 'click_download_ios_app'

--- a/packages/components/organisms/f-footer/src/tenants/en-IE.js
+++ b/packages/components/organisms/f-footer/src/tenants/en-IE.js
@@ -35,7 +35,7 @@ export default {
     downloadOurApps: 'Download our apps',
     appStoreIcons: [
         {
-            url: 'https://app.adjust.com/14v0t5?utm_medium=internal&campaign=footer',
+            url: 'https://app.adjust.com/oc511o?utm_medium=internal&campaign=footer-ie',
             name: 'ios',
             alt: 'Download on the App Store',
             gtm: 'click_download_ios_app'

--- a/packages/components/organisms/f-footer/src/tenants/en-NZ.js
+++ b/packages/components/organisms/f-footer/src/tenants/en-NZ.js
@@ -35,7 +35,7 @@ export default {
     downloadOurApps: 'Download our apps',
     appStoreIcons: [
         {
-            url: 'https://itunes.apple.com/nz/app/menulog-order-takeaway-food/id485249021?mt=8&&referrer=click%3D69811f6e-2144-4706-bafc-3d9ae07efd62',
+            url: 'https://apps.apple.com/nz/app/menulog-food-delivery/id327982905?mt=8&&referrer=click%3D69811f6e-2144-4706-bafc-3d9ae07efd62',
             name: 'ios',
             alt: 'Download on the App Store',
             gtm: 'click_download_ios_app'

--- a/packages/components/organisms/f-footer/src/tenants/es-ES.js
+++ b/packages/components/organisms/f-footer/src/tenants/es-ES.js
@@ -4,7 +4,7 @@ export default {
     downloadOurApps: 'Descárgate la app',
     appStoreIcons: [
         {
-            url: 'https://app.adjust.com/gxu4mb?utm_medium=internal&campaign=footer',
+            url: 'https://app.adjust.com/oc511o?utm_medium=internal&campaign=footer-es',
             name: 'ios',
             alt: 'Consíguelo en el App Store',
             gtm: 'click_download_ios_app'

--- a/packages/components/organisms/f-footer/src/tenants/it-IT.js
+++ b/packages/components/organisms/f-footer/src/tenants/it-IT.js
@@ -4,7 +4,7 @@ export default {
     downloadOurApps: "Scarica l'app",
     appStoreIcons: [
         {
-            url: 'https://app.adjust.com/6zamp7?utm_medium=internal&campaign=footer',
+            url: 'https://app.adjust.com/oc511o?utm_medium=internal&campaign=footer-it',
             name: 'ios',
             alt: 'Scarica su App Store',
             gtm: 'click_download_ios_app'


### PR DESCRIPTION
v7.3.0
------------------------------
*April 25, 2022*

### Changed
- Footer to use correct iOS app download links.