### PR TITLE
f-account-info@v0.22.0 - Redirect on 403

### DIFF
--- a/packages/components/pages/f-account-info/CHANGELOG.md
+++ b/packages/components/pages/f-account-info/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.22.0
+------------------------------
+*May 24 2022*
+
+### Removed
+- Temp logging to record if auth expired or not
+
+### Added
+- Prop for 'login path' which is now used for 403 responses when getting data.
+
+
 v0.21.2
 ------------------------------
 *May 3, 2022*

--- a/packages/components/pages/f-account-info/README.md
+++ b/packages/components/pages/f-account-info/README.md
@@ -69,15 +69,12 @@ There may be props that allow you to customise its functionality.
 
 The props that can be defined are as follows (if any):
 
-| Prop  | Type  | Default | Description |
-| ----- | ----- | ------- | ----------- |
-
-### Events
-
-The events that can be subscribed to are as follows (if any):
-
-| Event | Description |
-| ----- | ----------- |
+| Prop  | Type  |  Required | Description |
+| ----- | ----- |  ------- | ----------- |
+| authToken | string | false | the users authorisation token |
+| isAuthFinished | boolean | true | a flag indicating if the authorisation process has completed |
+| smartGatewayBaseUrl | string | true | the smartgateway host |
+| loginPath | string | false | the redirect path if the GET fails with a 403, if not supplied then will not redirect |
 
 ## Development
 

--- a/packages/components/pages/f-account-info/package.json
+++ b/packages/components/pages/f-account-info/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-account-info",
   "description": "Fozzie Account Info - The account information page",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "main": "dist/f-account-info.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [
@@ -54,8 +54,7 @@
     "@justeat/f-globalisation": "1.0.0",
     "@justeat/f-services": "1.13.0",
     "@justeat/f-vue-icons": "3.3.0",
-    "vuelidate": "0.7.6",
-    "jwt-decode": "3.1.2"
+    "vuelidate": "0.7.6"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0",

--- a/packages/components/pages/f-account-info/src/components/AccountInfo.vue
+++ b/packages/components/pages/f-account-info/src/components/AccountInfo.vue
@@ -369,6 +369,16 @@ export default {
             try {
                 await this.loadConsumerDetails({ api: this.consumerApi, authToken: this.authToken });
                 this.$log.info('Consumer details fetched successfully', standardLogTags);
+                // debug
+                let err;
+                if (window.location.search === '?debug') {
+                    err = new Error('DEBUG - 403 error');
+                    err.response = {
+                        status: 403
+                    };
+                    throw err;
+                }
+                // debug
             } catch (error) {
                 if (error && error.response && this.loginPath && error.response.status === 403) {
                     // Redirect to login page if the user is not authenticated then return here once logged in.

--- a/packages/components/pages/f-account-info/src/components/_tests/AccountInfo.test.js
+++ b/packages/components/pages/f-account-info/src/components/_tests/AccountInfo.test.js
@@ -252,15 +252,13 @@ describe('AccountInfo', () => {
 
         it('should log warning and redirect if 403', async () => {
             // Arrange
-            const error = {
-                response: {
-                    status: 403,
-                    statusText: 'Request failed with status code 403'
-                }
+            const err = new Error('TEST - 403 error');
+            err.response = {
+                status: 403
             };
             const errorActions = {
                 ...storeActions,
-                loadConsumerDetails: jest.fn().mockImplementationOnce(() => { throw error; })
+                loadConsumerDetails: jest.fn().mockImplementationOnce(() => { throw err; })
             };
 
             // Act
@@ -270,7 +268,7 @@ describe('AccountInfo', () => {
             expect(logMocks.warn).toHaveBeenCalledTimes(1);
             expect(logMocks.warn).toHaveBeenCalledWith(
                 'Unauthenticated fetching consumer details',
-                error,
+                err,
                 expect.arrayContaining(['account-pages', 'account-info'])
             );
             expect(pushRouteSpy).toHaveBeenCalledWith('/account/login?returnurl=/account/info');
@@ -282,15 +280,13 @@ describe('AccountInfo', () => {
                 ...sutProps,
                 loginPath: null
             };
-            const error = {
-                response: {
-                    status: 403,
-                    statusText: 'Request failed with status code 403'
-                }
+            const err = new Error('TEST - 403 error');
+            err.response = {
+                status: 403
             };
             const errorActions = {
                 ...storeActions,
-                loadConsumerDetails: jest.fn().mockImplementationOnce(() => { throw error; })
+                loadConsumerDetails: jest.fn().mockImplementationOnce(() => { throw err; })
             };
 
             // Act
@@ -300,7 +296,7 @@ describe('AccountInfo', () => {
             expect(logMocks.error).toHaveBeenCalledTimes(1);
             expect(logMocks.error).toHaveBeenCalledWith(
                 'Error fetching consumer details',
-                error,
+                err,
                 expect.arrayContaining(['account-pages', 'account-info'])
             );
             expect(pushRouteSpy).not.toHaveBeenCalled();

--- a/packages/components/pages/f-account-info/src/components/_tests/AccountInfo.test.js
+++ b/packages/components/pages/f-account-info/src/components/_tests/AccountInfo.test.js
@@ -15,13 +15,27 @@ let wrapper;
 let cookiesSpy;
 let httpSpy;
 let pushEventSpy;
+let pushRouteSpy;
 let sutMocks;
 let sutProps;
 let dataDefaults;
 let initialiseSpy;
+let windowSpy;
+let windowCopy;
+
+const GetWindowMock = () => {
+    windowCopy = { ...global.window };
+    const windowMock = ({
+        ...windowCopy,
+        location: { pathname: '/account/info' }
+    });
+    windowSpy = jest.spyOn(global, 'window', 'get');
+    windowSpy.mockImplementation(() => windowMock);
+};
 
 const logMocks = {
     info: jest.fn(),
+    warn: jest.fn(),
     error: jest.fn()
 };
 
@@ -79,6 +93,10 @@ describe('AccountInfo', () => {
         cookiesSpy = jest.fn();
         httpSpy = jest.fn();
         pushEventSpy = jest.fn();
+        pushRouteSpy = jest.fn();
+
+
+
         sutMocks = {
             $parent: {
                 $emit: jest.fn()
@@ -87,13 +105,18 @@ describe('AccountInfo', () => {
             $cookies: cookiesSpy,
             $log: logMocks,
             $gtm: {
-                pushEvent:  pushEventSpy
-            }
+                pushEvent: pushEventSpy
+            },
+            $router: {
+                push: pushRouteSpy
+            },
+            window: GetWindowMock()
         };
         sutProps = {
             authToken: token,
             isAuthFinished: true,
-            smartGatewayBaseUrl: baseUrl
+            smartGatewayBaseUrl: baseUrl,
+            loginPath: '/account/login'
         };
     });
 
@@ -206,7 +229,7 @@ describe('AccountInfo', () => {
             expect(element.exists()).toEqual(true);
         });
 
-        it('should log an error if loading preferences throws an error', async () => {
+        it('should log an error if loading user data throws an error', async () => {
             // Arrange
             const errorActions = {
                 ...storeActions,
@@ -223,9 +246,64 @@ describe('AccountInfo', () => {
             expect(logMocks.error).toHaveBeenCalledWith(
                 expect.any(String),
                 expect.any(Error),
-                expect.arrayContaining(['account-pages', 'account-info']),
-                expect.any(Object)
+                expect.arrayContaining(['account-pages', 'account-info'])
             );
+        });
+
+        it('should log warning and redirect if 403', async () => {
+            // Arrange
+            const error = {
+                response: {
+                    status: 403,
+                    statusText: 'Request failed with status code 403'
+                }
+            };
+            const errorActions = {
+                ...storeActions,
+                loadConsumerDetails: jest.fn().mockImplementationOnce(() => { throw error; })
+            };
+
+            // Act
+            wrapper = await mountAccountInfo({ actions: errorActions });
+
+            // Assert
+            expect(logMocks.warn).toHaveBeenCalledTimes(1);
+            expect(logMocks.warn).toHaveBeenCalledWith(
+                'Unauthenticated fetching consumer details',
+                error,
+                expect.arrayContaining(['account-pages', 'account-info'])
+            );
+            expect(pushRouteSpy).toHaveBeenCalledWith('/account/login?returnurl=/account/info');
+        });
+
+        it('should log error and not redirect if 403 and no loginPath supplied', async () => {
+            // Arrange
+            const propsData = {
+                ...sutProps,
+                loginPath: null
+            };
+            const error = {
+                response: {
+                    status: 403,
+                    statusText: 'Request failed with status code 403'
+                }
+            };
+            const errorActions = {
+                ...storeActions,
+                loadConsumerDetails: jest.fn().mockImplementationOnce(() => { throw error; })
+            };
+
+            // Act
+            wrapper = await mountAccountInfo({ actions: errorActions, propsData });
+
+            // Assert
+            expect(logMocks.error).toHaveBeenCalledTimes(1);
+            expect(logMocks.error).toHaveBeenCalledWith(
+                'Error fetching consumer details',
+                error,
+                expect.arrayContaining(['account-pages', 'account-info'])
+            );
+            expect(pushRouteSpy).not.toHaveBeenCalled();
         });
 
         it('should contain the correct url to change password', async () => {


### PR DESCRIPTION
### Removed
- Temp logging to record if auth expired or not

### Added
- Prop for 'login path' which is now used for 403 responses when getting data.