### PR TITLE
f-navigation-links@v2.0.0 - use new sass syntax

### DIFF
--- a/packages/components/molecules/f-navigation-links/CHANGELOG.md
+++ b/packages/components/molecules/f-navigation-links/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0
+-----------------------------
+*June 23, 2022*
+
+### Changed
+- Update to `@use` and `@forward` SASS syntax
+
+
 v1.3.0
 ------------------------------
 *June 22, 2022*

--- a/packages/components/molecules/f-navigation-links/package.json
+++ b/packages/components/molecules/f-navigation-links/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-navigation-links",
   "description": "Fozzie Navigation Links - A component to display a collection of supplied links",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "main": "dist/f-navigation-links.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@justeat/f-link": "3.1.1",
     "@justeat/f-wdio-utils": "0.11.0",
+    "@justeat/fozzie": "9.0.0-beta.5",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3"

--- a/packages/components/molecules/f-navigation-links/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-navigation-links/src/assets/scss/common.scss
@@ -1,1 +1,1 @@
-@import '@justeat/fozzie/src/scss/fozzie';
+// Add styles here so it can be injected first via vue.config.js.

--- a/packages/components/molecules/f-navigation-links/src/components/NavigationLinks.vue
+++ b/packages/components/molecules/f-navigation-links/src/components/NavigationLinks.vue
@@ -63,24 +63,26 @@ export default {
 </style>
 
 <style lang="scss">
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
 /**
 * .c-navigationLinks-link is intentionally not scoped as the consuming router application (Nuxt.js / Vue Router) will add active classes directly to
 * the router-link within <f-link>. CoreWeb Nuxt custom active link classes are: `is-link-active` and `is-link-exactActive`.
 */
 .c-navigationLinks-link {
     display: inline-block;
-    padding: spacing() 0 spacing() spacing(d);
-    border-left: 2px solid $color-border-default;
-    color: $color-content-link;
+    padding: f.spacing() 0 f.spacing() f.spacing(d);
+    border-left: 2px solid f.$color-border-default;
+    color: f.$color-content-link;
 
     &:focus,
     &:hover,
     &.is-link-exactActive {
-        border-left: 2px solid $color-interactive-brand;
+        border-left: 2px solid f.$color-interactive-brand;
         text-decoration: none;
     }
     &.is-link-exactActive {
-        font-weight: $font-weight-bold;
+        font-weight: f.$font-weight-bold;
     }
 }
 </style>

--- a/packages/components/molecules/f-navigation-links/vue.config.js
+++ b/packages/components/molecules/f-navigation-links/vue.config.js
@@ -16,7 +16,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@import "../assets/scss/common.scss";`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.52.14
+------------------------------
+*June 23, 2022*
+### Changed
+- updated vue.config to include f-navigation-links in components using @use and @forward
+
 
 v0.52.13
 ------------------------------

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private":true,
-  "version": "0.52.13",
+  "version": "0.52.14",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -49,7 +49,8 @@ module.exports = {
                         'f-media-element',
                         'f-promotions-showcase',
                         'f-mega-modal',
-                        'f-restaurant-card'
+                        'f-restaurant-card',
+                        'f-navigation-links'
                     ];
                     const pathContainsUpdatedComponentOrType = updateComponentsAndTypes.some(a => absPath.includes(a));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2496,6 +2496,11 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-4.1.0.tgz#43300dd377b6293157bd59378165cc64ace4ade1"
   integrity sha512-4xwep9kagPo+L6YeFIiU8A65BPhic1CUOzvfv2fzYYdGtYuGi2XVbu2xreYuvlQ/v7pitdW0MUqTZGsoJr+ZTg==
 
+"@justeat/f-navigation-links@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-navigation-links/-/f-navigation-links-1.3.0.tgz#430aa94513f4d451418c39a88b2135e5c5abcf4e"
+  integrity sha512-em/G3aiN/g7Gx5cSPGXDEoRogYjzIvgyoX1ecZ0iB4x6whfg/NmZ8jCbOxTW/9eLvhMuHv0lXv6wL0H5OnB0eA==
+
 "@justeat/f-popover@2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-popover/-/f-popover-2.3.0.tgz#4428d8b324a487a44e9179f357c6552403ab9db7"


### PR DESCRIPTION
f-navigation-links: v2.0.0
-----------------------------
*June 23, 2022*

### Changed
- Update to `@use` and `@forward` SASS syntax


Storybook: v0.52.14
------------------------------
*June 23, 2022*
### Changed
- updated vue.config to include f-navigation-links in components using @use and @forward