### PR TITLE
f-header@v10.4.0 (and other components) - Update to node 16 compatible dependencies

### DIFF
--- a/packages/components/molecules/f-searchbox/CHANGELOG.md
+++ b/packages/components/molecules/f-searchbox/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.0.0-beta.45
+------------------------------
+*July 26, 2022*
+
+### Added
+- Node 16 compatible dependencies
+
+
 v4.0.0-beta.44
  ------------------------------
  *July 19, 2022*

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -71,7 +71,7 @@
     "@justeat/f-button": "3.x",
     "@justeat/f-error-message": "1.x",
     "@justeat/f-globalisation": "0.x",
-    "@justeat/f-mega-modal": "3.x",
+    "@justeat/f-mega-modal": "7.x",
     "@justeat/f-vue-icons": "1.x",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/f-searchbox",
   "description": "Fozzie Searchbox – Just Eat Takeaway Global Searchbox",
   "tag": "beta",
-  "version": "4.0.0-beta.44",
+  "version": "4.0.0-beta.45",
   "main": "dist/f-searchbox.umd.min.js",
   "maxBundleSize": "60kB",
   "files": [
@@ -63,16 +63,16 @@
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
     "@justeat/f-button": "3.x",
     "@justeat/f-error-message": "1.x",
-    "@justeat/f-mega-modal": "3.x",
+    "@justeat/f-mega-modal": "7.x",
     "vue": "2.x",
     "vuex": "3.5.1"
   },
   "devDependencies": {
     "@justeat/f-button": "3.x",
     "@justeat/f-error-message": "1.x",
-    "@justeat/f-globalisation": "0.2.0",
+    "@justeat/f-globalisation": "0.x",
     "@justeat/f-mega-modal": "3.x",
-    "@justeat/f-vue-icons": "1.13.0",
+    "@justeat/f-vue-icons": "1.x",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -2,6 +2,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v10.4.0
+ ------------------------------
+ *July 26, 2022*
+
+ ### Added
+ - Node 16 compatible dependencies
+
 v10.3.0
  ------------------------------
  *July 25, 2022*

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -3,11 +3,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 v10.4.0
- ------------------------------
- *July 26, 2022*
+------------------------------
+*July 26, 2022*
 
- ### Added
- - Node 16 compatible dependencies
+### Added
+- Node 16 compatible dependencies
 
 v10.3.0
  ------------------------------

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header - Globalised Header Component",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "45kB",
   "files": [
@@ -49,7 +49,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.3.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
@@ -59,10 +59,10 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.12.13",
-    "@justeat/f-button": "3.x",
+    "@justeat/f-button": "4.x",
     "@justeat/f-popover": "2.x",
-    "@justeat/f-vue-icons": "3.4.0",
-    "@justeattakeaway/pie-icons-vue": "1.0.0",
+    "@justeat/f-vue-icons": "3.x",
+    "@justeattakeaway/pie-icons-vue": "1.x",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2279,7 +2279,7 @@
     "@justeat/f-services" "1.0.0"
     "@justeattakeaway/pie-icons-vue" "1.0.0"
 
-"@justeat/f-globalisation@0.2.0":
+"@justeat/f-globalisation@0.x":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-0.2.0.tgz#90ec559642c165b6325669c506c417abe09fa5dd"
   integrity sha512-WXBBl/nu88HxVKIuEt1/1KYnAB2XUImi+CK9ZdKQt/FiQolDMe+9hqxTRr2YSbeLXulGXR17WOCDAJQKwHU2Og==
@@ -2415,17 +2415,17 @@
   dependencies:
     "@justeat/f-dom" "0.4.0"
 
-"@justeat/f-vue-icons@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.13.0.tgz#83b483c300f4f43569a0fcb3ed47b7bcc189e2c7"
-  integrity sha512-3gXdEpIQD+wRUSsv7gKCzT/JD4XlKYtRiTd0JPFjkrC9btwfotD+Iax3c/kjRT+rpvYjxHQSgfd06CIfJ72rPA==
-  dependencies:
-    babel-helper-vue-jsx-merge-props "2.0.3"
-
 "@justeat/f-vue-icons@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.2.0.tgz#74b08c7539f3790cddc7f98df148c2642fcf0a75"
   integrity sha512-TI0Jwd2vBCVCwR26CDZhzp2Xdd35T+12sX3mkoztx14XpJ+EXJ7elR9SmI/N1vZ59o8sRP6Ix7iV+mSeAGv9Zg==
+  dependencies:
+    babel-helper-vue-jsx-merge-props "2.0.3"
+
+"@justeat/f-vue-icons@1.x":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-1.13.0.tgz#83b483c300f4f43569a0fcb3ed47b7bcc189e2c7"
+  integrity sha512-3gXdEpIQD+wRUSsv7gKCzT/JD4XlKYtRiTd0JPFjkrC9btwfotD+Iax3c/kjRT+rpvYjxHQSgfd06CIfJ72rPA==
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
 
@@ -2464,13 +2464,6 @@
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
 
-"@justeat/f-vue-icons@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-3.4.0.tgz#47743051d93e7a320d95bd2b7bd5e83580d60480"
-  integrity sha512-DK3uvkXqm7tjB0yDHdOaUVoOtKeBQb/WKAp0FnlnXCzl1YiOenNVggVcdqLLAmQn9GSZuhVK+aECCbDeohDjgQ==
-  dependencies:
-    babel-helper-vue-jsx-merge-props "2.0.3"
-
 "@justeat/f-vue-icons@3.7.0":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-3.7.0.tgz#53c343d32d4fc132fca8eb146521c5513c81c8bd"
@@ -2484,28 +2477,6 @@
   integrity sha512-6dEkYZevqi+Do2AiC0EoseGAxoqLRWwz/VJ57owa2IYd1ubJexaRYR4H6tGCqP7Bsn7B/cQgRdbGXQubRMLeeQ==
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
-
-"@justeat/f-wdio-utils@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.12.0.tgz#28cf4295e080e410d2cb41467f804fae641f8687"
-  integrity sha512-LUj+rGxP2MJBNZ4ZTRTqh5lYPJciiDPixNsWDw1IO9UjwEfsu70isc/FssLk4kRs1Hs0M2vprHGLlX7GXj0kfw==
-  dependencies:
-    "@justeat/f-services" "1.7.0"
-
-"@justeat/f-wdio-utils@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.4.0.tgz#6916a392777c88bc84e0d5a258e7e94c64ff7800"
-  integrity sha512-CQ69zuqvPGIAmDAF+EZM9dnBoIizBIMrl4L2tpvk27oRPKycQGgFIjfq1v/wTgVNwVXVJNCEG6zEKNjccSl+Ew==
-  dependencies:
-    "@justeat/f-services" "1.7.0"
-
-"@justeat/f-wdio-utils@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-1.1.0.tgz#a5b10a5055da8549dd13d02042e7f264b6f3dab3"
-  integrity sha512-TIS3uXOMlfJcArOM+PE5AR4oHprYu/ubEb8uXeA8BIyM5AEebRMTfnTLTVsgzVJnyObGI1h8PK1mWiBc8VVOEA==
-  dependencies:
-    "@axe-core/webdriverio" "4.4.3"
-    "@justeat/f-services" "1.7.0"
 
 "@justeat/feature-management@^1.0.0":
   version "1.0.1"
@@ -2569,7 +2540,7 @@
   resolved "https://registry.yarnpkg.com/@justeat/stylelint-config-fozzie/-/stylelint-config-fozzie-2.2.0.tgz#7cdab9fd0b341723eb52c93e88381130245438a2"
   integrity sha512-EPg/T/223kWeCG7MyrjKzBP6swaA2Y1R0WjltN2gVOR5bHjBc7yaDE0tK3O7pZriAKvNvH/YvFoB9MZsgkB8UA==
 
-"@justeattakeaway/pie-icons-vue@1.0.0":
+"@justeattakeaway/pie-icons-vue@1.0.0", "@justeattakeaway/pie-icons-vue@1.x":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@justeattakeaway/pie-icons-vue/-/pie-icons-vue-1.0.0.tgz#62f86c4fedb449c072e4d37955ad619d10baa9a2"
   integrity sha512-4HoFiGCB4wz3v9m70n8Box4k3dRFJAf7h4Gxg8zL/22YBchFl27owk0WaJuY3EP3t15LoGRFX1grFHWRD7vGdA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2306,11 +2306,6 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-4.10.0.tgz#59738afbb1bec54388270521ae8f6de0412d74fb"
   integrity sha512-Sz6A8xdkIdpA2jBfx4XJqCNIJt94FraYfF56wxEs0i9pJLBmgun5As2HPaPpg6sWrbmXA//b2L9bN7uNsZLdLw==
 
-"@justeat/f-mega-modal@3.x":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@justeat/f-mega-modal/-/f-mega-modal-3.0.2.tgz#81f2b5ca8519a6eca93f5643857df2a9c924666d"
-  integrity sha512-3M+wpcjOIIw3hKbtZqyRl3mwdi2zz90wFAJc5RtJciJ/VwD73bHNjvABRl/At+JZj2p0Ongjg11ezSayoKMGJg==
-
 "@justeat/f-popover@2.x":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@justeat/f-popover/-/f-popover-2.3.1.tgz#e2479ccda23715cca7e446dfeb8c3052450fc3b3"


### PR DESCRIPTION
Update the following components to have Node 16 compatible dependencies:

f-header
f-searchbox