### PR TITLE
updated molecules tests to use async to support Node 16 part 3 #trivial

### DIFF
--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -4,8 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-Latest (to be added to next release)
+Latest (add to next release)
 ------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
 *February 4, 2022*
 
 ### Changed

--- a/packages/components/molecules/f-searchbox/test-utils/component-objects/f-searchbox.component.js
+++ b/packages/components/molecules/f-searchbox/test-utils/component-objects/f-searchbox.component.js
@@ -7,15 +7,15 @@ module.exports = class SearchBox extends Page {
 
     get component () { return $('[data-test-id="searchbox-component"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/molecules/f-searchbox/test/component/f-searchbox.component.spec.js
+++ b/packages/components/molecules/f-searchbox/test/component/f-searchbox.component.spec.js
@@ -3,12 +3,12 @@ const Searchbox = require('../../test-utils/component-objects/f-searchbox.compon
 const searchbox = new Searchbox();
 
 describe('f-searchbox component tests', () => {
-    beforeEach(() => {
-        searchbox.load();
+    beforeEach(async () => {
+        await searchbox.load();
     });
 
-    it('should display the f-searchbox component', () => {
+    it('should display the f-searchbox component', async () => {
         // Assert
-        expect(searchbox.isComponentDisplayed()).toBe(true);
+        await expect(await searchbox.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/molecules/f-skeleton-loader/CHANGELOG.md
+++ b/packages/components/molecules/f-skeleton-loader/CHANGELOG.md
@@ -3,9 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-
-Latest (to be added to next release)
+Latest (add to next release)
 ------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
 *February 4, 2022*
 
 ### Changed

--- a/packages/components/molecules/f-skeleton-loader/test-utils/component-objects/f-skeleton-loader.component.js
+++ b/packages/components/molecules/f-skeleton-loader/test-utils/component-objects/f-skeleton-loader.component.js
@@ -7,15 +7,15 @@ module.exports = class SkeletonLoader extends Page {
 
     get component () { return $('[data-test-id="skeletonLoader"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 };

--- a/packages/components/molecules/f-skeleton-loader/test/component/f-skeleton-loader.component.spec.js
+++ b/packages/components/molecules/f-skeleton-loader/test/component/f-skeleton-loader.component.spec.js
@@ -3,12 +3,12 @@ const SkeletonLoader = require('../../test-utils/component-objects/f-skeleton-lo
 const skeletonLoader = new SkeletonLoader();
 
 describe('f-skeleton-loader component tests', () => {
-    beforeEach(() => {
-        skeletonLoader.load();
+    beforeEach(async () => {
+        await skeletonLoader.load();
     });
 
-    it('should display the f-skeleton-loader component', () => {
+    it('should display the f-skeleton-loader component', async () => {
         // Assert
-        expect(skeletonLoader.isComponentDisplayed()).toBe(true);
+        await expect(await skeletonLoader.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/molecules/f-tabs/CHANGELOG.md
+++ b/packages/components/molecules/f-tabs/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v2.1.0
 ------------------------------
 *May 22, 2022*

--- a/packages/components/molecules/f-tabs/test-utils/component-objects/f-tabs.component.js
+++ b/packages/components/molecules/f-tabs/test-utils/component-objects/f-tabs.component.js
@@ -9,19 +9,19 @@ module.exports = class Tabs extends Page {
 
     get tabButtons () { return $$('[data-test-id*="tab-button"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 
-    isTabButtonDisplayed () {
+    async isTabButtonDisplayed () {
         return this.tabButton.isDisplayed();
     }
 

--- a/packages/components/molecules/f-tabs/test/component/f-tabs.component.spec.js
+++ b/packages/components/molecules/f-tabs/test/component/f-tabs.component.spec.js
@@ -5,21 +5,21 @@ const Tabs = require('../../test-utils/component-objects/f-tabs.component');
 const tabs = new Tabs();
 
 describe('f-tabs component tests', () => {
-    beforeEach(() => {
-        tabs.load();
+    beforeEach(async () => {
+        await tabs.load();
     });
 
-    it('should display the f-tabs component', () => {
+    it('should display the f-tabs component', async () => {
         // Assert
-        expect(tabs.isComponentDisplayed()).toBe(true);
+        await expect(await tabs.isComponentDisplayed()).toBe(true);
     });
 
     forEach(['Your Stampcards', 'How it works'])
-        .it('should display individual tabs', tab => {
+        .it('should display individual tabs', async tab => {
             // Arrange
             tabs.expectedTabButton = tab;
 
             // Assert
-            expect(tabs.isTabButtonDisplayed(tab)).toBe(true);
+            await expect(await tabs.isTabButtonDisplayed(tab)).toBe(true);
         });
 });

--- a/packages/components/molecules/f-user-message/CHANGELOG.md
+++ b/packages/components/molecules/f-user-message/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+Latest (add to next release)
+------------------------------
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
+
 v3.2.0
 ------------------------------
 *May 13, 2022*

--- a/packages/components/molecules/f-user-message/test-utils/component-objects/f-user-message.component.js
+++ b/packages/components/molecules/f-user-message/test-utils/component-objects/f-user-message.component.js
@@ -8,19 +8,19 @@ module.exports = class UserMessage extends Page {
     get component () { return $('[data-test-id="user-message-component"]'); }
     get content () { return this.component.$('[data-test-id="user-message-content"]'); }
 
-    load () {
-        super.load(this.component);
+    async load () {
+        await super.load(this.component);
     }
 
-    waitForComponent () {
-        super.waitForComponent(this.component);
+    async waitForComponent () {
+        await super.waitForComponent(this.component);
     }
 
-    isComponentDisplayed () {
+    async isComponentDisplayed () {
         return this.component.isDisplayed();
     }
 
-    isContentDisplayed () {
+    async isContentDisplayed () {
         const messageContent = this.content.getText();
 
         return this.content.isDisplayed() && messageContent.length > 0;

--- a/packages/components/molecules/f-user-message/test/component/f-user-message.component.spec.js
+++ b/packages/components/molecules/f-user-message/test/component/f-user-message.component.spec.js
@@ -3,17 +3,17 @@ const UserMessage = require('../../test-utils/component-objects/f-user-message.c
 const userMessage = new UserMessage();
 
 describe('f-user-message component tests', () => {
-    beforeEach(() => {
-        userMessage.load();
+    beforeEach(async () => {
+        await userMessage.load();
     });
 
-    it('should display the user message component', () => {
+    it('should display the user message component', async () => {
         // Assert
-        expect(userMessage.isComponentDisplayed()).toBe(true);
+        await expect(await userMessage.isComponentDisplayed()).toBe(true);
     });
 
-    it('should display the user message content', () => {
+    it('should display the user message content', async () => {
         // Assert
-        expect(userMessage.isContentDisplayed()).toBe(true);
+        await expect(await userMessage.isContentDisplayed()).toBe(true);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2410,6 +2410,14 @@
     "@justeat/f-services" "1.0.0"
     "@justeat/f-vue-icons" "2.5.0"
 
+"@justeat/f-form-field@4.9.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-4.9.0.tgz#831d206f658ee22f22c52d71dabff4b6bc55de70"
+  integrity sha512-KJFdSUAXlJWCahqjE4cZDYm78xiU41mbED29yU4OVDCOF8coWPLfp8GbXmarRsO3zBa5To7Q26WRGEzxaHCn+g==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+    "@justeat/f-vue-icons" "2.5.0"
+
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-0.2.0.tgz#90ec559642c165b6325669c506c417abe09fa5dd"
@@ -2556,11 +2564,6 @@
     lodash-es "4.17.15"
     window-or-global "1.0.1"
 
-"@justeat/f-services@4.9.0":
-  version "1.15.0"
-  dependencies:
-    lodash-es "4.17.21"
-    window-or-global "1.0.1"
 "@justeat/f-tabs@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-tabs/-/f-tabs-2.0.0.tgz#6fc0b67edb2fee754c8d35a8c683989b0239adad"


### PR DESCRIPTION
### Changed
- Refactor searchbox, skeleton-loader, tabs and user-message WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.