### PR TITLE
f-registration@2.4.1 - Add tests for policy links

### DIFF
--- a/packages/components/pages/f-registration/CHANGELOG.md
+++ b/packages/components/pages/f-registration/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.4.1
+------------------------------
+*June 27, 2022*
+
+### Added
+- Component tests to check correct URLs for Ts & Cs, Privacy and Cookies policy links.
+
+
 v2.4.0
 ------------------------------
 *June 22, 2022*

--- a/packages/components/pages/f-registration/package.json
+++ b/packages/components/pages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "main": "dist/f-registration.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [

--- a/packages/components/pages/f-registration/test/component/f-registration.component.spec.js
+++ b/packages/components/pages/f-registration/test/component/f-registration.component.spec.js
@@ -21,16 +21,19 @@ describe('Shared - f-registration component tests', () => {
     });
 
     forEach([
-        ['termsAndConditionsLink', '/info/terms-and-conditions'],
-        ['privacyPolicyLink', '/info/privacy-policy'],
-        ['cookiesPolicyLink', '/info/cookies-policy']
+        ['termsAndConditionsLink', 'info/terms-and-conditions'],
+        ['privacyPolicyLink', 'info/privacy-policy'],
+        ['cookiesPolicyLink', 'info/cookies-policy']
     ])
     .it('should take you to the correct URL when clicking the `%s`', (linkName, expectedUrl) => {
+        // Arrange
+        const expectedUrlRegex = new RegExp(`^http(s?)://localhost:\\d+/${expectedUrl}$`);
+
         // Act
         registration[linkName].click();
-        browser.switchWindow(new RegExp(`^.*${expectedUrl}.*$`));
+        browser.switchWindow(expectedUrlRegex); // Link was opened in a new tab
 
         // Assert
-        expect(browser.getUrl()).toContain(expectedUrl);
+        expect(browser.getUrl()).toMatch(expectedUrlRegex);
     });
 });

--- a/packages/components/pages/f-registration/test/component/f-registration.component.spec.js
+++ b/packages/components/pages/f-registration/test/component/f-registration.component.spec.js
@@ -19,4 +19,18 @@ describe('Shared - f-registration component tests', () => {
         // Assert
         expect(registration.canBeClicked(link)).toBe(true);
     });
+
+    forEach([
+        ['termsAndConditionsLink', '/info/terms-and-conditions'],
+        ['privacyPolicyLink', '/info/privacy-policy'],
+        ['cookiesPolicyLink', '/info/cookies-policy']
+    ])
+    .it('should check if the legal documentation is clickable', (linkName, expectedUrl) => {
+        // Act
+        registration[linkName].click();
+        browser.switchWindow(new RegExp(`^.*${expectedUrl}.*$`));
+
+        // Assert
+        expect(browser.getUrl()).toContain(expectedUrl);
+    });
 });

--- a/packages/components/pages/f-registration/test/component/f-registration.component.spec.js
+++ b/packages/components/pages/f-registration/test/component/f-registration.component.spec.js
@@ -25,7 +25,7 @@ describe('Shared - f-registration component tests', () => {
         ['privacyPolicyLink', '/info/privacy-policy'],
         ['cookiesPolicyLink', '/info/cookies-policy']
     ])
-    .it('should check if the legal documentation is clickable', (linkName, expectedUrl) => {
+    .it('should take you to the correct URL when clicking the `%s`', (linkName, expectedUrl) => {
         // Act
         registration[linkName].click();
         browser.switchWindow(new RegExp(`^.*${expectedUrl}.*$`));


### PR DESCRIPTION
### Added
- Component tests to check correct URLs for Ts & Cs, Privacy and Cookies policy links.

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
