### PR TITLE
f-form-field@6.2.0 - Prevent form label from showing as required when no props/attributes are given

### DIFF
--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v6.2.0
+------------------------------
+*July 18, 2022*
+
+### Changed
+- Rename (internal) form label prop to prevent fields appearing as required by default.
+
+
 v6.1.0
 ------------------------------
 *July 15, 2022*

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-form-field",
   "description": "Fozzie Form Field - Fozzie Form Field Component",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "main": "dist/f-form-field.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [

--- a/packages/components/atoms/f-form-field/src/components/FormField.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormField.vue
@@ -15,7 +15,7 @@
                 v-if="shouldShowLabel"
                 :label-for="uniqueId"
                 :is-disabled="isDisabled"
-                :is-visually-required="showVisuallyRequiredIndicator"
+                :show-required-indicator="showRequiredIndicator"
                 v-bind="$props"
                 :data-test-id="testId.label">
                 {{ labelText }}
@@ -343,7 +343,7 @@ export default {
             return this.shouldShowLabelText && !this.isSelectionControl;
         },
 
-        showVisuallyRequiredIndicator () {
+        showRequiredIndicator () {
             return this.$attrs.required && this.isVisuallyRequired;
         }
     },

--- a/packages/components/atoms/f-form-field/src/components/FormLabel.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormLabel.vue
@@ -20,7 +20,7 @@
         <slot />
 
         <span
-            v-if="isVisuallyRequired"
+            v-if="showRequiredIndicator"
             aria-hidden="true">*</span>
 
         <span
@@ -60,9 +60,9 @@ export default {
             type: String,
             default: null
         },
-        isVisuallyRequired: {
+        showRequiredIndicator: {
             type: Boolean,
-            default: true
+            default: false
         }
     },
     computed: {

--- a/packages/components/atoms/f-form-field/src/components/FormSelectionControl.vue
+++ b/packages/components/atoms/f-form-field/src/components/FormSelectionControl.vue
@@ -22,7 +22,7 @@
             :id="`label-${$attrs.id}`"
             data-test-id="selection-control-form-label"
             :label-for="$attrs.id"
-            :is-visually-required="attributes.required && isVisuallyRequired"
+            :show-required-indicator="showRequiredIndicator"
             :label-description="$attrs.labelDescription"
         >
             {{ labelText }}
@@ -73,6 +73,10 @@ export default {
     },
 
     computed: {
+        showRequiredIndicator () {
+            return this.attributes.required && this.isVisuallyRequired;
+        },
+
         testId () {
             const formFieldName = (this.attributes && this.attributes.name ? this.attributes.name : null);
 


### PR DESCRIPTION
### Changed
- Rename (internal) form label prop to prevent fields appearing as required by default.

The prop for FormField and FormLabel had the same name, so in FormLabel, the value was coming automatically from the `v-bind="$props"` inside FormField. Splitting the name fixes this and helps give a better distinction between responsibilities. The label just needs to know whether or not to show the indicator (asterisk), the field needs to know in which situations to do this.

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
