### PR TITLE
#trivial - update common.scss imports

### DIFF
--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -357,7 +357,7 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
 
 .o-btn--primary,
 .o-btn--icon.o-btn--primary {
-    @include background-color($btn-primary-bgColor);
+    @include common.background-color($btn-primary-bgColor);
 
     &,
     &:link,
@@ -372,12 +372,12 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
     }
 
     &:hover {
-        @include background-color($btn-primary-bgColor--hover);
+        @include common.background-color($btn-primary-bgColor--hover);
     }
 
     &:active,
     &.o-btn--loading {
-        @include background-color($btn-primary-bgColor--active);
+        @include common.background-color($btn-primary-bgColor--active);
     }
 
     @include f.spinnerColor($btn-primary-loading-color, $btn-primary-loading-colorOpaque);
@@ -389,14 +389,14 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
 
     &.o-btn--sizeSmall,
     &.o-btn--sizeXSmall {
-        @include background-color(f.$color-interactive-primary);
+        @include common.background-color(f.$color-interactive-primary);
 
         &:hover {
-            @include background-color(lighten(f.$color-interactive-primary, f.$color-hover-02));
+            @include common.background-color(lighten(f.$color-interactive-primary, f.$color-hover-02));
         }
         &:active,
         &.o-btn--loading {
-            @include background-color(lighten(f.$color-interactive-primary, f.$color-active-02));
+            @include common.background-color(lighten(f.$color-interactive-primary, f.$color-active-02));
         }
     }
 }
@@ -404,14 +404,14 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
 .o-btn--icon.o-btn--primary {
     &.o-btn--sizeSmall,
     &.o-btn--sizeXSmall {
-        @include background-color($btn-primary-bgColor);
+        @include common.background-color($btn-primary-bgColor);
 
         &:hover {
-            @include background-color($btn-primary-bgColor--hover);
+            @include common.background-color($btn-primary-bgColor--hover);
         }
         &:active,
         &.o-btn--loading {
-            @include background-color($btn-primary-bgColor--active);
+            @include common.background-color($btn-primary-bgColor--active);
         }
     }
 }
@@ -423,7 +423,7 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
  */
 
 .o-btn--secondary {
-    @include background-color($btn-secondary-bgColor);
+    @include common.background-color($btn-secondary-bgColor);
     color: $btn-secondary-textColor;
 
     &:hover,
@@ -433,12 +433,12 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
     }
 
     &:hover {
-        @include background-color($btn-secondary-bgColor--hover);
+        @include common.background-color($btn-secondary-bgColor--hover);
     }
 
     &:active,
     &.o-btn--loading {
-        @include background-color($btn-secondary-bgColor--active);
+        @include common.background-color($btn-secondary-bgColor--active);
     }
 
     @include f.spinnerColor($btn-secondary-loading-color, $btn-secondary-loading-colorOpaque);
@@ -490,7 +490,7 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
  */
 
 .o-btn--ghost {
-    @include background-color($btn-ghost-bgColor);
+    @include common.background-color($btn-ghost-bgColor);
     color: $btn-ghost-textColor;
 
     &:hover,
@@ -500,12 +500,12 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
     }
 
     &:hover {
-        @include background-color($btn-ghost-bgColor--hover);
+        @include common.background-color($btn-ghost-bgColor--hover);
     }
 
     &:active,
     &.o-btn--loading {
-        @include background-color($btn-ghost-bgColor--active);
+        @include common.background-color($btn-ghost-bgColor--active);
     }
 
     @include f.spinnerColor($btn-ghost-loading-color, $btn-ghost-loading-colorOpaque);
@@ -524,7 +524,7 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
  */
 
 .o-btn--ghostTertiary {
-    @include background-color($btn-ghostTertiary-bgColor);
+    @include common.background-color($btn-ghostTertiary-bgColor);
     color: $btn-ghostTertiary-textColor;
 
     &:hover,
@@ -534,12 +534,12 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
     }
 
     &:hover {
-        @include background-color($btn-ghostTertiary-bgColor--hover);
+        @include common.background-color($btn-ghostTertiary-bgColor--hover);
     }
 
     &:active,
     &.o-btn--loading {
-        @include background-color($btn-ghostTertiary-bgColor--active);
+        @include common.background-color($btn-ghostTertiary-bgColor--active);
     }
 
     @include f.spinnerColor($btn-ghostTertiary-loading-color, $btn-ghostTertiary-loading-colorOpaque);
@@ -558,15 +558,15 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
  */
 
 .o-btn--inverse {
-    @include background-color(f.$color-interactive-inverse); // for icon button to have a white background when it is located on top of images/dark surfaces
+    @include common.background-color(f.$color-interactive-inverse); // for icon button to have a white background when it is located on top of images/dark surfaces
 
     &:hover {
-        @include background-color($btn-ghost-bgColor--hover);
+        @include common.background-color($btn-ghost-bgColor--hover);
     }
 
     &:active,
     &.o-btn--loading {
-        @include background-color($btn-ghost-bgColor--active);
+        @include common.background-color($btn-ghost-bgColor--active);
     }
 
     @include f.spinnerColor($btn-inverse-loading-color, $btn-inverse-loading-colorOpaque);
@@ -580,15 +580,15 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
  */
 
 .o-btn--ghostInverse {
-    @include background-color($btn-ghost-bgColor);
+    @include common.background-color($btn-ghost-bgColor);
 
     &:hover {
-        @include background-color(lighten(f.$color-black, f.$color-hover-02));
+        @include common.background-color(lighten(f.$color-black, f.$color-hover-02));
     }
 
     &:active,
     &.o-btn--loading {
-        @include background-color(lighten(f.$color-black, f.$color-active-02));
+        @include common.background-color(lighten(f.$color-black, f.$color-active-02));
     }
 
     @include f.spinnerColor($btn-ghostInverse-loading-color, $btn-ghostInverse-loading-colorOpaque);
@@ -801,7 +801,7 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
 
         &,
         &:hover {
-            @include background-color($btn-disabled-bgColor);
+            @include common.background-color($btn-disabled-bgColor);
             color: $btn-disabled-textColor;
         }
 

--- a/packages/components/atoms/f-button/vue.config.js
+++ b/packages/components/atoms/f-button/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/components/atoms/f-card/vue.config.js
+++ b/packages/components/atoms/f-card/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/components/atoms/f-error-message/vue.config.js
+++ b/packages/components/atoms/f-error-message/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/components/atoms/f-filter-pill/vue.config.js
+++ b/packages/components/atoms/f-filter-pill/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
@@ -138,7 +138,7 @@ $form-dropdown-iconIndent--large              : 25px;
 }
 
 .c-formDropdown-select {
-    padding-right: $form-input-iconPadding;
+    padding-right: common.$form-input-iconPadding;
 
     /* Remove default styling */
     outline: none;

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -414,7 +414,7 @@ $form-input-icon-verticalIndent--large         : 19px;
 $form-input-iconSize                           : 18px;
 
     ::placeholder {
-        color: $form-input-secondaryTextColour;
+        color: common.$form-input-secondaryTextColour;
     }
 
     .c-formField-field--textarea {
@@ -428,7 +428,7 @@ $form-input-iconSize                           : 18px;
             margin-top: 0;
 
             .c-formField-field {
-                border-radius: 0 0 $form-input-borderRadius $form-input-borderRadius;
+                border-radius: 0 0 common.$form-input-borderRadius common.$form-input-borderRadius;
                 border-top: 0;
             }
         }
@@ -442,7 +442,7 @@ $form-input-iconSize                           : 18px;
 
     .c-formField--grouped:nth-of-type(1) {
         .c-formField-field {
-            border-radius: $form-input-borderRadius $form-input-borderRadius 0 0;
+            border-radius: common.$form-input-borderRadius common.$form-input-borderRadius 0 0;
         }
     }
 
@@ -453,7 +453,7 @@ $form-input-iconSize                           : 18px;
             width: $form-input-iconSize;
 
             path {
-                fill: $form-input-secondaryTextColour;
+                fill: common.$form-input-secondaryTextColour;
             }
         }
     }
@@ -467,33 +467,33 @@ $form-input-iconSize                           : 18px;
     }
 
     .c-formField-icon--small {
-        @include indent-icon('bottom', $form-input-icon-verticalIndent--small);
+        @include common.indent-icon('bottom', $form-input-icon-verticalIndent--small);
     }
 
     .c-formField-icon--medium {
-        @include indent-icon('bottom', $form-input-icon-verticalIndent);
+        @include common.indent-icon('bottom', $form-input-icon-verticalIndent);
     }
 
     .c-formField-icon--large {
-        @include indent-icon('bottom', $form-input-icon-verticalIndent--large);
+        @include common.indent-icon('bottom', $form-input-icon-verticalIndent--large);
     }
 
     .c-formField-icon--leading {
-        @include indent-icon('leading', $form-input-icon-verticalIndent);
+        @include common.indent-icon('leading', $form-input-icon-verticalIndent);
     }
 
     .c-formField-icon--trailing {
-        @include indent-icon('trailing', $form-input-icon-verticalIndent);
+        @include common.indent-icon('trailing', $form-input-icon-verticalIndent);
     }
 
     .c-formField-padding--iconTrailing {
-        padding-right: $form-input-iconPadding;
+        padding-right: common.$form-input-iconPadding;
     }
 
     .c-formField-assistiveText {
         position: absolute;
         font-weight: f.$font-weight-regular;
-        color: $form-input-secondaryTextColour;
+        color: common.$form-input-secondaryTextColour;
         margin-top: f.spacing(a);
     }
 

--- a/packages/components/atoms/f-form-field/src/components/FormFieldAffixed.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormFieldAffixed.vue
@@ -120,9 +120,9 @@ export default {
 @use '@justeat/fozzie/src/scss/fozzie' as f;
 
 $affixed-field-sizes: (
-    small:  ($form-input-height--small, $form-input-padding--small),
-    medium: ($form-input-height, $form-input-padding),
-    large: ($form-input-height--large, $form-input-padding--large),
+    small:  (common.$form-input-height--small, common.$form-input-padding--small),
+    medium: (common.$form-input-height, common.$form-input-padding),
+    large: (common.$form-input-height--large, common.$form-input-padding--large),
 );
 
 .c-formField--affixed {
@@ -152,8 +152,8 @@ $affixed-field-sizes: (
 .c-formField-affix {
     height: 100%;
     font-family: f.$font-family-base;
-    @include f.font-size($form-input-fontSize);
-    color: $form-input-secondaryTextColour;
+    @include f.font-size(common.$form-input-fontSize);
+    color: common.$form-input-secondaryTextColour;
 }
 
 .c-formField-prefix {
@@ -174,10 +174,10 @@ $affixed-field-sizes: (
 }
 
 .c-formField--disabled {
-    @include disabled-field();
+    @include common.disabled-field();
 
     .c-formField-affix {
-        color: $form-input-textColour--disabled;
+        color: common.$form-input-textColour--disabled;
     }
 }
 </style>

--- a/packages/components/atoms/f-form-field/src/components/FormLabel.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormLabel.vue
@@ -105,7 +105,7 @@ $form-label-weight              : f.$font-weight-bold;
 .c-formField-label-details,
 .c-formField-label-description {
     font-weight: f.$font-weight-regular;
-    color: $form-input-secondaryTextColour;
+    color: common.$form-input-secondaryTextColour;
 }
 
 .c-formField-label-details {

--- a/packages/components/atoms/f-form-field/src/components/FormSelectionControl.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormSelectionControl.vue
@@ -148,7 +148,7 @@ export default {
 
     .c-formField-field--checkbox.c-formField--invalid + label:before,
     .c-formField-field--radio.c-formField--invalid + label:before {
-        border-color: $form-input-borderColour--invalid;
+        border-color: common.$form-input-borderColour--invalid;
     }
 
     .c-formField-field--checkbox:checked + label:before {

--- a/packages/components/atoms/f-form-field/vue.config.js
+++ b/packages/components/atoms/f-form-field/vue.config.js
@@ -15,7 +15,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
 

--- a/packages/components/atoms/f-image-tile/vue.config.js
+++ b/packages/components/atoms/f-image-tile/vue.config.js
@@ -16,7 +16,7 @@ module.exports = {
                 // eslint-disable-next-line quotes
                 additionalData: `
                     @use "sass:math";
-                    @use "../assets/scss/common.scss" as *;
+                    @use "../assets/scss/common.scss";
                 `
             });
     },

--- a/packages/components/atoms/f-link/vue.config.js
+++ b/packages/components/atoms/f-link/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/components/atoms/f-popover/vue.config.js
+++ b/packages/components/atoms/f-popover/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/components/atoms/f-spinner/vue.config.js
+++ b/packages/components/atoms/f-spinner/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/components/molecules/f-alert/vue.config.js
+++ b/packages/components/molecules/f-alert/vue.config.js
@@ -16,7 +16,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/components/molecules/f-breadcrumbs/vue.config.js
+++ b/packages/components/molecules/f-breadcrumbs/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/components/molecules/f-card-with-content/vue.config.js
+++ b/packages/components/molecules/f-card-with-content/vue.config.js
@@ -16,7 +16,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/components/molecules/f-media-element/vue.config.js
+++ b/packages/components/molecules/f-media-element/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/components/molecules/f-mega-modal/vue.config.js
+++ b/packages/components/molecules/f-mega-modal/vue.config.js
@@ -16,7 +16,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/components/molecules/f-promotions-showcase/vue.config.js
+++ b/packages/components/molecules/f-promotions-showcase/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             .options({
                 ...sassOptions,
                 // eslint-disable-next-line quotes
-                additionalData: `@use "../assets/scss/common.scss" as *;`
+                additionalData: `@use "../assets/scss/common.scss";`
             });
     },
     pluginOptions: {

--- a/packages/components/molecules/f-restaurant-card/src/assets/scss/common.scss
+++ b/packages/components/molecules/f-restaurant-card/src/assets/scss/common.scss
@@ -1,3 +1,3 @@
 // Add styles here so it can be injected first via vue.config.js.
-@import './animations';
-@import './mixins';
+@forward './animations';
+@forward './mixins';

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/DeliveryTimeMeta/DeliveryTimeMeta.vue
@@ -77,7 +77,7 @@ export default {
     display: flex;
 
     &:after {
-        @include dotSeparator;
+        @include common.dotSeparator;
 
         @include f.media('>mid') {
             display: none;

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantAvailability/RestaurantAvailability.vue
@@ -87,7 +87,7 @@ export default {
 }
 
 .c-restaurantCard-availability > .c-restaurantCard-availability-iconText + .c-restaurantCard-availability-message:before {
-    @include dotSeparator;
+    @include common.dotSeparator;
 }
 
 .c-restaurantCard-availability-iconText,

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantFees/RestaurantFees.vue
@@ -56,6 +56,6 @@ export default {
 }
 
 .c-restaurantCard-fees-item + .c-restaurantCard-fees-item:before {
-   @include dotSeparator;
+   @include common.dotSeparator;
 }
 </style>

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantSkeleton/RestaurantContentSkeleton.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantSkeleton/RestaurantContentSkeleton.vue
@@ -22,6 +22,6 @@ export default {
 
 .c-restaurantCard-skeleton {
     background-color: f.$color-skeleton-02;
-    @include skeletonLoader();
+    @include common.skeletonLoader();
 }
 </style>

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantSkeleton/RestaurantRatingSkeleton.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantSkeleton/RestaurantRatingSkeleton.vue
@@ -55,7 +55,7 @@ export default {
 }
 
 .c-restaurantCard-ratingSkeleton-icon {
-    @include skeletonLoader();
+    @include common.skeletonLoader();
     border-radius: 0;
     display: flex;
     align-items: center;

--- a/packages/components/molecules/f-restaurant-card/vue.config.js
+++ b/packages/components/molecules/f-restaurant-card/vue.config.js
@@ -27,7 +27,7 @@ module.exports = {
 
                     return `
                         @use "sass:math";
-                        @use "${relPath}" as *;
+                        @use "${relPath}";
                         ${content}`;
                 }
             });

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -30,12 +30,12 @@ module.exports = {
                         return `${content}`;
                     }
 
-                    const absPath = path.join(
+                    const absPathCommonScss = path.join(
                         resourcePath,
                         ...(new Array(levelsUpToSrc).fill('..')),
                         'assets/scss/common.scss'
                     );
-                    const relPath = path.relative(path.dirname(resourcePath), absPath)
+                    const relPathCommonScss = path.relative(path.dirname(resourcePath), absPathCommonScss)
                         .replace(new RegExp(path.sep.replace('\\', '\\\\'), 'g'), '/');
 
                     // add component names 1 by 1 to this array as they're updated
@@ -52,18 +52,18 @@ module.exports = {
                         'f-restaurant-card',
                         'f-navigation-links'
                     ];
-                    const pathContainsUpdatedComponentOrType = updateComponentsAndTypes.some(a => absPath.includes(a));
+                    const pathContainsUpdatedComponentOrType = updateComponentsAndTypes.some(a => absPathCommonScss.includes(a));
 
                     if (!pathContainsUpdatedComponentOrType) {
                         return `
                         @use "sass:math";
-                        @import "${relPath}";
+                        @import "${relPathCommonScss}";
                         ${content}`;
                     }
 
                     return `
                         @use "sass:math";
-                        @use "${relPath}" as *;
+                        @use "${relPathCommonScss}";
                         ${content}`;
                 }
             });


### PR DESCRIPTION
Uses the default namespace for `common.scss` file across components that are using `@use` and `@forward` Sass syntax.