### PR TITLE
f-cookie-banner-static - Ensure package is ignored from renovate.json #trivial

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     ],
     "commitMessagePrefix": "renovate - #trivial -",
     "ignoreDeps": ["chromedriver"],
+    "ignorePaths": ["./packages/components/organisms/f-cookie-banner/f-cookie-banner-static"],
     "prConcurrentLimit": 3,
     "packageRules": [
       {


### PR DESCRIPTION
Currently, f-cookie-banner-static package updates cause renovate to fail. This PR ignores f-cookie-banner-static from renovate to prevent automatic updates.