### PR TITLE
Refactor f-error-message, f-filter-pill and f-form-field WebDriverIO tests to use async in order to support Node 16 #trivial (part 2 of 3)

### DIFF
--- a/packages/components/atoms/f-error-message/CHANGELOG.md
+++ b/packages/components/atoms/f-error-message/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v1.2.0
 ------------------------------
 *May 13, 2022*

--- a/packages/components/atoms/f-error-message/test-utils/component-objects/f-error-message.component.js
+++ b/packages/components/atoms/f-error-message/test-utils/component-objects/f-error-message.component.js
@@ -7,15 +7,15 @@ module.exports = class ErrorMessage extends Page {
 
     get component () { return $('[data-test-id="error-message-component"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/atoms/f-error-message/test/component/f-error-message.component.spec.js
+++ b/packages/components/atoms/f-error-message/test/component/f-error-message.component.spec.js
@@ -3,12 +3,12 @@ const ErrorMessage = require('../../test-utils/component-objects/f-error-message
 const errorMessage = new ErrorMessage();
 
 describe('f-error-message component tests', () => {
-    beforeEach(() => {
-        errorMessage.load();
+    beforeEach(async () => {
+        await errorMessage.load();
     });
 
-    it('should display the f-error-message component', () => {
+    it('should display the f-error-message component', async () => {
         // Assert
-        expect(errorMessage.isComponentDisplayed()).toBe(true);
+        await expect(await errorMessage.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/atoms/f-filter-pill/CHANGELOG.md
+++ b/packages/components/atoms/f-filter-pill/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v0.8.0
 ------------------------------
 *May 9, 2022*

--- a/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
+++ b/packages/components/atoms/f-filter-pill/src/components/FilterPill.vue
@@ -5,7 +5,7 @@
                 [$style['c-filterPill--selected']]: isToggleSelected,
                 [$style['c-filterPill--disabled']]: isDisabled
             }]"
-        data-test-id="filter-item">
+        data-test-id="filter-pill-component">
         <filter-pill-skeleton
             v-if="isLoading"
             aria-hidden="true" />

--- a/packages/components/atoms/f-filter-pill/test-utils/component-objects/f-filter-pill.component.js
+++ b/packages/components/atoms/f-filter-pill/test-utils/component-objects/f-filter-pill.component.js
@@ -11,11 +11,15 @@ module.exports = class FilterPill extends Page {
         return $(COMPONENT);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    isComponentDisplayed () {
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
+    }
+
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/atoms/f-filter-pill/test/component/f-filter-pill.component.spec.js
+++ b/packages/components/atoms/f-filter-pill/test/component/f-filter-pill.component.spec.js
@@ -3,12 +3,12 @@ const FilterPill = require('../../test-utils/component-objects/f-filter-pill.com
 const filterPill = new FilterPill();
 
 describe('f-filter-pill component tests', () => {
-    beforeEach(() => {
-        filterPill.load();
+    beforeEach(async () => {
+        await filterPill.load();
     });
 
-    it('should display the f-filter-pill component', () => {
+    it('should display the f-filter-pill component', async () => {
         // Assert
-        expect(filterPill.isComponentDisplayed()).toBe(true);
+        await expect(await filterPill.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v4.10.0
 ------------------------------
 *May 13, 2022*

--- a/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field--visual.component.js
+++ b/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field--visual.component.js
@@ -7,7 +7,7 @@ module.exports = class FormField extends Page {
 
     get component () { return $('[data-test-id="formfield-container"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 };

--- a/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field.component.js
+++ b/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field.component.js
@@ -11,19 +11,19 @@ module.exports = class FormField extends Page {
 
     get input () { return $('[data-test-id="formfield-input"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 
-    isLabelDisplayed () {
+    async isLabelDisplayed () {
         return this.label.isDisplayed();
     }
 
@@ -33,11 +33,11 @@ module.exports = class FormField extends Page {
     * @description
     * The below function adds and displays the user's first name into the form-field component.
     */
-    addUserInput (userInput) {
-        this.input.setValue(userInput.firstName);
+    async addUserInput (userInput) {
+        await this.input.setValue(userInput.firstName);
     }
 
-    getUserInput () {
+    async getUserInput () {
         return this.input.getValue();
     }
 };

--- a/packages/components/atoms/f-form-field/test/component/f-form-field.component.spec.js
+++ b/packages/components/atoms/f-form-field/test/component/f-form-field.component.spec.js
@@ -3,30 +3,30 @@ const FormField = require('../../test-utils/component-objects/f-form-field.compo
 const formfield = new FormField();
 
 describe('f-form-field component tests', () => {
-    beforeEach(() => {
-        formfield.load();
+    beforeEach(async () => {
+        await formfield.load();
     });
 
-    it('should display f-form-field', () => {
+    it('should display f-form-field', async () => {
         // Assert
-        expect(formfield.isComponentDisplayed()).toBe(true);
+        await expect(await formfield.isComponentDisplayed()).toBe(true);
     });
 
-    it('should display Label', () => {
+    it('should display Label', async () => {
         // Assert
-        expect(formfield.isLabelDisplayed()).toBe(true);
+        await expect(await formfield.isLabelDisplayed()).toBe(true);
     });
 
-    it('should display user input', () => {
+    it('should display user input', async () => {
         // Arrange
         const userInput = {
             firstName: 'abcd'
         };
 
         // Act
-        formfield.addUserInput(userInput);
+        await formfield.addUserInput(userInput);
 
         // Assert
-        expect(formfield.getUserInput()).toEqual('abcd');
+        await expect(await formfield.getUserInput()).toEqual('abcd');
     });
 });

--- a/packages/components/atoms/f-form-field/test/visual/f-form-field.visual.spec.js
+++ b/packages/components/atoms/f-form-field/test/visual/f-form-field.visual.spec.js
@@ -4,43 +4,43 @@ describe('f-form-field visual tests', () => {
     let formField;
 
     describe('default state', () => {
-        it('should display all fields in the default state', () => {
+        it('should display all fields in the default state', async () => {
             // Arrange
             formField = new FormField();
 
             // Act
-            formField.load();
+            await formField.load();
 
             // Assert
-            browser.percyScreenshot('f-form-field - Base State', 'desktop');
+            await browser.percyScreenshot('f-form-field - Base State', 'desktop');
         });
     });
 
     describe('disabled state', () => {
-        it('should display all fields in a disabled state', () => {
+        it('should display all fields in a disabled state', async () => {
             // Arrange
-            formField = new FormField()
+            formField = await new FormField()
             .withQuery('args', 'isDisabled:disabled');
 
             // Act
-            formField.load();
+            await formField.load();
 
             // Assert
-            browser.percyScreenshot('f-form-field - Disabled State', 'desktop');
+            await browser.percyScreenshot('f-form-field - Disabled State', 'desktop');
         });
     });
 
     describe('errored state', () => {
-        it('should display all fields in an errored state', () => {
+        it('should display all fields in an errored state', async () => {
             // Arrange
-            formField = new FormField()
+            formField = await new FormField()
             .withQuery('args', 'hasError:true');
 
             // Act
-            formField.load();
+            await formField.load();
 
             // Assert
-            browser.percyScreenshot('f-form-field - Errored State', 'desktop');
+            await browser.percyScreenshot('f-form-field - Errored State', 'desktop');
         });
     });
 });


### PR DESCRIPTION
### Changed
- Refactor error-message, filter-pill and form-field WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.