### PR TITLE
f-mega-modal@v6.0.0 - use newer sass syntax

### DIFF
--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -3,12 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-Latest (to be added to next release)
-------------------------------
-*June 14, 2022*
+
+v6.0.0
+-----------------------------
+*June 20, 2022*
 
 ### Added
+*June 14, 2022*
 - Visual tests for default state.
+### Changed
+*June 20, 2022*
+- Update to `@use` and `@forward` SASS syntax
 
 
 v5.1.1

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -9,10 +9,8 @@ v6.0.0
 *June 20, 2022*
 
 ### Added
-*June 14, 2022*
 - Visual tests for default state.
 ### Changed
-*June 20, 2022*
 - Update to `@use` and `@forward` SASS syntax
 
 

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -8,8 +8,6 @@ v6.0.0
 -----------------------------
 *June 20, 2022*
 
-### Added
-- Visual tests for default state.
 ### Changed
 - Update to `@use` and `@forward` SASS syntax
 

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "5.1.1",
+  "version": "6.0.0",
   "main": "dist/f-mega-modal.common.js",
   "maxBundleSize": "6kB",
   "files": [
@@ -53,9 +53,10 @@
     "body-scroll-lock": "3.x"
   },
   "devDependencies": {
-    "@justeat/f-button": "3.3.0",
-    "@justeattakeaway/pie-icons-vue": "1.0.0",
+    "@justeat/f-button": "4.0.0",
     "@justeat/f-wdio-utils": "0.11.0",
+    "@justeat/fozzie": "9.0.0-beta.5",
+    "@justeattakeaway/pie-icons-vue": "1.0.0",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",

--- a/packages/components/molecules/f-mega-modal/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-mega-modal/src/assets/scss/common.scss
@@ -1,1 +1,1 @@
-@import '@justeat/fozzie/src/scss/fozzie';
+// Add styles here so it can be injected first via vue.config.js.

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -323,16 +323,18 @@ export default {
 </script>
 
 <style lang="scss" module>
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
 .c-megaModal {
-    z-index: zIndex(high);
+    z-index: f.zIndex(high);
 }
 
 .c-megaModal-content {
-    background-color: $color-container-default;
-    border-radius: $radius-rounded-d;
-    box-shadow: $elevation-04;
+    background-color: f.$color-container-default;
+    border-radius: f.$radius-rounded-d;
+    box-shadow: f.$elevation-04;
     display: none;
-    padding: spacing(e);
+    padding: f.spacing(e);
     position: fixed;
     right: 50%;
     text-align: start;
@@ -343,7 +345,7 @@ export default {
     &.is-positioned-bottom {
         border-radius: 0;
         bottom: -100vh;
-        box-shadow: $elevation-05;
+        box-shadow: f.$elevation-05;
         display: block;
         left: 0;
         top: auto;
@@ -360,19 +362,19 @@ export default {
         text-align: center;
     }
 
-    @include media('>=narrow') {
+    @include f.media('>=narrow') {
         width: 85%;
     }
 
-    @include media('<mid') {
-        min-width: em(22);
+    @include f.media('<mid') {
+        min-width: f.em(22);
 
         &.is-fullHeight {
             height: 100%;
         }
     }
 
-    @include media('>=mid') {
+    @include f.media('>=mid') {
         max-height: 90vh;
         max-width: 600px;
     }
@@ -383,7 +385,7 @@ export default {
 }
 
 .c-megaModal-content--narrow {
-    @include media('>=narrowMid') {
+    @include f.media('>=narrowMid') {
         max-width: 450px;
     }
 }
@@ -391,11 +393,11 @@ export default {
 .c-megaModal-content--wide {
     max-width: 1080px;
 
-    @include media('<huge') {
+    @include f.media('<huge') {
         max-width: 75%;
     }
 
-    @include media('<mid') {
+    @include f.media('<mid') {
         width: 100%;
         max-width: 100%;
     }
@@ -408,7 +410,7 @@ export default {
 
 .c-megaModal-content.c-megaModal-content--flush {
     .c-megaModal-closeBtn {
-        top: spacing(d);
+        top: f.spacing(d);
     }
 }
 
@@ -418,11 +420,11 @@ export default {
     overflow-x: hidden;
     overflow-y: auto;
 
-    @include media('>=mid') {
+    @include f.media('>=mid') {
         max-height: 550px;
     }
 
-    @include media('height<=narrowMid', '>=mid') {
+    @include f.media('height<=narrowMid', '>=mid') {
         max-height: 90vh;
     }
 }
@@ -432,16 +434,16 @@ export default {
         display: flex;
         opacity: 0.9;
         position: absolute;
-        right: spacing(d);
+        right: f.spacing(d);
         top: 22px;
-        z-index: zIndex(high);
+        z-index: f.zIndex(high);
 
-        @include media('>=mid') {
+        @include f.media('>=mid') {
             position: fixed;
         }
 
         svg path {
-            fill: $color-interactive-primary;
+            fill: f.$color-interactive-primary;
             width: 17px;
             height: 17px;
         }
@@ -453,11 +455,11 @@ export default {
 }
 
 .c-megaModal-title {
-    margin: 0 spacing(f) 0 0;
+    margin: 0 f.spacing(f) 0 0;
 
     .is-text-aligned-center & {
-        margin-left: spacing(e);
-        margin-right: spacing(e);
+        margin-left: f.spacing(e);
+        margin-right: f.spacing(e);
     }
 }
 </style>

--- a/packages/components/molecules/f-mega-modal/vue.config.js
+++ b/packages/components/molecules/f-mega-modal/vue.config.js
@@ -16,7 +16,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@import "../assets/scss/common.scss";`
+                additionalData: `@use "../assets/scss/common.scss" as *;`
             });
     },
     pluginOptions: {

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+
+v0.52.12
+------------------------------
+*June 22, 2022*
+### Changed
+- updated vue.config to include f-mega-modal in components using @use and @forward
+
+
 v0.52.11
 ------------------------------
 *June 22, 2022*

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private":true,
-  "version": "0.52.11",
+  "version": "0.52.12",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private":true,
-  "version": "0.52.12",
+  "version": "0.52.13",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -47,7 +47,8 @@ module.exports = {
                         'f-breadcrumbs',
                         'f-card-with-content',
                         'f-media-element',
-                        'f-promotions-showcase'
+                        'f-promotions-showcase',
+                        'f-mega-modal'
                     ];
                     const pathContainsUpdatedComponentOrType = updateComponentsAndTypes.some(a => absPath.includes(a));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14986,7 +14986,7 @@ include-media@1.4.9:
   resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.9.tgz#d0020b7be3eb2d54868a20943595ce380e0bc43b"
   integrity sha512-IUOcvWDCt6R5V0ktsGk6RbehkW9ks1dODN2ed1p+mhML82TteAl+/ElXy8AJ7ueIuVoKq2NioRVdW9FuwQNOew==
 
-include-media@eduardoboucas/include-media#2.0-release, "include-media@github:eduardoboucas/include-media#2.0-release":
+include-media@eduardoboucas/include-media#2.0-release:
   version "2.0.0"
   resolved "https://codeload.github.com/eduardoboucas/include-media/tar.gz/5398b556d4bb24186d360c950b19026f577ff8e5"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2766,6 +2766,14 @@
     "@justeat/pie-design-tokens" "1.4.0"
     include-media eduardoboucas/include-media#2.0-release
 
+"@justeat/fozzie@9.0.0-beta.5":
+  version "9.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-9.0.0-beta.5.tgz#14d7a2d7c6aba26e885295bc416560ea182736fd"
+  integrity sha512-ZE3XqqJM1+QJf1qW60yI8dP+9g2+u/PkxMtJh+DtxZILgegnXHfiz8iCBHOEsIPcn67fJjV4FOyqp3KY1J9qtw==
+  dependencies:
+    "@justeat/pie-design-tokens" "1.4.0"
+    include-media eduardoboucas/include-media#2.0-release
+
 "@justeat/pie-design-tokens@1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-1.4.0.tgz#adb4b3b7f5ed9ac9691e67e02b02264acd6dcfbf"
@@ -14978,7 +14986,7 @@ include-media@1.4.9:
   resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.9.tgz#d0020b7be3eb2d54868a20943595ce380e0bc43b"
   integrity sha512-IUOcvWDCt6R5V0ktsGk6RbehkW9ks1dODN2ed1p+mhML82TteAl+/ElXy8AJ7ueIuVoKq2NioRVdW9FuwQNOew==
 
-include-media@eduardoboucas/include-media#2.0-release:
+include-media@eduardoboucas/include-media#2.0-release, "include-media@github:eduardoboucas/include-media#2.0-release":
   version "2.0.0"
   resolved "https://codeload.github.com/eduardoboucas/include-media/tar.gz/5398b556d4bb24186d360c950b19026f577ff8e5"
 


### PR DESCRIPTION
f-mega-modal - v6.0.0
-----------------------------
*June 20, 2022*

### Changed
- Update to `@use` and `@forward` SASS syntax


v0.52.13
------------------------------
*June 22, 2022*
### Changed
- updated vue.config to include f-mega-modal in components using @use and @forward