### PR TITLE
storybook@v0.52.35 - Fix storybook deploy to use native git push

### DIFF
--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.52.35
+------------------------------
+*July 20, 2022*
+### Changed
+- `storybook:deploy` to use native git push
+
+### Removed
+- `@storybook/storybook-deployer` dependency
+
 v0.52.34
 ------------------------------
 *July 19, 2022*

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private":true,
-  "version": "0.52.34",
+  "version": "0.52.35",
   "scripts": {
     "storybook:deploy": "git push origin :gh-pages && git subtree push --prefix storybook-static origin gh-pages",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -3,7 +3,7 @@
   "private":true,
   "version": "0.52.34",
   "scripts": {
-    "storybook:deploy": "storybook-to-ghpages --existing-output-dir ./storybook-static",
+    "storybook:deploy": "git push origin :gh-pages && git subtree push --prefix storybook-static origin gh-pages",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -s public -p 8080 -c config/storybook",
     "storybook:serve-static": "http-server ./storybook-static"
@@ -21,7 +21,6 @@
     "@storybook/addon-essentials": "6.4.9",
     "@storybook/addon-knobs": "6.4.0",
     "@storybook/addon-links": "6.4.9",
-    "@storybook/storybook-deployer": "2.8.6",
     "@storybook/theming": "6.4.9",
     "@storybook/vue": "6.4.9",
     "cookie-universal": "2.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4770,17 +4770,6 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/storybook-deployer@2.8.6":
-  version "2.8.6"
-  resolved "https://registry.yarnpkg.com/@storybook/storybook-deployer/-/storybook-deployer-2.8.6.tgz#00c2e84f27dfaa88cb0785361453f23b1ebb4ea3"
-  integrity sha512-Bpe7ZtsR5NUuohK3VsQa+nxEHtVxMZZo3DRlRUZW5IZOmzmvSID3i+jkizloG9xO7sw5zUvlD31YMHm7OtdrMA==
-  dependencies:
-    git-url-parse "^11.1.2"
-    glob "^7.1.3"
-    parse-repo "^1.0.4"
-    shelljs "^0.8.1"
-    yargs "^15.0.0"
-
 "@storybook/theming@6.4.9":
   version "6.4.9"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.4.9.tgz#8ece44007500b9a592e71eca693fbeac90803b0d"
@@ -20289,11 +20278,6 @@ parse-path@^4.0.4:
     qs "^6.9.4"
     query-string "^6.13.8"
 
-parse-repo@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/parse-repo/-/parse-repo-1.0.4.tgz#74b91d2cb8675d11b99976a0065f6ce17fa1bcc8"
-  integrity sha512-RdwYLh7cmxByP/BfeZX0QfIVfeNrH2fWgK1aLsGK+G6nCO4WTlCks4J7aW0O3Ap9BCPDF/e8rGTT50giQr10zg==
-
 parse-url@^6.0.0:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-6.0.2.tgz#4a30b057bfc452af64512dfb1a7755c103db3ea1"
@@ -23716,7 +23700,7 @@ shell-quote@^1.6.1:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
-shelljs@^0.8.1, shelljs@^0.8.3, shelljs@^0.8.4:
+shelljs@^0.8.3, shelljs@^0.8.4:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
   integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
@@ -27298,7 +27282,7 @@ yargs@^14.2.2:
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
 
-yargs@^15.0.0, yargs@^15.3.1, yargs@^15.4.1:
+yargs@^15.3.1, yargs@^15.4.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION

v0.52.35
------------------------------
*July 20, 2022*
### Changed
- `storybook:deploy` to use native git push

### Removed
- `@storybook/storybook-deployer` dependency