### PR TITLE
f-spinner@v1.0.0 f-link@v3.00 f-popover@v3.0.0 - use new sass syntax

### DIFF
--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.0.0
+-----------------------------
+*Jun 17, 2022*
+
+### Changed
+- Update to `@use` and `@forward` SASS syntax
+
+
 v2.4.0
 ------------------------------
 *June 16, 2022*

--- a/packages/components/atoms/f-link/package.json
+++ b/packages/components/atoms/f-link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-link",
   "description": "Fozzie Link - Fozzie link component",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "main": "dist/f-link.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [
@@ -56,6 +56,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@justeat/f-wdio-utils": "0.11.0",
+    "@justeat/fozzie": "9.0.0-beta.2",
     "@vue/test-utils": "1.0.3"
   }
 }

--- a/packages/components/atoms/f-link/src/assets/scss/common.scss
+++ b/packages/components/atoms/f-link/src/assets/scss/common.scss
@@ -1,1 +1,1 @@
-@import  '@justeat/fozzie/src/scss/fozzie';
+// Add styles here so it can be injected first via vue.config.js.

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -130,18 +130,20 @@ export default {
 </script>
 
 <style lang="scss" module>
+@use  '@justeat/fozzie/src/scss/fozzie' as f;
+
 .o-link {
     & {
-        color: $color-content-link;
+        color: f.$color-content-link;
     }
 
     &:hover,
     &:focus {
-        color: darken($color-content-link, $color-hover-01);
+        color: darken(f.$color-content-link, f.$color-hover-01);
     }
 
     &:active {
-        color: darken($color-content-link, $color-active-01);
+        color: darken(f.$color-content-link, f.$color-active-01);
     }
 }
 
@@ -162,7 +164,7 @@ export default {
 }
 
 .o-link--bold {
-    font-weight: $font-weight-bold;
+    font-weight: f.$font-weight-bold;
 }
 
 .o-link--noBreak {
@@ -170,15 +172,15 @@ export default {
 }
 
 .o-link--distinct {
-    color: $color-content-link-distinct;
+    color: f.$color-content-link-distinct;
 
     &:hover,
     &:focus {
-        color: darken($color-content-link-distinct, $color-hover-01);
+        color: darken(f.$color-content-link-distinct, f.$color-hover-01);
     }
 
     &:active {
-        color: darken($color-content-link-distinct, $color-active-01);
+        color: darken(f.$color-content-link-distinct, f.$color-active-01);
     }
 }
 </style>

--- a/packages/components/atoms/f-link/vue.config.js
+++ b/packages/components/atoms/f-link/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@import "../assets/scss/common.scss";`
+                additionalData: `@use "../assets/scss/common.scss" as *;`
             });
     },
     pluginOptions: {

--- a/packages/components/atoms/f-popover/CHANGELOG.md
+++ b/packages/components/atoms/f-popover/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.0.0
+-----------------------------
+*Jun 17, 2022*
+
+### Changed
+- Update to `@use` and `@forward` SASS syntax
+
+
 v2.3.1
 -----------------------------
 *Jun 13, 2022*

--- a/packages/components/atoms/f-popover/package.json
+++ b/packages/components/atoms/f-popover/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-popover",
   "description": "Fozzie Popover - renders recieved content as a popover",
-  "version": "2.3.1",
+  "version": "3.0.0",
   "main": "dist/f-popover.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [
@@ -56,6 +56,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/f-wdio-utils": "0.11.0"
+    "@justeat/f-wdio-utils": "0.11.0",
+    "@justeat/fozzie": "9.0.0-beta.2"
   }
 }

--- a/packages/components/atoms/f-popover/src/assets/scss/common.scss
+++ b/packages/components/atoms/f-popover/src/assets/scss/common.scss
@@ -1,1 +1,1 @@
-@import  '@justeat/fozzie/src/scss/fozzie';
+// Add styles here so it can be injected first via vue.config.js.

--- a/packages/components/atoms/f-popover/src/components/Popover.vue
+++ b/packages/components/atoms/f-popover/src/components/Popover.vue
@@ -16,13 +16,15 @@ export default {
 </script>
 
 <style lang="scss" module>
-$popover-padding               : spacing(d);
+@use  '@justeat/fozzie/src/scss/fozzie' as f;
+
+$popover-padding               : f.spacing(d);
 
 .c-popover {
-    @include media('>mid') {
-        background-color: $color-container-default;
-        box-shadow: $elevation-02;
-        border-radius: $radius-rounded-c;
+    @include f.media('>mid') {
+        background-color: f.$color-container-default;
+        box-shadow: f.$elevation-02;
+        border-radius: f.$radius-rounded-c;
         padding: 0 $popover-padding;
         width: auto;
     }

--- a/packages/components/atoms/f-popover/vue.config.js
+++ b/packages/components/atoms/f-popover/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@import "../assets/scss/common.scss";`
+                additionalData: `@use "../assets/scss/common.scss" as *;`
             });
     },
     pluginOptions: {

--- a/packages/components/atoms/f-spinner/CHANGELOG.md
+++ b/packages/components/atoms/f-spinner/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.0.0
+------------------------------
+*Jun 17, 2022*
+
+### Changed
+- Update to `@use` and `@forward` SASS syntax
+
+
 v0.4.1
 -----------------------------
 *Jun 13, 2022*

--- a/packages/components/atoms/f-spinner/package.json
+++ b/packages/components/atoms/f-spinner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-spinner",
   "description": "Fozzie Spinner - loading indicator",
-  "version": "0.4.1",
+  "version": "1.0.0",
   "main": "dist/f-spinner.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@justeat/f-wdio-utils": "0.11.0",
+    "@justeat/fozzie": "9.0.0-beta.2",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3"

--- a/packages/components/atoms/f-spinner/src/assets/scss/common.scss
+++ b/packages/components/atoms/f-spinner/src/assets/scss/common.scss
@@ -1,1 +1,1 @@
-@import  '@justeat/fozzie/src/scss/fozzie';
+// Add styles here so it can be injected first via vue.config.js.

--- a/packages/components/atoms/f-spinner/src/components/Spinner.vue
+++ b/packages/components/atoms/f-spinner/src/components/Spinner.vue
@@ -40,7 +40,9 @@ export default {
 </script>
 
 <style lang="scss" module>
-@include loadingIndicator('large');
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
+@include f.loadingIndicator('large');
 
 .c-spinner {
     margin: 0 auto;

--- a/packages/components/atoms/f-spinner/vue.config.js
+++ b/packages/components/atoms/f-spinner/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@import "../assets/scss/common.scss";`
+                additionalData: `@use "../assets/scss/common.scss" as *;`
             });
     },
     pluginOptions: {

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.52.6
+------------------------------
+*June 17, 2022*
+### Changed
+- updated vue.config to include all atoms in components using @use and @forward
+
+
 v0.52.5
 ------------------------------
 *June 17, 2022*

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private":true,
-  "version": "0.52.5",
+  "version": "0.52.6",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -41,7 +41,7 @@ module.exports = {
                     // add component names 1 by 1 to this array as they're updated
                     // to the new Sass syntax OR the entire component folder if all completed
                     // i.e. // [ 'atoms', 'molecules', 'f-checkout' ]
-                    const updateComponentsAndTypes = ['f-button', 'f-card', 'f-error-message', 'f-filter-pill', 'f-form-field', 'f-image-tile'];
+                    const updateComponentsAndTypes = ['atoms'];
                     const pathContainsUpdatedComponentOrType = updateComponentsAndTypes.some(a => absPath.includes(a));
 
                     if (!pathContainsUpdatedComponentOrType) {


### PR DESCRIPTION
f-link - v3.0.0
-----------------------------
*Jun 17, 2022*

### Changed
- Update to `@use` and `@forward` SASS syntax


f-popover - v3.0.0
-----------------------------
*Jun 17, 2022*

### Changed
- Update to `@use` and `@forward` SASS syntax


f-link - v1.0.0
------------------------------
*Jun 17, 2022*

### Changed
- Update to `@use` and `@forward` SASS syntax


Storybook - v0.52.6
------------------------------
*June 17, 2022*
### Changed
- updated vue.config to include all atoms in components using @use and @forward