### PR TITLE
Atoms - Refactor tests to use ES6 / async await #trivial

### DIFF
--- a/packages/components/atoms/f-card/CHANGELOG.md
+++ b/packages/components/atoms/f-card/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.1.0
+------------------------------
+*July 4, 2022*
+
+### Changed
+- Update f-wdio-utils to v1.1.0 to use new Axe Core implementation.
+- Accessibility tests to be async.
+- Specs to ES6 syntax
+- Babel config to allow for async syntax in tests.
+
 v4.0.0
 ------------------------------
 *June 15, 2022*

--- a/packages/components/atoms/f-card/babel.config.js
+++ b/packages/components/atoms/f-card/babel.config.js
@@ -10,12 +10,10 @@ module.exports = api => {
     if (!isTest) {
         api.cache(true); // Caches the computed babel config function – https://babeljs.io/docs/en/config-files#apicache
         presets.push(['@vue/app', { useBuiltIns: builtIns }]);
+    } else {
+        // use current node version for transpiling test files
+        presets.push(['@babel/env', { targets: { node: 'current' } }]);
     }
-
-    // Alias for @babel/preset-env
-    // Hooks into browserslist to provide smart Babel transforms
-    // https://babeljs.io/docs/en/babel-preset-env
-    presets.push('@babel/env');
 
     return {
         presets,

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-card",
   "description": "Fozzie Card Component – Used for providing wrapper card styling to an element (or group of elements)",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/f-card.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [
@@ -55,7 +55,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/f-wdio-utils": "0.12.0",
+    "@justeat/f-wdio-utils": "1.1.0",
     "@justeat/fozzie": "9.0.0-beta.2"
   }
 }

--- a/packages/components/atoms/f-card/test-utils/component-objects/f-card.component.js
+++ b/packages/components/atoms/f-card/test-utils/component-objects/f-card.component.js
@@ -4,6 +4,6 @@ class Card extends Page {
     constructor () {
         super('atom', 'card-component');
     }
-};
+}
 
 export default new Card();

--- a/packages/components/atoms/f-card/test-utils/component-objects/f-card.component.js
+++ b/packages/components/atoms/f-card/test-utils/component-objects/f-card.component.js
@@ -1,7 +1,9 @@
-const Page = require('@justeat/f-wdio-utils/src/base.page');
+import Page from '@justeat/f-wdio-utils';
 
-module.exports = class Card extends Page {
+class Card extends Page {
     constructor () {
         super('atom', 'card-component');
     }
 };
+
+export default new Card();

--- a/packages/components/atoms/f-card/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-card/test/accessibility/axe-accessibility.spec.js
@@ -4,7 +4,7 @@ describe('Accessibility tests', () => {
     it('a11y - should test f-card component WCAG compliance', async () => {
         // Arrange
         await Card.load();
-        
+
         // Act
         const axeResults = await Card.getAxeResults('f-card');
 

--- a/packages/components/atoms/f-card/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-card/test/accessibility/axe-accessibility.spec.js
@@ -1,17 +1,12 @@
-const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
-
-const Card = require('../../test-utils/component-objects/f-card.component');
-
-const card = new Card();
+import Card from '../../test-utils/component-objects/f-card.component';
 
 describe('Accessibility tests', () => {
-    beforeEach(() => {
-        card.load();
-    });
-
-    it('a11y - should test f-card component WCAG compliance', () => {
+    it('a11y - should test f-card component WCAG compliance', async () => {
+        // Arrange
+        await Card.load();
+        
         // Act
-        const axeResults = getAxeResults('f-card');
+        const axeResults = await Card.getAxeResults('f-card');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-card/test/component/f-card.component.spec.js
+++ b/packages/components/atoms/f-card/test/component/f-card.component.spec.js
@@ -1,14 +1,11 @@
-const Card = require('../../test-utils/component-objects/f-card.component');
-
-const card = new Card();
+import Card from '../../test-utils/component-objects/f-card.component';
 
 describe('f-card component tests', () => {
-    beforeEach(async () => {
-        await card.load();
-    });
-
     it('should display the f-card component', async () => {
+        // Arrange
+        await Card.load();
+        
         // Assert
-        await expect(await card.isComponentDisplayed()).toBe(true);
+        await expect(await Card.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/atoms/f-card/test/component/f-card.component.spec.js
+++ b/packages/components/atoms/f-card/test/component/f-card.component.spec.js
@@ -4,7 +4,7 @@ describe('f-card component tests', () => {
     it('should display the f-card component', async () => {
         // Arrange
         await Card.load();
-        
+
         // Assert
         await expect(await Card.isComponentDisplayed()).toBe(true);
     });

--- a/packages/components/atoms/f-error-message/CHANGELOG.md
+++ b/packages/components/atoms/f-error-message/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.1.0
+------------------------------
+*July 4, 2022*
+
+### Changed
+- Update f-wdio-utils to v1.1.0 to use new Axe Core implementation.
+- Accessibility tests to be async.
+- Specs to ES6 syntax
+
 
 v2.0.0
 ------------------------------

--- a/packages/components/atoms/f-error-message/package.json
+++ b/packages/components/atoms/f-error-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-error-message",
   "description": "Fozzie Error Message – Generic inline error message",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "dist/f-error-message.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [
@@ -55,7 +55,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/f-wdio-utils": "0.12.0",
+    "@justeat/f-wdio-utils": "1.1.0",
     "@justeat/fozzie": "9.0.0-beta.2"
   }
 }

--- a/packages/components/atoms/f-error-message/test-utils/component-objects/f-error-message.component.js
+++ b/packages/components/atoms/f-error-message/test-utils/component-objects/f-error-message.component.js
@@ -1,7 +1,9 @@
-const Page = require('@justeat/f-wdio-utils/src/base.page');
+import Page from '@justeat/f-wdio-utils';
 
-module.exports = class ErrorMessage extends Page {
+class ErrorMessage extends Page {
     constructor () {
         super('atom', 'error-message-component');
     }
 };
+
+export default new ErrorMessage();

--- a/packages/components/atoms/f-error-message/test-utils/component-objects/f-error-message.component.js
+++ b/packages/components/atoms/f-error-message/test-utils/component-objects/f-error-message.component.js
@@ -4,6 +4,6 @@ class ErrorMessage extends Page {
     constructor () {
         super('atom', 'error-message-component');
     }
-};
+}
 
 export default new ErrorMessage();

--- a/packages/components/atoms/f-error-message/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-error-message/test/accessibility/axe-accessibility.spec.js
@@ -1,17 +1,11 @@
-const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
-
-const ErrorMessage = require('../../test-utils/component-objects/f-error-message.component');
-
-const errorMessage = new ErrorMessage();
+import ErrorMessage from '../../test-utils/component-objects/f-error-message.component';
 
 describe('Accessibility tests', () => {
-    beforeEach(() => {
-        errorMessage.load();
-    });
-
-    it('a11y - should test f-error-message component WCAG compliance', () => {
+    it('a11y - should test f-error-message component WCAG compliance', async () => {
+        // Arrange
+        await ErrorMessage.load();
         // Act
-        const axeResults = getAxeResults('f-error-message');
+        const axeResults = await ErrorMessage.getAxeResults('f-error-message');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-error-message/test/component/f-error-message.component.spec.js
+++ b/packages/components/atoms/f-error-message/test/component/f-error-message.component.spec.js
@@ -4,7 +4,7 @@ describe('f-error-message component tests', () => {
     it('should display the f-error-message component', async () => {
         // Arrange
         await ErrorMessage.load();
-        
+
         // Assert
         await expect(await ErrorMessage.isComponentDisplayed()).toBe(true);
     });

--- a/packages/components/atoms/f-error-message/test/component/f-error-message.component.spec.js
+++ b/packages/components/atoms/f-error-message/test/component/f-error-message.component.spec.js
@@ -1,14 +1,11 @@
-const ErrorMessage = require('../../test-utils/component-objects/f-error-message.component');
-
-const errorMessage = new ErrorMessage();
+import ErrorMessage from '../../test-utils/component-objects/f-error-message.component';
 
 describe('f-error-message component tests', () => {
-    beforeEach(async () => {
-        await errorMessage.load();
-    });
-
     it('should display the f-error-message component', async () => {
+        // Arrange
+        await ErrorMessage.load();
+        
         // Assert
-        await expect(await errorMessage.isComponentDisplayed()).toBe(true);
+        await expect(await ErrorMessage.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/atoms/f-filter-pill/CHANGELOG.md
+++ b/packages/components/atoms/f-filter-pill/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.1.0
+------------------------------
+*July 4, 2022*
+
+### Changed
+- Update f-wdio-utils to v1.1.0 to use new Axe Core implementation.
+- Accessibility tests to be async.
+- Specs to ES6 syntax
+
 
 v1.0.0
 -----------------------------

--- a/packages/components/atoms/f-filter-pill/package.json
+++ b/packages/components/atoms/f-filter-pill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-filter-pill",
   "description": "Fozzie Filter Pill - An interactive component for filter toggles.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/f-filter-pill.umd.min.js",
   "files": [
     "dist",
@@ -49,7 +49,7 @@
     "@justeat/browserslist-config-fozzie": ">=1.2.0"
   },
   "devDependencies": {
-    "@justeat/f-wdio-utils": "0.12.0",
+    "@justeat/f-wdio-utils": "1.1.0",
     "@justeat/fozzie": "9.0.0-beta.2",
     "@vue/cli-plugin-babel": "4.5.15",
     "@vue/cli-plugin-unit-jest": "4.5.15",

--- a/packages/components/atoms/f-filter-pill/test-utils/component-objects/f-filter-pill.component.js
+++ b/packages/components/atoms/f-filter-pill/test-utils/component-objects/f-filter-pill.component.js
@@ -4,6 +4,6 @@ class FilterPill extends Page {
     constructor () {
         super('atom', 'filter-pill-component');
     }
-};
+}
 
 export default new FilterPill();

--- a/packages/components/atoms/f-filter-pill/test-utils/component-objects/f-filter-pill.component.js
+++ b/packages/components/atoms/f-filter-pill/test-utils/component-objects/f-filter-pill.component.js
@@ -1,7 +1,9 @@
-const Page = require('@justeat/f-wdio-utils/src/base.page');
+import Page from '@justeat/f-wdio-utils';
 
-module.exports = class FilterPill extends Page {
+class FilterPill extends Page {
     constructor () {
         super('atom', 'filter-pill-component');
     }
 };
+
+export default new FilterPill();

--- a/packages/components/atoms/f-filter-pill/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-filter-pill/test/accessibility/axe-accessibility.spec.js
@@ -4,7 +4,7 @@ describe('Accessibility tests', () => {
     it('a11y - should test f-filter-pill component WCAG compliance', async () => {
         // Arrange
         await FilterPill.load();
-        
+
         // Act
         const axeResults = await FilterPill.getAxeResults('f-filter-pill');
 

--- a/packages/components/atoms/f-filter-pill/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-filter-pill/test/accessibility/axe-accessibility.spec.js
@@ -1,17 +1,12 @@
-import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
-
-const FilterPill = require('../../test-utils/component-objects/f-filter-pill.component');
-
-const filterPill = new FilterPill();
+import FilterPill from '../../test-utils/component-objects/f-filter-pill.component';
 
 describe('Accessibility tests', () => {
-    beforeEach(() => {
-        filterPill.load();
-    });
-
-    it('a11y - should test f-filter-pill component WCAG compliance', () => {
+    it('a11y - should test f-filter-pill component WCAG compliance', async () => {
+        // Arrange
+        await FilterPill.load();
+        
         // Act
-        const axeResults = getAxeResults('f-filter-pill');
+        const axeResults = await FilterPill.getAxeResults('f-filter-pill');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-filter-pill/test/component/f-filter-pill.component.spec.js
+++ b/packages/components/atoms/f-filter-pill/test/component/f-filter-pill.component.spec.js
@@ -1,14 +1,11 @@
-const FilterPill = require('../../test-utils/component-objects/f-filter-pill.component');
-
-const filterPill = new FilterPill();
+import FilterPill from '../../test-utils/component-objects/f-filter-pill.component';
 
 describe('f-filter-pill component tests', () => {
-    beforeEach(async () => {
-        await filterPill.load();
-    });
-
     it('should display the f-filter-pill component', async () => {
+        // Arrange
+        await FilterPill.load();
+        
         // Assert
-        await expect(await filterPill.isComponentDisplayed()).toBe(true);
+        await expect(await FilterPill.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/atoms/f-filter-pill/test/component/f-filter-pill.component.spec.js
+++ b/packages/components/atoms/f-filter-pill/test/component/f-filter-pill.component.spec.js
@@ -4,7 +4,7 @@ describe('f-filter-pill component tests', () => {
     it('should display the f-filter-pill component', async () => {
         // Arrange
         await FilterPill.load();
-        
+
         // Assert
         await expect(await FilterPill.isComponentDisplayed()).toBe(true);
     });

--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -3,9 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-Latest (add to next release)
+v5.1.0
 ------------------------------
-*June 20, 2021*
+*July 4, 2022*
+
+### Changed
+- Update f-wdio-utils to v1.1.0 to use new Axe Core implementation.
+- Accessibility tests to be async.
+- Specs to ES6 syntax
 
 ### Fixed
 - Missing/duplicated storybook props.

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field - Fozzie Form Field Component",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "main": "dist/f-form-field.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [
@@ -58,7 +58,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/f-wdio-utils": "0.12.0",
+    "@justeat/f-wdio-utils": "1.1.0",
     "@justeat/fozzie": "9.0.0-beta.2",
     "postcss-assets": "5.0.0"
   }

--- a/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field--visual.component.js
+++ b/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field--visual.component.js
@@ -1,9 +1,11 @@
-const Page = require('@justeat/f-wdio-utils/src/base.page');
+import Page from '@justeat/f-wdio-utils/src/base.page';
 
-module.exports = class FormField extends Page {
+class FormField extends Page {
     constructor () {
         super('atom-folder', 'f-form-field--form-field-component');
     }
 
     get component () { return $('[data-test-id="formfield-container"]'); }
 };
+
+export default new FormField();

--- a/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field--visual.component.js
+++ b/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field--visual.component.js
@@ -6,6 +6,6 @@ class FormField extends Page {
     }
 
     get component () { return $('[data-test-id="formfield-container"]'); }
-};
+}
 
 export default new FormField();

--- a/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field.component.js
+++ b/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field.component.js
@@ -28,6 +28,6 @@ class FormField extends Page {
     async getUserInput () {
         return this.input.getValue();
     }
-};
+}
 
 export default new FormField();

--- a/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field.component.js
+++ b/packages/components/atoms/f-form-field/test-utils/component-objects/f-form-field.component.js
@@ -1,6 +1,6 @@
-const Page = require('@justeat/f-wdio-utils/src/base.page');
+import Page from '@justeat/f-wdio-utils';
 
-module.exports = class FormField extends Page {
+class FormField extends Page {
     constructor () {
         super('atom-folder', 'f-form-field--text-input-default-component');
     }
@@ -29,3 +29,5 @@ module.exports = class FormField extends Page {
         return this.input.getValue();
     }
 };
+
+export default new FormField();

--- a/packages/components/atoms/f-form-field/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-form-field/test/accessibility/axe-accessibility.spec.js
@@ -1,4 +1,4 @@
-import FormField from'../../test-utils/component-objects/f-form-field.component';
+import FormField from '../../test-utils/component-objects/f-form-field.component';
 
 describe('Accessibility tests', () => {
     it('a11y - should test f-formField component WCAG compliance', async () => {

--- a/packages/components/atoms/f-form-field/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-form-field/test/accessibility/axe-accessibility.spec.js
@@ -1,17 +1,11 @@
-const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
-
-const FormField = require('../../test-utils/component-objects/f-form-field.component');
-
-const formfield = new FormField();
+import FormField from'../../test-utils/component-objects/f-form-field.component';
 
 describe('Accessibility tests', () => {
-    beforeEach(() => {
-        formfield.load();
-    });
-
-    it('a11y - should test f-formField component WCAG compliance', () => {
+    it('a11y - should test f-formField component WCAG compliance', async () => {
+        // Arrange
+        await FormField.load();
         // Act
-        const axeResults = getAxeResults('f-form-field');
+        const axeResults = await FormField.getAxeResults('f-form-field');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-form-field/test/component/f-form-field.component.spec.js
+++ b/packages/components/atoms/f-form-field/test/component/f-form-field.component.spec.js
@@ -1,20 +1,18 @@
-const FormField = require('../../test-utils/component-objects/f-form-field.component');
-
-const formfield = new FormField();
+import FormField from'../../test-utils/component-objects/f-form-field.component';
 
 describe('f-form-field component tests', () => {
     beforeEach(async () => {
-        await formfield.load();
+        await FormField.load();
     });
 
     it('should display f-form-field', async () => {
         // Assert
-        await expect(await formfield.isComponentDisplayed()).toBe(true);
+        await expect(await FormField.isComponentDisplayed()).toBe(true);
     });
 
     it('should display Label', async () => {
         // Assert
-        await expect(await formfield.isLabelDisplayed()).toBe(true);
+        await expect(await FormField.isLabelDisplayed()).toBe(true);
     });
 
     it('should display user input', async () => {
@@ -24,9 +22,9 @@ describe('f-form-field component tests', () => {
         };
 
         // Act
-        await formfield.addUserInput(userInput);
+        await FormField.addUserInput(userInput);
 
         // Assert
-        await expect(await formfield.getUserInput()).toEqual('abcd');
+        await expect(await FormField.getUserInput()).toEqual('abcd');
     });
 });

--- a/packages/components/atoms/f-form-field/test/component/f-form-field.component.spec.js
+++ b/packages/components/atoms/f-form-field/test/component/f-form-field.component.spec.js
@@ -1,4 +1,4 @@
-import FormField from'../../test-utils/component-objects/f-form-field.component';
+import FormField from '../../test-utils/component-objects/f-form-field.component';
 
 describe('f-form-field component tests', () => {
     beforeEach(async () => {

--- a/packages/components/atoms/f-form-field/test/visual/f-form-field.visual.spec.js
+++ b/packages/components/atoms/f-form-field/test/visual/f-form-field.visual.spec.js
@@ -1,17 +1,10 @@
-const FormField = require('../../test-utils/component-objects/f-form-field--visual.component');
+import FormField from '../../test-utils/component-objects/f-form-field--visual.component';
 
 describe('f-form-field visual tests', () => {
-    let formField;
-
-    beforeEach(async () => {
-        // Arrange
-        formField = new FormField();
-    });
-
     describe('default state', () => {
         it('should display all fields in the default state', async () => {
             // Act
-            await formField.load();
+            await FormField.load();
 
             // Assert
             await browser.percyScreenshot('f-form-field - Base State', 'desktop');
@@ -21,7 +14,7 @@ describe('f-form-field visual tests', () => {
     describe('disabled state', () => {
         it('should display all fields in a disabled state', async () => {
             // Act
-            await formField.load({ isDisabled: true });
+            await FormField.load({ isDisabled: true });
 
             // Assert
             await browser.percyScreenshot('f-form-field - Disabled State', 'desktop');
@@ -31,7 +24,7 @@ describe('f-form-field visual tests', () => {
     describe('errored state', () => {
         it('should display all fields in an errored state', async () => {
             // Act
-            await formField.load({ hasError: true });
+            await FormField.load({ hasError: true });
 
             // Assert
             await browser.percyScreenshot('f-form-field - Errored State', 'desktop');
@@ -41,7 +34,7 @@ describe('f-form-field visual tests', () => {
     describe('none required state', () => {
         it('should display all fields in an none required state', async () => {
             // Act
-            await formField.load({ isRequired: false });
+            await FormField.load({ isRequired: false });
 
             // Assert
             await browser.percyScreenshot('f-form-field - None required State', 'desktop');

--- a/packages/components/atoms/f-image-tile/CHANGELOG.md
+++ b/packages/components/atoms/f-image-tile/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.1.0
+------------------------------
+*July 4, 2022*
+
+### Changed
+- Update f-wdio-utils to v1.1.0 to use new Axe Core implementation.
+- Accessibility tests to be async.
+- Specs to ES6 syntax
+
 v1.0.1
 -----------------------------
 *Jun 23, 2022*

--- a/packages/components/atoms/f-image-tile/package.json
+++ b/packages/components/atoms/f-image-tile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-image-tile",
   "description": "Fozzie Image Tile - An interactive tile component containing an image, text and link.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "dist/f-image-tile.umd.min.js",
   "files": [
     "dist",
@@ -53,7 +53,7 @@
     "@justeat/browserslist-config-fozzie": ">=1.2.0"
   },
   "devDependencies": {
-    "@justeat/f-wdio-utils": "0.12.0",
+    "@justeat/f-wdio-utils": "1.1.0",
     "@justeat/fozzie": "9.0.0-beta.2",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",

--- a/packages/components/atoms/f-image-tile/test-utils/component-objects/f-image-tile.component.js
+++ b/packages/components/atoms/f-image-tile/test-utils/component-objects/f-image-tile.component.js
@@ -1,6 +1,6 @@
-const Page = require('@justeat/f-wdio-utils/src/base.page');
+import Page from'@justeat/f-wdio-utils';
 
-module.exports = class ImageTile extends Page {
+class ImageTile extends Page {
     constructor () {
         super('atom', 'image-tile-component');
     }
@@ -9,3 +9,5 @@ module.exports = class ImageTile extends Page {
         return this.component.isClickable();
     }
 };
+
+export default new ImageTile();

--- a/packages/components/atoms/f-image-tile/test-utils/component-objects/f-image-tile.component.js
+++ b/packages/components/atoms/f-image-tile/test-utils/component-objects/f-image-tile.component.js
@@ -1,4 +1,4 @@
-import Page from'@justeat/f-wdio-utils';
+import Page from '@justeat/f-wdio-utils';
 
 class ImageTile extends Page {
     constructor () {
@@ -8,6 +8,6 @@ class ImageTile extends Page {
     async isComponentClickable () {
         return this.component.isClickable();
     }
-};
+}
 
 export default new ImageTile();

--- a/packages/components/atoms/f-image-tile/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-image-tile/test/accessibility/axe-accessibility.spec.js
@@ -4,7 +4,7 @@ describe('Accessibility tests', () => {
     it('a11y - should test f-image-tile component WCAG compliance', async () => {
         // Arrange
         await ImageTile.load();
-        
+
         // Act
         const axeResults = await ImageTile.getAxeResults('f-image-tile');
 

--- a/packages/components/atoms/f-image-tile/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-image-tile/test/accessibility/axe-accessibility.spec.js
@@ -1,16 +1,12 @@
-import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
-
-const ImageTile = require('../../test-utils/component-objects/f-image-tile.component');
-
-const imageTile = new ImageTile();
+import ImageTile from '../../test-utils/component-objects/f-image-tile.component';
 
 describe('Accessibility tests', () => {
-    beforeEach(() => {
-        imageTile.load();
-    });
-    it('a11y - should test f-image-tile component WCAG compliance', () => {
+    it('a11y - should test f-image-tile component WCAG compliance', async () => {
+        // Arrange
+        await ImageTile.load();
+        
         // Act
-        const axeResults = getAxeResults('f-image-tile');
+        const axeResults = await ImageTile.getAxeResults('f-image-tile');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-image-tile/test/component/f-image-tile.component.spec.js
+++ b/packages/components/atoms/f-image-tile/test/component/f-image-tile.component.spec.js
@@ -1,19 +1,17 @@
-const ImageTile = require('../../test-utils/component-objects/f-image-tile.component');
-
-const imageTile = new ImageTile();
+import ImageTile from '../../test-utils/component-objects/f-image-tile.component';
 
 describe('f-image-tile component tests', () => {
     beforeEach(async () => {
-        await imageTile.load();
+        await ImageTile.load();
     });
 
     it('should display the f-image-tile component', async () => {
         // Assert
-        await expect(await imageTile.isComponentDisplayed()).toBe(true);
+        await expect(await ImageTile.isComponentDisplayed()).toBe(true);
     });
 
     it('should check that the f-image-tile component is clickable', async () => {
         // Assert
-        await expect(await imageTile.isComponentClickable()).toBe(true);
+        await expect(await ImageTile.isComponentClickable()).toBe(true);
     });
 });

--- a/packages/components/atoms/f-link/CHANGELOG.md
+++ b/packages/components/atoms/f-link/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.2.0
+------------------------------
+*July 4, 2022*
+
+### Changed
+- Update f-wdio-utils to v1.1.0 to use new Axe Core implementation.
+- Accessibility tests to be async.
+- Specs to ES6 syntax
+
 
 v3.1.1
 ------------------------------

--- a/packages/components/atoms/f-link/package.json
+++ b/packages/components/atoms/f-link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-link",
   "description": "Fozzie Link - Fozzie link component",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "main": "dist/f-link.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
-    "@justeat/f-wdio-utils": "0.12.0",
+    "@justeat/f-wdio-utils": "1.1.0",
     "@justeat/fozzie": "9.0.0-beta.2",
     "@vue/test-utils": "1.0.3"
   }

--- a/packages/components/atoms/f-link/test-utils/component-objects/f-link.component.js
+++ b/packages/components/atoms/f-link/test-utils/component-objects/f-link.component.js
@@ -4,6 +4,6 @@ class Link extends Page {
     constructor () {
         super('atom', 'v-link-component');
     }
-};
+}
 
 export default new Link();

--- a/packages/components/atoms/f-link/test-utils/component-objects/f-link.component.js
+++ b/packages/components/atoms/f-link/test-utils/component-objects/f-link.component.js
@@ -1,7 +1,9 @@
-const Page = require('@justeat/f-wdio-utils/src/base.page');
+import Page from '@justeat/f-wdio-utils';
 
-module.exports = class Link extends Page {
+class Link extends Page {
     constructor () {
         super('atom', 'v-link-component');
     }
 };
+
+export default new Link();

--- a/packages/components/atoms/f-link/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-link/test/accessibility/axe-accessibility.spec.js
@@ -4,7 +4,7 @@ describe('Accessibility tests', () => {
     it('a11y - should test f-link component WCAG compliance', async () => {
         // Arrange
         await Link.load();
-        
+
         // Act
         const axeResults = await Link.getAxeResults('f-link');
 

--- a/packages/components/atoms/f-link/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-link/test/accessibility/axe-accessibility.spec.js
@@ -1,16 +1,12 @@
-import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
-
-const Link = require('../../test-utils/component-objects/f-link.component');
-
-const link = new Link();
+import Link from '../../test-utils/component-objects/f-link.component';
 
 describe('Accessibility tests', () => {
-    beforeEach(() => {
-        link.load();
-    });
-    it('a11y - should test f-link component WCAG compliance', () => {
+    it('a11y - should test f-link component WCAG compliance', async () => {
+        // Arrange
+        await Link.load();
+        
         // Act
-        const axeResults = getAxeResults('f-link');
+        const axeResults = await Link.getAxeResults('f-link');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-link/test/component/f-link.component.spec.js
+++ b/packages/components/atoms/f-link/test/component/f-link.component.spec.js
@@ -1,14 +1,11 @@
-const Link = require('../../test-utils/component-objects/f-link.component');
-
-const link = new Link();
+import Link from '../../test-utils/component-objects/f-link.component';
 
 describe('f-link component tests', () => {
-    beforeEach(async () => {
-        await link.load();
-    });
-
     it('should display the f-link component', async () => {
+        // Arrange
+        await Link.load();
+
         // Assert
-        await expect(await link.isComponentDisplayed()).toBe(true);
+        await expect(await Link.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/atoms/f-popover/CHANGELOG.md
+++ b/packages/components/atoms/f-popover/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.1.0
+------------------------------
+*July 4, 2022*
+
+### Changed
+- Update f-wdio-utils to v1.1.0 to use new Axe Core implementation.
+- Accessibility tests to be async.
+- Specs to ES6 syntax
+
 
 v3.0.0
 -----------------------------

--- a/packages/components/atoms/f-popover/package.json
+++ b/packages/components/atoms/f-popover/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-popover",
   "description": "Fozzie Popover - renders recieved content as a popover",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "dist/f-popover.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [
@@ -56,7 +56,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/f-wdio-utils": "0.12.0",
+    "@justeat/f-wdio-utils": "1.1.0",
     "@justeat/fozzie": "9.0.0-beta.2"
   }
 }

--- a/packages/components/atoms/f-popover/test-utils/component-objects/f-popover.component.js
+++ b/packages/components/atoms/f-popover/test-utils/component-objects/f-popover.component.js
@@ -1,7 +1,9 @@
-const Page = require('@justeat/f-wdio-utils/src/base.page');
+import Page from '@justeat/f-wdio-utils';
 
-module.exports = class Popover extends Page {
+class Popover extends Page {
     constructor () {
         super('atom', 'popover-component');
     }
 };
+
+export default new Popover();

--- a/packages/components/atoms/f-popover/test-utils/component-objects/f-popover.component.js
+++ b/packages/components/atoms/f-popover/test-utils/component-objects/f-popover.component.js
@@ -4,6 +4,6 @@ class Popover extends Page {
     constructor () {
         super('atom', 'popover-component');
     }
-};
+}
 
 export default new Popover();

--- a/packages/components/atoms/f-popover/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-popover/test/accessibility/axe-accessibility.spec.js
@@ -4,7 +4,7 @@ describe('Accessibility tests', () => {
     it('a11y - should test f-popover component WCAG compliance', async () => {
         // Arrange
         await Popover.load();
-        
+
         // Act
         const axeResults = await Popover.getAxeResults('f-popover');
 

--- a/packages/components/atoms/f-popover/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-popover/test/accessibility/axe-accessibility.spec.js
@@ -1,16 +1,12 @@
-const { getAxeResults } = require('../../../../../../test/utils/axe-helper');
-
-const Popover = require('../../test-utils/component-objects/f-popover.component');
-
-const popover = new Popover();
+import Popover from '../../test-utils/component-objects/f-popover.component';
 
 describe('Accessibility tests', () => {
-    beforeEach(() => {
-        popover.load();
-    });
-    it('a11y - should test f-popover component WCAG compliance', () => {
+    it('a11y - should test f-popover component WCAG compliance', async () => {
+        // Arrange
+        await Popover.load();
+        
         // Act
-        const axeResults = getAxeResults('f-popover');
+        const axeResults = await Popover.getAxeResults('f-popover');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-popover/test/component/f-popover.component.spec.js
+++ b/packages/components/atoms/f-popover/test/component/f-popover.component.spec.js
@@ -4,7 +4,7 @@ describe('f-popover component tests', () => {
     it('should display the f-popover component', async () => {
         // Arrange
         await Popover.load();
-        
+
         // Assert
         await expect(await Popover.isComponentDisplayed()).toBe(true);
     });

--- a/packages/components/atoms/f-popover/test/component/f-popover.component.spec.js
+++ b/packages/components/atoms/f-popover/test/component/f-popover.component.spec.js
@@ -1,14 +1,11 @@
-const Popover = require('../../test-utils/component-objects/f-popover.component');
-
-const popover = new Popover();
+import Popover from '../../test-utils/component-objects/f-popover.component';
 
 describe('f-popover component tests', () => {
-    beforeEach(async () => {
-        await popover.load();
-    });
-
     it('should display the f-popover component', async () => {
+        // Arrange
+        await Popover.load();
+        
         // Assert
-        await expect(await popover.isComponentDisplayed()).toBe(true);
+        await expect(await Popover.isComponentDisplayed()).toBe(true);
     });
 });

--- a/packages/components/atoms/f-spinner/CHANGELOG.md
+++ b/packages/components/atoms/f-spinner/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.1.0
+------------------------------
+*July 4, 2022*
+
+### Changed
+- Update f-wdio-utils to v1.1.0 to use new Axe Core implementation.
+- Accessibility tests to be async.
+- Specs to ES6 syntax
+
 
 v1.0.0
 ------------------------------

--- a/packages/components/atoms/f-spinner/package.json
+++ b/packages/components/atoms/f-spinner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-spinner",
   "description": "Fozzie Spinner - loading indicator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/f-spinner.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [
@@ -53,7 +53,7 @@
     "@justeat/browserslist-config-fozzie": ">=1.2.0"
   },
   "devDependencies": {
-    "@justeat/f-wdio-utils": "0.12.0",
+    "@justeat/f-wdio-utils": "1.1.0",
     "@justeat/fozzie": "9.0.0-beta.2",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",

--- a/packages/components/atoms/f-spinner/test-utils/component-objects/f-spinner.component.js
+++ b/packages/components/atoms/f-spinner/test-utils/component-objects/f-spinner.component.js
@@ -1,8 +1,9 @@
 import Page from '@justeat/f-wdio-utils';
+
 class Spinner extends Page {
     constructor () {
         super('atom', 'v-spinner-component');
     }
-};
+}
 
 export default new Spinner();

--- a/packages/components/atoms/f-spinner/test-utils/component-objects/f-spinner.component.js
+++ b/packages/components/atoms/f-spinner/test-utils/component-objects/f-spinner.component.js
@@ -1,7 +1,8 @@
-const Page = require('@justeat/f-wdio-utils/src/base.page');
-
-module.exports = class Spinner extends Page {
+import Page from '@justeat/f-wdio-utils';
+class Spinner extends Page {
     constructor () {
         super('atom', 'v-spinner-component');
     }
 };
+
+export default new Spinner();

--- a/packages/components/atoms/f-spinner/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-spinner/test/accessibility/axe-accessibility.spec.js
@@ -1,19 +1,12 @@
-import { getAxeResults } from '../../../../../../test/utils/axe-helper'; // eslint-disable-line import/no-relative-packages
-
-const Spinner = require('../../test-utils/component-objects/f-spinner.component');
-
-let spinner;
+import Spinner from '../../test-utils/component-objects/f-spinner.component';
 
 describe('Accessibility tests', () => {
-    beforeEach(() => {
-        spinner = new Spinner();
+    it('a11y - should test f-spinner component WCAG compliance', async () => {
+        // Arrange
+        await Spinner.load();
 
-        spinner.load();
-    });
-
-    it('a11y - should test f-spinner component WCAG compliance', () => {
         // Act
-        const axeResults = getAxeResults('f-spinner');
+        const axeResults = await Spinner.getAxeResults('f-spinner');
 
         // Assert
         expect(axeResults.violations.length).toBe(0);

--- a/packages/components/atoms/f-spinner/test/component/f-spinner.component.spec.js
+++ b/packages/components/atoms/f-spinner/test/component/f-spinner.component.spec.js
@@ -1,17 +1,12 @@
 /* eslint-disable class-methods-use-this */
-const Spinner = require('../../test-utils/component-objects/f-spinner.component');
-
-let spinner;
+import Spinner from '../../test-utils/component-objects/f-spinner.component';
 
 describe('f-spinner component tests', () => {
-    beforeEach(async () => {
-        spinner = new Spinner();
-
-        await spinner.load();
-    });
-
     it('should display the f-spinner component', async () => {
+        // Arrange
+        await Spinner.load();
+
         // Assert
-        await expect(await spinner.isComponentDisplayed()).toBe(true);
+        await expect(await Spinner.isComponentDisplayed()).toBe(true);
     });
 });


### PR DESCRIPTION
### Changed
- Update f-wdio-utils to v1.1.0 to use new Axe Core implementation.
- Accessibility tests to be async.
- Specs to ES6 syntax