### PR TITLE
Refactor f-button and f-card WebDriverIO tests to use async in order to support Node 16 #trivial (part 1 of 3)

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
 
 v3.4.0
 ------------------------------

--- a/packages/components/atoms/f-button/test-utils/component-objects/f-button--action.component.js
+++ b/packages/components/atoms/f-button/test-utils/component-objects/f-button--action.component.js
@@ -7,19 +7,19 @@ module.exports = class ActionButton extends Page {
 
     get component () { return $('[data-test-id="action-button-component"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 
-    isComponentClickable () {
+    async isComponentClickable () {
         return this.component.isClickable();
     }
 };

--- a/packages/components/atoms/f-button/test-utils/component-objects/f-button--icon.component.js
+++ b/packages/components/atoms/f-button/test-utils/component-objects/f-button--icon.component.js
@@ -7,19 +7,19 @@ module.exports = class IconButton extends Page {
 
     get component () { return $('[data-test-id="action-button-component"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 
-    isComponentClickable () {
+    async isComponentClickable () {
         return this.component.isClickable();
     }
 };

--- a/packages/components/atoms/f-button/test-utils/component-objects/f-button--link.component.js
+++ b/packages/components/atoms/f-button/test-utils/component-objects/f-button--link.component.js
@@ -7,19 +7,19 @@ module.exports = class LinkButton extends Page {
 
     get component () { return $('[data-test-id="link-button-component"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 
-    isComponentClickable () {
+    async isComponentClickable () {
         return this.component.isClickable();
     }
 };

--- a/packages/components/atoms/f-button/test/component/f-button.component.spec.js
+++ b/packages/components/atoms/f-button/test/component/f-button.component.spec.js
@@ -5,69 +5,69 @@ const IconButton = require('../../test-utils/component-objects/f-button--icon.co
 let button;
 
 describe('f-button component tests', () => {
-    it('should display the f-button action component', () => {
+    it('should display the f-button action component', async () => {
         // Arrange
         button = new ActionButton();
 
         // Act
-        button.load();
+        await button.load();
 
         // Assert
-        expect(button.isComponentDisplayed()).toBe(true);
+        await expect(await button.isComponentDisplayed()).toBe(true);
     });
 
-    it('should check that the f-button action component is clickable', () => {
+    it('should check that the f-button action component is clickable', async () => {
         // Arrange
         button = new ActionButton();
 
         // Act
-        button.load();
+        await button.load();
 
         // Assert
-        expect(button.isComponentClickable()).toBe(true);
+        await expect(await button.isComponentClickable()).toBe(true);
     });
 
-    it('should display the f-button link component', () => {
+    it('should display the f-button link component', async () => {
         // Arrange
         button = new LinkButton();
 
         // Act
-        button.load();
+        await button.load();
 
         // Assert
-        expect(button.isComponentDisplayed()).toBe(true);
+        await expect(await button.isComponentDisplayed()).toBe(true);
     });
 
-    it('should check that the f-button link component is clickable', () => {
+    it('should check that the f-button link component is clickable', async () => {
         // Arrange
         button = new LinkButton();
 
         // Act
-        button.load();
+        await button.load();
 
         // Assert
-        expect(button.isComponentClickable()).toBe(true);
+        await expect(await button.isComponentClickable()).toBe(true);
     });
 
-    it('should display the f-button icon component', () => {
+    it('should display the f-button icon component', async () => {
         // Arrange
         button = new IconButton();
 
         // Act
-        button.load();
+        await button.load();
 
         // Assert
-        expect(button.isComponentDisplayed()).toBe(true);
+        await expect(await button.isComponentDisplayed()).toBe(true);
     });
 
-    it('should check that the f-button icon component is clickable', () => {
+    it('should check that the f-button icon component is clickable', async () => {
         // Arrange
         button = new IconButton();
 
         // Act
-        button.load();
+        await button.load();
 
         // Assert
-        expect(button.isComponentClickable()).toBe(true);
+        await expect(await button.isComponentClickable()).toBe(true);
     });
 });

--- a/packages/components/atoms/f-button/test/visual/f-button.visual.desktop.spec.js
+++ b/packages/components/atoms/f-button/test/visual/f-button.visual.desktop.spec.js
@@ -6,166 +6,166 @@ let button;
 
 describe('f-button Desktop visual tests', () => {
     describe('primary, secondary, outline and ghost buttons in all 4 sizes', () => {
-        it('should be displayed', () => {
+        it('should be displayed', async () => {
             // Arrange
             button = new ActionButton();
 
             // Act
-            button.load();
+            await button.load();
 
             // Assert
-            browser.percyScreenshot('f-button - Action', 'desktop');
+            await browser.percyScreenshot('f-button - Action', 'desktop');
         });
 
         describe('in isLoading state', () => {
-            it('should be displayed', () => {
+            it('should be displayed', async () => {
                 // Arrange
                 button = new ActionButton();
-                button.withQuery('args', 'isLoading');
+                await button.withQuery('args', 'isLoading');
 
                 // Act
-                button.load();
+                await button.load();
 
                 // Assert
-                browser.percyScreenshot('f-button - Action - Loading', 'desktop');
+                await browser.percyScreenshot('f-button - Action - Loading', 'desktop');
             });
         });
 
         describe('in disabled state', () => {
-            it('should be displayed', () => {
+            it('should be displayed', async () => {
                 // Arrange
                 button = new ActionButton();
-                button.withQuery('args', 'disabled');
+                await button.withQuery('args', 'disabled');
 
                 // Act
-                button.load();
+                await button.load();
 
                 // Assert
-                browser.percyScreenshot('f-button - Action - Disabled', 'desktop');
+                await browser.percyScreenshot('f-button - Action - Disabled', 'desktop');
             });
         });
 
         describe('in state with leading icon', () => {
-            it('should be displayed', () => {
+            it('should be displayed', async () => {
                 // Arrange
                 button = new ActionButton();
-                button.withQuery('args', 'hasIcon:leading');
+                await button.withQuery('args', 'hasIcon:leading');
 
                 // Act
-                button.load();
+                await button.load();
 
                 // Assert
-                browser.percyScreenshot('f-button - Action - With Leading Icon', 'desktop');
+                await browser.percyScreenshot('f-button - Action - With Leading Icon', 'desktop');
             });
         });
 
         describe('in state with trailing icon', () => {
-            it('should be displayed', () => {
+            it('should be displayed', async () => {
                 // Arrange
                 button = new ActionButton();
-                button.withQuery('args', 'hasIcon:trailing');
+                await button.withQuery('args', 'hasIcon:trailing');
 
                 // Act
-                button.load();
+                await button.load();
 
                 // Assert
-                browser.percyScreenshot('f-button - Action - With Trailing Icon', 'desktop');
+                await browser.percyScreenshot('f-button - Action - With Trailing Icon', 'desktop');
             });
         });
     });
 
     describe('link button', () => {
-        it('should be displayed in all 4 sizes', () => {
+        it('should be displayed in all 4 sizes', async () => {
             // Arrange
             button = new LinkButton();
 
             // Act
-            button.load();
+            await button.load();
 
             // Assert
-            browser.percyScreenshot('f-button - Link', 'desktop');
+            await browser.percyScreenshot('f-button - Link', 'desktop');
         });
 
         describe('in isLoading state', () => {
-            it('should be displayed in all 4 sizes', () => {
+            it('should be displayed in all 4 sizes', async () => {
                 // Arrange
                 button = new LinkButton();
-                button.withQuery('args', 'isLoading');
+                await button.withQuery('args', 'isLoading');
 
                 // Act
-                button.load();
+                await button.load();
 
                 // Assert
-                browser.percyScreenshot('f-button - Link - Loading', 'desktop');
+                await browser.percyScreenshot('f-button - Link - Loading', 'desktop');
             });
         });
 
         describe('in disabled state', () => {
-            it('should be displayed', () => {
+            it('should be displayed', async () => {
                 // Arrange
                 button = new LinkButton();
-                button.withQuery('args', 'disabled');
+                await button.withQuery('args', 'disabled');
 
                 // Act
-                button.load();
+                await button.load();
 
                 // Assert
-                browser.percyScreenshot('f-button - Link - Disabled', 'desktop');
+                await browser.percyScreenshot('f-button - Link - Disabled', 'desktop');
             });
         });
 
         describe('in state with leading icon', () => {
-            it('should be displayed', () => {
+            it('should be displayed', async () => {
                 // Arrange
                 button = new LinkButton();
-                button.withQuery('args', 'hasIcon:leading');
+                await button.withQuery('args', 'hasIcon:leading');
 
                 // Act
-                button.load();
+                await button.load();
 
                 // Assert
-                browser.percyScreenshot('f-button - Link - With Leading Icon', 'desktop');
+                await browser.percyScreenshot('f-button - Link - With Leading Icon', 'desktop');
             });
         });
 
         describe('in state with trailing icon', () => {
-            it('should be displayed', () => {
+            it('should be displayed', async () => {
                 // Arrange
                 button = new LinkButton();
-                button.withQuery('args', 'hasIcon:trailing');
+                await button.withQuery('args', 'hasIcon:trailing');
 
                 // Act
-                button.load();
+                await button.load();
 
                 // Assert
-                browser.percyScreenshot('f-button - Link - With Trailing Icon', 'desktop');
+                await browser.percyScreenshot('f-button - Link - With Trailing Icon', 'desktop');
             });
         });
     });
 
     describe('all valid iconButton types in all sizes', () => {
-        it('should be displayed', () => {
+        it('should be displayed', async () => {
             // Arrange
             button = new IconButton();
 
             // Act
-            button.load();
+            await button.load();
 
             // Assert
-            browser.percyScreenshot('f-button - Icon', 'desktop');
+            await browser.percyScreenshot('f-button - Icon', 'desktop');
         });
 
         describe('in isLoading state', () => {
-            it('should be displayed', () => {
+            it('should be displayed', async () => {
                 // Arrange
                 button = new IconButton();
-                button.withQuery('args', 'isLoading');
+                await button.withQuery('args', 'isLoading');
 
                 // Act
-                button.load();
+                await button.load();
 
                 // Assert
-                browser.percyScreenshot('f-button - Icon - Loading', 'desktop');
+                await browser.percyScreenshot('f-button - Icon - Loading', 'desktop');
             });
         });
     });

--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -4,7 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (to be added to next release)
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 ------------------------------
 *February 4, 2022*
 

--- a/packages/components/atoms/f-card/test-utils/component-objects/f-card.component.js
+++ b/packages/components/atoms/f-card/test-utils/component-objects/f-card.component.js
@@ -7,15 +7,15 @@ module.exports = class Card extends Page {
 
     get component () { return $('[data-test-id="card-component"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/atoms/f-card/test/component/f-card.component.spec.js
+++ b/packages/components/atoms/f-card/test/component/f-card.component.spec.js
@@ -3,12 +3,12 @@ const Card = require('../../test-utils/component-objects/f-card.component');
 const card = new Card();
 
 describe('f-card component tests', () => {
-    beforeEach(() => {
-        card.load();
+    beforeEach(async () => {
+        await card.load();
     });
 
-    it('should display the f-card component', () => {
+    it('should display the f-card component', async () => {
         // Assert
-        expect(card.isComponentDisplayed()).toBe(true);
+        await expect(await card.isComponentDisplayed()).toBe(true);
     });
 });


### PR DESCRIPTION
### Changed
- Refactor button and card WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.