### PR TITLE
Fix local build concurrency issue #trivial

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "7.11.0",
   "private": true,
   "scripts": {
-    "build": "turbo run build --continue",
+    "build": "turbo run build --continue --concurrency=1",
     "bundlewatch": "bundlewatch --config bundlewatch.config.js",
     "lint": "turbo run lint --continue",
     "lint:fix": "turbo run lint -- --fix --continue",

--- a/packages/components/organisms/f-cookie-banner-static/package.json
+++ b/packages/components/organisms/f-cookie-banner-static/package.json
@@ -5,7 +5,7 @@
   "description": "Fozzie Cookie Banner configuration to compile via vue cli prerender to vanilla js/css",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "yarn install && yarn cache clean @justeat/f-cookie-banner && yarn gulp"
+    "build:static": "yarn install && yarn cache clean @justeat/f-cookie-banner && yarn gulp"
   },
   "browserslist": [
     "extends @justeat/browserslist-config-fozzie"

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "prepublishOnly": "yarn lint && yarn test && yarn build && yarn build:static-files",
     "build": "vue-cli-service build --target lib --name f-cookie-banner ./src/index.js",
-    "build:static-files": "yarn --cwd ../f-cookie-banner-static build",
+    "build:static-files": "yarn --cwd ../f-cookie-banner-static build:static",
     "demo": "vue serve --port 8080 ./src/demo/Index.vue",
     "lint": "eslint \"!(dist)/**/*.{js,vue}\"",
     "lint:fix": "yarn lint --fix",


### PR DESCRIPTION
This PR forces a concurrency of 1 so that running the `build` task locally doesn't fall over.

It also renames the `build` task in `f-cookie-banner-static` to `build:static` to prevent it being built by lerna.