### PR TITLE
f-checkout@v3.26.0 - update error messages

### DIFF
--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -11,7 +11,7 @@ v3.26.0
 ### Changed
  - Invalid field error summary to be read with error messages.
 
- ### Added
+### Added
  - Focus to first inline error.
 
 

--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.26.0
+------------------------------
+*April 28, 2022*
+
+### Changed
+ - Invalid field error summary to be read with error messages.
+
+ ### Added
+ - Focus to first inline error.
+
+
 v3.25.0
 ------------------------------
 *April 13, 2022*

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "3.25.0",
+  "version": "3.26.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "120kB",
   "files": [

--- a/packages/components/pages/f-checkout/src/components/CheckoutForm.vue
+++ b/packages/components/pages/f-checkout/src/components/CheckoutForm.vue
@@ -5,8 +5,8 @@
         @submit.prevent="onFormSubmit">
         <section
             v-if="invalidFieldsSummary"
+            id="error-summary-container"
             class="is-visuallyHidden"
-            role="alert"
             data-test-id="error-summary-container">
             {{ invalidFieldsSummary }}
         </section>
@@ -154,9 +154,11 @@ export default {
 
             if (!invalidFieldCount) return null;
 
-            return invalidFieldCount === 1 ?
+            const invalidStatusMessage = invalidFieldCount === 1 ?
                 this.$t('errorMessages.singleFieldError') :
                 this.$t('errorMessages.multipleFieldErrors', { errorCount: invalidFieldCount });
+
+            return `${invalidStatusMessage}.`;
         },
 
         fieldTranslations () {
@@ -171,9 +173,13 @@ export default {
          */
         scrollToFirstInlineError () {
             this.$nextTick(() => {
-                const firstInlineError = document.querySelector('[data-js-error-message]');
+                const firstInlineError = document.querySelector('[aria-invalid="true"]');
 
                 this.scrollToElement(firstInlineError, { offset: -100 });
+
+                firstInlineError?.focus({
+                    preventScroll: true
+                });
             });
         },
 

--- a/packages/components/pages/f-checkout/src/components/CheckoutFormField.vue
+++ b/packages/components/pages/f-checkout/src/components/CheckoutFormField.vue
@@ -8,7 +8,7 @@
         v-bind="isGrouped && groupedProps"
         :has-error="hasError"
         :aria-invalid="hasError"
-        :aria-describedby="hasError && translations.errorName"
+        :aria-describedby="hasError && `error-summary-container ${translations.errorName}`"
         :aria-label="isPhoneNumber && formattedMobileNumberForScreenReader"
         @blur="hasInvalidErrorMessage && formFieldBlur()"
         @input="updateUserDetails({ fieldType, fieldName, value: $event })">

--- a/packages/components/pages/f-checkout/src/components/_tests/CheckoutForm.test.js
+++ b/packages/components/pages/f-checkout/src/components/_tests/CheckoutForm.test.js
@@ -288,7 +288,7 @@ describe('CheckoutForm', () => {
 
                 const scrollToElementSpy = jest.spyOn(wrapper.vm, 'scrollToElement');
 
-                const firstErrorElement = document.querySelector('[data-js-error-message]');
+                const firstErrorElement = document.querySelector('[aria-invalid="true"]');
 
                 // Act
                 wrapper.vm.scrollToFirstInlineError(firstErrorElement);

--- a/packages/components/pages/f-checkout/src/components/_tests/__snapshots__/CheckoutForm.test.js.snap
+++ b/packages/components/pages/f-checkout/src/components/_tests/__snapshots__/CheckoutForm.test.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CheckoutForm computed :: invalidFieldsSummary :: should return the error summary with the number of invalid fields when there are more than one 1`] = `"There are 4 errors in the form"`;
+exports[`CheckoutForm computed :: invalidFieldsSummary :: should return the error summary with the number of invalid fields when there are more than one 1`] = `"There are 4 errors in the form."`;
 
-exports[`CheckoutForm computed :: invalidFieldsSummary :: should return the error summary with the number of invalid fields when there is only one 1`] = `"There is 1 error in the form"`;
+exports[`CheckoutForm computed :: invalidFieldsSummary :: should return the error summary with the number of invalid fields when there is only one 1`] = `"There is 1 error in the form."`;


### PR DESCRIPTION
Previously voiceover would only read 'You have * errors in the form' on the first submit. Screen readers would not be updated that there are still errors in the form after submitting again. 

Now when the submit button is pressed focus is put on the first error message. Each field will read 'There are * errors in the form. Please enter your ...'

### Changed
 - Invalid field error summary to be read with error messages.

### Added
 - Focus to first inline error.