### PR TITLE
f-cookie-banner-static@v1.0.1:  Remove yarn cache --all

### DIFF
--- a/packages/components/organisms/f-cookie-banner-static/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner-static/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.0.1
+------------------------------
+*June 7, 2022*
+
+### Changed
+- Specified cleaning `f-cookie-banner` cache instead of `cache clean --all` from `build` step.
+
 v1.0.0
 ------------------------------
 *May 24, 2022*

--- a/packages/components/organisms/f-cookie-banner-static/package.json
+++ b/packages/components/organisms/f-cookie-banner-static/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@justeat/f-cookie-banner-static",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Fozzie Cookie Banner configuration to compile via vue cli prerender to vanilla js/css",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "yarn install && yarn cache clean --all && yarn gulp"
+    "build": "yarn install && yarn cache clean @justeat/f-cookie-banner && yarn gulp"
   },
   "browserslist": [
     "extends @justeat/browserslist-config-fozzie"


### PR DESCRIPTION
The `yarn cache --all` is causing the global cache to be erased locally on each build of f-cookie-banner-static.  This makes builds much longer as we can't cache, it also causes instabilities due to the cache being purged whilst other builds are going on.

We're not able to fix this properly right now (i.e. don't use purging the Yarn cache) however we can reduce it's scope to just purging the _f-cookie-banner_.