### PR TITLE
f-link@3.1.1 - Move data-test-id back from prop to attribute

### DIFF
--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.1.1
+------------------------------
+*June 21, 2022*
+
+### Changed
+- Moved `data-test-id` back to an attribute to avoid issues when stubbing with vue-test-utils.
+
+
 v3.1.0
 ------------------------------
 *June 17, 2022*

--- a/packages/components/atoms/f-link/README.md
+++ b/packages/components/atoms/f-link/README.md
@@ -78,8 +78,8 @@ The props that can be defined are as follows (if any):
 | `isFullWidth` | `Boolean` | `false` | Link set as full width. |
 | `noLineBreak` | `Boolean` | `false` | Removes white space. |
 | `isDistinct` | `Boolean` | `false` | Changes default link colour (dark grey) to blue. |
-| `dataTestId` | `String` | `"v-link-component"` | Allows you to specify a custom `data-test-id`. |
 | `link-class` | `String` | `n/a` (this is an optional attribute rather than a required prop) |  Allows parent component to add a CSS class to the `<a>` or `<router-link>`  |
+| `data-test-id` | `String` | `"v-link-component"` (this is an optional attribute rather than a required prop) | This allows you to specify a custom `data-test-id` which is applied to the link. |
 
 ## Development
 

--- a/packages/components/atoms/f-link/package.json
+++ b/packages/components/atoms/f-link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-link",
   "description": "Fozzie Link - Fozzie link component",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "dist/f-link.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/components/atoms/f-link/src/components/Link.vue
+++ b/packages/components/atoms/f-link/src/components/Link.vue
@@ -66,11 +66,6 @@ export default {
         isDistinct: {
             type: Boolean,
             default: false
-        },
-
-        dataTestId: {
-            type: String,
-            default: 'v-link-component'
         }
     },
 
@@ -103,6 +98,10 @@ export default {
             }
 
             return null;
+        },
+
+        dataTestId () {
+            return this.$attrs['data-test-id'] || 'v-link-component';
         },
 
         descriptionId () {

--- a/packages/components/atoms/f-link/stories/Link.stories.js
+++ b/packages/components/atoms/f-link/stories/Link.stories.js
@@ -48,7 +48,7 @@ export const VLinkComponent = () => ({
         },
 
         dataTestId: {
-            default: text('dataTestId', 'v-link-component')
+            default: text('data-test-id (via attribute, not a prop)', 'v-link-component')
         }
     },
 
@@ -60,7 +60,6 @@ export const VLinkComponent = () => ({
 
     template: `<v-link
                     link-class="myLinkClass"
-                    :data-test-id="dataTestId"
                     v-bind="{
                         ...(href ? { href } : to ? { to } : {})
                     }"
@@ -70,7 +69,8 @@ export const VLinkComponent = () => ({
                     :no-line-break="noLineBreak"
                     :is-external-site="isExternalSite"
                     :target="target"
-                    :isDistinct="isDistinct">
+                    :isDistinct="isDistinct"
+                    :data-test-id="dataTestId">
                     <span>This is a Link</span>
                 </v-link>`
 });


### PR DESCRIPTION
### Changed
- Moved `data-test-id` back to an attribute to avoid issues when stubbing with vue-test-utils.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
