### PR TITLE
f-account-info@v1.4.0 - Update f-account-info to have node 16 compatible deps

### DIFF
--- a/packages/components/pages/f-account-info/CHANGELOG.md
+++ b/packages/components/pages/f-account-info/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.4.0
+------------------------------
+*July 27, 2022*
+
+### Added
+- Node 16 compatible dependencies.
+
+
 v1.3.0
 ------------------------------
 *July 25, 2022*

--- a/packages/components/pages/f-account-info/package.json
+++ b/packages/components/pages/f-account-info/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-account-info",
   "description": "Fozzie Account Info - The account information page",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "dist/f-account-info.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [
@@ -51,9 +51,9 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-globalisation": "1.0.0",
-    "@justeat/f-services": "1.13.0",
-    "@justeat/f-vue-icons": "3.3.0",
+    "@justeat/f-globalisation": "1.x",
+    "@justeat/f-services": "1.x",
+    "@justeat/f-vue-icons": "3.x",
     "vuelidate": "0.7.6"
   },
   "peerDependencies": {
@@ -68,7 +68,7 @@
     "vuex": ">=3.5.1"
   },
   "devDependencies": {
-    "@justeat/f-alert": "5.x",
+    "@justeat/f-alert": "6.x",
     "@justeat/f-button": "4.x",
     "@justeat/f-card": "4.x",
     "@justeat/f-card-with-content": "3.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,13 +2225,6 @@
     eslint-config-airbnb-base "15.0.0"
     eslint-plugin-vue "8.4.0"
 
-"@justeat/f-alert@5.x":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@justeat/f-alert/-/f-alert-5.0.1.tgz#80fb4a1480fb85cdb2bf94ad2020f9fa2f286d05"
-  integrity sha512-Jx06KGeM0geE9XJrh7vyhQxtSLhIXmiMY4sw31cDcFX9S0N/FrEOLpxiul+oTfNQGWlVrEq4t7NdqOQ1H2zgvA==
-  dependencies:
-    "@justeat/f-services" "1.0.0"
-
 "@justeat/f-braze-adapter@5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-braze-adapter/-/f-braze-adapter-5.0.0.tgz#5f38225e6c0f570f9294b47705345b386debac2c"
@@ -2359,14 +2352,6 @@
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-1.11.0.tgz#2705cdcb83434527c9fe1bccfbdd0222e25ab38b"
   integrity sha512-/DCnsOQmfEkz/dyD/u5VMaKDwEzAAjwW+qePXh6ofxNRm7SR9dWS0Qvwzg+kQvZ3ktN6b20PfcUcalLf00guFw==
-  dependencies:
-    lodash-es "4.17.21"
-    window-or-global "1.0.1"
-
-"@justeat/f-services@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-1.13.0.tgz#bb8d92eb77d6b62b571edcd618dbc54ffedcb8ac"
-  integrity sha512-jm3DW0sI1A3VAKvSM511Hm6rWRxbXBKxsjLrkFEpwJ5Opn/EB0av14DbyeljSDjGACJjDKfmY3K+/fviL2bofg==
   dependencies:
     lodash-es "4.17.21"
     window-or-global "1.0.1"
@@ -13520,7 +13505,7 @@ include-media@1.4.9:
   resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.9.tgz#d0020b7be3eb2d54868a20943595ce380e0bc43b"
   integrity sha512-IUOcvWDCt6R5V0ktsGk6RbehkW9ks1dODN2ed1p+mhML82TteAl+/ElXy8AJ7ueIuVoKq2NioRVdW9FuwQNOew==
 
-"include-media@github:eduardoboucas/include-media#2.0-release":
+include-media@eduardoboucas/include-media#2.0-release:
   version "2.0.0"
   resolved "https://codeload.github.com/eduardoboucas/include-media/tar.gz/5398b556d4bb24186d360c950b19026f577ff8e5"
 


### PR DESCRIPTION
v1.4.0
------------------------------
*July 27, 2022*

### Added
- Node 16 compatible dependencies.