### PR TITLE
#trivial f-cookie-banner - Removed New from tests naming conventions

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest – to be added to the next release
+------------------------------
+*May 11, 2022*
+
+### Removed
+- Use of `New` from visual, component & acessibility test naming conventions.
+
+
 v3.8.4
 ------------------------------
 *May 11, 2022*

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -8,7 +8,7 @@ Latest – to be added to the next release
 *May 11, 2022*
 
 ### Removed
-- Use of `New` from visual, component & acessibility test naming conventions.
+- Use of `New` from visual, component & accessibility test naming conventions.
 
 
 v3.8.4

--- a/packages/components/organisms/f-cookie-banner/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/accessibility/axe-accessibility.spec.js
@@ -23,7 +23,7 @@ describe('Legacy Accessibility tests', () => {
         expect(axeResults.violations.length).toBe(0);
     });
 
-    it('a11y - should test new f-cookie-banner component WCAG compliance', () => {
+    it('a11y - should test the f-cookie-banner component WCAG compliance', () => {
         // Arrange
         cookieConsentBanner = new CookieConsentBanner();
         cookieConsentBanner.withQuery('args', 'locale:en-GB');

--- a/packages/components/organisms/f-cookie-banner/test/component/f-cookie-consent-banner.component.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/component/f-cookie-consent-banner.component.spec.js
@@ -4,7 +4,7 @@ const CookieBanner = require('../../test-utils/component-objects/f-cookie-consen
 
 let cookieBanner;
 
-describe('New - f-cookie-banner component tests', () => {
+describe('f-cookie-banner component tests', () => {
     beforeEach(() => {
         cookieBanner = new CookieBanner();
     });

--- a/packages/components/organisms/f-cookie-banner/test/visual/f-cookie-consent-banner.visual.desktop.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/visual/f-cookie-consent-banner.visual.desktop.spec.js
@@ -4,7 +4,7 @@ const CookieBanner = require('../../test-utils/component-objects/f-cookie-consen
 
 let cookieBanner;
 
-describe('New - f-cookie-banner Desktop Visual Tests', () => {
+describe('f-cookie-banner Desktop Visual Tests', () => {
     beforeEach(() => {
         // Arrange
         cookieBanner = new CookieBanner();

--- a/packages/components/organisms/f-cookie-banner/test/visual/f-cookie-consent-banner.visual.mobile.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/visual/f-cookie-consent-banner.visual.mobile.spec.js
@@ -4,7 +4,7 @@ const CookieBanner = require('../../test-utils/component-objects/f-cookie-consen
 
 let cookieBanner;
 
-describe('New - f-cookie-banner Mobile Visual Tests', () => {
+describe('f-cookie-banner Mobile Visual Tests', () => {
     beforeEach(() => {
         // Arrange
         cookieBanner = new CookieBanner();


### PR DESCRIPTION
Latest – to be added to the next release
------------------------------
*May 11, 2022*

### Removed
- Use of `New` from visual, component & accessibility test naming conventions.