### PR TITLE
fozzie-components@v7.21.0 - Update components to use Node 16 compatible version of f-services #trival #globalconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v7.21.0
+------------------------------
+*July 26, 2022*
+
+### Changed
+- Components to use Node 16 compatible verisons of f-services
+
+### Removed
+`lerna.json`
+
 v7.20.1
 ------------------------------
 *July 26, 2022*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "7.20.1",
+  "version": "7.21.0",
   "private": true,
   "scripts": {
     "build": "turbo run build --continue",

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -46,7 +46,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "0.13.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1"

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -48,8 +48,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.0.0",
-    "@justeattakeaway/pie-icons-vue": "1.0.0"
+    "@justeat/f-services": "1.x",
+    "@justeattakeaway/pie-icons-vue": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1"

--- a/packages/components/atoms/f-link/package.json
+++ b/packages/components/atoms/f-link/package.json
@@ -47,7 +47,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.7.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"

--- a/packages/components/atoms/f-popover/package.json
+++ b/packages/components/atoms/f-popover/package.json
@@ -47,7 +47,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.7.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"

--- a/packages/components/atoms/f-spinner/package.json
+++ b/packages/components/atoms/f-spinner/package.json
@@ -47,7 +47,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.7.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -48,7 +48,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.0.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -3,7 +3,7 @@
   "description": "Fozzie Alert – Fozzie Alert Component",
   "version": "6.2.0",
   "main": "dist/f-alert.umd.min.js",
-  "maxBundleSize": "15kB",
+  "maxBundleSize": "20kB",
   "files": [
     "dist"
   ],

--- a/packages/components/molecules/f-breadcrumbs/package.json
+++ b/packages/components/molecules/f-breadcrumbs/package.json
@@ -53,7 +53,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.0.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1"

--- a/packages/components/molecules/f-media-element/package.json
+++ b/packages/components/molecules/f-media-element/package.json
@@ -47,7 +47,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.7.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -55,7 +55,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.0.0",
+    "@justeat/f-services": "1.x",
     "axios": "0.21.2",
     "lodash.debounce": "4.0.8"
   },

--- a/packages/components/molecules/f-skeleton-loader/package.json
+++ b/packages/components/molecules/f-skeleton-loader/package.json
@@ -47,7 +47,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.7.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"

--- a/packages/components/molecules/f-tabs/package.json
+++ b/packages/components/molecules/f-tabs/package.json
@@ -47,7 +47,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.0.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1"

--- a/packages/components/molecules/f-user-message/CHANGELOG.md
+++ b/packages/components/molecules/f-user-message/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.3.0
+------------------------------
+*July 28, 2022*
+
+### Changed
+- f-services implementation to use new major version.
+
+
 v4.2.0
  ------------------------------
  *July 19, 2022*

--- a/packages/components/molecules/f-user-message/package.json
+++ b/packages/components/molecules/f-user-message/package.json
@@ -3,7 +3,7 @@
   "description": "Fozzie User Message – Globalised User Message Component",
   "version": "4.2.0",
   "main": "dist/f-user-message.umd.min.js",
-  "maxBundleSize": "15kB",
+  "maxBundleSize": "25kB",
   "files": [
     "dist"
   ],

--- a/packages/components/molecules/f-user-message/package.json
+++ b/packages/components/molecules/f-user-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-user-message",
   "description": "Fozzie User Message – Globalised User Message Component",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "main": "dist/f-user-message.umd.min.js",
   "maxBundleSize": "25kB",
   "files": [

--- a/packages/components/molecules/f-user-message/package.json
+++ b/packages/components/molecules/f-user-message/package.json
@@ -46,8 +46,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "0.13.2",
-    "@justeattakeaway/pie-icons-vue": "1.0.0",
+    "@justeat/f-services": "1.x",
+    "@justeattakeaway/pie-icons-vue": "1.x",
     "axios": "0.21.2",
     "lodash-es": "4.17.21"
   },

--- a/packages/components/molecules/f-user-message/src/components/UserMessage.vue
+++ b/packages/components/molecules/f-user-message/src/components/UserMessage.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script>
-import sharedServices from '@justeat/f-services';
+import { globalisationServices } from '@justeat/f-services';
 import { ClockIcon } from '@justeattakeaway/pie-icons-vue';
 import tenantConfigs from '../tenants';
 import UserMessageApi from '../services/UserMessageApi';
@@ -38,8 +38,8 @@ export default {
         }
     },
     data () {
-        const locale = sharedServices.getLocale(tenantConfigs, this.locale, this.$i18n);
-        const theme = sharedServices.getTheme(locale);
+        const locale = globalisationServices.getLocale(tenantConfigs, this.locale, this.$i18n);
+        const theme = globalisationServices.getTheme(locale);
 
         return {
             theme,

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -48,7 +48,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.3.0",
+    "@justeat/f-services": "1.x",
     "@justeattakeaway/pie-icons-vue": "1.0.0",
     "@justeat/f-vue-icons": "3.10.0",
     "v-click-outside": "3.1.2"

--- a/packages/components/organisms/f-form/package.json
+++ b/packages/components/organisms/f-form/package.json
@@ -47,14 +47,14 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.7.0",
-    "@justeat/f-globalisation": "1.0.0",
+    "@justeat/f-services": "1.x",
+    "@justeat/f-globalisation": "1.x",
     "vue-scrollto": "2.20.0",
     "vuelidate": "0.7.6"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0",
-    "@justeat/f-button": "3.x",
+    "@justeat/f-button": "4.x",
     "@justeat/f-form-field": "4.x",
     "@justeat/f-error-message": "1.x"
   },

--- a/packages/components/organisms/f-status-banner/package.json
+++ b/packages/components/organisms/f-status-banner/package.json
@@ -50,7 +50,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.7.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0",

--- a/packages/components/pages/f-account-info/package.json
+++ b/packages/components/pages/f-account-info/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@justeat/f-globalisation": "1.0.0",
-    "@justeat/f-services": "1.13.0",
+    "@justeat/f-services": "1.x",
     "@justeat/f-vue-icons": "3.3.0",
     "vuelidate": "0.7.6"
   },

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -3,7 +3,7 @@
   "description": "Fozzie Checkout - Fozzie Checkout Component",
   "version": "4.4.0",
   "main": "dist/f-checkout.umd.min.js",
-  "maxBundleSize": "130kB",
+  "maxBundleSize": "140kB",
   "files": [
     "dist",
     "test-utils",

--- a/packages/components/pages/f-contact-preferences/package.json
+++ b/packages/components/pages/f-contact-preferences/package.json
@@ -51,8 +51,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.7.0",
-    "@justeat/f-globalisation": "1.0.0"
+    "@justeat/f-services": "1.x",
+    "@justeat/f-globalisation": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0",

--- a/packages/components/pages/f-mfa/package.json
+++ b/packages/components/pages/f-mfa/package.json
@@ -46,7 +46,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.16.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"

--- a/packages/services/f-performance/package.json
+++ b/packages/services/f-performance/package.json
@@ -36,7 +36,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.7.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"

--- a/packages/services/f-test-data-creator/package.json
+++ b/packages/services/f-test-data-creator/package.json
@@ -37,7 +37,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.7.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"

--- a/packages/services/f-wdio-utils/package.json
+++ b/packages/services/f-wdio-utils/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "@axe-core/webdriverio": "4.4.3",
-    "@justeat/f-services": "1.7.0"
+    "@justeat/f-services": "1.x"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "4.5.16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,14 +1079,6 @@
     "@babel/helper-create-regexp-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/polyfill@7.7.0":
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.7.0.tgz#e1066e251e17606ec7908b05617f9b7f8180d8f3"
-  integrity sha512-/TS23MVvo34dFmf8mwCisCbWGrfhbiWZSwBo6HkADTBhUa2Q/jWltyY/tpofz/b6/RIhqaqQcquptCirqIhOaQ==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.2"
-
 "@babel/polyfill@^7.2.5":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.12.1.tgz#1f2d6371d1261bbd961f3c5d5909150e12d0bd96"
@@ -2322,23 +2314,6 @@
     lodash.debounce "4.0.8"
     mitt "3.0.0"
 
-"@justeat/f-services@0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.13.0.tgz#b0fc67948e94800ba176addb9d92cce444d28c8e"
-  integrity sha512-iHfmZho2yvP8Bz2UrE9DYh2yMEf7jzINXkL6mtsM8CuSpJAjP4gVI9oQVMzEku7pOWDz6pZaTZT5mVu6Q6o8BQ==
-  dependencies:
-    "@babel/polyfill" "7.7.0"
-    lodash-es "4.17.15"
-    window-or-global "1.0.1"
-
-"@justeat/f-services@0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-0.13.2.tgz#35f41fc84bd6b93e0823f89a1ee4f5c8f571040b"
-  integrity sha512-XJAyoSieSZQ08ad0ntThZk+1O6zdIGQVhJkWTG9C4g8/tpGROg60UiUQXVcvvXQv4Vp1XveSZyhtFMG9iAInQw==
-  dependencies:
-    lodash-es "4.17.15"
-    window-or-global "1.0.1"
-
 "@justeat/f-services@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-1.0.0.tgz#790bd0443840eb96dec1411066023db10433ed8f"
@@ -2363,28 +2338,12 @@
     lodash-es "4.17.21"
     window-or-global "1.0.1"
 
-"@justeat/f-services@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-1.13.0.tgz#bb8d92eb77d6b62b571edcd618dbc54ffedcb8ac"
-  integrity sha512-jm3DW0sI1A3VAKvSM511Hm6rWRxbXBKxsjLrkFEpwJ5Opn/EB0av14DbyeljSDjGACJjDKfmY3K+/fviL2bofg==
-  dependencies:
-    lodash-es "4.17.21"
-    window-or-global "1.0.1"
-
 "@justeat/f-services@1.16.0":
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-1.16.0.tgz#947174c10872f37a0f11c16aa0c0aa177f998e06"
   integrity sha512-I5JZVROnbSrnjrCWk6G5BGzT6QTXWYowZdwXWZi/x8Ox0rZtHmZEHwqd0evufhHezGOgzE6gz0KeMTPHs4/ubA==
   dependencies:
     lodash-es "4.17.21"
-    window-or-global "1.0.1"
-
-"@justeat/f-services@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-services/-/f-services-1.3.0.tgz#0165f7fe3f69e0b6e6388bce7194e080bbfc9445"
-  integrity sha512-OTFFi7gBBzDphpUse2bcBo36nk+F+J4pEo/yivxdTrUEVYE6zcSht+ZRD+t4T7cncRDIue7AaCADdKpGIOhD2Q==
-  dependencies:
-    lodash-es "4.17.15"
     window-or-global "1.0.1"
 
 "@justeat/f-services@1.4.0":
@@ -13520,7 +13479,7 @@ include-media@1.4.9:
   resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.9.tgz#d0020b7be3eb2d54868a20943595ce380e0bc43b"
   integrity sha512-IUOcvWDCt6R5V0ktsGk6RbehkW9ks1dODN2ed1p+mhML82TteAl+/ElXy8AJ7ueIuVoKq2NioRVdW9FuwQNOew==
 
-"include-media@github:eduardoboucas/include-media#2.0-release":
+include-media@eduardoboucas/include-media#2.0-release:
   version "2.0.0"
   resolved "https://codeload.github.com/eduardoboucas/include-media/tar.gz/5398b556d4bb24186d360c950b19026f577ff8e5"
 
@@ -20821,7 +20780,7 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
+regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==


### PR DESCRIPTION
This PR
- Updates any dependants of `@justeat/f-services` to use Node 16 compatible version.
- Refactors `@justeat/f-user-message` to use new major version of `@justeat/f-services`, so that it's inline with other components.