### PR TITLE
Improve renovate config #trivial

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,25 @@
 {
     "extends": [
       "config:base",
-      ":automergeMinor",
-      ":automergeRequireAllStatusChecks",
-      "schedule:earlyMondays"
+      "schedule:earlyMondays",
+      ":rebaseStalePrs",
+      ":disableMajorUpdates",
+      ":dependencyDashboard"
     ],
-    "commitMessagePrefix": "renovate - #trivial #globalconfig -",
+    "commitMessagePrefix": "renovate - #trivial -",
+    "ignoreDeps": ["chromedriver"],
+    "prConcurrentLimit": 3,
     "packageRules": [
       {
-        "packagePatterns": [
+        "matchPackagePatterns": [
           "*"
         ],
-        "minor": {
-          "groupName": "all non-major dependencies",
-          "groupSlug": "all-minor-patch"
-        }
+        "matchUpdateTypes": [
+          "minor",
+          "patch"
+        ],
+        "groupName": "all non-major dependencies",
+        "groupSlug": "all-minor-patch"
       }
     ]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
     "extends": [
       "config:base",
-      "schedule:earlyMondays",
+      "schedule:weekly",
       ":rebaseStalePrs",
       ":disableMajorUpdates",
       ":dependencyDashboard"


### PR DESCRIPTION
This PR adds the following to the Renovate config:

- Disables major package bumps
- Rebases stale PR's
- Runs automated checks every Monday morning
- Limits open Renovate PR's to 3
- Ignores 'chromedriver' updates
- Enables the Renovate dependency dashboard