### PR TITLE
f-alert@v5.0.0 - Update f-alert to new sass syntax

### DIFF
--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+
+v5.0.0
+------------------------------
+*Jun 17, 2022*
+
+### Changed
+- Update to `@use` and `@forward` SASS syntax
+
+
 v4.4.1
 ------------------------------
 *Jun 9, 2022*

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-alert",
   "description": "Fozzie Alert – Fozzie Alert Component",
-  "version": "4.4.1",
+  "version": "5.0.0",
   "main": "dist/f-alert.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [
@@ -55,8 +55,9 @@
     "@justeat/f-button": "3.x"
   },
   "devDependencies": {
-    "@justeat/f-button": "3.3.0",
+    "@justeat/f-button": "4.0.0",
     "@justeat/f-wdio-utils": "0.11.0",
+    "@justeat/fozzie": "9.0.0-beta.3",
     "@justeattakeaway/pie-icons-vue": "1.0.0",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",

--- a/packages/components/molecules/f-alert/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-alert/src/assets/scss/common.scss
@@ -1,1 +1,1 @@
-@import  '@justeat/fozzie/src/scss/fozzie';
+// Add styles here so it can be injected first via vue.config.js.

--- a/packages/components/molecules/f-alert/src/components/Alert.vue
+++ b/packages/components/molecules/f-alert/src/components/Alert.vue
@@ -112,12 +112,14 @@ export default {
 </script>
 
 <style lang="scss" module>
-$alert-borderRadius: $radius-rounded-c;
+@use  '@justeat/fozzie/src/scss/fozzie' as f;
+
+$alert-borderRadius: f.$radius-rounded-c;
 
 .c-alert {
     position: relative;
-    padding: spacing(d);
-    margin-top: spacing(d);
+    padding: f.spacing(d);
+    margin-top: f.spacing(d);
     border: 0;
     border-radius: $alert-borderRadius;
 }
@@ -128,44 +130,44 @@ $alert-borderRadius: $radius-rounded-c;
 }
 
 .c-alert--success {
-    @include alert-variant($color-support-positive-02, $color-content-default);
+    @include f.alert-variant(f.$color-support-positive-02, f.$color-content-default);
     path {
-        fill: $color-support-positive;
+        fill: f.$color-support-positive;
     }
 }
 
 .c-alert--warning {
-    @include alert-variant($color-support-warning-02, $color-content-default);
+    @include f.alert-variant(f.$color-support-warning-02, f.$color-content-default);
     path {
-        fill: $color-support-warning;
+        fill: f.$color-support-warning;
     }
 }
 
 .c-alert--danger {
-    @include alert-variant($color-support-error-02, $color-content-default);
+    @include f.alert-variant(f.$color-support-error-02, f.$color-content-default);
     path {
-        fill: $color-support-error;
+        fill: f.$color-support-error;
     }
 }
 
 .c-alert--info {
-    @include alert-variant($color-support-info-02, $color-content-default);
+    @include f.alert-variant(f.$color-support-info-02, f.$color-content-default);
     path {
-        fill: $color-support-info;
+        fill: f.$color-support-info;
     }
 }
 
 .c-alert-heading {
-    @include font-size(subheading-s);
+    @include f.font-size(subheading-s);
     vertical-align: middle;
     margin-top: 0;
-    margin-left: spacing(d);
-    margin-bottom: spacing(a);
+    margin-left: f.spacing(d);
+    margin-bottom: f.spacing(a);
 }
 
 .c-alert-content {
-    @include font-size(body-l);
-    margin-left: spacing(g);
+    @include f.font-size(body-l);
+    margin-left: f.spacing(g);
 }
 
 .c-alert-icon {
@@ -175,7 +177,7 @@ $alert-borderRadius: $radius-rounded-c;
 
 .c-alert-dismiss {
     margin-left: auto;
-    z-index: zIndex(high);
+    z-index: f.zIndex(high);
 
     &:hover {
         cursor: pointer;
@@ -186,7 +188,7 @@ $alert-borderRadius: $radius-rounded-c;
     width: 20px !important;
     height: 20px !important;
     path {
-        fill: $color-content-subdued;
+        fill: f.$color-content-subdued;
     }
 }
 </style>

--- a/packages/components/molecules/f-alert/vue.config.js
+++ b/packages/components/molecules/f-alert/vue.config.js
@@ -16,7 +16,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@import "../assets/scss/common.scss";`
+                additionalData: `@use "../assets/scss/common.scss" as *;`
             });
     },
     pluginOptions: {

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+
+v0.52.7
+------------------------------
+*June 17, 2022*
+### Changed
+- updated vue.config to include f-alert in components using @use and @forward
+
+
 v0.52.6
 ------------------------------
 *June 17, 2022*

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private":true,
-  "version": "0.52.6",
+  "version": "0.52.7",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -41,7 +41,7 @@ module.exports = {
                     // add component names 1 by 1 to this array as they're updated
                     // to the new Sass syntax OR the entire component folder if all completed
                     // i.e. // [ 'atoms', 'molecules', 'f-checkout' ]
-                    const updateComponentsAndTypes = ['atoms'];
+                    const updateComponentsAndTypes = ['atoms', 'f-alert'];
                     const pathContainsUpdatedComponentOrType = updateComponentsAndTypes.some(a => absPath.includes(a));
 
                     if (!pathContainsUpdatedComponentOrType) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2742,13 +2742,6 @@
   dependencies:
     "@justeat/f-services" "1.7.0"
 
-"@justeat/f-wdio-utils@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.6.0.tgz#0d5ea0ca9cc5b6bc9cd74b350e74cc62379d88f0"
-  integrity sha512-/yI/Nq3IZ8X0k+V0RBB4dNWFPOomSIt67FxBqgvI1Ig0HKd9tqTCxzTaDiKP3Bu9GlxLDHhdpS9HLNawTLsLgQ==
-  dependencies:
-    "@justeat/f-services" "1.7.0"
-
 "@justeat/f-wdio-utils@0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.8.1.tgz#2c9715657176e85ed1388d6bc3ea9256c776d504"
@@ -2776,6 +2769,14 @@
   version "9.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-9.0.0-beta.2.tgz#678404404597eac15b9b45362febae090af5fcaf"
   integrity sha512-DuiVeJ0EEmVB7YkxrhFGyjxEMVzBI1f+sp2RQlVVM/F7wbTuF4enFBZzN6WtF0PDQB8BxA1g9s/uJS7uCI2l+Q==
+  dependencies:
+    "@justeat/pie-design-tokens" "1.4.0"
+    include-media eduardoboucas/include-media#2.0-release
+
+"@justeat/fozzie@9.0.0-beta.3":
+  version "9.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-9.0.0-beta.3.tgz#e97815d3f1fff757b783fc216ad594876b652c1e"
+  integrity sha512-Yqp7ODkSieLbie91zJpemOxwKN8xRraIttXUPS3djp6mkoQDOT7UhF+rz0JaMiJMD0hJLUHqezKsjwPU+A1VJg==
   dependencies:
     "@justeat/pie-design-tokens" "1.4.0"
     include-media eduardoboucas/include-media#2.0-release
@@ -14992,7 +14993,7 @@ include-media@1.4.9:
   resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.9.tgz#d0020b7be3eb2d54868a20943595ce380e0bc43b"
   integrity sha512-IUOcvWDCt6R5V0ktsGk6RbehkW9ks1dODN2ed1p+mhML82TteAl+/ElXy8AJ7ueIuVoKq2NioRVdW9FuwQNOew==
 
-include-media@eduardoboucas/include-media#2.0-release:
+include-media@eduardoboucas/include-media#2.0-release, "include-media@github:eduardoboucas/include-media#2.0-release":
   version "2.0.0"
   resolved "https://codeload.github.com/eduardoboucas/include-media/tar.gz/5398b556d4bb24186d360c950b19026f577ff8e5"
 


### PR DESCRIPTION
f-alert - v5.0.0
------------------------------
*Jun 17, 2022*

### Changed
- Update to `@use` and `@forward` SASS syntax


Storybook - v0.52.7
------------------------------
*June 17, 2022*
### Changed
- updated vue.config to include f-alert in components using @use and @forward