### PR TITLE
f-checkout@3.32.1 - Add new props to checkout readme (minor)

### DIFF
--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.32.1
+------------------------------
+*June 28, 2022*
+
+### Added
+- New props to README
+  
+
 v3.32.0
 ------------------------------
 *June 22, 2022*

--- a/packages/components/pages/f-checkout/README.md
+++ b/packages/components/pages/f-checkout/README.md
@@ -85,6 +85,8 @@ The props that can be defined are as follows:
 | `loginUrl` | `String` | `-` | URL to navigate to if the user wishes to change account. |
 | `paymentPageUrlPrefix` | `String` | `-` | URL prefix to navigate to after the order has been successfully placed, so the user can pay. The `orderId` will be appended to this URL to form the full URL. |
 | `applicationName` | `String` | `-` | The name of the application using this component. |
+| `getNoteConfigUrl` | `String` | - | URL for the API called to get the note configuration for split notes |
+| `checkoutFeatures` | `Object` | - | Object containing relevant feature flags set in CoreWeb configuration files |
 
 ### Events
 

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout - Fozzie Checkout Component",
-  "version": "3.32.0",
+  "version": "3.32.1",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "125kB",
   "files": [


### PR DESCRIPTION
A really small change to add the new props to the documentation in the README