### PR TITLE
fozzie-components@v7.7.0 - Add Renovate to automatically create PR's for minor dependency updates - #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v7.7.0
+------------------------------
+*May 10, 2022*
+
+### Added
+- Renovate for automatic version bumps of minor dependencies
+
 v7.6.0
 ------------------------------
 *April 13, 2022*

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,10 +1,12 @@
 /* global danger, fail, message */
 const { pr } = danger.github;
 const bodyAndTitle = (pr.body + pr.title).toLowerCase();
+const prAuthor = pr.author.toLowerCase();
 const isTrivial = bodyAndTitle.includes('#trivial'); // turns off all danger checks
+const isRenovateBot = prAuthor === 'renovate'; // turns off all danger checks
 const isGlobalConfigUpdate = bodyAndTitle.includes('#globalconfig'); // turns off danger checks for packages outside the root
 
-if (!isTrivial) {
+if (!isTrivial || !isRenovateBot) {
     const failedChangelogs = [];
     const failedVersionBumps = [];
     const packageDirectories = [

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,7 +1,7 @@
 /* global danger, fail, message */
 const { pr } = danger.github;
 const bodyAndTitle = (pr.body + pr.title).toLowerCase();
-const prAuthor = pr.author.toLowerCase();
+const prAuthor = pr.user.login.toLowerCase();
 const isTrivial = bodyAndTitle.includes('#trivial'); // turns off all danger checks
 const isRenovateBot = prAuthor === 'renovate'; // turns off all danger checks
 const isGlobalConfigUpdate = bodyAndTitle.includes('#globalconfig'); // turns off danger checks for packages outside the root

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "7.6.0",
+  "version": "7.7.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell \"lerna run $LERNA_ARGS build --stream\"",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+    "extends": [
+      "config:base",
+      ":automergeMinor",
+      ":automergeRequireAllStatusChecks",
+      "schedule:earlyMondays"
+    ],
+    "commitMessagePrefix": "renovate -",
+    "packageRules": [
+      {
+        "packagePatterns": [
+          "*"
+        ],
+        "minor": {
+          "groupName": "all non-major dependencies",
+          "groupSlug": "all-minor-patch"
+        }
+      }
+    ]
+  }

--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,10 @@
     "extends": [
       "config:base",
       ":automergeMinor",
-      ":automergeRequireAllStatusChecks"
+      ":automergeRequireAllStatusChecks",
+      "schedule:earlyMondays"
     ],
-    "commitMessagePrefix": "renovate -",
+    "commitMessagePrefix": "renovate - #trivial -",
     "packageRules": [
       {
         "packagePatterns": [
@@ -15,8 +16,5 @@
           "groupSlug": "all-minor-patch"
         }
       }
-    ],
-    "schedule": [
-        "every weekday"
     ]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
     "extends": [
       "config:base",
       ":automergeMinor",
-      ":automergeRequireAllStatusChecks",
-      "schedule:every weekday"
+      ":automergeRequireAllStatusChecks"
     ],
     "commitMessagePrefix": "renovate -",
     "packageRules": [
@@ -16,5 +15,8 @@
           "groupSlug": "all-minor-patch"
         }
       }
+    ],
+    "schedule": [
+        "every weekday"
     ]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
       ":automergeRequireAllStatusChecks",
       "schedule:earlyMondays"
     ],
-    "commitMessagePrefix": "renovate - #trivial -",
+    "commitMessagePrefix": "renovate -",
     "packageRules": [
       {
         "packagePatterns": [

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
       "config:base",
       ":automergeMinor",
       ":automergeRequireAllStatusChecks",
-      "schedule:earlyMondays"
+      "schedule:every weekday"
     ],
     "commitMessagePrefix": "renovate -",
     "packageRules": [


### PR DESCRIPTION
This PR adds Renovate to the monorepo to manage version bumps of minor packages. The bot will run once a week on Monday morning and create a PR automatically like so:

![Screenshot 2022-05-09 at 12 08 29](https://user-images.githubusercontent.com/14013357/167398162-5ddb7c19-737e-4733-a215-c0cad86c1ef0.png)


Note: PR's will be merged automatically provided they pass the CI checks.

