### PR TITLE
generator-component@2.12.1 - Fix closing brace

### DIFF
--- a/packages/tools/generator-component/CHANGELOG.md
+++ b/packages/tools/generator-component/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.12.1
+------------------------------
+*July 07, 2022*
+
+### Fixed
+- Missing closing brace in package.json generator template.
+
+
 v2.12.0
 ------------------------------
 *July 06, 2022*

--- a/packages/tools/generator-component/generators/app/templates/__package__.json
+++ b/packages/tools/generator-component/generators/app/templates/__package__.json
@@ -58,8 +58,8 @@
 <% if(config.isComponent) { %>    "@justeat/f-wdio-utils": "0.12.0",
     "@vue/cli-plugin-babel": "4.5.15",
     "@vue/cli-plugin-unit-jest": "4.5.15",
-    "@vue/test-utils": "1.2.2"<% }
-    "core-js": "3.19.1",
+    "@vue/test-utils": "1.2.2"<% } else { %>
+"core-js": "3.19.1",
     "eslint": "7.32.0",
     "jest-extended": "0.11.5"<% } %><% if(config.needsTestingApiMocks) { %>,
     "axios": "0.24.0"<%

--- a/packages/tools/generator-component/package.json
+++ b/packages/tools/generator-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/generator-component",
   "description": "Generator Component – A generator for Fozzie components",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "files": [
     "generators"
   ],


### PR DESCRIPTION
### Fixed
- Missing closing brace in package.json generator template.