### PR TITLE
f-form-field@6.0.0 - Replace `isRequired` prop with `required` attribute

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -3,6 +3,26 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v6.0.0
+------------------------------
+*July 12, 2022*
+
+### Removed
+- **BREAKING**: `isRequired` prop in favour of the standard HTML attribute.
+- `aria-required` attributes as they were not adding anything.
+  - `required` behaves as expected for all major screen reader / browser combinations, except Chrome and Firefox with Android Talkback. `aria-required` also does not work for these combinations.
+
+### Changed
+- Now handles `required` attribute and passes this through to each element, e.g., `input`, `select`, `textarea`.
+
+### Added
+- `isVisuallyRequired` prop.
+  - When `true`, required fields will display a visual indicator that the field is required, e.g., an asterisk.
+  - When `false`, fields can still be required but no visual indicator will be shown.
+  - If the field is not required then the indicator will not be shown, regardless of this prop's value.
+
+
 v5.1.0
 ------------------------------
 *July 4, 2022*
@@ -18,7 +38,7 @@ v5.1.0
 
 v5.0.0
 -----------------------------
-*Jun 16, 2022*
+*June 16, 2022*
 
 ### Changed
 - Update to `@use` and `@forward` SASS syntax
@@ -26,7 +46,7 @@ v5.0.0
 
 v4.13.1
 -----------------------------
-*Jun 13, 2022*
+*June 13, 2022*
 
 ### Changed
 - Bumped wdio version and fixed breaking changes.
@@ -34,7 +54,7 @@ v4.13.1
 
 v4.13.0
 ------------------------------
-*Jun 8, 2022*
+*June 8, 2022*
 
 ### Added
 - `isRequired` prop to add `*` to form label and `aria-required` attribute to input.
@@ -42,7 +62,7 @@ v4.13.0
 
 v4.12.0
 ------------------------------
-*Jun 7, 2022*
+*June 7, 2022*
 
 ### Changed
 - Swapped CaretIcon with CaretDownFilledIcon via @justeattakeaway/pie-icons-vue
@@ -147,7 +167,7 @@ v4.5.1
 
 v4.5.0
 ------------------------------
-*December 06, 2021*
+*December 6, 2021*
 
 ### Removed
 - `u-spacing` class from label description
@@ -159,7 +179,7 @@ v4.5.0
 
 v4.4.0
 ------------------------------
-*December 02, 2021*
+*December 2, 2021*
 
 ### Changed
 - Ensure label and label description colour is correct when checkbox is disabled
@@ -167,7 +187,7 @@ v4.4.0
 
 v4.3.0
 ------------------------------
-*December 01, 2021*
+*December 1, 2021*
 
 ### Changed
 - Ensure `labelDescription` prop is passed to checkbox label.
@@ -371,6 +391,7 @@ v1.12.0
 
 ### Added
 - Textarea element to the formField component
+
 
 v1.11.0
 ------------------------------

--- a/packages/components/atoms/f-form-field/README.md
+++ b/packages/components/atoms/f-form-field/README.md
@@ -85,7 +85,8 @@ The props that can be defined are as follows (if any):
 | `shouldShowLabelText` | `Boolean` | `true` | Hides the label if set to `false` |
 | `suffix` | `String` | `''` | Suffix will display on the right of the input field. |
 | `value` | `String` or `Number` | `''` | The value of the form field. |
-| `isRequired` | `Boolean` | `true` | Adds `*` to form label and `aria-required` attribute to input if `true`. |
+| `isVisuallyRequired` | `Boolean` | `true` | Adds a visual indicator (e.g., an asterisk) to the form field label when the field also has the attribute `required=required`. When false, a field can still be required but there will be no visual indicator. |
+| `required` | `Boolean` | `n/a` This is an optional attribute, not a prop. | This attribute will be passed to the native field elements (e.g., `input`, `select`, `textarea`) and should be passed to fields that are required for the form to be valid. **Fields are now not required by default.** |
 
 
 ### Slots

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field - Fozzie Form Field Component",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "main": "dist/f-form-field.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [

--- a/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormDropdown.vue
@@ -11,7 +11,6 @@
                     [$style['c-formField-padding--iconLeading']]: hasIcon
                 }]"
             :disabled="attributes.disabled"
-            :aria-required="isRequired"
             :data-test-id="testId.select"
             v-bind="attributes"
             :value="value"
@@ -46,7 +45,7 @@ export default {
     props: {
         attributes: {
             type: Object,
-            default: () => {}
+            default: () => ({})
         },
         value: {
             type: String,
@@ -67,10 +66,6 @@ export default {
         hasIcon: {
             type: Boolean,
             default: false
-        },
-        isRequired: {
-            type: Boolean,
-            default: true
         }
     },
 

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -15,7 +15,7 @@
                 v-if="shouldShowLabel"
                 :label-for="uniqueId"
                 :is-disabled="isDisabled"
-                :is-visually-required="$attrs.required && isVisuallyRequired"
+                :is-visually-required="showVisuallyRequiredIndicator"
                 v-bind="$props"
                 :data-test-id="testId.label">
                 {{ labelText }}
@@ -41,7 +41,6 @@
                 v-else-if="isSelectionControl"
                 :id="uniqueId"
                 :attributes="$attrs"
-                :is-visually-required="isVisuallyRequired"
                 v-bind="$props"
                 v-on="listeners" />
 
@@ -342,6 +341,10 @@ export default {
 
         shouldShowLabel () {
             return this.shouldShowLabelText && !this.isSelectionControl;
+        },
+
+        showVisuallyRequiredIndicator () {
+            return this.$attrs.required && this.isVisuallyRequired;
         }
     },
 

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -15,6 +15,7 @@
                 v-if="shouldShowLabel"
                 :label-for="uniqueId"
                 :is-disabled="isDisabled"
+                :is-visually-required="$attrs.required && isVisuallyRequired"
                 v-bind="$props"
                 :data-test-id="testId.label">
                 {{ labelText }}
@@ -40,6 +41,7 @@
                 v-else-if="isSelectionControl"
                 :id="uniqueId"
                 :attributes="$attrs"
+                :is-visually-required="isVisuallyRequired"
                 v-bind="$props"
                 v-on="listeners" />
 
@@ -48,7 +50,6 @@
                 :id="`${uniqueId}`"
                 :aria-labelledby="`label-${uniqueId}`"
                 :value="value"
-                :aria-required="isRequired"
                 v-bind="$attrs"
                 :class="[
                     $style['c-formField-field'],
@@ -64,7 +65,6 @@
                 :aria-labelledby="`label-${uniqueId}`"
                 :value="value"
                 v-bind="$attrs"
-                :aria-required="isRequired"
                 :type="normalisedInputType"
                 :min="normalisedInputType === 'number' ? minNumber : false"
                 :max="normalisedInputType === 'number' ? maxNumber : false"
@@ -235,7 +235,7 @@ export default {
             validator: value => (value.length <= 3)
         },
 
-        isRequired: {
+        isVisuallyRequired: {
             type: Boolean,
             default: true
         }

--- a/packages/components/atoms/f-form-field/src/components/FormFieldAffixed.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormFieldAffixed.vue
@@ -16,7 +16,6 @@
             :disabled="attributes.disabled"
             v-bind="attributes"
             :value="value"
-            :aria-required="isRequired"
             :data-test-id="testId.input"
             @change="updateInput">
 
@@ -53,7 +52,7 @@ export default {
     props: {
         attributes: {
             type: Object,
-            default: () => {}
+            default: () => ({})
         },
 
         prefix: {
@@ -79,11 +78,6 @@ export default {
         value: {
             type: String,
             default: ''
-        },
-
-        isRequired: {
-            type: Boolean,
-            default: true
         }
     },
 

--- a/packages/components/atoms/f-form-field/src/components/FormLabel.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormLabel.vue
@@ -20,7 +20,7 @@
         <slot />
 
         <span
-            v-if="isRequired"
+            v-if="isVisuallyRequired"
             aria-hidden="true">*</span>
 
         <span
@@ -42,7 +42,7 @@ export default {
     props: {
         attributes: {
             type: Object,
-            default: () => {}
+            default: () => ({})
         },
         labelFor: {
             type: String,
@@ -60,7 +60,7 @@ export default {
             type: String,
             default: null
         },
-        isRequired: {
+        isVisuallyRequired: {
             type: Boolean,
             default: true
         }

--- a/packages/components/atoms/f-form-field/src/components/FormSelectionControl.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormSelectionControl.vue
@@ -8,7 +8,6 @@
             :type="inputType"
             :value="value"
             :data-test-id="testId.input"
-            :aria-required="isRequired"
             :class="[
                 $style['c-formField-field'],
                 $style['c-formField-field--noFocus'],
@@ -23,7 +22,7 @@
             :id="`label-${$attrs.id}`"
             data-test-id="selection-control-form-label"
             :label-for="$attrs.id"
-            :is-required="isRequired"
+            :is-visually-required="attributes.required && isVisuallyRequired"
             :label-description="$attrs.labelDescription"
         >
             {{ labelText }}
@@ -67,7 +66,7 @@ export default {
             type: Boolean,
             default: false
         },
-        isRequired: {
+        isVisuallyRequired: {
             type: Boolean,
             default: true
         }

--- a/packages/components/atoms/f-form-field/stories/SharedArgTypes.js
+++ b/packages/components/atoms/f-form-field/stories/SharedArgTypes.js
@@ -35,9 +35,13 @@ export default {
         control: { type: 'boolean' },
         description: 'Select whether to show label text or not'
     },
-    isRequired: {
+    required: {
         control: { type: 'boolean' },
-        description: 'Is field value required'
+        description: 'Is this a required field?'
+    },
+    isVisuallyRequired: {
+        control: { type: 'boolean' },
+        description: 'Should there be a visual indicator that this field is required?'
     }
 };
 export const sharedArgs = {
@@ -45,7 +49,8 @@ export const sharedArgs = {
     hasError: false,
     isDisabled: false,
     shouldShowLabelText: true,
-    isRequired: true
+    required: true,
+    isVisuallyRequired: true
 };
 
 export const sharedFieldProperties = `
@@ -54,7 +59,8 @@ export const sharedFieldProperties = `
     :label-description="labelDescription"
     :assistive-text="assistiveText"
     :should-show-label-text="shouldShowLabelText"
-    :is-required="isRequired"
+    :required="required"
+    :is-visually-required="isVisuallyRequired"
     :disabled="isDisabled"
     :has-error="hasError"
 `;

--- a/packages/components/atoms/f-form-field/test/visual/f-form-field.visual.spec.js
+++ b/packages/components/atoms/f-form-field/test/visual/f-form-field.visual.spec.js
@@ -32,18 +32,26 @@ describe('f-form-field visual tests', () => {
     });
 
     describe('required state', () => {
-        it.each([
-            ['WITH', true],
-            ['WITHOUT', false]
-        ])('should be able to display required fields %s visual indicator', async (withOrWithout, isVisuallyRequired) => {
+        it('should be able to display required fields WITH visual indicator', async () => {
             // Act
             await FormField.load({
                 required: true,
-                isVisuallyRequired
+                isVisuallyRequired: true
             });
 
             // Assert
-            await browser.percyScreenshot(`f-form-field - Required ${withOrWithout} visual indicator', 'desktop`);
+            await browser.percyScreenshot('f-form-field - Required WITH visual indicator', 'desktop');
+        });
+
+        it('should be able to display required fields WITHOUT visual indicator', async () => {
+            // Act
+            await FormField.load({
+                required: true,
+                isVisuallyRequired: false
+            });
+
+            // Assert
+            await browser.percyScreenshot('f-form-field - Required WITHOUT visual indicator', 'desktop');
         });
     });
 });

--- a/packages/components/atoms/f-form-field/test/visual/f-form-field.visual.spec.js
+++ b/packages/components/atoms/f-form-field/test/visual/f-form-field.visual.spec.js
@@ -31,13 +31,19 @@ describe('f-form-field visual tests', () => {
         });
     });
 
-    describe('none required state', () => {
-        it('should display all fields in an none required state', async () => {
+    describe('required state', () => {
+        it.each([
+            ['WITH', true],
+            ['WITHOUT', false]
+        ])('should be able to display required fields %s visual indicator', async (withOrWithout, isVisuallyRequired) => {
             // Act
-            await FormField.load({ isRequired: false });
+            await FormField.load({
+                required: true,
+                isVisuallyRequired
+            });
 
             // Assert
-            await browser.percyScreenshot('f-form-field - None required State', 'desktop');
+            await browser.percyScreenshot(`f-form-field - Required ${withOrWithout} visual indicator', 'desktop`);
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,6 +2437,14 @@
     "@justeat/f-services" "1.0.0"
     "@justeattakeaway/pie-icons-vue" "1.0.0"
 
+"@justeat/f-form-field@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-form-field/-/f-form-field-5.1.0.tgz#b293fc82d61deee7515d98ac7e68348a4a1a455c"
+  integrity sha512-VJ0Rxhjav7//5Wft7mm+O8ZmoKjv6rJCztJnVv+k3pF6PJXWExFX6BkuG925HBDO3BltAVoEVTtu3C7Olc+sqg==
+  dependencies:
+    "@justeat/f-services" "1.0.0"
+    "@justeattakeaway/pie-icons-vue" "1.0.0"
+
 "@justeat/f-globalisation@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-0.2.0.tgz#90ec559642c165b6325669c506c417abe09fa5dd"


### PR DESCRIPTION
### Removed
- **BREAKING**: `isRequired` prop in favour of the standard HTML attribute.
- `aria-required` attributes as they were not adding anything.
  - `required` behaves as expected for all major screen reader / browser combinations, except Chrome and Firefox with Android Talkback. `aria-required` also does not work for these combinations.

### Changed
- Now handles `required` attribute and passes this through to each element, e.g., `input`, `select`, `textarea`.

### Added
- `isVisuallyRequired` prop.
  - When `true`, required fields will display a visual indicator that the field is required, e.g., an asterisk.
  - When `false`, fields can still be required but no visual indicator will be shown.
  - If the field is not required then the indicator will not be shown, regardless of this prop's value.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
