### PR TITLE
f-media-element@v3.0.0 - update to newer sass syntax

### DIFF
--- a/packages/components/molecules/f-media-element/CHANGELOG.md
+++ b/packages/components/molecules/f-media-element/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+
+v3.0.0
+-----------------------------
+*June 20, 2022*
+
+### Changed
+- Update to `@use` and `@forward` SASS syntax
+
+
 v2.0.1
 ------------------------------
 *Jun 9, 2022*

--- a/packages/components/molecules/f-media-element/package.json
+++ b/packages/components/molecules/f-media-element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-media-element",
   "description": "Fozzie Media Element - provides ability to display text and an image in different orientations",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "main": "dist/f-media-element.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [
@@ -56,6 +56,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/f-wdio-utils": "0.11.0"
+    "@justeat/f-wdio-utils": "0.11.0",
+    "@justeat/fozzie": "9.0.0-beta.3"
   }
 }

--- a/packages/components/molecules/f-media-element/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-media-element/src/assets/scss/common.scss
@@ -1,1 +1,1 @@
-@import '@justeat/fozzie/src/scss/fozzie';
+// Add styles here so it can be injected first via vue.config.js.

--- a/packages/components/molecules/f-media-element/src/components/MediaElement.vue
+++ b/packages/components/molecules/f-media-element/src/components/MediaElement.vue
@@ -129,6 +129,8 @@ export default {
 </script>
 
 <style lang="scss" module>
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
 $font-sizes: (
     sm: (
         title: heading-s,
@@ -152,7 +154,7 @@ $font-sizes: (
     )
 );
 
-$mediaElement-content-margin: spacing(e);
+$mediaElement-content-margin: f.spacing(e);
 
 .c-mediaElement {
     display: flex;
@@ -181,7 +183,7 @@ $mediaElement-content-margin: spacing(e);
 }
 
 
-@each $name, $value in $breakpoints {
+@each $name, $value in f.$breakpoints {
 
     /**
     * Modifier – .c-mediaElement--gte--$name--col
@@ -191,7 +193,7 @@ $mediaElement-content-margin: spacing(e);
      *
      * Applies flex direction column on $name
      */
-    @include media('>='+$name) {
+    @include f.media('>='+$name) {
         .c-mediaElement--gte--#{$name}--col {
             flex-direction: column;
 
@@ -222,7 +224,7 @@ $mediaElement-content-margin: spacing(e);
     *
     * Applies flex direction column on $name
     */
-    @include media('>'+$name) {
+    @include f.media('>'+$name) {
         .c-mediaElement--gt--#{$name}--col {
             flex-direction: column;
 
@@ -253,7 +255,7 @@ $mediaElement-content-margin: spacing(e);
     *
     * Applies flex direction column on $name
     */
-    @include media('<='+$name) {
+    @include f.media('<='+$name) {
         .c-mediaElement--lte--#{$name}--col {
             flex-direction: column;
 
@@ -284,7 +286,7 @@ $mediaElement-content-margin: spacing(e);
     *
     * Applies flex direction column on $name
     */
-    @include media('<'+$name) {
+    @include f.media('<'+$name) {
         .c-mediaElement--lt--#{$name}--col {
             flex-direction: column;
 
@@ -383,15 +385,15 @@ $mediaElement-content-margin: spacing(e);
 @each $size, $value in $font-sizes {
     .c-mediaElement-contentFontSize--#{$size} {
         & .c-mediaElement-title {
-            @include font-size(map-get($value, 'title'));
+            @include f.font-size(map-get($value, 'title'));
         }
         & .c-mediaElement-text {
-            @include font-size(map-get($value, 'text'));
+            @include f.font-size(map-get($value, 'text'));
             @if $size == sm {
-                margin-top: spacing(a);
+                margin-top: f.spacing(a);
             }
             @else if $size == md {
-                margin-top: spacing();
+                margin-top: f.spacing();
             }
         }
     }

--- a/packages/components/molecules/f-media-element/vue.config.js
+++ b/packages/components/molecules/f-media-element/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@import "../assets/scss/common.scss";`
+                additionalData: `@use "../assets/scss/common.scss" as *;`
             });
     },
     pluginOptions: {

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.52.10
+------------------------------
+*June 20, 2022*
+### Changed
+- updated vue.config to include f-media-element in components using @use and @forward
+
 
 v0.52.9
 ------------------------------

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private":true,
-  "version": "0.52.9",
+  "version": "0.52.10",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -41,7 +41,7 @@ module.exports = {
                     // add component names 1 by 1 to this array as they're updated
                     // to the new Sass syntax OR the entire component folder if all completed
                     // i.e. // [ 'atoms', 'molecules', 'f-checkout' ]
-                    const updateComponentsAndTypes = ['atoms', 'f-alert', 'f-breadcrumbs', 'f-card-with-content'];
+                    const updateComponentsAndTypes = ['atoms', 'f-alert', 'f-breadcrumbs', 'f-card-with-content', 'f-media-element'];
                     const pathContainsUpdatedComponentOrType = updateComponentsAndTypes.some(a => absPath.includes(a));
 
                     if (!pathContainsUpdatedComponentOrType) {


### PR DESCRIPTION
f-media-element: v3.0.0
-----------------------------
*June 20, 2022*

### Changed
- Update to `@use` and `@forward` SASS syntax


Storybook: v0.52.10
------------------------------
*June 20, 2022*
### Changed
- updated vue.config to include f-media-element in components using @use and @forward