### PR TITLE
f-cookie-banner-static@v1.0.2 - update f-cookie-banner version

### DIFF
--- a/packages/components/organisms/f-cookie-banner-static/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner-static/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v1.0.2
+------------------------------
+*June 28, 2022*
+
+### Changed
+- Update `f-cookie-banner` dependency version.
+
 v1.0.1
 ------------------------------
 *June 7, 2022*

--- a/packages/components/organisms/f-cookie-banner-static/package.json
+++ b/packages/components/organisms/f-cookie-banner-static/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner-static",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Fozzie Cookie Banner configuration to compile via vue cli prerender to vanilla js/css",
   "license": "Apache-2.0",
   "scripts": {
@@ -11,7 +11,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-cookie-banner": "3.9.0"
+    "@justeat/f-cookie-banner": "4.0.0"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.52.24
+------------------------------
+*June 29, 2022*
+### Changed
+- updated lerna command to correctly build dependencies
+
+
 v0.52.23
 ------------------------------
 *June 28, 2022*

--- a/packages/storybook/config/storybook/story.config.js
+++ b/packages/storybook/config/storybook/story.config.js
@@ -4,7 +4,7 @@ let outputChangedComponentPackages;
 
 const getChangedPackageStories = () => {
     try {
-        outputChangedComponentPackages = execSync('npx lerna ls --since origin/master --json');
+        outputChangedComponentPackages = execSync('npx lerna ls --since origin/master --json --include-dependencies');
     } catch (error) {
         console.info('No changed component packages found.');
         process.exit(0);

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private":true,
-  "version": "0.52.23",
+  "version": "0.52.24",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --script storybook:build",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,6 +2397,15 @@
   dependencies:
     "@justeat/f-services" "0.13.0"
 
+"@justeat/f-content-cards@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-7.4.0.tgz#a3ee8e3dddc28f0fe8305546b1b7666787518735"
+  integrity sha512-kzNub50NlpHb/F1xLzlV9J2Unn8yu4opv4JlyPBih08CBSaYKAvIfyGhcFzAPq22pPMlqjXrdVpYU4cP6wLtSA==
+  dependencies:
+    "@babel/plugin-proposal-class-properties" "7.12.13"
+    "@justeat/f-services" "1.0.1"
+    core-js "3.6.5"
+
 "@justeat/f-content-cards@8.0.0-beta.4":
   version "8.0.0-beta.4"
   resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-8.0.0-beta.4.tgz#ff7690532e6743ff4f2b83dd4d7aad04e1485c0a"
@@ -2405,13 +2414,6 @@
     "@babel/plugin-proposal-class-properties" "7.12.13"
     "@justeat/f-services" "1.0.1"
     core-js "3.6.5"
-
-"@justeat/f-cookie-banner@3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-cookie-banner/-/f-cookie-banner-3.9.0.tgz#1d005d448e412dab0f976da19293287c455b5cf8"
-  integrity sha512-Yi93qveb5mSZBF6XKoNMJQVTWxYPZN8HNJsrJcLPJHeuHdHUeLKqJJpp5h2l9oQAsS/bP4qNB3GcQ93egOEXoA==
-  dependencies:
-    "@justeat/f-services" "1.14.0"
 
 "@justeat/f-dom@0.4.0":
   version "0.4.0"


### PR DESCRIPTION
f-cookie-banner-static: v1.0.2
------------------------------
*June 28, 2022*

### Changed
- Update `f-cookie-banner` dependency version.


Storybook: v0.52.24
------------------------------
*June 29, 2022*
### Changed
- updated lerna command to correctly build dependencies