### PR TITLE
f-error-message@v2.0.0 - use new sass @use syntax

### DIFF
--- a/packages/components/atoms/f-error-message/CHANGELOG.md
+++ b/packages/components/atoms/f-error-message/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0
+------------------------------
+*June 15, 2022*
+
+### Changed
+- *** Breaking change *** - Implement @use for fozzie where required.
+
+
 v1.2.1
 -----------------------------
 *Jun 10, 2022*

--- a/packages/components/atoms/f-error-message/package.json
+++ b/packages/components/atoms/f-error-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-error-message",
   "description": "Fozzie Error Message – Generic inline error message",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "main": "dist/f-error-message.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [
@@ -55,6 +55,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/f-wdio-utils": "0.11.0"
+    "@justeat/f-wdio-utils": "0.11.0",
+    "@justeat/fozzie": "9.0.0-beta.2"
   }
 }

--- a/packages/components/atoms/f-error-message/src/assets/scss/common.scss
+++ b/packages/components/atoms/f-error-message/src/assets/scss/common.scss
@@ -1,1 +1,1 @@
-@import  '@justeat/fozzie/src/scss/fozzie';
+// Add styles here so it can be injected first via vue.config.js.

--- a/packages/components/atoms/f-error-message/src/components/ErrorMessage.vue
+++ b/packages/components/atoms/f-error-message/src/components/ErrorMessage.vue
@@ -36,17 +36,19 @@ export default {
 </script>
 
 <style lang="scss" module>
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
 .c-errorMessage {
     position: relative;
-    color: $color-content-error;
-    @include font-size();
-    margin-top: spacing();
+    color: f.$color-content-error;
+    @include f.font-size();
+    margin-top: f.spacing();
 }
 
 .c-errorMessage-content {
     display: block;
     overflow: hidden;
-    margin-left: spacing(e);
+    margin-left: f.spacing(e);
 }
 
 .c-errorMessage-icon {
@@ -55,7 +57,7 @@ export default {
     margin-top: 2px;
 
     path {
-        fill: $color-support-error;
+        fill: f.$color-support-error;
     }
 }
 </style>

--- a/packages/components/atoms/f-error-message/vue.config.js
+++ b/packages/components/atoms/f-error-message/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@import "../assets/scss/common.scss";`
+                additionalData: `@use "../assets/scss/common.scss" as *;`
             });
     },
     pluginOptions: {

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.52.2
+------------------------------
+*June 16, 2022*
+
+### Changed
+- updated vue.config to include f-error-message in components using @use and @forward
+
+
 v0.52.0
 ------------------------------
 *June 16, 2022*

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private":true,
-  "version": "0.52.0",
+  "version": "0.52.2",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -41,7 +41,7 @@ module.exports = {
                     // add component names 1 by 1 to this array as they're updated
                     // to the new Sass syntax OR the entire component folder if all completed
                     // i.e. // [ 'atoms', 'molecules', 'f-checkout' ]
-                    const updateComponentsAndTypes = [ 'f-button' ];
+                    const updateComponentsAndTypes = ['f-button', 'f-error-message'];
                     const pathContainsUpdatedComponentOrType = updateComponentsAndTypes.some(a => absPath.includes(a));
 
                     if (!pathContainsUpdatedComponentOrType) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14987,7 +14987,7 @@ include-media@1.4.9:
   resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.9.tgz#d0020b7be3eb2d54868a20943595ce380e0bc43b"
   integrity sha512-IUOcvWDCt6R5V0ktsGk6RbehkW9ks1dODN2ed1p+mhML82TteAl+/ElXy8AJ7ueIuVoKq2NioRVdW9FuwQNOew==
 
-"include-media@github:eduardoboucas/include-media#2.0-release":
+include-media@eduardoboucas/include-media#2.0-release:
   version "2.0.0"
   resolved "https://codeload.github.com/eduardoboucas/include-media/tar.gz/5398b556d4bb24186d360c950b19026f577ff8e5"
 


### PR DESCRIPTION
f-error-message v2.0.0
------------------------------
*June 15, 2022*

### Changed
- *** Breaking change *** - Implement @use for fozzie where required.

storybook v0.52.2
------------------------------
*June 16, 2022*

### Changed
- updated vue.config to include f-error-message in components using @use and @forward