### PR TITLE
f-card@v4.0.0 - use new sass @use syntax

### DIFF
--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.0.0
+------------------------------
+*June 15, 2022*
+
+### Changed
+- *** Breaking change *** - Implement @use for fozzie where required.
+- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
+- Upgraded to ESLint v8
+
+### Removed
+- unneeded `load` and `waitForComponent` functions from component object
+
 
 v3.6.1
 -----------------------------

--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -9,11 +9,6 @@ v4.0.0
 
 ### Changed
 - *** Breaking change *** - Implement @use for fozzie where required.
-- Refactor WebDriverIO tests to use async in order to support Node 16 using `codemod` utility.
-- Upgraded to ESLint v8
-
-### Removed
-- unneeded `load` and `waitForComponent` functions from component object
 
 
 v3.6.1

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card",
   "description": "Fozzie Card Component – Used for providing wrapper card styling to an element (or group of elements)",
-  "version": "3.6.1",
+  "version": "4.0.0",
   "main": "dist/f-card.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [
@@ -55,6 +55,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/f-wdio-utils": "0.11.0"
+    "@justeat/f-wdio-utils": "0.11.0",
+    "@justeat/fozzie": "9.0.0-beta.2"
   }
 }

--- a/packages/components/atoms/f-card/src/assets/scss/common.scss
+++ b/packages/components/atoms/f-card/src/assets/scss/common.scss
@@ -1,1 +1,1 @@
-@import  '@justeat/fozzie/src/scss/fozzie';
+// Add styles here so it can be injected first via vue.config.js.

--- a/packages/components/atoms/f-card/src/components/Card.vue
+++ b/packages/components/atoms/f-card/src/components/Card.vue
@@ -102,11 +102,13 @@ export default {
 </script>
 
 <style lang="scss" module>
-$card-bgColor                             : $color-container-default;
-$card-borderColor                         : $color-border-default;
-$card-borderRadius                        : $radius-rounded-c;
-$card-padding                             : spacing(d);
-$card-padding-large                       : spacing(f);
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
+$card-bgColor                             : f.$color-container-default;
+$card-borderColor                         : f.$color-border-default;
+$card-borderRadius                        : f.$radius-rounded-c;
+$card-padding                             : f.spacing(d);
+$card-padding-large                       : f.spacing(f);
 $card--pageContentWrapper-width           : 472px; // so that it falls on our 8px spacing grid
 
 .c-card {
@@ -120,7 +122,7 @@ $card--pageContentWrapper-width           : 472px; // so that it falls on our 8p
         &.c-card-innerSpacing--large {
             padding: $card-padding-large $card-padding;
 
-            @include media('>=mid') {
+            @include f.media('>=mid') {
                 padding: $card-padding-large;
             }
         }
@@ -137,28 +139,28 @@ $card--pageContentWrapper-width           : 472px; // so that it falls on our 8p
     .c-card--pageContentWrapper {
         width: 100%;
         transition: 250ms padding ease-in-out;
-        margin: spacing(g) 0;
+        margin: f.spacing(g) 0;
 
-        @include media('>=#{$card--pageContentWrapper-width}') {
+        @include f.media('>=#{$card--pageContentWrapper-width}') {
             width: $card--pageContentWrapper-width;
-            margin: spacing(g) auto;
+            margin: f.spacing(g) auto;
         }
 
         & > .c-card-innerSpacing {
-            padding: spacing(e) 6% 0;
+            padding: f.spacing(e) 6% 0;
 
-            @include media('>=narrow') {
-                padding: spacing(h) 10%;
+            @include f.media('>=narrow') {
+                padding: f.spacing(h) 10%;
             }
 
-            @include media('>=#{$card--pageContentWrapper-width}') {
-                padding: spacing(h) spacing(j);
+            @include f.media('>=#{$card--pageContentWrapper-width}') {
+                padding: f.spacing(h) f.spacing(j);
             }
         }
     }
 
     .c-card-heading {
-        margin-bottom: spacing(d);
+        margin-bottom: f.spacing(d);
     }
 
     .c-card-heading--centerAligned {

--- a/packages/components/atoms/f-card/vue.config.js
+++ b/packages/components/atoms/f-card/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@import "../assets/scss/common.scss";`
+                additionalData: `@use "../assets/scss/common.scss" as *;`
             });
     },
     pluginOptions: {

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.52.1
+------------------------------
+*June 16, 2022*
+
+### Changed
+- updated vue.config to include f-card in components using @use and @forward
+
+
 v0.52.0
 ------------------------------
 *June 16, 2022*

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private":true,
-  "version": "0.52.0",
+  "version": "0.52.1",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -41,7 +41,7 @@ module.exports = {
                     // add component names 1 by 1 to this array as they're updated
                     // to the new Sass syntax OR the entire component folder if all completed
                     // i.e. // [ 'atoms', 'molecules', 'f-checkout' ]
-                    const updateComponentsAndTypes = [ 'f-button' ];
+                    const updateComponentsAndTypes = ['f-button', 'f-card'];
                     const pathContainsUpdatedComponentOrType = updateComponentsAndTypes.some(a => absPath.includes(a));
 
                     if (!pathContainsUpdatedComponentOrType) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14987,7 +14987,7 @@ include-media@1.4.9:
   resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.9.tgz#d0020b7be3eb2d54868a20943595ce380e0bc43b"
   integrity sha512-IUOcvWDCt6R5V0ktsGk6RbehkW9ks1dODN2ed1p+mhML82TteAl+/ElXy8AJ7ueIuVoKq2NioRVdW9FuwQNOew==
 
-"include-media@github:eduardoboucas/include-media#2.0-release":
+include-media@eduardoboucas/include-media#2.0-release:
   version "2.0.0"
   resolved "https://codeload.github.com/eduardoboucas/include-media/tar.gz/5398b556d4bb24186d360c950b19026f577ff8e5"
 


### PR DESCRIPTION
f-card v4.0.0
------------------------------
*June 15, 2022*

### Changed
- *** Breaking change *** - Implement @use for fozzie where required.

storybook v0.52.1
------------------------------
*June 16, 2022*

### Changed
- updated vue.config to include f-card in components using @use and @forward
