### PR TITLE
f-alert@v5.0.1 - Read alert messages to accessible users

### DIFF
--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -3,12 +3,20 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v4.4.2
+v5.5.1
 ------------------------------
 *Jun 20, 2022*
 
 ### Fixed
 - Alert messages are now read out to accessible users when displayed
+
+
+v5.0.0
+------------------------------
+*Jun 17, 2022*
+
+### Changed
+- Update to `@use` and `@forward` SASS syntax
 
 
 v4.4.1

--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.4.2
+------------------------------
+*Jun 20, 2022*
+
+### Fixed
+- Alert messages are now read out to accessible users when displayed
+
 
 v4.4.1
 ------------------------------

--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -19,15 +19,6 @@ v5.0.0
 - Update to `@use` and `@forward` SASS syntax
 
 
-
-v5.0.0
-------------------------------
-*Jun 17, 2022*
-
-### Changed
-- Update to `@use` and `@forward` SASS syntax
-
-
 v4.4.1
 ------------------------------
 *Jun 9, 2022*

--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v5.5.1
+v5.0.1
 ------------------------------
 *Jun 20, 2022*
 

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-alert",
   "description": "Fozzie Alert – Fozzie Alert Component",
-  "version": "4.4.2",
+  "version": "5.0.1",
   "main": "dist/f-alert.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-alert",
   "description": "Fozzie Alert – Fozzie Alert Component",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "main": "dist/f-alert.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/molecules/f-alert/src/components/Alert.vue
+++ b/packages/components/molecules/f-alert/src/components/Alert.vue
@@ -4,7 +4,8 @@
         :class="[$style['c-alert'],
                  $style[`c-alert--${type}`]]"
         data-test-id="alert-component"
-        role="alert">
+        role="alert"
+        :aria-live="areaLiveAttribute">
         <div
             :class="$style['c-alert-headingContainer']">
             <component
@@ -101,6 +102,12 @@ export default {
     computed: {
         icon () {
             return `${this.type}Icon`;
+        },
+
+        areaLiveAttribute () {
+            return this.type === 'success' || this.type === 'danger'
+                ? 'polite'
+                : 'off';
         }
     },
     methods: {

--- a/packages/components/molecules/f-alert/src/components/Alert.vue
+++ b/packages/components/molecules/f-alert/src/components/Alert.vue
@@ -5,7 +5,7 @@
                  $style[`c-alert--${type}`]]"
         data-test-id="alert-component"
         role="alert"
-        :aria-live="areaLiveAttribute">
+        :aria-live="ariaLiveAttribute">
         <div
             :class="$style['c-alert-headingContainer']">
             <component
@@ -104,7 +104,7 @@ export default {
             return `${this.type}Icon`;
         },
 
-        areaLiveAttribute () {
+        ariaLiveAttribute () {
             return this.type === 'success' || this.type === 'danger'
                 ? 'polite'
                 : 'off';

--- a/packages/components/molecules/f-alert/src/components/_tests/Alert.test.js
+++ b/packages/components/molecules/f-alert/src/components/_tests/Alert.test.js
@@ -1,7 +1,12 @@
-import { shallowMount } from '@vue/test-utils';
+import {
+    shallowMount
+} from '@vue/test-utils';
 import FAlert from '../Alert.vue';
 
-const defaultPropsData = { heading: 'Alert title', type: 'info' };
+const defaultPropsData = {
+    heading: 'Alert title',
+    type: 'info'
+};
 
 describe('Alert', () => {
     afterEach(() => {
@@ -10,7 +15,9 @@ describe('Alert', () => {
 
     it('should be defined', () => {
         // Arrange & Act
-        const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
+        const wrapper = shallowMount(FAlert, {
+            propsData: defaultPropsData
+        });
 
         // Assert
         expect(wrapper.exists()).toBe(true);
@@ -18,7 +25,9 @@ describe('Alert', () => {
 
     it('should have the alert role for accessibility purposes', () => {
         // Arrange
-        const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
+        const wrapper = shallowMount(FAlert, {
+            propsData: defaultPropsData
+        });
 
         // Act
         const alert = wrapper.find('[data-test-id="alert-component"]');
@@ -30,7 +39,12 @@ describe('Alert', () => {
     describe('icon', () => {
         it.each(['danger', 'success', 'info', 'warning'])('should show the %s icon for type %s', type => {
             // Arrange
-            const wrapper = shallowMount(FAlert, { propsData: { heading: 'Alert title', type } });
+            const wrapper = shallowMount(FAlert, {
+                propsData: {
+                    heading: 'Alert title',
+                    type
+                }
+            });
 
             // Act
             const icon = wrapper.find('[data-test-id="alert-icon"]');
@@ -43,7 +57,9 @@ describe('Alert', () => {
     describe('heading', () => {
         it('should render the heading passed into the alert', () => {
             // Arrange
-            const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
+            const wrapper = shallowMount(FAlert, {
+                propsData: defaultPropsData
+            });
 
             // Act
             const heading = wrapper.find('[data-test-id="alert-heading"]');
@@ -56,7 +72,12 @@ describe('Alert', () => {
     describe('dismiss', () => {
         it('should render the dismiss button if `isDismissible` is true', () => {
             // Arrange
-            const wrapper = shallowMount(FAlert, { propsData: { ...defaultPropsData, isDismissible: true } });
+            const wrapper = shallowMount(FAlert, {
+                propsData: {
+                    ...defaultPropsData,
+                    isDismissible: true
+                }
+            });
 
             // Act
             const dismiss = wrapper.find('[data-test-id="alert-dismiss"]');
@@ -67,7 +88,12 @@ describe('Alert', () => {
 
         it('should not render the dismiss button if `isDismissible` is false', () => {
             // Arrange
-            const wrapper = shallowMount(FAlert, { propsData: { ...defaultPropsData, isDismissible: false } });
+            const wrapper = shallowMount(FAlert, {
+                propsData: {
+                    ...defaultPropsData,
+                    isDismissible: false
+                }
+            });
 
             // Act
             const dismiss = wrapper.find('[data-test-id="alert-dismiss"]');
@@ -81,7 +107,10 @@ describe('Alert', () => {
             const dismissSpy = jest.spyOn(FAlert.methods, 'dismiss');
 
             const wrapper = shallowMount(FAlert, {
-                propsData: { ...defaultPropsData, isDismissible: true }
+                propsData: {
+                    ...defaultPropsData,
+                    isDismissible: true
+                }
             });
 
             // Act
@@ -96,10 +125,14 @@ describe('Alert', () => {
         describe('type', () => {
             it('should be required', () => {
                 // Arrange
-                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
+                const wrapper = shallowMount(FAlert, {
+                    propsData: defaultPropsData
+                });
 
                 // Act
-                const { type } = wrapper.vm.$options.props;
+                const {
+                    type
+                } = wrapper.vm.$options.props;
 
                 // Assert
                 expect(type.required).toBe(true);
@@ -107,10 +140,14 @@ describe('Alert', () => {
 
             it('should only allow `danger`, `success`, `info` or `warning` to be passed in.', () => {
                 // Arrange
-                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
+                const wrapper = shallowMount(FAlert, {
+                    propsData: defaultPropsData
+                });
 
                 // Act
-                const { type } = wrapper.vm.$options.props;
+                const {
+                    type
+                } = wrapper.vm.$options.props;
 
                 // Assert
                 expect(type.validator('invalid')).toBeFalsy();
@@ -124,10 +161,14 @@ describe('Alert', () => {
         describe('heading', () => {
             it('should be required', () => {
                 // Arrange
-                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
+                const wrapper = shallowMount(FAlert, {
+                    propsData: defaultPropsData
+                });
 
                 // Act
-                const { heading } = wrapper.vm.$options.props;
+                const {
+                    heading
+                } = wrapper.vm.$options.props;
 
                 // Assert
                 expect(heading.required).toBe(true);
@@ -139,7 +180,9 @@ describe('Alert', () => {
         describe('dismiss', () => {
             it('should set `isDismissed` to `true`', () => {
                 // Arrange
-                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
+                const wrapper = shallowMount(FAlert, {
+                    propsData: defaultPropsData
+                });
 
                 // Act
                 wrapper.vm.dismiss();
@@ -154,13 +197,51 @@ describe('Alert', () => {
         describe('icon', () => {
             it('should return the type with `Icon` camelCased', () => {
                 // Arrange
-                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
+                const wrapper = shallowMount(FAlert, {
+                    propsData: defaultPropsData
+                });
 
                 // Act
                 const result = wrapper.vm.icon;
 
                 // Assert
                 expect(result).toBe('infoIcon');
+            });
+        });
+
+        describe('areaLiveAttribute', () => {
+            it.each(['success', 'danger'])('should return "polite" when alert type is %p', type => {
+                // Arrange
+                const props = {
+                    heading: 'Alert title',
+                    type
+                };
+                const wrapper = shallowMount(FAlert, {
+                    propsData: props
+                });
+
+                // Act
+                const result = wrapper.vm.areaLiveAttribute;
+
+                // Assert
+                expect(result).toBe('polite');
+            });
+
+            it.each(['warning', 'info'])('should return "off" when alert type is %p', type => {
+                // Arrange
+                const props = {
+                    heading: 'Alert title',
+                    type
+                };
+                const wrapper = shallowMount(FAlert, {
+                    propsData: props
+                });
+
+                // Act
+                const result = wrapper.vm.areaLiveAttribute;
+
+                // Assert
+                expect(result).toBe('off');
             });
         });
     });

--- a/packages/components/molecules/f-alert/src/components/_tests/Alert.test.js
+++ b/packages/components/molecules/f-alert/src/components/_tests/Alert.test.js
@@ -1,12 +1,7 @@
-import {
-    shallowMount
-} from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import FAlert from '../Alert.vue';
 
-const defaultPropsData = {
-    heading: 'Alert title',
-    type: 'info'
-};
+const defaultPropsData = { heading: 'Alert title', type: 'info' };
 
 describe('Alert', () => {
     afterEach(() => {
@@ -15,9 +10,7 @@ describe('Alert', () => {
 
     it('should be defined', () => {
         // Arrange & Act
-        const wrapper = shallowMount(FAlert, {
-            propsData: defaultPropsData
-        });
+        const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
         // Assert
         expect(wrapper.exists()).toBe(true);
@@ -25,9 +18,7 @@ describe('Alert', () => {
 
     it('should have the alert role for accessibility purposes', () => {
         // Arrange
-        const wrapper = shallowMount(FAlert, {
-            propsData: defaultPropsData
-        });
+        const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
         // Act
         const alert = wrapper.find('[data-test-id="alert-component"]');
@@ -39,12 +30,7 @@ describe('Alert', () => {
     describe('icon', () => {
         it.each(['danger', 'success', 'info', 'warning'])('should show the %s icon for type %s', type => {
             // Arrange
-            const wrapper = shallowMount(FAlert, {
-                propsData: {
-                    heading: 'Alert title',
-                    type
-                }
-            });
+            const wrapper = shallowMount(FAlert, { propsData: { heading: 'Alert title', type } });
 
             // Act
             const icon = wrapper.find('[data-test-id="alert-icon"]');
@@ -57,9 +43,7 @@ describe('Alert', () => {
     describe('heading', () => {
         it('should render the heading passed into the alert', () => {
             // Arrange
-            const wrapper = shallowMount(FAlert, {
-                propsData: defaultPropsData
-            });
+            const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
             // Act
             const heading = wrapper.find('[data-test-id="alert-heading"]');
@@ -72,12 +56,7 @@ describe('Alert', () => {
     describe('dismiss', () => {
         it('should render the dismiss button if `isDismissible` is true', () => {
             // Arrange
-            const wrapper = shallowMount(FAlert, {
-                propsData: {
-                    ...defaultPropsData,
-                    isDismissible: true
-                }
-            });
+            const wrapper = shallowMount(FAlert, { propsData: { ...defaultPropsData, isDismissible: true } });
 
             // Act
             const dismiss = wrapper.find('[data-test-id="alert-dismiss"]');
@@ -88,12 +67,7 @@ describe('Alert', () => {
 
         it('should not render the dismiss button if `isDismissible` is false', () => {
             // Arrange
-            const wrapper = shallowMount(FAlert, {
-                propsData: {
-                    ...defaultPropsData,
-                    isDismissible: false
-                }
-            });
+            const wrapper = shallowMount(FAlert, { propsData: { ...defaultPropsData, isDismissible: false } });
 
             // Act
             const dismiss = wrapper.find('[data-test-id="alert-dismiss"]');
@@ -107,10 +81,7 @@ describe('Alert', () => {
             const dismissSpy = jest.spyOn(FAlert.methods, 'dismiss');
 
             const wrapper = shallowMount(FAlert, {
-                propsData: {
-                    ...defaultPropsData,
-                    isDismissible: true
-                }
+                propsData: { ...defaultPropsData, isDismissible: true }
             });
 
             // Act
@@ -125,14 +96,10 @@ describe('Alert', () => {
         describe('type', () => {
             it('should be required', () => {
                 // Arrange
-                const wrapper = shallowMount(FAlert, {
-                    propsData: defaultPropsData
-                });
+                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
                 // Act
-                const {
-                    type
-                } = wrapper.vm.$options.props;
+                const { type } = wrapper.vm.$options.props;
 
                 // Assert
                 expect(type.required).toBe(true);
@@ -140,14 +107,10 @@ describe('Alert', () => {
 
             it('should only allow `danger`, `success`, `info` or `warning` to be passed in.', () => {
                 // Arrange
-                const wrapper = shallowMount(FAlert, {
-                    propsData: defaultPropsData
-                });
+                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
                 // Act
-                const {
-                    type
-                } = wrapper.vm.$options.props;
+                const { type } = wrapper.vm.$options.props;
 
                 // Assert
                 expect(type.validator('invalid')).toBeFalsy();
@@ -161,14 +124,10 @@ describe('Alert', () => {
         describe('heading', () => {
             it('should be required', () => {
                 // Arrange
-                const wrapper = shallowMount(FAlert, {
-                    propsData: defaultPropsData
-                });
+                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
                 // Act
-                const {
-                    heading
-                } = wrapper.vm.$options.props;
+                const { heading } = wrapper.vm.$options.props;
 
                 // Assert
                 expect(heading.required).toBe(true);
@@ -180,9 +139,7 @@ describe('Alert', () => {
         describe('dismiss', () => {
             it('should set `isDismissed` to `true`', () => {
                 // Arrange
-                const wrapper = shallowMount(FAlert, {
-                    propsData: defaultPropsData
-                });
+                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
                 // Act
                 wrapper.vm.dismiss();
@@ -197,9 +154,7 @@ describe('Alert', () => {
         describe('icon', () => {
             it('should return the type with `Icon` camelCased', () => {
                 // Arrange
-                const wrapper = shallowMount(FAlert, {
-                    propsData: defaultPropsData
-                });
+                const wrapper = shallowMount(FAlert, { propsData: defaultPropsData });
 
                 // Act
                 const result = wrapper.vm.icon;
@@ -208,41 +163,43 @@ describe('Alert', () => {
                 expect(result).toBe('infoIcon');
             });
         });
+    });
 
-        describe('areaLiveAttribute', () => {
-            it.each(['success', 'danger'])('should return "polite" when alert type is %p', type => {
-                // Arrange
-                const props = {
-                    heading: 'Alert title',
-                    type
-                };
-                const wrapper = shallowMount(FAlert, {
-                    propsData: props
-                });
+    describe('ariaLiveAttribute', () => {
+        it.each(['success', 'danger'])('should return "polite" when alert type is %p', type => {
+            // Arrange
+            const propsData = {
+                heading: 'Alert title',
+                type
+            };
 
-                // Act
-                const result = wrapper.vm.areaLiveAttribute;
-
-                // Assert
-                expect(result).toBe('polite');
+            const wrapper = shallowMount(FAlert, {
+                propsData
             });
 
-            it.each(['warning', 'info'])('should return "off" when alert type is %p', type => {
-                // Arrange
-                const props = {
-                    heading: 'Alert title',
-                    type
-                };
-                const wrapper = shallowMount(FAlert, {
-                    propsData: props
-                });
+            // Act
+            const result = wrapper.vm.ariaLiveAttribute;
 
-                // Act
-                const result = wrapper.vm.areaLiveAttribute;
+            // Assert
+            expect(result).toBe('polite');
+        });
 
-                // Assert
-                expect(result).toBe('off');
+        it.each(['warning', 'info'])('should return "off" when alert type is %p', type => {
+            // Arrange
+            const propsData = {
+                heading: 'Alert title',
+                type
+            };
+
+            const wrapper = shallowMount(FAlert, {
+                propsData
             });
+
+            // Act
+            const result = wrapper.vm.ariaLiveAttribute;
+
+            // Assert
+            expect(result).toBe('off');
         });
     });
 });

--- a/packages/components/molecules/f-alert/test-utils/component-objects/f-alert.component.js
+++ b/packages/components/molecules/f-alert/test-utils/component-objects/f-alert.component.js
@@ -7,6 +7,12 @@ module.exports = class Alert extends Page {
 
     get exitButton () { return $('[data-test-id="alert-dismiss"]'); }
 
+    get alertComponent () { return $('[data-test-id="alert-component"]'); }
+
+    async hasAriaLiveAttribute () {
+        return this.alertComponent;
+    }
+
     async clickExitButton () {
         await this.exitButton.click();
     }

--- a/packages/components/molecules/f-alert/test-utils/component-objects/f-alert.component.js
+++ b/packages/components/molecules/f-alert/test-utils/component-objects/f-alert.component.js
@@ -9,7 +9,7 @@ module.exports = class Alert extends Page {
 
     get alertComponent () { return $('[data-test-id="alert-component"]'); }
 
-    async hasAriaLiveAttribute () {
+    async alertRootComponent () {
         return this.alertComponent;
     }
 

--- a/packages/components/molecules/f-alert/test/component/f-alert.component.spec.js
+++ b/packages/components/molecules/f-alert/test/component/f-alert.component.spec.js
@@ -22,7 +22,7 @@ describe('f-alert component tests', () => {
 
     it('should include aria-live attribute', async () => {
         // Assert
-        const result = await alert.hasAriaLiveAttribute();
+        const result = await alert.alertRootComponent();
         await expect(result).toHaveAttr('aria-live');
     });
 });

--- a/packages/components/molecules/f-alert/test/component/f-alert.component.spec.js
+++ b/packages/components/molecules/f-alert/test/component/f-alert.component.spec.js
@@ -19,4 +19,10 @@ describe('f-alert component tests', () => {
         // Assert
         await expect(await alert.isComponentDisplayed()).toBe(false);
     });
+
+    it('should include aria-live attribute', async () => {
+        // Assert
+        const result = await alert.hasAriaLiveAttribute();
+        await expect(result).toHaveAttr('aria-live');
+    });
 });


### PR DESCRIPTION
- Alert messages (success and danger) are now read out when displayed on screen.
- This only works if the alert is rendered using `v-show` in the parent component, as `aria-live` needs to be present on DOM load, `v-if` excludes the markup from the DOM