### PR TITLE
f-breadcrumbs@v4.0.0 - use new sass syntax

### DIFF
--- a/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
+++ b/packages/components/molecules/f-breadcrumbs/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.0.0
+-----------------------------
+*June 20, 2022*
+
+### Changed
+- Update to `@use` and `@forward` SASS syntax
+
+
 v3.2.2
 ------------------------------
 *Jun 9, 2022*

--- a/packages/components/molecules/f-breadcrumbs/package.json
+++ b/packages/components/molecules/f-breadcrumbs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-breadcrumbs",
   "description": "Fozzie Bread Crumbs – Provides clickable paths back to previous pages",
-  "version": "3.2.2",
+  "version": "4.0.0",
   "main": "dist/f-breadcrumbs.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [
@@ -62,6 +62,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/f-wdio-utils": "0.11.0"
+    "@justeat/f-wdio-utils": "0.11.0",
+    "@justeat/fozzie": "9.0.0-beta.3"
   }
 }

--- a/packages/components/molecules/f-breadcrumbs/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-breadcrumbs/src/assets/scss/common.scss
@@ -1,1 +1,1 @@
-@import '@justeat/fozzie/src/scss/fozzie';
+// Add styles here so it can be injected first via vue.config.js.

--- a/packages/components/molecules/f-breadcrumbs/src/components/BreadCrumbs.vue
+++ b/packages/components/molecules/f-breadcrumbs/src/components/BreadCrumbs.vue
@@ -73,12 +73,14 @@ export default {
 </script>
 
 <style lang="scss" module>
-$breadcrumbs-text-colour-noBackground: $color-content-default;
-$breadcrumbs-text-colour-hasBackground: $color-content-light;
-$breadcrumbs-background-colour: rgba($color-black, 0.6);
-$breadcrumbs-border-radius: $radius-rounded-e;
-$breadcrumbs-not-active-font-weight: $font-weight-bold;
-$breadcrumbs-active-font-weight: $font-weight-regular;
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
+$breadcrumbs-text-colour-noBackground: f.$color-content-default;
+$breadcrumbs-text-colour-hasBackground: f.$color-content-light;
+$breadcrumbs-background-colour: rgba(f.$color-black, 0.6);
+$breadcrumbs-border-radius: f.$radius-rounded-e;
+$breadcrumbs-not-active-font-weight: f.$font-weight-bold;
+$breadcrumbs-active-font-weight: f.$font-weight-regular;
 
 .c-breadcrumbs {
     display: flex;
@@ -95,20 +97,20 @@ $breadcrumbs-active-font-weight: $font-weight-regular;
 .c-breadcrumbs-list--hasBackground {
     background-color: $breadcrumbs-background-colour;
     border-radius: $breadcrumbs-border-radius;
-    padding: 0 spacing();
+    padding: 0 f.spacing();
 }
 
 .c-breadcrumbs-item {
-    padding: spacing(a) spacing();
+    padding: f.spacing(a) f.spacing();
 
-    @include media('<narrowMid') {
-        padding: spacing(a) spacing(d) spacing(a) spacing();
+    @include f.media('<narrowMid') {
+        padding: f.spacing(a) f.spacing(d) f.spacing(a) f.spacing();
     }
 }
 
 .c-breadcrumbs-item,
 .c-breadcrumbs-separator {
-    @include media('<narrowMid') {
+    @include f.media('<narrowMid') {
         display: none;
 
         &:nth-last-child(-n+4):not(:nth-last-child(-n+2)) {
@@ -164,8 +166,8 @@ $breadcrumbs-active-font-weight: $font-weight-regular;
         color: $breadcrumbs-text-colour-hasBackground;
     }
 
-    @include media('<narrowMid') {
-        margin-left: spacing(c);
+    @include f.media('<narrowMid') {
+        margin-left: f.spacing(c);
         transform: scale(0.6, 1.2) rotate(180deg);
         margin-top: 2px;
     }

--- a/packages/components/molecules/f-breadcrumbs/vue.config.js
+++ b/packages/components/molecules/f-breadcrumbs/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@import "../assets/scss/common.scss";`
+                additionalData: `@use "../assets/scss/common.scss" as *;`
             });
     },
     pluginOptions: {

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
+
+v0.52.8
+------------------------------
+*June 20, 2022*
+### Changed
+- updated vue.config to include f-breadcrumbs in components using @use and @forward
+
+
 v0.52.7
 ------------------------------
 *June 17, 2022*

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private":true,
-  "version": "0.52.7",
+  "version": "0.52.8",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -41,7 +41,7 @@ module.exports = {
                     // add component names 1 by 1 to this array as they're updated
                     // to the new Sass syntax OR the entire component folder if all completed
                     // i.e. // [ 'atoms', 'molecules', 'f-checkout' ]
-                    const updateComponentsAndTypes = ['atoms', 'f-alert'];
+                    const updateComponentsAndTypes = ['atoms', 'f-alert', 'f-breadcrumbs'];
                     const pathContainsUpdatedComponentOrType = updateComponentsAndTypes.some(a => absPath.includes(a));
 
                     if (!pathContainsUpdatedComponentOrType) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14993,7 +14993,7 @@ include-media@1.4.9:
   resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.9.tgz#d0020b7be3eb2d54868a20943595ce380e0bc43b"
   integrity sha512-IUOcvWDCt6R5V0ktsGk6RbehkW9ks1dODN2ed1p+mhML82TteAl+/ElXy8AJ7ueIuVoKq2NioRVdW9FuwQNOew==
 
-include-media@eduardoboucas/include-media#2.0-release, "include-media@github:eduardoboucas/include-media#2.0-release":
+include-media@eduardoboucas/include-media#2.0-release:
   version "2.0.0"
   resolved "https://codeload.github.com/eduardoboucas/include-media/tar.gz/5398b556d4bb24186d360c950b19026f577ff8e5"
 


### PR DESCRIPTION
f-breadcrumbs - v4.0.0
-----------------------------
*June 20, 2022*

### Changed
- Update to `@use` and `@forward` SASS syntax


Storybook - v0.52.8
------------------------------
*June 20, 2022*
### Changed
- updated vue.config to include f-breadcrumbs in components using @use and @forward
