### PR TITLE
f-content-cards@v8.0.0-beta.1 - updating to beta to pull into offers page

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v8.0.0-beta.1
+------------------------------
+*May 11, 2022*
+
+### Changed
+- Updated to beta for use in offers page
+
+
 v8.0.0-alpha.8
 ------------------------------
 *May 4, 2022*

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "8.0.0-alpha.8",
+  "version": "8.0.0-beta.1",
   "main": "dist/f-content-cards.umd.min.js",
   "maxBundleSize": "80kB",
   "files": [


### PR DESCRIPTION
PR just converts it into a beta so it can be used in offers page, It now works as expected and further work will be added to this beta over time.
