### PR TITLE
f-wdio-utils@v0.10.0 - updated load function

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "babel-jest": "26.1.0",
     "babel-loader": "8.1.0",
     "bundlewatch": "0.3.1",
-    "chromedriver": "96.0.0",
+    "chromedriver": "101.0.0",
     "cross-env": "7.0.2",
     "css-loader": "1.0.1",
     "danger": "10.2.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "babel-jest": "26.1.0",
     "babel-loader": "8.1.0",
     "bundlewatch": "0.3.1",
-    "chromedriver": "101.0.0",
+    "chromedriver": "96.0.0",
     "cross-env": "7.0.2",
     "css-loader": "1.0.1",
     "danger": "10.2.1",

--- a/packages/services/f-wdio-utils/CHANGELOG.md
+++ b/packages/services/f-wdio-utils/CHANGELOG.md
@@ -8,7 +8,7 @@ v0.10.0
 *May 24, 2022*
 
 ### Changed
-- Updated load function to take in storybook args as objects
+- load function to take in storybook args as objects
 
 
 v0.9.0

--- a/packages/services/f-wdio-utils/CHANGELOG.md
+++ b/packages/services/f-wdio-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.10.0
+------------------------------
+*May 24, 2022*
+
+### Changed
+- Updated load function to take in storybook args as objects
+
+
 v0.9.0
 ------------------------------
 *May 24, 2022*

--- a/packages/services/f-wdio-utils/CHANGELOG.md
+++ b/packages/services/f-wdio-utils/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.10.0
 ------------------------------
-*May 24, 2022*
+*June 1, 2022*
 
 ### Changed
 - load function to take in storybook args as objects

--- a/packages/services/f-wdio-utils/package.json
+++ b/packages/services/f-wdio-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-wdio-utils",
   "description": "Fozzie Wdio Utils - webdriverIO page object",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "files": [
     "src/"
   ],

--- a/packages/services/f-wdio-utils/src/page.object.js
+++ b/packages/services/f-wdio-utils/src/page.object.js
@@ -11,8 +11,8 @@ class Page {
         this.path = '';
     }
 
-    load (component) {
-        const pageUrl = buildUrl(this.componentType, this.componentName, this.path);
+    load (component, queries) {
+        const pageUrl = buildUrl(this.componentType, this.componentName, this.composePath(queries));
         this.open(pageUrl);
         this.waitForComponent(component);
     }
@@ -26,9 +26,12 @@ class Page {
         component.waitForExist({ timeout: timeoutMs });
     }
 
-    withQuery (name, value) {
-        this.path += `&${name}=${value}`;
-        return this;
+    composePath (queries) {
+        if (!queries) { return ''; }
+
+        return `&args=${Object.keys(queries)
+        .map(name => `${name}:${queries[name]}`)
+        .join(';')}`;
     }
 
     /**


### PR DESCRIPTION
New load function to make it easier to pass in storybook args in our component, a11y & visual tests

Footer example:

Before:
`footer.withQuery('args', 'locale:en-GB;showCountrySelector:true');`
`footer.load();`

After:
`        footer.load(footer.component, {
            locale: 'en-GB',
            showCountrySelector: true
        });`

