### PR TITLE
removed load and waitForComponent functions from component object (atoms) #trivial

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Latest (add to next release)
 ------------------------------
+*May 27, 2021*
+
+### Removed
+- unneeded `load` and `waitForComponent` functions from component object
+
 *May 26, 2021*
 
 ### Changed

--- a/packages/components/atoms/f-button/test-utils/component-objects/f-button--action.component.js
+++ b/packages/components/atoms/f-button/test-utils/component-objects/f-button--action.component.js
@@ -7,14 +7,6 @@ module.exports = class ActionButton extends Page {
 
     get component () { return $('[data-test-id="action-button-component"]'); }
 
-    async load () {
-        await super.load(this.component);
-    }
-
-    async waitForComponent () {
-        await super.waitForComponent(this.component);
-    }
-
     async isComponentDisplayed () {
         return this.component.isDisplayed();
     }

--- a/packages/components/atoms/f-button/test-utils/component-objects/f-button--icon.component.js
+++ b/packages/components/atoms/f-button/test-utils/component-objects/f-button--icon.component.js
@@ -7,13 +7,13 @@ module.exports = class IconButton extends Page {
 
     get component () { return $('[data-test-id="action-button-component"]'); }
 
-    async load () {
-        await super.load(this.component);
-    }
+    // async load () {
+    //     await super.load(this.component);
+    // }
 
-    async waitForComponent () {
-        await super.waitForComponent(this.component);
-    }
+    // async waitForComponent () {
+    //     await super.waitForComponent(this.component);
+    // }
 
     async isComponentDisplayed () {
         return this.component.isDisplayed();

--- a/packages/components/atoms/f-button/test-utils/component-objects/f-button--icon.component.js
+++ b/packages/components/atoms/f-button/test-utils/component-objects/f-button--icon.component.js
@@ -7,14 +7,6 @@ module.exports = class IconButton extends Page {
 
     get component () { return $('[data-test-id="action-button-component"]'); }
 
-    // async load () {
-    //     await super.load(this.component);
-    // }
-
-    // async waitForComponent () {
-    //     await super.waitForComponent(this.component);
-    // }
-
     async isComponentDisplayed () {
         return this.component.isDisplayed();
     }

--- a/packages/components/atoms/f-button/test-utils/component-objects/f-button--link.component.js
+++ b/packages/components/atoms/f-button/test-utils/component-objects/f-button--link.component.js
@@ -7,14 +7,6 @@ module.exports = class LinkButton extends Page {
 
     get component () { return $('[data-test-id="link-button-component"]'); }
 
-    // async load () {
-    //     await super.load(this.component);
-    // }
-
-    // async waitForComponent () {
-    //     await super.waitForComponent(this.component);
-    // }
-
     async isComponentDisplayed () {
         return this.component.isDisplayed();
     }

--- a/packages/components/atoms/f-button/test-utils/component-objects/f-button--link.component.js
+++ b/packages/components/atoms/f-button/test-utils/component-objects/f-button--link.component.js
@@ -7,13 +7,13 @@ module.exports = class LinkButton extends Page {
 
     get component () { return $('[data-test-id="link-button-component"]'); }
 
-    async load () {
-        await super.load(this.component);
-    }
+    // async load () {
+    //     await super.load(this.component);
+    // }
 
-    async waitForComponent () {
-        await super.waitForComponent(this.component);
-    }
+    // async waitForComponent () {
+    //     await super.waitForComponent(this.component);
+    // }
 
     async isComponentDisplayed () {
         return this.component.isDisplayed();

--- a/packages/components/atoms/f-button/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-button/test/accessibility/axe-accessibility.spec.js
@@ -12,7 +12,7 @@ describe('Accessibility tests', () => {
         button = new ActionButton();
 
         // Act
-        button.load();
+        button.load(button.component);
         const axeResults = getAxeResults('f-button - action');
 
         // Assert
@@ -24,7 +24,7 @@ describe('Accessibility tests', () => {
         button = new LinkButton();
 
         // Act
-        button.load();
+        button.load(button.component);
         const axeResults = getAxeResults('f-button - link');
 
         // Assert
@@ -36,7 +36,7 @@ describe('Accessibility tests', () => {
         button = new IconButton();
 
         // Act
-        button.load();
+        button.load(button.component);
         const axeResults = getAxeResults('f-button - icon');
 
         // Assert

--- a/packages/components/atoms/f-button/test/component/f-button.component.spec.js
+++ b/packages/components/atoms/f-button/test/component/f-button.component.spec.js
@@ -10,7 +10,7 @@ describe('f-button component tests', () => {
         button = new ActionButton();
 
         // Act
-        await button.load();
+        await button.load(button.component);
 
         // Assert
         await expect(await button.isComponentDisplayed()).toBe(true);
@@ -21,7 +21,7 @@ describe('f-button component tests', () => {
         button = new ActionButton();
 
         // Act
-        await button.load();
+        await button.load(button.component);
 
         // Assert
         await expect(await button.isComponentClickable()).toBe(true);
@@ -32,7 +32,7 @@ describe('f-button component tests', () => {
         button = new LinkButton();
 
         // Act
-        await button.load();
+        await button.load(button.component);
 
         // Assert
         await expect(await button.isComponentDisplayed()).toBe(true);
@@ -43,7 +43,7 @@ describe('f-button component tests', () => {
         button = new LinkButton();
 
         // Act
-        await button.load();
+        await button.load(button.component);
 
         // Assert
         await expect(await button.isComponentClickable()).toBe(true);
@@ -54,7 +54,7 @@ describe('f-button component tests', () => {
         button = new IconButton();
 
         // Act
-        await button.load();
+        await button.load(button.component);
 
         // Assert
         await expect(await button.isComponentDisplayed()).toBe(true);
@@ -65,7 +65,7 @@ describe('f-button component tests', () => {
         button = new IconButton();
 
         // Act
-        await button.load();
+        await button.load(button.component);
 
         // Assert
         await expect(await button.isComponentClickable()).toBe(true);

--- a/packages/components/atoms/f-button/test/visual/f-button.visual.desktop.spec.js
+++ b/packages/components/atoms/f-button/test/visual/f-button.visual.desktop.spec.js
@@ -11,7 +11,7 @@ describe('f-button Desktop visual tests', () => {
             button = new ActionButton();
 
             // Act
-            await button.load();
+            await button.load(button.component);
 
             // Assert
             await browser.percyScreenshot('f-button - Action', 'desktop');
@@ -24,7 +24,7 @@ describe('f-button Desktop visual tests', () => {
                 await button.withQuery('args', 'isLoading');
 
                 // Act
-                await button.load();
+                await button.load(button.component);
 
                 // Assert
                 await browser.percyScreenshot('f-button - Action - Loading', 'desktop');
@@ -38,7 +38,7 @@ describe('f-button Desktop visual tests', () => {
                 await button.withQuery('args', 'disabled');
 
                 // Act
-                await button.load();
+                await button.load(button.component);
 
                 // Assert
                 await browser.percyScreenshot('f-button - Action - Disabled', 'desktop');
@@ -52,7 +52,7 @@ describe('f-button Desktop visual tests', () => {
                 await button.withQuery('args', 'hasIcon:leading');
 
                 // Act
-                await button.load();
+                await button.load(button.component);
 
                 // Assert
                 await browser.percyScreenshot('f-button - Action - With Leading Icon', 'desktop');
@@ -66,7 +66,7 @@ describe('f-button Desktop visual tests', () => {
                 await button.withQuery('args', 'hasIcon:trailing');
 
                 // Act
-                await button.load();
+                await button.load(button.component);
 
                 // Assert
                 await browser.percyScreenshot('f-button - Action - With Trailing Icon', 'desktop');
@@ -80,7 +80,7 @@ describe('f-button Desktop visual tests', () => {
             button = new LinkButton();
 
             // Act
-            await button.load();
+            await button.load(button.component);
 
             // Assert
             await browser.percyScreenshot('f-button - Link', 'desktop');
@@ -93,7 +93,7 @@ describe('f-button Desktop visual tests', () => {
                 await button.withQuery('args', 'isLoading');
 
                 // Act
-                await button.load();
+                await button.load(button.component);
 
                 // Assert
                 await browser.percyScreenshot('f-button - Link - Loading', 'desktop');
@@ -107,7 +107,7 @@ describe('f-button Desktop visual tests', () => {
                 await button.withQuery('args', 'disabled');
 
                 // Act
-                await button.load();
+                await button.load(button.component);
 
                 // Assert
                 await browser.percyScreenshot('f-button - Link - Disabled', 'desktop');
@@ -121,7 +121,7 @@ describe('f-button Desktop visual tests', () => {
                 await button.withQuery('args', 'hasIcon:leading');
 
                 // Act
-                await button.load();
+                await button.load(button.component);
 
                 // Assert
                 await browser.percyScreenshot('f-button - Link - With Leading Icon', 'desktop');
@@ -135,7 +135,7 @@ describe('f-button Desktop visual tests', () => {
                 await button.withQuery('args', 'hasIcon:trailing');
 
                 // Act
-                await button.load();
+                await button.load(button.component);
 
                 // Assert
                 await browser.percyScreenshot('f-button - Link - With Trailing Icon', 'desktop');
@@ -149,7 +149,7 @@ describe('f-button Desktop visual tests', () => {
             button = new IconButton();
 
             // Act
-            await button.load();
+            await button.load(button.component);
 
             // Assert
             await browser.percyScreenshot('f-button - Icon', 'desktop');
@@ -162,7 +162,7 @@ describe('f-button Desktop visual tests', () => {
                 await button.withQuery('args', 'isLoading');
 
                 // Act
-                await button.load();
+                await button.load(button.component);
 
                 // Assert
                 await browser.percyScreenshot('f-button - Icon - Loading', 'desktop');

--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -6,13 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Latest (add to next release)
 ------------------------------
+*May 27, 2021*
+
+### Removed
+- unneeded `load` and `waitForComponent` functions from component object
+
 *May 26, 2021*
 
 ### Changed
 - Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
 
-
-------------------------------
 *February 4, 2022*
 
 ### Changed

--- a/packages/components/atoms/f-card/test-utils/component-objects/f-card.component.js
+++ b/packages/components/atoms/f-card/test-utils/component-objects/f-card.component.js
@@ -7,14 +7,6 @@ module.exports = class Card extends Page {
 
     get component () { return $('[data-test-id="card-component"]'); }
 
-    async load () {
-        await super.load(this.component);
-    }
-
-    async waitForComponent () {
-        await super.waitForComponent(this.component);
-    }
-
     async isComponentDisplayed () {
         return this.component.isDisplayed();
     }

--- a/packages/components/atoms/f-card/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-card/test/accessibility/axe-accessibility.spec.js
@@ -6,7 +6,7 @@ const card = new Card();
 
 describe('Accessibility tests', () => {
     beforeEach(() => {
-        card.load();
+        card.load(card.component);
     });
 
     it('a11y - should test f-card component WCAG compliance', () => {

--- a/packages/components/atoms/f-card/test/component/f-card.component.spec.js
+++ b/packages/components/atoms/f-card/test/component/f-card.component.spec.js
@@ -4,7 +4,7 @@ const card = new Card();
 
 describe('f-card component tests', () => {
     beforeEach(async () => {
-        await card.load();
+        await card.load(card.component);
     });
 
     it('should display the f-card component', async () => {

--- a/packages/components/atoms/f-error-message/CHANGELOG.md
+++ b/packages/components/atoms/f-error-message/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Latest (add to next release)
 ------------------------------
+*May 27, 2021*
+
+### Removed
+- unneeded `load` and `waitForComponent` functions from component object
+
 *May 26, 2021*
 
 ### Changed

--- a/packages/components/atoms/f-error-message/test-utils/component-objects/f-error-message.component.js
+++ b/packages/components/atoms/f-error-message/test-utils/component-objects/f-error-message.component.js
@@ -7,14 +7,6 @@ module.exports = class ErrorMessage extends Page {
 
     get component () { return $('[data-test-id="error-message-component"]'); }
 
-    async load () {
-        await super.load(this.component);
-    }
-
-    async waitForComponent () {
-        await super.waitForComponent(this.component);
-    }
-
     async isComponentDisplayed () {
         return this.component.isDisplayed();
     }

--- a/packages/components/atoms/f-error-message/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-error-message/test/accessibility/axe-accessibility.spec.js
@@ -6,7 +6,7 @@ const errorMessage = new ErrorMessage();
 
 describe('Accessibility tests', () => {
     beforeEach(() => {
-        errorMessage.load();
+        errorMessage.load(errorMessage.component);
     });
 
     it('a11y - should test f-error-message component WCAG compliance', () => {

--- a/packages/components/atoms/f-error-message/test/component/f-error-message.component.spec.js
+++ b/packages/components/atoms/f-error-message/test/component/f-error-message.component.spec.js
@@ -4,7 +4,7 @@ const errorMessage = new ErrorMessage();
 
 describe('f-error-message component tests', () => {
     beforeEach(async () => {
-        await errorMessage.load();
+        await errorMessage.load(errorMessage.component);
     });
 
     it('should display the f-error-message component', async () => {

--- a/packages/components/atoms/f-filter-pill/CHANGELOG.md
+++ b/packages/components/atoms/f-filter-pill/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Latest (add to next release)
 ------------------------------
+*May 27, 2021*
+
+### Removed
+- unneeded `load` and `waitForComponent` functions from component object
+
 *May 26, 2021*
 
 ### Changed

--- a/packages/components/atoms/f-filter-pill/test-utils/component-objects/f-filter-pill.component.js
+++ b/packages/components/atoms/f-filter-pill/test-utils/component-objects/f-filter-pill.component.js
@@ -6,18 +6,7 @@ module.exports = class FilterPill extends Page {
         super('atom', 'filter-pill-component');
     }
 
-    get component () {
-        // eslint-disable-next-line no-undef
-        return $(COMPONENT);
-    }
-
-    async load () {
-        await super.load(this.component);
-    }
-
-    async waitForComponent () {
-        await super.waitForComponent(this.component);
-    }
+    get component () { return $(COMPONENT); }
 
     async isComponentDisplayed () {
         return this.component.isDisplayed();

--- a/packages/components/atoms/f-filter-pill/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-filter-pill/test/accessibility/axe-accessibility.spec.js
@@ -6,7 +6,7 @@ const filterPill = new FilterPill();
 
 describe('Accessibility tests', () => {
     beforeEach(() => {
-        filterPill.load();
+        filterPill.load(filterPill.component);
     });
 
     it('a11y - should test f-filter-pill component WCAG compliance', () => {

--- a/packages/components/atoms/f-filter-pill/test/component/f-filter-pill.component.spec.js
+++ b/packages/components/atoms/f-filter-pill/test/component/f-filter-pill.component.spec.js
@@ -4,7 +4,7 @@ const filterPill = new FilterPill();
 
 describe('f-filter-pill component tests', () => {
     beforeEach(async () => {
-        await filterPill.load();
+        await filterPill.load(filterPill.component);
     });
 
     it('should display the f-filter-pill component', async () => {

--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Latest (add to next release)
 ------------------------------
+*May 27, 2021*
+
+### Removed
+- unneeded `load` and `waitForComponent` functions from component object
+
 *May 26, 2021*
 
 ### Changed

--- a/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field--visual.component.js
+++ b/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field--visual.component.js
@@ -6,8 +6,4 @@ module.exports = class FormField extends Page {
     }
 
     get component () { return $('[data-test-id="formfield-container"]'); }
-
-    async load () {
-        await super.load(this.component);
-    }
 };

--- a/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field.component.js
+++ b/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field.component.js
@@ -11,14 +11,6 @@ module.exports = class FormField extends Page {
 
     get input () { return $('[data-test-id="formfield-input"]'); }
 
-    async load () {
-        await super.load(this.component);
-    }
-
-    async waitForComponent () {
-        await super.waitForComponent(this.component);
-    }
-
     async isComponentDisplayed () {
         return this.component.isDisplayed();
     }

--- a/packages/components/atoms/f-form-field/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-form-field/test/accessibility/axe-accessibility.spec.js
@@ -6,7 +6,7 @@ const formfield = new FormField();
 
 describe('Accessibility tests', () => {
     beforeEach(() => {
-        formfield.load();
+        formfield.load(formfield.component);
     });
 
     it('a11y - should test f-formField component WCAG compliance', () => {

--- a/packages/components/atoms/f-form-field/test/component/f-form-field.component.spec.js
+++ b/packages/components/atoms/f-form-field/test/component/f-form-field.component.spec.js
@@ -4,7 +4,7 @@ const formfield = new FormField();
 
 describe('f-form-field component tests', () => {
     beforeEach(async () => {
-        await formfield.load();
+        await formfield.load(formfield.component);
     });
 
     it('should display f-form-field', async () => {

--- a/packages/components/atoms/f-form-field/test/visual/f-form-field.visual.spec.js
+++ b/packages/components/atoms/f-form-field/test/visual/f-form-field.visual.spec.js
@@ -9,7 +9,7 @@ describe('f-form-field visual tests', () => {
             formField = new FormField();
 
             // Act
-            await formField.load();
+            await formField.load(formField.component);
 
             // Assert
             await browser.percyScreenshot('f-form-field - Base State', 'desktop');
@@ -23,7 +23,7 @@ describe('f-form-field visual tests', () => {
             .withQuery('args', 'isDisabled:disabled');
 
             // Act
-            await formField.load();
+            await formField.load(formField.component);
 
             // Assert
             await browser.percyScreenshot('f-form-field - Disabled State', 'desktop');
@@ -37,7 +37,7 @@ describe('f-form-field visual tests', () => {
             .withQuery('args', 'hasError:true');
 
             // Act
-            await formField.load();
+            await formField.load(formField.component);
 
             // Assert
             await browser.percyScreenshot('f-form-field - Errored State', 'desktop');

--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Latest (add to next release)
 ------------------------------
+*May 27, 2021*
+
+### Removed
+- unneeded `load` and `waitForComponent` functions from component object
+
 *May 26, 2021*
 
 ### Changed

--- a/packages/components/atoms/f-image-tile/test-utils/component-objects/f-image-tile.component.js
+++ b/packages/components/atoms/f-image-tile/test-utils/component-objects/f-image-tile.component.js
@@ -7,14 +7,6 @@ module.exports = class ImageTile extends Page {
 
     get component () { return $('[data-test-id="image-tile-component"]'); }
 
-    async load () {
-        await super.load(this.component);
-    }
-
-    async waitForComponent () {
-        await super.waitForComponent(this.component);
-    }
-
     async isComponentDisplayed () {
         return this.component.isDisplayed();
     }

--- a/packages/components/atoms/f-image-tile/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-image-tile/test/accessibility/axe-accessibility.spec.js
@@ -6,7 +6,7 @@ const imageTile = new ImageTile();
 
 describe('Accessibility tests', () => {
     beforeEach(() => {
-        imageTile.load();
+        imageTile.load(imageTile.component);
     });
     it('a11y - should test f-image-tile component WCAG compliance', () => {
         // Act

--- a/packages/components/atoms/f-image-tile/test/component/f-image-tile.component.spec.js
+++ b/packages/components/atoms/f-image-tile/test/component/f-image-tile.component.spec.js
@@ -4,7 +4,7 @@ const imageTile = new ImageTile();
 
 describe('f-image-tile component tests', () => {
     beforeEach(async () => {
-        await imageTile.load();
+        await imageTile.load(imageTile.component);
     });
 
     it('should display the f-image-tile component', async () => {

--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Latest (add to next release)
 ------------------------------
+*May 27, 2021*
+
+### Removed
+- unneeded `load` and `waitForComponent` functions from component object
+
 *May 26, 2021*
 
 ### Changed

--- a/packages/components/atoms/f-link/test-utils/component-objects/f-link.component.js
+++ b/packages/components/atoms/f-link/test-utils/component-objects/f-link.component.js
@@ -7,14 +7,6 @@ module.exports = class Link extends Page {
 
     get component () { return $('[data-test-id="link-component"]'); }
 
-    async load () {
-        await super.load(this.component);
-    }
-
-    async waitForComponent () {
-        await super.waitForComponent(this.component);
-    }
-
     async isComponentDisplayed () {
         return this.component.isDisplayed();
     }

--- a/packages/components/atoms/f-link/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-link/test/accessibility/axe-accessibility.spec.js
@@ -6,7 +6,7 @@ const link = new Link();
 
 describe('Accessibility tests', () => {
     beforeEach(() => {
-        link.load();
+        link.load(link.component);
     });
     it('a11y - should test f-link component WCAG compliance', () => {
         // Act

--- a/packages/components/atoms/f-link/test/component/f-link.component.spec.js
+++ b/packages/components/atoms/f-link/test/component/f-link.component.spec.js
@@ -4,7 +4,7 @@ const link = new Link();
 
 describe('f-link component tests', () => {
     beforeEach(async () => {
-        await link.load();
+        await link.load(link.component);
     });
 
     it('should display the f-link component', async () => {

--- a/packages/components/atoms/f-popover/CHANGELOG.md
+++ b/packages/components/atoms/f-popover/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (add to next release)
+------------------------------
+*May 27, 2021*
+
+### Removed
+- unneeded `load` and `waitForComponent` functions from component object
+
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+
 
 v2.3.0
 ------------------------------

--- a/packages/components/atoms/f-popover/test-utils/component-objects/f-popover.component.js
+++ b/packages/components/atoms/f-popover/test-utils/component-objects/f-popover.component.js
@@ -7,14 +7,6 @@ module.exports = class Popover extends Page {
 
     get component () { return $('[data-test-id="popover"]'); }
 
-    async load () {
-        await super.load(this.component);
-    }
-
-    async waitForComponent () {
-        await super.waitForComponent(this.component);
-    }
-
     async isComponentDisplayed () {
         return this.component.isDisplayed();
     }

--- a/packages/components/atoms/f-popover/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-popover/test/accessibility/axe-accessibility.spec.js
@@ -6,7 +6,7 @@ const popover = new Popover();
 
 describe('Accessibility tests', () => {
     beforeEach(() => {
-        popover.load();
+        popover.load(popover.component);
     });
     it('a11y - should test f-popover component WCAG compliance', () => {
         // Act

--- a/packages/components/atoms/f-popover/test/component/f-popover.component.spec.js
+++ b/packages/components/atoms/f-popover/test/component/f-popover.component.spec.js
@@ -4,7 +4,7 @@ const popover = new Popover();
 
 describe('f-popover component tests', () => {
     beforeEach(async () => {
-        await popover.load();
+        await popover.load(popover.component);
     });
 
     it('should display the f-popover component', async () => {

--- a/packages/components/atoms/f-spinner/CHANGELOG.md
+++ b/packages/components/atoms/f-spinner/CHANGELOG.md
@@ -15,10 +15,6 @@ Latest (add to next release)
 
 ### Changed
 - Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
-*May 26, 2021*
-
-### Changed
-- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
 
 
 v0.4.0

--- a/packages/components/atoms/f-spinner/CHANGELOG.md
+++ b/packages/components/atoms/f-spinner/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Latest (add to next release)
 ------------------------------
+*May 27, 2021*
+
+### Removed
+- unneeded `load` and `waitForComponent` functions from component object
+
+*May 26, 2021*
+
+### Changed
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
 *May 26, 2021*
 
 ### Changed

--- a/packages/components/atoms/f-spinner/test-utils/component-objects/f-spinner.component.js
+++ b/packages/components/atoms/f-spinner/test-utils/component-objects/f-spinner.component.js
@@ -7,14 +7,6 @@ module.exports = class Spinner extends Page {
 
     get component () { return $('[data-test-id="spinner-component"]'); }
 
-    async load () {
-        await super.load(this.component);
-    }
-
-    async waitForComponent () {
-        await super.waitForComponent(this.component);
-    }
-
     async isComponentDisplayed () {
         return this.component.isDisplayed();
     }

--- a/packages/components/atoms/f-spinner/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-spinner/test/accessibility/axe-accessibility.spec.js
@@ -8,7 +8,7 @@ describe('Accessibility tests', () => {
     beforeEach(() => {
         spinner = new Spinner();
 
-        spinner.load();
+        spinner.load(spinner.component);
     });
 
     it('a11y - should test f-spinner component WCAG compliance', () => {

--- a/packages/components/atoms/f-spinner/test/component/f-spinner.component.spec.js
+++ b/packages/components/atoms/f-spinner/test/component/f-spinner.component.spec.js
@@ -7,7 +7,7 @@ describe('f-spinner component tests', () => {
     beforeEach(async () => {
         spinner = new Spinner();
 
-        await spinner.load();
+        await spinner.load(spinner.component);
     });
 
     it('should display the f-spinner component', async () => {


### PR DESCRIPTION
Latest (add to next release)
------------------------------
*May 27, 2021*

### Removed
- unneeded `load` and `waitForComponent` functions from component object

we can call these functions from the Page class directly -[https://github.com/justeat/fozzie-components/blob/master/packages/services/f-wdio-utils/src/page.object.js](here)