### PR TITLE
Revert back to declaring f-wdio-utils as devDependency  #globalconfig #trivial

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@babel/preset-env": "7.14.9",
     "@justeat/browserslist-config-fozzie": "1.2.0",
     "@justeat/eslint-config-fozzie": "5.1.0",
-    "@justeat/f-wdio-utils": "1.x",
     "@justeat/fozzie": "8.2.0",
     "@justeat/stylelint-config-fozzie": "2.2.0",
     "@percy/cli": "1.0.5",

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@justeattakeaway/pie-icons-vue": "1.0.0",
     "@justeat/fozzie": "9.0.0-beta.2",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -55,6 +55,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/fozzie": "9.0.0-beta.2"
+    "@justeat/fozzie": "9.0.0-beta.2",
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/atoms/f-error-boundary/package.json
+++ b/packages/components/atoms/f-error-boundary/package.json
@@ -45,6 +45,7 @@
     "@justeat/browserslist-config-fozzie": ">=1.2.0"
   },
   "devDependencies": {
+    "@justeat/f-wdio-utils": "1.x",
     "core-js": "3.19.1",
     "vite-plugin-vue2": "1.9.0"
   }

--- a/packages/components/atoms/f-error-message/package.json
+++ b/packages/components/atoms/f-error-message/package.json
@@ -55,6 +55,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/fozzie": "9.0.0-beta.2"
+    "@justeat/fozzie": "9.0.0-beta.2",
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/atoms/f-filter-pill/package.json
+++ b/packages/components/atoms/f-filter-pill/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@justeat/fozzie": "9.0.0-beta.2",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.15",
     "@vue/cli-plugin-unit-jest": "4.5.15",
     "@vue/test-utils": "1.2.2"

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -59,6 +59,7 @@
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
     "@justeat/fozzie": "9.0.0-beta.2",
+    "@justeat/f-wdio-utils": "1.x",
     "postcss-assets": "5.0.0"
   }
 }

--- a/packages/components/atoms/f-image-tile/package.json
+++ b/packages/components/atoms/f-image-tile/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@justeat/fozzie": "9.0.0-beta.2",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3"

--- a/packages/components/atoms/f-link/package.json
+++ b/packages/components/atoms/f-link/package.json
@@ -56,6 +56,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@justeat/fozzie": "9.0.0-beta.2",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/test-utils": "1.0.3"
   }
 }

--- a/packages/components/atoms/f-popover/package.json
+++ b/packages/components/atoms/f-popover/package.json
@@ -56,6 +56,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/fozzie": "9.0.0-beta.2"
+    "@justeat/fozzie": "9.0.0-beta.2",
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/atoms/f-spinner/package.json
+++ b/packages/components/atoms/f-spinner/package.json
@@ -56,6 +56,7 @@
     "@justeat/fozzie": "9.0.0-beta.2",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
-    "@vue/test-utils": "1.0.3"
+    "@vue/test-utils": "1.0.3",
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@justeat/f-button": "4.x",
     "@justeat/fozzie": "9.0.0-beta.6",
+    "@justeat/f-wdio-utils": "1.x",
     "@justeattakeaway/pie-icons-vue": "1.0.0",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",

--- a/packages/components/molecules/f-breadcrumbs/package.json
+++ b/packages/components/molecules/f-breadcrumbs/package.json
@@ -62,6 +62,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/fozzie": "9.0.0-beta.3"
+    "@justeat/fozzie": "9.0.0-beta.3",
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/molecules/f-card-with-content/package.json
+++ b/packages/components/molecules/f-card-with-content/package.json
@@ -57,6 +57,7 @@
     "@justeat/f-button": "4.x",
     "@justeat/f-card": "4.x",
     "@justeat/f-vue-icons": "3.0.0",
+    "@justeat/f-wdio-utils": "1.x",
     "@justeat/fozzie": "9.0.0-beta.3",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",

--- a/packages/components/molecules/f-media-element/package.json
+++ b/packages/components/molecules/f-media-element/package.json
@@ -56,6 +56,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/fozzie": "9.0.0-beta.3"
+    "@justeat/fozzie": "9.0.0-beta.3",
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@justeat/f-button": "4.x",
     "@justeat/fozzie": "9.0.0-beta.5",
+    "@justeat/f-wdio-utils": "1.x",
     "@justeattakeaway/pie-icons-vue": "1.0.0",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",

--- a/packages/components/molecules/f-navigation-links/package.json
+++ b/packages/components/molecules/f-navigation-links/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@justeat/f-link": "3.x",
     "@justeat/fozzie": "9.0.0-beta.5",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3"

--- a/packages/components/molecules/f-promotions-showcase/package.json
+++ b/packages/components/molecules/f-promotions-showcase/package.json
@@ -55,6 +55,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/fozzie": "9.0.0-beta.3"
+    "@justeat/fozzie": "9.0.0-beta.3",
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -56,6 +56,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/fozzie": "9.0.0-beta.5"
+    "@justeat/fozzie": "9.0.0-beta.5",
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -73,6 +73,7 @@
     "@justeat/f-globalisation": "0.2.0",
     "@justeat/f-mega-modal": "3.x",
     "@justeat/f-vue-icons": "1.13.0",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",

--- a/packages/components/molecules/f-skeleton-loader/package.json
+++ b/packages/components/molecules/f-skeleton-loader/package.json
@@ -56,6 +56,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/fozzie": "9.0.0-beta.5"
+    "@justeat/fozzie": "9.0.0-beta.5",
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/molecules/f-tabs/package.json
+++ b/packages/components/molecules/f-tabs/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
-    "@vue/test-utils": "1.0.3"
+    "@vue/test-utils": "1.0.3",
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/molecules/f-user-message/package.json
+++ b/packages/components/molecules/f-user-message/package.json
@@ -60,6 +60,7 @@
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
     "axios-mock-adapter": "1.18.2",
-    "@justeat/fozzie": "9.0.0-beta.5"
+    "@justeat/fozzie": "9.0.0-beta.5",
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -62,6 +62,7 @@
     "@braze/web-sdk": "^3.3.0",
     "@justeat/f-braze-adapter": "5.0.0",
     "@justeat/f-vue-icons": "1.2.0",
+    "@justeat/f-wdio-utils": "1.x",
     "@justeat/fozzie": "9.0.0-beta.5",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -62,6 +62,7 @@
     "@justeat/f-link": "3.x",
     "@justeat/f-mega-modal": "7.x",
     "@justeat/f-vue-icons": "2.x",
+    "@justeat/f-wdio-utils": "1.x",
     "@justeat/fozzie": "9.0.0-beta.5",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -60,6 +60,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/fozzie": "9.0.0-beta.5"
+    "@justeat/fozzie": "9.0.0-beta.5",
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/organisms/f-form/package.json
+++ b/packages/components/organisms/f-form/package.json
@@ -62,6 +62,7 @@
     "@justeat/f-button": "3.x",
     "@justeat/f-form-field": "4.x",
     "@justeat/f-error-message": "1.x",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.15",
     "@vue/cli-plugin-unit-jest": "4.5.15",
     "@vue/test-utils": "1.2.2"

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -62,6 +62,7 @@
     "@justeat/f-button": "3.x",
     "@justeat/f-popover": "2.x",
     "@justeat/f-vue-icons": "3.4.0",
+    "@justeat/f-wdio-utils": "1.x",
     "@justeattakeaway/pie-icons-vue": "1.0.0",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",

--- a/packages/components/organisms/f-status-banner/package.json
+++ b/packages/components/organisms/f-status-banner/package.json
@@ -61,6 +61,7 @@
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/fozzie": "9.0.0-beta.5"
+    "@justeat/fozzie": "9.0.0-beta.5",
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/pages/f-account-info/package.json
+++ b/packages/components/pages/f-account-info/package.json
@@ -76,6 +76,7 @@
     "@justeat/f-form-field": "6.x",
     "@justeat/f-link": "3.x",
     "@justeat/fozzie": "9.0.0-beta.6",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.15",
     "@vue/cli-plugin-unit-jest": "4.5.15",
     "@vue/test-utils": "1.2.2"

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -83,6 +83,7 @@
     "@justeat/f-link": "3.x",
     "@justeat/f-mega-modal": "7.x",
     "@justeat/f-vue-icons": "3.0.0",
+    "@justeat/f-wdio-utils": "1.x",
     "@justeat/fozzie": "9.0.0-beta.6",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",

--- a/packages/components/pages/f-contact-preferences/package.json
+++ b/packages/components/pages/f-contact-preferences/package.json
@@ -70,6 +70,7 @@
     "@justeat/f-card-with-content": "3.x",
     "@justeat/f-form-field": "6.x",
     "@justeat/f-vue-icons": "3.3.0",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@justeat/fozzie": "9.0.0-beta.6",

--- a/packages/components/pages/f-loyalty/package.json
+++ b/packages/components/pages/f-loyalty/package.json
@@ -72,6 +72,7 @@
     "@justeat/f-tabs": "3.x",
     "@justeat/f-trak": "0.x",
     "@justeat/fozzie": "9.0.0-beta.6",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",

--- a/packages/components/pages/f-mfa/package.json
+++ b/packages/components/pages/f-mfa/package.json
@@ -52,6 +52,7 @@
     "@justeat/browserslist-config-fozzie": ">=1.2.0"
   },
   "devDependencies": {
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.15",
     "@vue/cli-plugin-unit-jest": "4.5.15",
     "@vue/test-utils": "1.2.2",

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -72,6 +72,7 @@
     "@justeat/f-searchbox": "6.x",
     "@justeat/f-trak": "0.x",
     "@justeat/fozzie": "9.0.0-beta.6",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",

--- a/packages/components/pages/f-registration/package.json
+++ b/packages/components/pages/f-registration/package.json
@@ -72,6 +72,7 @@
     "@justeat/f-http": "0.x",
     "@justeat/f-link": "3.x",
     "@justeat/f-vue-icons": "2.7.0",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.8",
     "@vue/cli-plugin-unit-jest": "4.5.8",
     "@vue/test-utils": "1.1.1",

--- a/packages/components/pages/f-takeawaypay-activation/package.json
+++ b/packages/components/pages/f-takeawaypay-activation/package.json
@@ -63,6 +63,7 @@
     "@justeat/f-button": "4.x",
     "@justeat/f-card": "4.x",
     "@justeat/f-vue-icons": "3.x",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@justeat/fozzie": "9.0.0-beta.6",

--- a/packages/components/templates/f-template-subnav/package.json
+++ b/packages/components/templates/f-template-subnav/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@justeat/f-breadcrumbs": "4.x",
     "@justeat/f-navigation-links": "2.x",
+    "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2485,28 +2485,6 @@
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
 
-"@justeat/f-wdio-utils@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.12.0.tgz#28cf4295e080e410d2cb41467f804fae641f8687"
-  integrity sha512-LUj+rGxP2MJBNZ4ZTRTqh5lYPJciiDPixNsWDw1IO9UjwEfsu70isc/FssLk4kRs1Hs0M2vprHGLlX7GXj0kfw==
-  dependencies:
-    "@justeat/f-services" "1.7.0"
-
-"@justeat/f-wdio-utils@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-0.4.0.tgz#6916a392777c88bc84e0d5a258e7e94c64ff7800"
-  integrity sha512-CQ69zuqvPGIAmDAF+EZM9dnBoIizBIMrl4L2tpvk27oRPKycQGgFIjfq1v/wTgVNwVXVJNCEG6zEKNjccSl+Ew==
-  dependencies:
-    "@justeat/f-services" "1.7.0"
-
-"@justeat/f-wdio-utils@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-wdio-utils/-/f-wdio-utils-1.1.0.tgz#a5b10a5055da8549dd13d02042e7f264b6f3dab3"
-  integrity sha512-TIS3uXOMlfJcArOM+PE5AR4oHprYu/ubEb8uXeA8BIyM5AEebRMTfnTLTVsgzVJnyObGI1h8PK1mWiBc8VVOEA==
-  dependencies:
-    "@axe-core/webdriverio" "4.4.3"
-    "@justeat/f-services" "1.7.0"
-
 "@justeat/feature-management@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@justeat/feature-management/-/feature-management-1.0.1.tgz#1c60864658400def14a9389b10af6c586b3099c7"
@@ -2977,9 +2955,9 @@
   integrity sha512-OT3/Xiuo1V4cHwqdDQfuvfMDRf7GhMrHK9HCiHE2dOakLqmIM0fexiCoD0k5Bd7fgjZ9G5YmFT9k5ymBmT9oOA==
 
 "@percy/sdk-utils@^1.0.0":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.6.3.tgz#3a21fc90578d682c7cc36ecb5487664a026a4ca0"
-  integrity sha512-Q3x88t04BYd9glJYAClm/B0FMhEEIj69ExKQhbCjXWVuH7M5gvRdfImNiZQq5QevgeYcKwhPmO2CEkYhTO5Vig==
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.6.4.tgz#c5884dc3b4bf53354b02573b89e9cd945555d418"
+  integrity sha512-17bsvTiYzD/dmCJi5z2xh+usZOuIJ6AzxDRTplKGltFeSUr3t2rx33Z3lNoA33O/dCyl11eBK+p26p/Nwm87fQ==
 
 "@percy/webdriverio@2.0.1":
   version "2.0.1"
@@ -4124,9 +4102,9 @@
   integrity sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==
 
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
-  version "4.17.29"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz#2a1795ea8e9e9c91b4a4bbe475034b20c1ec711c"
-  integrity sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==
+  version "4.17.30"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz#0f2f99617fa8f9696170c46152ccf7500b34ac04"
+  integrity sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -4369,9 +4347,9 @@
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
 "@types/prettier@^2.0.0":
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.3.tgz#68ada76827b0010d0db071f739314fa429943d0a"
-  integrity sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.4.tgz#ad899dad022bab6b5a9f0a0fe67c2f7a4a8950ed"
+  integrity sha512-fOwvpvQYStpb/zHMx0Cauwywu9yLDmzWiiQBC7gJyq5tYLUXFZvDG7VK1B7WBxxjBJNKFOZ0zLoOQn8vmATbhw==
 
 "@types/pretty-hrtime@^1.0.0":
   version "1.0.1"
@@ -10282,9 +10260,9 @@ ejs@^3.0.1, ejs@^3.1.5:
     jake "^10.8.5"
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.564, electron-to-chromium@^1.4.188:
-  version "1.4.199"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.199.tgz#e0384fde79fdda89880e8be58196a9153e04db3b"
-  integrity sha512-WIGME0Cs7oob3mxsJwHbeWkH0tYkIE/sjkJ8ML2BYmuRcjhRl/q5kVDXG7W9LOOKwzPU5M0LBlXRq9rlSgnNlg==
+  version "1.4.202"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.202.tgz#0c2ed733f42b02ec49a955c5badfcc65888c390b"
+  integrity sha512-JYsK2ex9lmQD27kj19fhXYxzFJ/phLAkLKHv49A5UY6kMRV2xED3qMMLg/voW/+0AR6wMiI+VxlmK9NDtdxlPA==
 
 element-resize-detector@^1.2.2:
   version "1.2.4"
@@ -13554,7 +13532,7 @@ include-media@1.4.9:
   resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.9.tgz#d0020b7be3eb2d54868a20943595ce380e0bc43b"
   integrity sha512-IUOcvWDCt6R5V0ktsGk6RbehkW9ks1dODN2ed1p+mhML82TteAl+/ElXy8AJ7ueIuVoKq2NioRVdW9FuwQNOew==
 
-include-media@eduardoboucas/include-media#2.0-release:
+"include-media@github:eduardoboucas/include-media#2.0-release":
   version "2.0.0"
   resolved "https://codeload.github.com/eduardoboucas/include-media/tar.gz/5398b556d4bb24186d360c950b19026f577ff8e5"
 
@@ -21500,9 +21478,9 @@ rollup@^0.66.6:
     "@types/node" "*"
 
 rollup@^2.58.0, rollup@^2.59.0:
-  version "2.77.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.0.tgz#749eaa5ac09b6baa52acc076bc46613eddfd53f4"
-  integrity sha512-vL8xjY4yOQEw79DvyXLijhnhh+R/O9zpF/LEgkCebZFtb6ELeN9H3/2T0r8+mp+fFTBHZ5qGpOpW2ela2zRt3g==
+  version "2.77.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.2.tgz#6b6075c55f9cc2040a5912e6e062151e42e2c4e3"
+  integrity sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
This PR reverts back to our old implementation of having `f-wdio-utils` explicitly defined as a `devDependency` in our components.

I was under the impression that having a single version at the root of the monorepo worked, but this isn't the case, as Turborepo will only build devDeps that're defined in the components package.json