### PR TITLE
updated molecules tests to use async to support Node 16 (part 1) #trivial

### DIFF
--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v4.4.0
 ------------------------------
 *May 13, 2022*

--- a/packages/components/molecules/f-alert/test-utils/component-objects/f-alert.component.js
+++ b/packages/components/molecules/f-alert/test-utils/component-objects/f-alert.component.js
@@ -9,19 +9,19 @@ module.exports = class Alert extends Page {
 
     get exitButton () { return $('[data-test-id="alert-dismiss"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component, 1000);
+    async waitForComponent () {
+        await super.waitForComponent(this.component, 1000);
     }
 
-    clickExitButton () {
-        this.exitButton.click();
+    async clickExitButton () {
+        await this.exitButton.click();
     }
 };

--- a/packages/components/molecules/f-alert/test/component/f-alert.component.spec.js
+++ b/packages/components/molecules/f-alert/test/component/f-alert.component.spec.js
@@ -3,20 +3,20 @@ const Alert = require('../../test-utils/component-objects/f-alert.component');
 const alert = new Alert();
 
 describe('f-alert component tests', () => {
-    beforeEach(() => {
-        alert.load();
+    beforeEach(async () => {
+        await alert.load();
     });
 
-    it('should display the f-alert component', () => {
+    it('should display the f-alert component', async () => {
         // Assert
-        expect(alert.isComponentDisplayed()).toBe(true);
+        await expect(await alert.isComponentDisplayed()).toBe(true);
     });
 
-    it('should close alert when exit button is clicked', () => {
+    it('should close alert when exit button is clicked', async () => {
         // Act
-        alert.clickExitButton();
+        await alert.clickExitButton();
 
         // Assert
-        expect(alert.isComponentDisplayed()).toBe(false);
+        await expect(await alert.isComponentDisplayed()).toBe(false);
     });
 });

--- a/packages/components/molecules/f-alert/test/visual/f-alert.visual.spec.js
+++ b/packages/components/molecules/f-alert/test/visual/f-alert.visual.spec.js
@@ -11,23 +11,23 @@ forEach(['success', 'warning', 'info', 'danger'])
         alert.path = `&args=type:${type};`;
     });
 
-    it('should display the f-alert (%s) component as dismissible', () => {
+    it('should display the f-alert (%s) component as dismissible', async () => {
         // Act
-        alert.load();
+        await alert.load();
 
         // Assert
-        browser.percyScreenshot(`f-alert - ${type} - dismissible`, 'desktop');
+        await browser.percyScreenshot(`f-alert - ${type} - dismissible`, 'desktop');
     });
 
-    it('should display the f-alert (%s) component as undismissible', () => {
+    it('should display the f-alert (%s) component as undismissible', async () => {
         // Arrange
         alert.path += 'isDismissible:false';
 
         // Act
-        alert.load();
-        alert.waitForComponent();
+        await alert.load();
+        await alert.waitForComponent();
 
         // Assert
-        browser.percyScreenshot(`f-alert - ${type} - undismissible`, 'desktop');
+        await browser.percyScreenshot(`f-alert - ${type} - undismissible`, 'desktop');
     });
 });

--- a/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
+++ b/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v3.2.1
 ------------------------------
 *March 18, 2022*

--- a/packages/components/molecules/f-breadcrumbs/test-utils/component-objects/f-breadcrumbs.component.js
+++ b/packages/components/molecules/f-breadcrumbs/test-utils/component-objects/f-breadcrumbs.component.js
@@ -7,15 +7,15 @@ module.exports = class Breadcrumbs extends Page {
 
     get component () { return $('[data-test-id="breadcrumbs-component"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/molecules/f-breadcrumbs/test/component/f-breadcrumbs.component.spec.js
+++ b/packages/components/molecules/f-breadcrumbs/test/component/f-breadcrumbs.component.spec.js
@@ -3,11 +3,11 @@ const Breadcrumbs = require('../../test-utils/component-objects/f-breadcrumbs.co
 const breadcrumbs = new Breadcrumbs();
 
 describe('f-breadcrumbs component tests', () => {
-    beforeEach(() => {
-        breadcrumbs.load();
+    beforeEach(async () => {
+        await breadcrumbs.load();
     });
-    it('should display the f-breadcrumbs component', () => {
+    it('should display the f-breadcrumbs component', async () => {
         // Assert
-        expect(breadcrumbs.isComponentDisplayed()).toBe(true);
+        await expect(await breadcrumbs.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/molecules/f-card-with-content/CHANGELOG.md
+++ b/packages/components/molecules/f-card-with-content/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v1.1.0
 ------------------------------
 *February 2, 2021*

--- a/packages/components/molecules/f-card-with-content/test-utils/component-objects/f-card-with-content.component.js
+++ b/packages/components/molecules/f-card-with-content/test-utils/component-objects/f-card-with-content.component.js
@@ -7,15 +7,15 @@ module.exports = class CardWithContent extends Page {
 
     get component () { return $('[data-test-id="cardWithContent"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/molecules/f-card-with-content/test/component/f-card-with-content.component.spec.js
+++ b/packages/components/molecules/f-card-with-content/test/component/f-card-with-content.component.spec.js
@@ -3,12 +3,12 @@ const CardWithContent = require('../../test-utils/component-objects/f-card-with-
 const cardWithContent = new CardWithContent();
 
 describe('f-card-with-content component tests', () => {
-    beforeEach(() => {
-        cardWithContent.load();
+    beforeEach(async () => {
+        await cardWithContent.load();
     });
 
-    it('should display the f-card-with-content component', () => {
+    it('should display the f-card-with-content component', async () => {
         // Assert
-        expect(cardWithContent.isComponentDisplayed()).toBe(true);
+        await expect(await cardWithContent.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/molecules/f-media-element/CHANGELOG.md
+++ b/packages/components/molecules/f-media-element/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
 
 v2.0.0
 ------------------------------

--- a/packages/components/molecules/f-media-element/test-utils/component-objects/f-media-element.component.js
+++ b/packages/components/molecules/f-media-element/test-utils/component-objects/f-media-element.component.js
@@ -7,15 +7,15 @@ module.exports = class MediaElement extends Page {
 
     get component () { return $('[data-test-id="mediaElement-component"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/molecules/f-media-element/test/component/f-media-element.component.spec.js
+++ b/packages/components/molecules/f-media-element/test/component/f-media-element.component.spec.js
@@ -3,12 +3,12 @@ const MediaElement = require('../../test-utils/component-objects/f-media-element
 const mediaElement = new MediaElement();
 
 describe('f-media-element component tests', () => {
-    beforeEach(() => {
-        mediaElement.load();
+    beforeEach(async () => {
+        await mediaElement.load();
     });
 
-    it('should display the f-media-element component', () => {
+    it('should display the f-media-element component', async () => {
         // Assert
-        expect(mediaElement.isComponentDisplayed()).toBe(true);
+        await expect(await mediaElement.isComponentDisplayed()).toBe(true);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4827,7 +4827,7 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@testim/chrome-version@^1.1.2":
+"@testim/chrome-version@^1.0.7":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.1.2.tgz#092005c5b77bd3bb6576a4677110a11485e11864"
   integrity sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw==
@@ -7128,7 +7128,7 @@ axios@0.21.2:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@0.21.4, axios@^0.21.1:
+axios@0.21.4, axios@^0.21.1, axios@^0.21.2:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
@@ -7148,13 +7148,6 @@ axios@^0.19.0:
   integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
-
-axios@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
-  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
-  dependencies:
-    follow-redirects "^1.14.4"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -9026,13 +9019,13 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-chromedriver@101.0.0:
-  version "101.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-101.0.0.tgz#ad19003008dd5df1770a1ad96059a9c5fe78e365"
-  integrity sha512-LkkWxy6KM/0YdJS8qBeg5vfkTZTRamhBfOttb4oic4echDgWvCU1E8QcBbUBOHqZpSrYMyi7WMKmKMhXFUaZ+w==
+chromedriver@96.0.0:
+  version "96.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-96.0.0.tgz#c8473498e4c94950fa168187b112019cce9e5c6c"
+  integrity sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==
   dependencies:
-    "@testim/chrome-version" "^1.1.2"
-    axios "^0.24.0"
+    "@testim/chrome-version" "^1.0.7"
+    axios "^0.21.2"
     del "^6.0.0"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.0"
@@ -12739,7 +12732,7 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.7:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.7:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
   integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2410,6 +2410,14 @@
     "@justeat/f-services" "1.0.0"
     "@justeat/f-vue-icons" "2.5.0"
 
+"@justeat/f-form-field@4.9.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-4.9.0.tgz#831d206f658ee22f22c52d71dabff4b6bc55de70"
+  integrity sha512-KJFdSUAXlJWCahqjE4cZDYm78xiU41mbED29yU4OVDCOF8coWPLfp8GbXmarRsO3zBa5To7Q26WRGEzxaHCn+g==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+    "@justeat/f-vue-icons" "2.5.0"
+
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-0.2.0.tgz#90ec559642c165b6325669c506c417abe09fa5dd"
@@ -2556,11 +2564,6 @@
     lodash-es "4.17.15"
     window-or-global "1.0.1"
 
-"@justeat/f-services@4.9.0":
-  version "1.15.0"
-  dependencies:
-    lodash-es "4.17.21"
-    window-or-global "1.0.1"
 "@justeat/f-tabs@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-tabs/-/f-tabs-2.0.0.tgz#6fc0b67edb2fee754c8d35a8c683989b0239adad"
@@ -4824,7 +4827,7 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@testim/chrome-version@^1.0.7":
+"@testim/chrome-version@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.1.2.tgz#092005c5b77bd3bb6576a4677110a11485e11864"
   integrity sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw==
@@ -7125,7 +7128,7 @@ axios@0.21.2:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@0.21.4, axios@^0.21.1, axios@^0.21.2:
+axios@0.21.4, axios@^0.21.1:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
@@ -7145,6 +7148,13 @@ axios@^0.19.0:
   integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
+
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+  dependencies:
+    follow-redirects "^1.14.4"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -9016,13 +9026,13 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-chromedriver@96.0.0:
-  version "96.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-96.0.0.tgz#c8473498e4c94950fa168187b112019cce9e5c6c"
-  integrity sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==
+chromedriver@101.0.0:
+  version "101.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-101.0.0.tgz#ad19003008dd5df1770a1ad96059a9c5fe78e365"
+  integrity sha512-LkkWxy6KM/0YdJS8qBeg5vfkTZTRamhBfOttb4oic4echDgWvCU1E8QcBbUBOHqZpSrYMyi7WMKmKMhXFUaZ+w==
   dependencies:
-    "@testim/chrome-version" "^1.0.7"
-    axios "^0.21.2"
+    "@testim/chrome-version" "^1.1.2"
+    axios "^0.24.0"
     del "^6.0.0"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.0"
@@ -12729,7 +12739,7 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.7:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.7:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
   integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==


### PR DESCRIPTION
### Changed
- Refactor alert, breadcrumbs, card-with-content and media-element WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.