### PR TITLE
f-checkout@3.28.0 - Remove axios retry wrapper

### DIFF
--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.28.0
+------------------------------
+*May 3, 2022*
+
+### Removed
+ - Retry wrapper for Axios
+
+
 v3.27.0
 ------------------------------
 *May 3, 2022*

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout – Fozzie Checkout Component",
-  "version": "3.27.0",
+  "version": "3.28.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "120kB",
   "files": [

--- a/packages/components/pages/f-checkout/src/services/checkoutApi.js
+++ b/packages/components/pages/f-checkout/src/services/checkoutApi.js
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import retryWrapper from '../axios-retry-wrapper';
 import { VUEX_CHECKOUT_EXPERIMENTATION_MODULE } from '../constants';
 
 export default {
@@ -51,7 +50,6 @@ export default {
     },
 
     async getNoteConfiguration (url, timeout) {
-        retryWrapper(axios, { retryAmount: 3 });
         const config = {
             headers: {
                 'Content-Type': 'application/json'

--- a/packages/components/pages/f-checkout/src/store/checkout.module.js
+++ b/packages/components/pages/f-checkout/src/store/checkout.module.js
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import jwtDecode from 'jwt-decode';
-import retryWrapper from '../axios-retry-wrapper';
 import addressService from '../services/addressService';
 import {
     VUEX_CHECKOUT_ANALYTICS_MODULE, DEFAULT_CHECKOUT_ISSUE, DOB_REQUIRED_ISSUE, AGE_VERIFICATION_ISSUE, ERROR_TYPES,
@@ -328,7 +327,6 @@ export default {
                 },
                 timeout
             };
-            retryWrapper(axios, { retryAmount: 3 });
             const { data } = await axios.get(url, config);
 
             const addressDetails = addressService.getClosestAddress(data, tenant, currentPostcode);


### PR DESCRIPTION
After a discussion around retries, it has been decided this isn't something we should do now as we don't want to overload APIs when they're failing already.