### PR TITLE
fozzie-components@v7.14.2 - Fix bundlewatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ commands:
               source $BASH_ENV
             else
             echo 'export RUN_ALL=false' >> $BASH_ENV
+            source $BASH_ENV
               echo 'Root files not changed'
             fi
 
@@ -66,7 +67,7 @@ commands:
             then
               yarn << parameters.command_name >>
             else
-              yarn << parameters.command_name >> --filter=[master]
+              yarn << parameters.command_name >> --filter=...[master]
             fi
 
   build_packages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v7.14.2
+------------------------------
+*June 27, 2022*
+
+### Fixed
+- Bug with BASH_ENV not being updated in CircleCI config.
+- Evaluation in bundlewatch.config.js
+
 v7.14.1
 ------------------------------
 *June 27, 2022*

--- a/bundlewatch.config.js
+++ b/bundlewatch.config.js
@@ -12,7 +12,7 @@ const getMaxSizeForPackage = packageLocation => {
 
 const getChangedPackageLocations = () => {
     let outputPackages;
-    let command = process.env.CIRCLE_BRANCH === 'master' || process.env.RUN_ALL ? "npx lerna ls --json" : "npx lerna ls --since origin/master --json" 
+    let command = process.env.CIRCLE_BRANCH === 'master' || process.env.RUN_ALL === 'true' ? "npx lerna ls --json" : "npx lerna ls --since origin/master --json" 
 
     try {
         outputPackages = execSync(command);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "7.14.1",
+  "version": "7.14.2",
   "private": true,
   "scripts": {
     "build": "turbo run build --continue",


### PR DESCRIPTION
v7.14.2
------------------------------
*June 27, 2022*

### Fixed
- Bug with BASH_ENV not being updated in CircleCI config.
- Evaluation in bundlewatch.config.js