### PR TITLE
fozzie-components@v7.14.1 - Fix Bundlewatch to only run against changed packages and it's dependants.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,6 +309,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - detect_root_change
       - run:
          name: Run Bundlewatch checks
          command: yarn bundlewatch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ commands:
             then
               yarn << parameters.command_name >>
             else
-              yarn << parameters.command_name >> --filter=[master] --no-deps
+              yarn << parameters.command_name >> --filter=[master]
             fi
 
   build_packages:
@@ -304,17 +304,16 @@ jobs:
       - slack_notify_fail
       - slack_notify_success
 
-  # Disabling temporarily whilst we fix Bundlewatch implementation.
-  # bundlewatch:
-  #   executor: node
-  #   steps:
-  #     - attach_workspace:
-  #         at: .
-  #     - run:
-  #        name: Run Bundlewatch checks
-  #        command: yarn bundlewatch
-  #     - slack_notify_fail
-  #     - slack_notify_success
+  bundlewatch:
+    executor: node
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+         name: Run Bundlewatch checks
+         command: yarn bundlewatch
+      - slack_notify_fail
+      - slack_notify_success
 
   unit-tests:
     executor: node
@@ -414,15 +413,14 @@ workflows:
               ignore: ['gh-pages']
           requires:
             - danger-checks
-      # Disabling temporarily whilst we fix Bundlewatch implementation.
-      # - bundlewatch:
-      #     name: bundlewatch
-      #     context: web-core
-      #     filters:
-      #       branches:
-      #         ignore: ['gh-pages']
-      #     requires:
-      #       - build
+      - bundlewatch:
+          name: bundlewatch
+          context: web-core
+          filters:
+            branches:
+              ignore: ['gh-pages']
+          requires:
+            - build
       - unit-tests:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,16 +304,17 @@ jobs:
       - slack_notify_fail
       - slack_notify_success
 
-  bundlewatch:
-    executor: node
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-         name: Run Bundlewatch checks
-         command: yarn bundlewatch
-      - slack_notify_fail
-      - slack_notify_success
+  # Disabling temporarily whilst we fix Bundlewatch implementation.
+  # bundlewatch:
+  #   executor: node
+  #   steps:
+  #     - attach_workspace:
+  #         at: .
+  #     - run:
+  #        name: Run Bundlewatch checks
+  #        command: yarn bundlewatch
+  #     - slack_notify_fail
+  #     - slack_notify_success
 
   unit-tests:
     executor: node
@@ -413,14 +414,15 @@ workflows:
               ignore: ['gh-pages']
           requires:
             - danger-checks
-      - bundlewatch:
-          name: bundlewatch
-          context: web-core
-          filters:
-            branches:
-              ignore: ['gh-pages']
-          requires:
-            - build
+      # Disabling temporarily whilst we fix Bundlewatch implementation.
+      # - bundlewatch:
+      #     name: bundlewatch
+      #     context: web-core
+      #     filters:
+      #       branches:
+      #         ignore: ['gh-pages']
+      #     requires:
+      #       - build
       - unit-tests:
           matrix:
             parameters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ v7.14.1
 *June 27, 2022*
 
 ### Changed
-- Ignored bundlewatch step in CircleCI config.
+- Fixed bundlewatch to only run against changed packages.
 
 
 v7.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v7.14.1
+------------------------------
+*June 27, 2022*
+
+### Changed
+- Ignored bundlewatch step in CircleCI config.
+
 
 v7.14.0
 ------------------------------

--- a/bundlewatch.config.js
+++ b/bundlewatch.config.js
@@ -12,10 +12,11 @@ const getMaxSizeForPackage = packageLocation => {
 
 const getChangedPackageLocations = () => {
     let outputPackages;
-    let command = process.env.CIRCLE_BRANCH === 'master' ? "npx lerna ls --json" : "npx lerna ls --since origin/master --json" 
+    let command = process.env.CIRCLE_BRANCH === 'master' || process.env.RUN_ALL ? "npx lerna ls --json" : "npx lerna ls --since origin/master --json" 
 
     try {
         outputPackages = execSync(command);
+        console.log(outputPackages);
     } catch (error) {
         console.info('No changed packages found.');
         process.exit(0);

--- a/bundlewatch.config.js
+++ b/bundlewatch.config.js
@@ -16,7 +16,6 @@ const getChangedPackageLocations = () => {
 
     try {
         outputPackages = execSync(command);
-        console.log(outputPackages);
     } catch (error) {
         console.info('No changed packages found.');
         process.exit(0);

--- a/bundlewatch.config.js
+++ b/bundlewatch.config.js
@@ -10,11 +10,12 @@ const getMaxSizeForPackage = packageLocation => {
     return maxBundleSize;
 };
 
-const getPackageLocations = () => {
+const getChangedPackageLocations = () => {
     let outputPackages;
+    let command = process.env.CIRCLE_BRANCH === 'master' ? "npx lerna ls --json" : "npx lerna ls --since origin/master --json" 
 
     try {
-        outputPackages = execSync('npx lerna ls --json');
+        outputPackages = execSync(command);
     } catch (error) {
         console.info('No changed packages found.');
         process.exit(0);
@@ -27,7 +28,7 @@ const getPackageLocations = () => {
     return packageLocations.filter(packageLocation => getMaxSizeForPackage(packageLocation) !== undefined);
 };
 
-const packagesLocations = getPackageLocations();
+const packagesLocations = getChangedPackageLocations();
 
 const files = packagesLocations.map(packageLocation => ({
     path: `${packageLocation}/dist/*+(.min|.min.umd|.es).js`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "7.14.0",
+  "version": "7.14.1",
   "private": true,
   "scripts": {
     "build": "turbo run build --continue",

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-button",
-  "description": "Fozzie Buttron – The generic button component",
+  "description": "Fozzie Button – The generic button component",
   "version": "4.0.0",
   "main": "dist/f-button.umd.min.js",
   "maxBundleSize": "5kB",

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-button",
-  "description": "Fozzie Button – The generic button component",
+  "description": "Fozzie Buttron – The generic button component",
   "version": "4.0.0",
   "main": "dist/f-button.umd.min.js",
   "maxBundleSize": "5kB",

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -3,6 +3,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v9.17.1
+------------------------------
+*June 27, 2022*
+
+### Changed
+- `maxSize` to prevent bundlewatch failure.
+
 
 v9.17.0
 ------------------------------

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header - Globalised Header Component",
-  "version": "9.17.0",
+  "version": "9.17.1",
   "main": "dist/f-header.umd.min.js",
-  "maxBundleSize": "40kB",
+  "maxBundleSize": "45kB",
   "files": [
     "dist",
     "test-utils"


### PR DESCRIPTION
Currently bundlewatch fails when diffing for non-global changes due to use no longer using the CircleCI cache.

This PR should fix Bundlewatch to only run against changed packages and its dependants.