### PR TITLE
f-content-cards@v8.0.0 - use newer sass syntax

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v8.0.0
+-----------------------------
+*June 23, 2022*
+
+### Changed
+- Update to `@use` and `@forward` SASS syntax
+
+
 Latest (add to next release)
 ------------------------------
 *May 31, 2021*

--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -9,7 +9,7 @@ v8.0.0
 *June 27, 2022*
 
 ### Changed
-- Update to `@use` and `@forward` SASS syntax
+- **breaking changes** Update to `@use` and `@forward` SASS syntax
 
 
 Latest (add to next release)

--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v8.0.0
 -----------------------------
-*June 23, 2022*
+*June 27, 2022*
 
 ### Changed
 - Update to `@use` and `@forward` SASS syntax

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "7.4.0",
+  "version": "8.0.0",
   "main": "dist/f-content-cards.umd.min.js",
   "maxBundleSize": "75kB",
   "files": [
@@ -63,6 +63,7 @@
     "@justeat/f-braze-adapter": "5.0.0",
     "@justeat/f-vue-icons": "1.2.0",
     "@justeat/f-wdio-utils": "0.5.0",
+    "@justeat/fozzie": "9.0.0-beta.5",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",

--- a/packages/components/organisms/f-content-cards/src/assets/scss/_card-styles.scss
+++ b/packages/components/organisms/f-content-cards/src/assets/scss/_card-styles.scss
@@ -1,3 +1,5 @@
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
 @mixin card-container {
     width: 100%;
     text-decoration: initial;
@@ -17,11 +19,11 @@
   display: flex;
   flex-direction: column;
   flex: 0 0 40%;
-  margin: 0 spacing() spacing(e) 0;
+  margin: 0 f.spacing() f.spacing(e) 0;
   width: 100%;
 
-  @include media('>=narrowMid') {
-    margin: 0 spacing() spacing(e);
+  @include f.media('>=narrowMid') {
+    margin: 0 f.spacing() f.spacing(e);
   }
 }
 
@@ -29,7 +31,7 @@
   width: 100%;
   background-repeat: repeat;
   background-size: cover;
-  background-color: $color-container-subtle;
+  background-color: f.$color-container-subtle;
   background-position: center;
-  border-radius: $radius-rounded-c $radius-rounded-c 0 0;
+  border-radius: f.$radius-rounded-c f.$radius-rounded-c 0 0;
 }

--- a/packages/components/organisms/f-content-cards/src/assets/scss/common.scss
+++ b/packages/components/organisms/f-content-cards/src/assets/scss/common.scss
@@ -1,1 +1,1 @@
-@import '@justeat/fozzie/src/scss/fozzie';
+@forward 'card-styles';

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardContainer.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/CardContainer.vue
@@ -138,28 +138,28 @@ export default {
 </script>
 
 <style lang="scss" module>
-    @import '../../../src/assets/scss/card-styles';
+    @use '@justeat/fozzie/src/scss/fozzie' as f;
 
     .c-content-card-body {
         flex-grow: 1;
     }
 
     .c-contentCard {
-        @include card-container;
+        @include common.card-container;
 
-        margin-right: spacing(d);
-        margin-bottom: spacing(d);
+        margin-right: f.spacing(d);
+        margin-bottom: f.spacing(d);
 
-        @include media('>=narrowMid') {
+        @include f.media('>=narrowMid') {
             max-width: 370px;
         }
 
-        @include media('<=narrowMid') {
+        @include f.media('<=narrowMid') {
             margin-right: 0;
         }
 
         .c-contentCards--wrap & {
-            @include card-container-wrapped;
+            @include common.card-container-wrapped;
         }
 
         /**
@@ -169,17 +169,17 @@ export default {
             position: relative;
 
             .c-contentCard-info {
-                padding-top: spacing(j) + spacing(h);
-                padding-bottom: spacing(d);
-                border-radius: $radius-rounded-c;
+                padding-top: f.spacing(j) + f.spacing(h);
+                padding-bottom: f.spacing(d);
+                border-radius: f.$radius-rounded-c;
             }
 
             .c-contentCard-bgImg {
                 position: absolute;
                 left: 0;
                 right: 0;
-                top: spacing(d);
-                z-index: zIndex(mid);
+                top: f.spacing(d);
+                z-index: f.zIndex(mid);
                 width: 114px; // 1
                 height: 114px; // 1
                 margin: 0 auto;
@@ -192,13 +192,13 @@ export default {
     }
 
     .c-contentCard-bgImg {
-        @include card-bg-image;
+        @include common.card-bg-image;
 
         min-height: 170px;
     }
 
     .c-contentCard-title {
-        margin-top: spacing();
+        margin-top: f.spacing();
         text-align: center;
 
         // This is a super weird way to truncate text to 2 lines
@@ -213,13 +213,13 @@ export default {
     }
 
     .c-contentCard-subTitle {
-        @include font-size(body-l);
-        font-weight: $font-weight-regular;
-        margin-top: spacing();
+        @include f.font-size(body-l);
+        font-weight: f.$font-weight-regular;
+        margin-top: f.spacing();
     }
 
     .c-contentCard-text {
-        margin-top: spacing(a);
+        margin-top: f.spacing(a);
         text-align: center;
     }
 
@@ -230,22 +230,22 @@ export default {
         flex-direction: column;
         align-items: center;
         min-height: 164px; // min-height set to the height of an card with a one-line title
-        background-color: $color-container-default;
-        padding: spacing(d);
-        box-shadow: $elevation-01;
-        border-radius: 0 0 $radius-rounded-c $radius-rounded-c;
+        background-color: f.$color-container-default;
+        padding: f.spacing(d);
+        box-shadow: f.$elevation-01;
+        border-radius: 0 0 f.$radius-rounded-c f.$radius-rounded-c;
     }
 
     .c-contentCard-footer {
         width: 100%;
         flex-shrink: 0;
-        margin-top: spacing();
+        margin-top: f.spacing();
         text-align: center;
     }
 
     .c-contentCard-thumbnail {
-        border: 1px solid $color-border-subtle;
-        margin-top: - (32px + spacing(d)); // This offsets the thumbnail above the top of the info card
+        border: 1px solid f.$color-border-subtle;
+        margin-top: - (32px + f.spacing(d)); // This offsets the thumbnail above the top of the info card
         width: 48px;
         min-height: 48px;
     }
@@ -253,8 +253,8 @@ export default {
     .c-postOrderCardContainer {
         .c-contentCard-thumbnail {
             position: absolute;
-            top: spacing(d);
-            left: spacing(d);
+            top: f.spacing(d);
+            left: f.spacing(d);
             margin: 0;
             border: none;
         }
@@ -266,22 +266,22 @@ export default {
             display: block;
             text-align: left;
             min-height: 0;
-            padding: spacing(e) 0 0 0;
+            padding: f.spacing(e) 0 0 0;
 
-            @include media ('<mid') {
-                border: 1px solid $color-border-strong;
-                padding: spacing(e);
-                border-radius: 0 0 $radius-rounded-c $radius-rounded-c;
+            @include f.media ('<mid') {
+                border: 1px solid f.$color-border-strong;
+                padding: f.spacing(e);
+                border-radius: 0 0 f.$radius-rounded-c f.$radius-rounded-c;
             }
         }
 
         .c-contentCard-title {
             text-align: left;
-            margin: 0 0 spacing(d);
+            margin: 0 0 f.spacing(d);
         }
 
         .c-contentCard-subTitle {
-            @include font-size(body-s);
+            @include f.font-size(body-s);
 
             text-align: left;
             margin: 0;
@@ -296,10 +296,10 @@ export default {
 
         .c-contentCard-bgImg {
             overflow: hidden;
-            border-radius: $radius-rounded-c;
+            border-radius: f.$radius-rounded-c;
 
-            @include media ('<mid') {
-                border-radius: $radius-rounded-c $radius-rounded-c 0 0;
+            @include f.media ('<mid') {
+                border-radius: f.$radius-rounded-c f.$radius-rounded-c 0 0;
             }
         }
 
@@ -318,19 +318,19 @@ export default {
             left: 0;
             top: 0;
 
-            @include media('<mid') {
-                top: spacing(d);
-                left: spacing(d);
+            @include f.media('<mid') {
+                top: f.spacing(d);
+                left: f.spacing(d);
             }
         }
 
         .c-contentCard-info {
-            padding: 0 0 0 spacing(i);
+            padding: 0 0 0 f.spacing(i);
 
-            @include media('<mid') {
+            @include f.media('<mid') {
                 position: relative;
-                padding: spacing(d) spacing(d) spacing(d) spacing(i);
-                border-radius: $radius-rounded-c;
+                padding: f.spacing(d) f.spacing(d) f.spacing(d) f.spacing(i);
+                border-radius: f.$radius-rounded-c;
             }
         }
     }
@@ -340,12 +340,12 @@ export default {
     }
 
     .c-emboldenedText--subtitle {
-        @include font-size(body-l);
-        margin-top: spacing(d);
+        @include f.font-size(body-l);
+        margin-top: f.spacing(d);
     }
 
     .c-emboldenedText--text {
-        @include font-size(body-s);
+        @include f.font-size(body-s);
         font-weight: bold;
         margin-top: 0;
     }

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/FirstTimeCustomerCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/FirstTimeCustomerCard.vue
@@ -49,16 +49,18 @@ export default {
 </script>
 
 <style lang="scss" module>
-$banner-bgColour : $color-support-brand-02;
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
+$banner-bgColour : f.$color-support-brand-02;
 $banner-bgColour-legacy : #cd381f;
 
 .c-restaurantCard-banner {
     position: relative;
     display: inline-block;
     background: $banner-bgColour;
-    padding: 0 spacing();
-    margin: spacing(d) 0 spacing() 0;
-    border-radius: $radius-rounded-c;
+    padding: 0 f.spacing();
+    margin: f.spacing(d) 0 f.spacing() 0;
+    border-radius: f.$radius-rounded-c;
 }
 
 .c-restaurantCard-banner-content {
@@ -67,8 +69,8 @@ $banner-bgColour-legacy : #cd381f;
 }
 
 .c-restaurantCard-footer {
-    @include font-size(caption);
+    @include f.font-size(caption);
     font-weight: bold;
-    margin-top: spacing(a);
+    margin-top: f.spacing(a);
 }
 </style>

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/GroupHeaderCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/GroupHeaderCard.vue
@@ -19,12 +19,14 @@ export default {
 </script>
 
 <style lang="scss" module>
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
 .c-contentCards--group-title {
     width: 100%;
-    margin-bottom: spacing(d);
+    margin-bottom: f.spacing(d);
 
     &:not(:first-child) {
-        margin-top: spacing(e);
+        margin-top: f.spacing(e);
     }
 
 }

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/PostOrderCard.vue
@@ -103,26 +103,28 @@ export default {
 </script>
 
 <style lang="scss" module>
+    @use '@justeat/fozzie/src/scss/fozzie' as f;
+
     .c-postOrderCard {
-        border: 1px solid $color-border-strong;
-        border-radius: $radius-rounded-c;
-        padding: spacing(e);
+        border: 1px solid f.$color-border-strong;
+        border-radius: f.$radius-rounded-c;
+        padding: f.spacing(e);
         max-width: 100%;
         flex: 1 1 0%; // do not remove unit its intentional for IE11
 
-        @include media ('<mid') {
+        @include f.media ('<mid') {
             border: none;
             padding: 0;
         }
 
         .c-postOrderCard-title {
-            @include font-size(heading-m);
+            @include f.font-size(heading-m);
 
-            margin-bottom: spacing(d);
+            margin-bottom: f.spacing(d);
             text-align: left;
 
-            @include media ('<mid') {
-                margin: spacing(d);
+            @include f.media ('<mid') {
+                margin: f.spacing(d);
             }
         }
     }

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/PromotionCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/PromotionCard.vue
@@ -68,18 +68,20 @@ export default {
 </script>
 
 <style lang="scss" module>
-$btn-secondary-bgColor              : $color-interactive-secondary;
-$btn-secondary-bgColor--hover       : darken($color-interactive-secondary, $color-hover-01);
-$btn-secondary-bgColor--active      : darken($color-interactive-secondary, $color-active-01);
-$btn-secondary-textColor            : $color-content-interactive-secondary;
-$btn-secondary-textColor--hover     : $color-content-interactive-secondary;
-$btn-secondary-textColor--active    : $color-content-interactive-secondary;
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
+$btn-secondary-bgColor              : f.$color-interactive-secondary;
+$btn-secondary-bgColor--hover       : darken(f.$color-interactive-secondary, f.$color-hover-01);
+$btn-secondary-bgColor--active      : darken(f.$color-interactive-secondary, f.$color-active-01);
+$btn-secondary-textColor            : f.$color-content-interactive-secondary;
+$btn-secondary-textColor--hover     : f.$color-content-interactive-secondary;
+$btn-secondary-textColor--active    : f.$color-content-interactive-secondary;
 
     .c-contentCard-linkPromo2 {
-        font-weight: $font-weight-bold;
+        font-weight: f.$font-weight-bold;
         text-decoration: none;
-        @include font-size(body-l);
-        color: $color-content-link;
+        @include f.font-size(body-l);
+        color: f.$color-content-link;
         display: block;
     }
 
@@ -91,15 +93,15 @@ $btn-secondary-textColor--active    : $color-content-interactive-secondary;
         overflow: visible;
         text-align: center;
         cursor: pointer;
-        margin-right: spacing();
+        margin-right: f.spacing();
         display: inline-block;
         vertical-align: middle;
 
-        padding: spacing() 1.2em;
-        border-radius: $radius-rounded-c;
-        font-weight: $font-weight-bold;
-        font-family: $font-family-base;
-        @include font-size('body-l');
+        padding: f.spacing() 1.2em;
+        border-radius: f.$radius-rounded-c;
+        font-weight: f.$font-weight-bold;
+        font-family: f.$font-family-base;
+        @include f.font-size('body-l');
         text-decoration: none;
 
         &,

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/SkeletonLoader.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/SkeletonLoader.vue
@@ -35,10 +35,12 @@ export default {
 </script>
 
 <style lang="scss" module>
+    @use '@justeat/fozzie/src/scss/fozzie' as f;
+
     .c-skeletonLoader {
         margin-top: 40px;
 
-        @include media('>=narrowMid') {
+        @include f.media('>=narrowMid') {
             display: flex;
             flex-flow: wrap;
             flex-direction: row;
@@ -46,23 +48,23 @@ export default {
     }
 
     .c-skeletonLoader-card {
-        border-radius: $radius-rounded-c;
+        border-radius: f.$radius-rounded-c;
         display: flex;
         flex-direction: column;
         flex: 0 0 40%;
-        margin: 0 spacing() spacing(e) 0;
+        margin: 0 f.spacing() f.spacing(e) 0;
         width: 100%;
-        padding: spacing(e) spacing(d);
-        box-shadow: $elevation-01;
+        padding: f.spacing(e) f.spacing(d);
+        box-shadow: f.$elevation-01;
 
-        @include media('>=narrowMid') {
+        @include f.media('>=narrowMid') {
             flex-direction: row;
             max-width: 370px;
             flex: 0 0 40%;
         }
 
         .c-skeletonLoader--fullWidth & {
-            @include media('>=narrowMid') {
+            @include f.media('>=narrowMid') {
                 max-width: 100%;
                 flex: 0 0 100%;
             }
@@ -77,17 +79,17 @@ export default {
     .c-skeletonLoader-card:empty {
         position: relative;
         height: 403px; // 1
-        background-color: $color-container-default;
+        background-color: f.$color-container-default;
         background-repeat: no-repeat;
 
         // 2
-        background-image: radial-gradient(0 at 0 0, $color-grey-40 99%, transparent 0),
+        background-image: radial-gradient(0 at 0 0, f.$color-grey-40 99%, transparent 0),
                           linear-gradient(to right, white 20px, transparent 0), // 2.1 right margin
-                          linear-gradient($color-grey-40 20px, transparent 0), // 2.2 title placeholder
-                          linear-gradient($color-grey-40 220px, transparent 0), // 2.3 main image placeholder
-                          linear-gradient($color-grey-40 20px, transparent 0), // 2.4 line one placeholder
-                          linear-gradient($color-grey-40 20px, transparent 0), // 2.5 line two placeholder
-                          linear-gradient($color-grey-40 20px, transparent 0); // 2.6 line three placeholder
+                          linear-gradient(f.$color-grey-40 20px, transparent 0), // 2.2 title placeholder
+                          linear-gradient(f.$color-grey-40 220px, transparent 0), // 2.3 main image placeholder
+                          linear-gradient(f.$color-grey-40 20px, transparent 0), // 2.4 line one placeholder
+                          linear-gradient(f.$color-grey-40 20px, transparent 0), // 2.5 line two placeholder
+                          linear-gradient(f.$color-grey-40 20px, transparent 0); // 2.6 line three placeholder
         background-size: 100px 457px,
                          20px 100%, // 2.1
                          50% 20px, // 2.2
@@ -116,12 +118,12 @@ export default {
 
         &.c-skeletonLoader-card--promo {
             // 3
-            background-image: radial-gradient(0 at 0 0, $color-grey-40 99%, transparent 0),
-                              linear-gradient(to left, $color-grey-50 46px, transparent 0), // 3.1 icon placeholder
-                              linear-gradient($color-grey-40 170px, transparent 0), // 3.2 main image placeholder
-                              linear-gradient($color-grey-40 20px, transparent 0), //  3.3 line one placeholder
-                              linear-gradient($color-grey-40 20px, transparent 0), // 3.4 line two placeholder
-                              linear-gradient($color-grey-40 20px, transparent 0); // 3.5 line three placeholder
+            background-image: radial-gradient(0 at 0 0, f.$color-grey-40 99%, transparent 0),
+                              linear-gradient(to left, f.$color-grey-50 46px, transparent 0), // 3.1 icon placeholder
+                              linear-gradient(f.$color-grey-40 170px, transparent 0), // 3.2 main image placeholder
+                              linear-gradient(f.$color-grey-40 20px, transparent 0), //  3.3 line one placeholder
+                              linear-gradient(f.$color-grey-40 20px, transparent 0), // 3.4 line two placeholder
+                              linear-gradient(f.$color-grey-40 20px, transparent 0); // 3.5 line three placeholder
 
             background-size: 100px 457px,
                              50% 46px, // 3.1

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
@@ -275,8 +275,10 @@ export default {
 </script>
 
 <style lang="scss" module>
-$stampCard-subStatus-colour: $color-support-positive;
-$stampCard-expiryInfo-colour: $color-content-subdued;
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
+$stampCard-subStatus-colour: f.$color-support-positive;
+$stampCard-expiryInfo-colour: f.$color-content-subdued;
 
 $stampCard-iconSize-landscape: 56px;
 $stampCard-iconSize-portrait: 48px;
@@ -289,40 +291,40 @@ $stampCard-responsive-tabletViewBreakpoint: '<=mid';
     max-width: 392px;
     display: flex;
     flex-direction: column;
-    padding: spacing(d);
-    border-radius: $radius-rounded-c;
-    box-shadow: $elevation-01;
+    padding: f.spacing(d);
+    border-radius: f.$radius-rounded-c;
+    box-shadow: f.$elevation-01;
 
     &,
     &:hover,
     &:visited,
     &:focus {
-        color: $color-content-default;
+        color: f.$color-content-default;
     }
 
-    @include media($stampCard-responsive-tabletViewBreakpoint) {
+    @include f.media($stampCard-responsive-tabletViewBreakpoint) {
         max-width: 344px;
     }
 
-    @include media($stampCard-responsive-mobileViewBreakpoint) {
+    @include f.media($stampCard-responsive-mobileViewBreakpoint) {
         width: auto;
         max-width: none;
     }
 }
 
 .c-stampCard1-headerDetails {
-    margin-bottom: spacing();
+    margin-bottom: f.spacing();
 }
 
 .c-stampCard1-icon {
     float: left;
-    margin-right: spacing(d);
-    margin-bottom: spacing();
+    margin-right: f.spacing(d);
+    margin-bottom: f.spacing();
     width: $stampCard-iconSize-landscape;
     height: $stampCard-iconSize-landscape;
-    border-radius: $radius-rounded-c;
+    border-radius: f.$radius-rounded-c;
 
-    @include media($stampCard-responsive-mobileViewBreakpoint) {
+    @include f.media($stampCard-responsive-mobileViewBreakpoint) {
         width: $stampCard-iconSize-portrait;
         height: $stampCard-iconSize-portrait;
     }
@@ -330,20 +332,20 @@ $stampCard-responsive-tabletViewBreakpoint: '<=mid';
 
 .c-stampCard1-title {
     margin-top: 0;
-    margin-bottom: spacing(a);
+    margin-bottom: f.spacing(a);
 
-    @include media($stampCard-responsive-mobileViewBreakpoint) {
-        @include font-size(heading-s, true, narrow);
+    @include f.media($stampCard-responsive-mobileViewBreakpoint) {
+        @include f.font-size(heading-s, true, narrow);
     }
 }
 
 .c-stampCard1-statusText {
-    margin: spacing(a) spacing(d) 0 spacing(d);
+    margin: f.spacing(a) f.spacing(d) 0 f.spacing(d);
 }
 
 .c-stampCard1-subStatusText {
     color: $stampCard-subStatus-colour;
-    margin-bottom: spacing();
+    margin-bottom: f.spacing();
 }
 
 .c-stampCard1-expiryInfo {
@@ -357,7 +359,7 @@ $stampCard-responsive-tabletViewBreakpoint: '<=mid';
     width: 100%;
     padding-top: 10px;
 
-    @include media($stampCard-responsive-mobileViewBreakpoint) {
+    @include f.media($stampCard-responsive-mobileViewBreakpoint) {
         padding-top: 0;
     }
 }
@@ -368,7 +370,7 @@ $stampCard-responsive-tabletViewBreakpoint: '<=mid';
     width: 45px;
     padding: 0 0 100%;
 
-    @include media($stampCard-responsive-mobileViewBreakpoint) {
+    @include f.media($stampCard-responsive-mobileViewBreakpoint) {
         width: 40px;
     }
 }

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCardPromotionCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCardPromotionCard.vue
@@ -82,23 +82,23 @@ export default {
 </script>
 
 <style lang="scss" module>
-@import '../../../src/assets/scss/card-styles';
+@use '@justeat/fozzie/src/scss/fozzie' as f;
 
-$stampCard-promo-shadow: $elevation-01;
+$stampCard-promo-shadow: f.$elevation-01;
 
 .c-stampCardPromotion1 {
-    @include card-container;
+    @include common.card-container;
 
     position: relative;
     border: none;
 
-    @include media('>narrowMid') {
+    @include f.media('>narrowMid') {
         max-width: 344px;
-        border-radius: $radius-rounded-c;
+        border-radius: f.$radius-rounded-c;
         box-shadow: $stampCard-promo-shadow;
     }
 
-    @include media('>mid') {
+    @include f.media('>mid') {
         max-width: 392px;
     }
 }
@@ -108,82 +108,82 @@ $stampCard-promo-shadow: $elevation-01;
 }
 
 .c-stampCardPromotion1-bgImg {
-    @include card-bg-image;
+    @include common.card-bg-image;
 }
 
 .c-stampCardPromotion1-img {
     display: block;
     width: 100%;
-    border-radius: $radius-rounded-c $radius-rounded-c 0 0;
+    border-radius: f.$radius-rounded-c f.$radius-rounded-c 0 0;
 }
 
 .c-stampCardPromotion1-icon {
     position: absolute;
-    top: spacing(d);
-    left: spacing(d);
+    top: f.spacing(d);
+    left: f.spacing(d);
     margin: 0;
-    border-radius: $radius-rounded-c;
-    border: 0.5px solid $color-border-default;
+    border-radius: f.$radius-rounded-c;
+    border: 0.5px solid f.$color-border-default;
 
-    @include media('>narrowMid') {
-        top: spacing(c) - 2px;
+    @include f.media('>narrowMid') {
+        top: f.spacing(c) - 2px;
     }
 }
 
 .c-stampCardPromotion1-info {
-    padding: spacing(d);
-    background-color: $color-container-default;
+    padding: f.spacing(d);
+    background-color: f.$color-container-default;
     position: static;
     display: block;
     text-align: left;
     min-height: 0;
 
-    margin-top: - spacing(e);
-    margin-left: spacing(d);
-    margin-right: spacing(d) - 1px;
-    border-radius: $radius-rounded-c;
+    margin-top: - f.spacing(e);
+    margin-left: f.spacing(d);
+    margin-right: f.spacing(d) - 1px;
+    border-radius: f.$radius-rounded-c;
     box-shadow: $stampCard-promo-shadow;
 
-    @include media ('>narrowMid') {
+    @include f.media ('>narrowMid') {
         margin: 0;
         box-shadow: none;
     }
 }
 
 .c-stampCardPromotion1-title {
-     @include font-size(subheading-s, false, narrow);
+     @include f.font-size(subheading-s, false, narrow);
 
-     @include media ('>narrowMid') {
-         @include font-size(subheading-s, false);
+     @include f.media ('>narrowMid') {
+         @include f.font-size(subheading-s, false);
      }
 }
 
 .c-stampCardPromotion1-statusText {
-    @include font-size(body-s);
+    @include f.font-size(body-s);
 
-    margin-top: spacing(a);
+    margin-top: f.spacing(a);
 
-    @include media ('>narrowMid') {
-        @include font-size('body-l', false);
+    @include f.media ('>narrowMid') {
+        @include f.font-size('body-l', false);
     }
 }
 
 .c-stampCardPromotion1-link {
-    @include font-size('body-l', false);
+    @include f.font-size('body-l', false);
     text-decoration: none;
-    font-weight: $font-weight-bold;
-    margin-top: spacing();
+    font-weight: f.$font-weight-bold;
+    margin-top: f.spacing();
 
     & {
-        color: $color-content-link;
+        color: f.$color-content-link;
     }
 
     &:hover, &:focus {
-        color: darken($color-content-link, $color-hover-01);
+        color: darken(f.$color-content-link, f.$color-hover-01);
     }
 
     &:active {
-        color: darken($color-content-link, $color-active-01);
+        color: darken(f.$color-content-link, f.$color-active-01);
     }
 }
 </style>

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/TermsAndConditionsCard.vue
@@ -83,28 +83,30 @@ export default {
 </script>
 
 <style lang="scss" module>
+    @use '@justeat/fozzie/src/scss/fozzie' as f;
+
   .c-contentCards-tnc-card-shell {
-    background-color: $color-container-default;
-    padding: spacing(e);
+    background-color: f.$color-container-default;
+    padding: f.spacing(e);
     text-align: center;
   }
 
   .c-contentCards-tnc-card-primaryHeader {
-    @include font-size(heading-s);
-    color: $color-content-default;
+    @include f.font-size(heading-s);
+    color: f.$color-content-default;
 
-    @include media('>=narrow') {
-      @include font-size(heading-xl);
+    @include f.media('>=narrow') {
+      @include f.font-size(heading-xl);
     }
   }
 
   .c-contentCards-tnc-card-secondaryHeader {
-    @include font-size(body-s);
-    color: $color-content-subdued;
-    margin-top: spacing(d);
+    @include f.font-size(body-s);
+    color: f.$color-content-subdued;
+    margin-top: f.spacing(d);
 
-    @include media('>=narrow') {
-      @include font-size(heading-s);
+    @include f.media('>=narrow') {
+      @include f.font-size(heading-s);
     }
   }
 </style>

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard1.vue
@@ -142,14 +142,16 @@ export default {
 </script>
 
 <style lang="scss" module>
+    @use '@justeat/fozzie/src/scss/fozzie' as f;
+
     .c-contentCards-homePromotionCard1 {
         text-decoration: initial;
         display: block;
-        padding: spacing(e) 0 spacing(d);
+        padding: f.spacing(e) 0 f.spacing(d);
         width: 100%;
 
-        @include media('>mid') {
-            padding: spacing(e) 0;
+        @include f.media('>mid') {
+            padding: f.spacing(e) 0;
         }
     }
 
@@ -165,9 +167,9 @@ export default {
         align-items: center;
         justify-content: center;
         width: 100%;
-        margin-bottom: spacing(d);
+        margin-bottom: f.spacing(d);
 
-        @include media('>mid') {
+        @include f.media('>mid') {
             width: 50%;
             margin-bottom: 0;
         }
@@ -181,35 +183,35 @@ export default {
     .c-contentCards-homePromotionCard1-subtitle {
         display: none;
 
-        @include media('>mid') {
+        @include f.media('>mid') {
             display: unset;
-            @include font-size(heading-m);
+            @include f.font-size(heading-m);
         }
     }
 
         .c-contentCards-homePromotionCard1-subtitle--light {
-            color: $color-content-light;
+            color: f.$color-content-light;
         }
 
     .c-contentCards-homePromotionCard1-innerCard {
         width: 100%;
         padding: 0;
 
-        @include media('>mid') {
+        @include f.media('>mid') {
             width: 50%;
 
             :global(.c-contentCards-homePromotionCard2) {
-                padding-left: spacing(g);
+                padding-left: f.spacing(g);
             }
 
             :global(.c-contentCards-homePromotionCard2-title) {
-                @include font-size(heading-m);
-                margin-bottom: spacing();
+                @include f.font-size(heading-m);
+                margin-bottom: f.spacing();
             }
 
             :global(.c-contentCards-homePromotionCard2-text) {
-                @include font-size(subheading-s);
-                margin-top: spacing();
+                @include f.font-size(subheading-s);
+                margin-top: f.spacing();
             }
         }
     }

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/homePromotionCard/HomePromotionCard2.vue
@@ -154,60 +154,62 @@ export default {
 </script>
 
 <style lang="scss" module>
+    @use '@justeat/fozzie/src/scss/fozzie' as f;
+
     .c-contentCards-homePromotionCard2 {
         text-decoration: initial;
         position: relative;
         display: block;
         width: 100%;
-        box-shadow: $elevation-01;
-        border-radius: $radius-rounded-c;
-        padding: spacing(d) calc(35% + #{spacing()}) spacing(d) spacing(d);
+        box-shadow: f.$elevation-01;
+        border-radius: f.$radius-rounded-c;
+        padding: f.spacing(d) calc(35% + #{f.spacing()}) f.spacing(d) f.spacing(d);
         max-width: 800px; //to replicate max-width of searchbox
         margin: auto;
 
-        @include media('>narrow') {
+        @include f.media('>narrow') {
             padding-right: 208px;
             width: 95%; //to replicate width of searchbox
         }
 
         .c-contentCards-homePromotionCard2-link {
-            @include font-size('body-l', false);
+            @include f.font-size('body-l', false);
             text-decoration: none;
-            font-weight: $font-weight-bold;
+            font-weight: f.$font-weight-bold;
 
             & {
-                color: $color-content-link;
+                color: f.$color-content-link;
             }
 
             &:hover, &:focus {
-                color: darken($color-content-link, $color-hover-01);
+                color: darken(f.$color-content-link, f.$color-hover-01);
             }
 
             &:active {
-                color: darken($color-content-link, $color-active-01);
+                color: darken(f.$color-content-link, f.$color-active-01);
             }
         }
 
         .c-contentCards-homePromotionCard2-text {
-            color: $color-content-subdued;
+            color: f.$color-content-subdued;
         }
 
         &.c-contentCards-homePromotionCard2--light {
             .c-contentCards-homePromotionCard2-text {
-                color: $color-content-light;
+                color: f.$color-content-light;
             }
 
             .c-contentCards-homePromotionCard2-title {
-                color: $color-grey-20;
+                color: f.$color-grey-20;
             }
         }
     }
 
     .c-contentCards-homePromotionCard2-title {
-        @include font-size(heading-m);
+        @include f.font-size(heading-m);
 
-        @include media('<=narrow') {
-            @include font-size(heading-m, true, narrow);
+        @include f.media('<=narrow') {
+            @include f.font-size(heading-m, true, narrow);
         }
     }
 
@@ -221,7 +223,7 @@ export default {
         background: right center no-repeat;
         background-size: contain;
 
-        @include media('>narrow') {
+        @include f.media('>narrow') {
             width: 200px;
         }
     }

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/voucherCard/VoucherCard.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/voucherCard/VoucherCard.vue
@@ -170,38 +170,40 @@ export default {
 </script>
 
 <style lang="scss" module>
+    @use '@justeat/fozzie/src/scss/fozzie' as f;
+
     .c-contentCard-voucher {
         display: flex;
         width: 100%;
-        font-family: $font-family-base;
-        border: solid $color-border-strong;
+        font-family: f.$font-family-base;
+        border: solid f.$color-border-strong;
         border-width: 1px 0 0;
-        padding-top: spacing(d);
-        margin-top: spacing(d);
+        padding-top: f.spacing(d);
+        margin-top: f.spacing(d);
         cursor: pointer;
         background: transparent;
     }
 
     .c-contentCard-voucher-code,
     .c-contentCard-voucher-copy {
-        @include font-size(16, false);
+        @include f.font-size(16, false);
         width: 50%;
     }
 
     .c-contentCard-voucher-code {
-        font-weight: $font-weight-regular;
-        color: $color-grey-40;
+        font-weight: f.$font-weight-regular;
+        color: f.$color-grey-40;
         text-align: left;
     }
 
     .c-contentCard-voucher-copy {
-        font-weight: $font-weight-bold;
-        color: $color-content-link;
+        font-weight: f.$font-weight-bold;
+        color: f.$color-content-link;
         text-align: right;
     }
 
     .c-contentCard-voucher-copy-copied {
-        color: $color-content-default;
+        color: f.$color-content-default;
     }
 
     .c-contentCard-voucher-copy-transition-out {
@@ -217,10 +219,10 @@ export default {
     }
 
     .c-contentCard-voucher-code-cooldown-tick {
-        fill: $color-content-default;
-        width: spacing(d);
-        height: spacing(d);
+        fill: f.$color-content-default;
+        width: f.spacing(d);
+        height: f.spacing(d);
         padding: 0;
-        margin-top: -#{spacing()};
+        margin-top: -#{f.spacing()};
     }
 </style>

--- a/packages/components/organisms/f-content-cards/vue.config.js
+++ b/packages/components/organisms/f-content-cards/vue.config.js
@@ -32,7 +32,7 @@ module.exports = {
                     const relPath = path.relative(path.dirname(resourcePath), absPath)
                         .replace(new RegExp(path.sep.replace('\\', '\\\\'), 'g'), '/');
 
-                    return `@import "${relPath}";
+                    return `@use "${relPath}";
                             ${content}`;
                 }
             });

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.52.22
+------------------------------
+*June 27, 2022*
+### Changed
+- updated vue.config to include f-content-cards in components using @use and @forward
+
+
 v0.52.21
 ------------------------------
 *June 27, 2022*

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private":true,
-  "version": "0.52.21",
+  "version": "0.52.22",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/packages/storybook/vue.config.js
+++ b/packages/storybook/vue.config.js
@@ -45,6 +45,7 @@ module.exports = {
                         'atoms',
                         'molecules',
                         'f-status-banner',
+                        'f-content-cards',
                         'templates'
                     ];
                     const pathContainsUpdatedComponentOrType = updateComponentsAndTypes.some(a => absPathCommonScss.includes(a));


### PR DESCRIPTION
f-content-cards: v8.0.0
-----------------------------
*June 27, 2022*

### Changed
- **breaking changes** Update to `@use` and `@forward` SASS syntax


Storybook: v0.52.22
------------------------------
*June 27, 2022*
### Changed
- updated vue.config to include f-content-cards in components using @use and @forward