### PR TITLE
f-services@1.15.0 - Add regex for Irish postcode validation

### DIFF
--- a/packages/services/f-services/CHANGELOG.md
+++ b/packages/services/f-services/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.15.0
+------------------------------
+*May 11, 2022*
+
+### Added
+- Irish postcode validations
+
+
 v1.14.0
 ------------------------------
 *February 21, 2022*

--- a/packages/services/f-services/package.json
+++ b/packages/services/f-services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-services",
   "description": "Fozzie Services - Shared Services for Components and projects",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "main": "dist/f-services.umd.js",
   "maxBundleSize": "15kB",
   "module": "dist/f-services.es.js",

--- a/packages/services/f-services/src/validations.js
+++ b/packages/services/f-services/src/validations.js
@@ -31,6 +31,7 @@ const getFormValidationState = $v => {
 
 const POSTCODE_REGEX = {
     'en-GB': /^\s*[A-z]{1,2}[ ]?[0-9]{1,2}[A-z]?[ ]*[0-9][A-z]{2}\s*$/,
+    'en-IE': /(?:^[AC-FHKNPRTV-Y][0-9]{2}|D6W)[ -]?[0-9AC-FHKNPRTV-Y]{4}$/,
     'es-ES': /^\d{5}$/,
     'it-IT': /^\d{5}$/,
     'en-AU': /^\d{4}$/,

--- a/packages/services/f-services/tests/validations.test.js
+++ b/packages/services/f-services/tests/validations.test.js
@@ -233,6 +233,25 @@ describe('isValidPostcode', () => {
         // Assert
         expect(actual).toBe(expected);
     });
+
+    it.each([
+        ['D24 FT12', true],
+        ['D22 TF12', true],
+        ['B32 AC21', false],
+        ['0123456', false],
+        ['AR51 1AA', false],
+        ['1 2 3 4 5', false],
+        ['not even trying', false],
+        ['01!23', false],
+        ['', false],
+        [null, false]
+    ])('should validate %s as %s with `en-IE` locale', (postcode, expected) => {
+        // Act
+        const actual = isValidPostcode(postcode, 'en-IE');
+
+        // Assert
+        expect(actual).toBe(expected);
+    });
 });
 
 describe('isValidPhoneNumber', () => {


### PR DESCRIPTION
Small addition to f-services to include postcode (eircode) validation to be used in f-checkout.