### PR TITLE
Refactor f-image-tile, f-popover and f-spinner WebDriverIO tests to use async in order to support Node 16 #trivial (part 3 of 3)

### DIFF
--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v0.12.0
 ------------------------------
 *May 9, 2022*
@@ -33,7 +41,7 @@ v0.10.3
 *March 10, 2022*
 
 ### Added
-- checked attribute 
+- checked attribute
 
 ### Changed
 - `href` always added to link
@@ -58,7 +66,7 @@ v0.10.0
 *February 25, 2022*
 
 ### Changed
-        
+
 - Moved `isToggleSelected` assignment into created lifecycle method for SSR
 - Updated stories to use args instead of default value
 - Added label style for `isLink`

--- a/packages/components/atoms/f-image-tile/test-utils/component-objects/f-image-tile.component.js
+++ b/packages/components/atoms/f-image-tile/test-utils/component-objects/f-image-tile.component.js
@@ -7,19 +7,19 @@ module.exports = class ImageTile extends Page {
 
     get component () { return $('[data-test-id="image-tile-component"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 
-    isComponentClickable () {
+    async isComponentClickable () {
         return this.component.isClickable();
     }
 };

--- a/packages/components/atoms/f-image-tile/test/component/f-image-tile.component.spec.js
+++ b/packages/components/atoms/f-image-tile/test/component/f-image-tile.component.spec.js
@@ -3,17 +3,17 @@ const ImageTile = require('../../test-utils/component-objects/f-image-tile.compo
 const imageTile = new ImageTile();
 
 describe('f-image-tile component tests', () => {
-    beforeEach(() => {
-        imageTile.load();
+    beforeEach(async () => {
+        await imageTile.load();
     });
 
-    it('should display the f-image-tile component', () => {
+    it('should display the f-image-tile component', async () => {
         // Assert
-        expect(imageTile.isComponentDisplayed()).toBe(true);
+        await expect(await imageTile.isComponentDisplayed()).toBe(true);
     });
 
-    it('should check that the f-image-tile component is clickable', () => {
+    it('should check that the f-image-tile component is clickable', async () => {
         // Assert
-        expect(imageTile.isComponentClickable()).toBe(true);
+        await expect(await imageTile.isComponentClickable()).toBe(true);
     });
 });

--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v2.3.0
 ------------------------------
 *November 8, 2021*

--- a/packages/components/atoms/f-link/test-utils/component-objects/f-link.component.js
+++ b/packages/components/atoms/f-link/test-utils/component-objects/f-link.component.js
@@ -7,15 +7,15 @@ module.exports = class Link extends Page {
 
     get component () { return $('[data-test-id="link-component"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/atoms/f-link/test/component/f-link.component.spec.js
+++ b/packages/components/atoms/f-link/test/component/f-link.component.spec.js
@@ -3,12 +3,12 @@ const Link = require('../../test-utils/component-objects/f-link.component');
 const link = new Link();
 
 describe('f-link component tests', () => {
-    beforeEach(() => {
-        link.load();
+    beforeEach(async () => {
+        await link.load();
     });
 
-    it('should display the f-link component', () => {
+    it('should display the f-link component', async () => {
         // Assert
-        expect(link.isComponentDisplayed()).toBe(true);
+        await expect(await link.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/atoms/f-popover/test-utils/component-objects/f-popover.component.js
+++ b/packages/components/atoms/f-popover/test-utils/component-objects/f-popover.component.js
@@ -7,15 +7,15 @@ module.exports = class Popover extends Page {
 
     get component () { return $('[data-test-id="popover"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/atoms/f-popover/test/component/f-popover.component.spec.js
+++ b/packages/components/atoms/f-popover/test/component/f-popover.component.spec.js
@@ -3,12 +3,12 @@ const Popover = require('../../test-utils/component-objects/f-popover.component'
 const popover = new Popover();
 
 describe('f-popover component tests', () => {
-    beforeEach(() => {
-        popover.load();
+    beforeEach(async () => {
+        await popover.load();
     });
 
-    it('should display the f-popover component', () => {
+    it('should display the f-popover component', async () => {
         // Assert
-        expect(popover.isComponentDisplayed()).toBe(true);
+        await expect(await popover.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/atoms/f-spinner/CHANGELOG.md
+++ b/packages/components/atoms/f-spinner/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v0.4.0
 ------------------------------
 *March 22, 2022*

--- a/packages/components/atoms/f-spinner/test-utils/component-objects/f-spinner.component.js
+++ b/packages/components/atoms/f-spinner/test-utils/component-objects/f-spinner.component.js
@@ -7,15 +7,15 @@ module.exports = class Spinner extends Page {
 
     get component () { return $('[data-test-id="spinner-component"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/atoms/f-spinner/test/component/f-spinner.component.spec.js
+++ b/packages/components/atoms/f-spinner/test/component/f-spinner.component.spec.js
@@ -4,14 +4,14 @@ const Spinner = require('../../test-utils/component-objects/f-spinner.component'
 let spinner;
 
 describe('f-spinner component tests', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
         spinner = new Spinner();
 
-        spinner.load();
+        await spinner.load();
     });
 
-    it('should display the f-spinner component', () => {
+    it('should display the f-spinner component', async () => {
         // Assert
-        expect(spinner.isComponentDisplayed()).toBe(true);
+        await expect(await spinner.isComponentDisplayed()).toBe(true);
     });
 });


### PR DESCRIPTION
### Changed
- Refactor image-tile, popover and spinner WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.