### PR TITLE
f-template-subnav@0.6.0 - Use latest f-navigation-links

### DIFF
--- a/packages/components/templates/f-template-subnav/CHANGELOG.md
+++ b/packages/components/templates/f-template-subnav/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.6.0
+------------------------------
+*June 22, 2022*
+
+### Changed
+- Updated `f-navigation-links` to v1.3.0.
+
+
 v0.5.1
 ------------------------------
 *March 18, 2022*

--- a/packages/components/templates/f-template-subnav/package.json
+++ b/packages/components/templates/f-template-subnav/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-template-subnav",
   "description": "Fozzie Template Sub Nav - SPA template with breadcrumb, lefthand navigation and centre slot",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "main": "dist/f-template-subnav.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@justeat/f-breadcrumbs": "3.2.1",
-    "@justeat/f-navigation-links": "1.1.0",
+    "@justeat/f-navigation-links": "1.3.0",
     "@justeat/f-wdio-utils": "0.4.0",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2496,11 +2496,6 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-4.1.0.tgz#43300dd377b6293157bd59378165cc64ace4ade1"
   integrity sha512-4xwep9kagPo+L6YeFIiU8A65BPhic1CUOzvfv2fzYYdGtYuGi2XVbu2xreYuvlQ/v7pitdW0MUqTZGsoJr+ZTg==
 
-"@justeat/f-navigation-links@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-navigation-links/-/f-navigation-links-1.1.0.tgz#ad3f0ae6eff67e625c9878bbd6a050a236c663d8"
-  integrity sha512-4aPChcvInn0sGVJkERS9VecU9Hq5K6l7ALK7Qvy/qu9NuPPbm7nWvOytsCPez8d6i2W/zkkb1UTyMzAg/momew==
-
 "@justeat/f-popover@2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-popover/-/f-popover-2.3.0.tgz#4428d8b324a487a44e9179f357c6552403ab9db7"


### PR DESCRIPTION
*June 22, 2022*

### Changed
- Updated `f-navigation-links` to v1.3.0.

---

See #1955 for f-link updates

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
