### PR TITLE
f-content-cards@v8.0.0-beta.2 - removing unnecessary height value

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v8.0.0-beta.2
+------------------------------
+*May 23, 2022*
+
+### Changed
+- removing unnecessary height value
+
+
 v8.0.0-beta.1
 ------------------------------
 *May 11, 2022*

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "8.0.0-beta.1",
+  "version": "8.0.0-beta.2",
   "main": "dist/f-content-cards.umd.min.js",
   "maxBundleSize": "80kB",
   "files": [

--- a/packages/components/organisms/f-content-cards/src/components/templates/ContentCardImage.vue
+++ b/packages/components/organisms/f-content-cards/src/components/templates/ContentCardImage.vue
@@ -32,7 +32,6 @@ export default {
 $image-borderRadius: $radius-rounded-c;
 
 .c-content-cardImage--wrapper {
-    height: 160px;
     overflow: hidden;
     position: relative;
 }


### PR DESCRIPTION
PR removes a height style from content card image component, no longer required.
