### PR TITLE
updated molecules tests to use async to support Node 16 (part 2) #trivial

### DIFF
--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v5.1.0
 ------------------------------
 *May 13, 2022*

--- a/packages/components/molecules/f-mega-modal/test-utils/component-objects/f-mega-modal.component.js
+++ b/packages/components/molecules/f-mega-modal/test-utils/component-objects/f-mega-modal.component.js
@@ -9,23 +9,23 @@ module.exports = class MegaModal extends Page {
     get megaModalTitle () { return $('[data-test-id="mega-modal-title"]'); }
     get megaModalContent () { return $('[data-test-id="mega-modal-content"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 
-    isTitleDisplayed () {
+    async isTitleDisplayed () {
         return this.megaModalTitle.isDisplayed();
     }
 
-    isContentDisplayed () {
+    async isContentDisplayed () {
         return this.megaModalTitle.isDisplayed();
     }
 };

--- a/packages/components/molecules/f-mega-modal/test/component/f-mega-modal.component.spec.js
+++ b/packages/components/molecules/f-mega-modal/test/component/f-mega-modal.component.spec.js
@@ -3,22 +3,22 @@ const MegaModal = require('../../test-utils/component-objects/f-mega-modal.compo
 const megaModal = new MegaModal();
 
 describe('f-mega-modal component tests', () => {
-    beforeEach(() => {
-        megaModal.load();
+    beforeEach(async () => {
+        await megaModal.load();
     });
 
-    it('should display f-mega-modal component', () => {
+    it('should display f-mega-modal component', async () => {
         // Assert
-        expect(megaModal.isComponentDisplayed()).toBe(true);
+        await expect(await megaModal.isComponentDisplayed()).toBe(true);
     });
 
-    it('should display the title', () => {
+    it('should display the title', async () => {
         // Assert
-        expect(megaModal.isTitleDisplayed()).toBe(true);
+        await expect(await megaModal.isTitleDisplayed()).toBe(true);
     });
 
-    it('should display the content', () => {
+    it('should display the content', async () => {
         // Assert
-        expect(megaModal.isContentDisplayed()).toBe(true);
+        await expect(await megaModal.isContentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/molecules/f-navigation-links/CHANGELOG.md
+++ b/packages/components/molecules/f-navigation-links/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v1.2.0
 ------------------------------
 *May 22, 2022*

--- a/packages/components/molecules/f-navigation-links/test-utils/component-objects/f-navigation-links.component.js
+++ b/packages/components/molecules/f-navigation-links/test-utils/component-objects/f-navigation-links.component.js
@@ -7,15 +7,15 @@ module.exports = class NavigationLinks extends Page {
 
     get component () { return $('[data-test-id="navigationLinks"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/molecules/f-navigation-links/test/component/f-navigation-links.component.spec.js
+++ b/packages/components/molecules/f-navigation-links/test/component/f-navigation-links.component.spec.js
@@ -3,14 +3,14 @@ const NavigationLinks = require('../../test-utils/component-objects/f-navigation
 let navigationLinks;
 
 describe('f-navigation-links component tests', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
         navigationLinks = new NavigationLinks();
 
-        navigationLinks.load();
+        await navigationLinks.load();
     });
 
-    it('should display the f-navigation-links component', () => {
+    it('should display the f-navigation-links component', async () => {
         // Assert
-        expect(navigationLinks.isComponentDisplayed()).toBe(true);
+        await expect(await navigationLinks.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/molecules/f-promotions-showcase/CHANGELOG.md
+++ b/packages/components/molecules/f-promotions-showcase/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
 
 v0.5.1
 ------------------------------

--- a/packages/components/molecules/f-promotions-showcase/test-utils/component-objects/f-promotions-showcase.component.js
+++ b/packages/components/molecules/f-promotions-showcase/test-utils/component-objects/f-promotions-showcase.component.js
@@ -7,15 +7,15 @@ module.exports = class PromotionsShowcase extends Page {
 
     get component () { return $('[data-test-id="promotionsShowcase"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/molecules/f-promotions-showcase/test/component/f-promotions-showcase.component.spec.js
+++ b/packages/components/molecules/f-promotions-showcase/test/component/f-promotions-showcase.component.spec.js
@@ -3,12 +3,12 @@ const PromotionsShowcase = require('../../test-utils/component-objects/f-promoti
 const promotionsShowcase = new PromotionsShowcase();
 
 describe('f-promotions-showcase component tests', () => {
-    beforeEach(() => {
-        promotionsShowcase.load();
+    beforeEach(async () => {
+        await promotionsShowcase.load();
     });
 
-    it('should display the f-promotions-showcase component', () => {
+    it('should display the f-promotions-showcase component', async () => {
         // Assert
-        expect(promotionsShowcase.isComponentDisplayed()).toBe(true);
+        await expect(await promotionsShowcase.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v0.29.5
 ------------------------------
 *April 22, 2022*

--- a/packages/components/molecules/f-restaurant-card/test-utils/component-objects/f-restaurant-card.component.js
+++ b/packages/components/molecules/f-restaurant-card/test-utils/component-objects/f-restaurant-card.component.js
@@ -7,15 +7,15 @@ module.exports = class RestaurantCard extends Page {
 
     get component () { return $('[data-test-id="restaurant"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/molecules/f-restaurant-card/test/component/f-restaurant-card.component.spec.js
+++ b/packages/components/molecules/f-restaurant-card/test/component/f-restaurant-card.component.spec.js
@@ -3,12 +3,12 @@ const RestaurantCard = require('../../test-utils/component-objects/f-restaurant-
 const restaurantCard = new RestaurantCard();
 
 describe('f-restaurant-card component tests', () => {
-    beforeEach(() => {
-        restaurantCard.load();
+    beforeEach(async () => {
+        await restaurantCard.load();
     });
 
-    it('should display the f-restaurant-card component', () => {
+    it('should display the f-restaurant-card component', async () => {
         // Assert
-        expect(restaurantCard.isComponentDisplayed()).toBe(true);
+        await expect(await restaurantCard.isComponentDisplayed()).toBe(true);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2410,6 +2410,14 @@
     "@justeat/f-services" "1.0.0"
     "@justeat/f-vue-icons" "2.5.0"
 
+"@justeat/f-form-field@4.9.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-4.9.0.tgz#831d206f658ee22f22c52d71dabff4b6bc55de70"
+  integrity sha512-KJFdSUAXlJWCahqjE4cZDYm78xiU41mbED29yU4OVDCOF8coWPLfp8GbXmarRsO3zBa5To7Q26WRGEzxaHCn+g==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+    "@justeat/f-vue-icons" "2.5.0"
+
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-0.2.0.tgz#90ec559642c165b6325669c506c417abe09fa5dd"
@@ -2556,11 +2564,6 @@
     lodash-es "4.17.15"
     window-or-global "1.0.1"
 
-"@justeat/f-services@4.9.0":
-  version "1.15.0"
-  dependencies:
-    lodash-es "4.17.21"
-    window-or-global "1.0.1"
 "@justeat/f-tabs@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-tabs/-/f-tabs-2.0.0.tgz#6fc0b67edb2fee754c8d35a8c683989b0239adad"


### PR DESCRIPTION
### Changed
- Refactor mega-modal, navigation-links, promotions-showcase and restaurant-card WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.