### PR TITLE
f-offers@v1.12.0-beta.2 - Adding updated ContentCards package

### DIFF
--- a/packages/components/pages/f-offers/CHANGELOG.md
+++ b/packages/components/pages/f-offers/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.12.0-beta.2
+------------------------------
+*May 24, 2022*
+
+### Changed
+- Updated content cards to get fix to small style issue
+
+
 v1.12.0-beta.1
 ------------------------------
 *May 11, 2022*

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-offers",
   "description": "Fozzie Offers - displays offers to the customers",
-  "version": "1.12.0-beta.1",
+  "version": "1.12.0-beta.2",
   "main": "dist/f-offers.umd.min.js",
   "maxBundleSize": "150kB",
   "files": [
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@braze/web-sdk": "3.3.0",
-    "@justeat/f-content-cards": "8.0.0-beta.1",
+    "@justeat/f-content-cards": "8.0.0-beta.3",
     "@justeat/f-button": "3.0.2",
     "@justeat/f-media-element": "2.0.0",
     "@justeat/f-searchbox": "6.7.0",

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@braze/web-sdk": "3.3.0",
-    "@justeat/f-content-cards": "8.0.0-beta.3",
+    "@justeat/f-content-cards": "8.0.0-beta.4",
     "@justeat/f-button": "3.0.2",
     "@justeat/f-media-element": "2.0.0",
     "@justeat/f-searchbox": "6.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2322,10 +2322,10 @@
   dependencies:
     "@justeat/f-services" "0.13.0"
 
-"@justeat/f-content-cards@8.0.0-beta.3":
-  version "8.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-8.0.0-beta.3.tgz#6f986f217e52dece9db6a532b5ba85812842d6b1"
-  integrity sha512-Mi4Dvt+dKzlFu785nOsDx6Tpp1PdCZHxACHQ9wYbaVJ2n6TerdUe+eo97fwUF8s4B3f41ZV6fc0K+rvZD/wqXA==
+"@justeat/f-content-cards@8.0.0-beta.4":
+  version "8.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-8.0.0-beta.4.tgz#ff7690532e6743ff4f2b83dd4d7aad04e1485c0a"
+  integrity sha512-cLUbPemnxsaQ8Ljxm5Kyu4uOEBWFNi3QEC89c1QtBbmwZ2/kc1Sz2V51zMdilBHCLG93/Cn8bQYl+bOODJskrw==
   dependencies:
     "@babel/plugin-proposal-class-properties" "7.12.13"
     "@justeat/f-services" "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2322,10 +2322,10 @@
   dependencies:
     "@justeat/f-services" "0.13.0"
 
-"@justeat/f-content-cards@8.0.0-beta.1":
-  version "8.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-8.0.0-beta.1.tgz#4cc67b07314f9a786440fbbaa3e6acf76c5363dd"
-  integrity sha512-qQu4n83K0clBld0fH6dOgLBqc+PpvPziOjjbnwGeaeEblKqg4hi9rm/YzVsb89ohzm+XAaQOf5/TCqs7SOS2jw==
+"@justeat/f-content-cards@8.0.0-beta.3":
+  version "8.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-8.0.0-beta.3.tgz#6f986f217e52dece9db6a532b5ba85812842d6b1"
+  integrity sha512-Mi4Dvt+dKzlFu785nOsDx6Tpp1PdCZHxACHQ9wYbaVJ2n6TerdUe+eo97fwUF8s4B3f41ZV6fc0K+rvZD/wqXA==
   dependencies:
     "@babel/plugin-proposal-class-properties" "7.12.13"
     "@justeat/f-services" "1.0.1"


### PR DESCRIPTION
Updating the `f-content-cards` to be latest beta version.

![Screenshot 2022-05-26 at 09 55 04](https://user-images.githubusercontent.com/15876339/170455573-3c9bc1b5-c298-414d-9fab-43096a349bf9.png)
