### PR TITLE
f-card-with-content@v2.0.0 - use newer sass syntax

### DIFF
--- a/packages/components/molecules/f-card-with-content/CHANGELOG.md
+++ b/packages/components/molecules/f-card-with-content/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0
+-----------------------------
+*June 20, 2022*
+
+### Changed
+- Update to `@use` and `@forward` SASS syntax
+
+
 v1.1.1
 ------------------------------
 *Jun 9, 2022*

--- a/packages/components/molecules/f-card-with-content/package.json
+++ b/packages/components/molecules/f-card-with-content/package.json
@@ -54,8 +54,8 @@
     "@justeat/f-card": "3.x"
   },
   "devDependencies": {
-    "@justeat/f-button": "3.3.0",
-    "@justeat/f-card": "3.6.0",
+    "@justeat/f-button": "4.0.0",
+    "@justeat/f-card": "4.0.0",
     "@justeat/f-vue-icons": "3.0.0",
     "@justeat/f-wdio-utils": "0.11.0",
     "@justeat/fozzie": "9.0.0-beta.3",

--- a/packages/components/molecules/f-card-with-content/package.json
+++ b/packages/components/molecules/f-card-with-content/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card-with-content",
   "description": "Fozzie Card With Content - A page content card which can contain an image, heading, text, and (primary and secondary) buttons",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "main": "dist/f-card-with-content.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [
@@ -58,6 +58,7 @@
     "@justeat/f-card": "3.6.0",
     "@justeat/f-vue-icons": "3.0.0",
     "@justeat/f-wdio-utils": "0.11.0",
+    "@justeat/fozzie": "9.0.0-beta.3",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3"

--- a/packages/components/molecules/f-card-with-content/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-card-with-content/src/assets/scss/common.scss
@@ -1,1 +1,1 @@
-@import '@justeat/fozzie/src/scss/fozzie';
+// Add styles here so it can be injected first via vue.config.js.

--- a/packages/components/molecules/f-card-with-content/src/components/CardWithContent.vue
+++ b/packages/components/molecules/f-card-with-content/src/components/CardWithContent.vue
@@ -85,6 +85,8 @@ export default {
 </script>
 
 <style lang="scss" module>
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
 .c-cardWithContent {
     display: flex;
     flex-direction: column;
@@ -94,25 +96,25 @@ export default {
 
 .c-cardWithContent-heading {
     margin-bottom: 0;
-    @include font-size('heading-l', true, 'narrow');
+    @include f.font-size('heading-l', true, 'narrow');
 
-    @include media('>=wide') {
-        @include font-size('heading-l', true, 'default');
+    @include f.media('>=wide') {
+        @include f.font-size('heading-l', true, 'default');
     }
 }
 
 .c-cardWithContent-description {
-    @include font-size('body-l');
-    margin-top: spacing();
+    @include f.font-size('body-l');
+    margin-top: f.spacing();
 }
 
 .c-cardWithContent-button {
-    margin: spacing(f) 0 spacing(a);
+    margin: f.spacing(f) 0 f.spacing(a);
 }
 
 .c-cardWithContent-icon {
     margin: auto;
-    margin-bottom: spacing(f);
+    margin-bottom: f.spacing(f);
     width: 200px;
 }
 </style>

--- a/packages/components/molecules/f-card-with-content/vue.config.js
+++ b/packages/components/molecules/f-card-with-content/vue.config.js
@@ -16,7 +16,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@import "../assets/scss/common.scss";`
+                additionalData: `@use "../assets/scss/common.scss" as *;`
             });
     },
     pluginOptions: {

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
+v0.52.9
+------------------------------
+*June 20, 2022*
+### Changed
+- updated vue.config to include f-card-with-content in components using @use and @forward
+
 
 v0.52.8
 ------------------------------

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private":true,
-  "version": "0.52.8",
+  "version": "0.52.9",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -41,7 +41,7 @@ module.exports = {
                     // add component names 1 by 1 to this array as they're updated
                     // to the new Sass syntax OR the entire component folder if all completed
                     // i.e. // [ 'atoms', 'molecules', 'f-checkout' ]
-                    const updateComponentsAndTypes = ['atoms', 'f-alert', 'f-breadcrumbs'];
+                    const updateComponentsAndTypes = ['atoms', 'f-alert', 'f-breadcrumbs', 'f-card-with-content'];
                     const pathContainsUpdatedComponentOrType = updateComponentsAndTypes.some(a => absPath.includes(a));
 
                     if (!pathContainsUpdatedComponentOrType) {


### PR DESCRIPTION
f-card-with-content: v2.0.0
-----------------------------
*June 20, 2022*

### Changed
- Update to `@use` and `@forward` SASS syntax

Local:
<img width="532" alt="Screenshot 2022-06-20 at 12 03 17" src="https://user-images.githubusercontent.com/16766185/174588151-3fb7b073-05ef-4995-b4f8-da7264a4f2f1.png">

Prod:
<img width="571" alt="Screenshot 2022-06-20 at 12 03 42" src="https://user-images.githubusercontent.com/16766185/174588185-b70a71a2-2e9f-48b2-8595-16f5cebb538e.png">



Storybook: v0.52.9
------------------------------
*June 20, 2022*
### Changed
- updated vue.config to include f-card-with-content in components using @use and @forward