### PR TITLE
f-restaurant-card@v1.3.0 - Update dependencies to be Node 16 compatible.

### DIFF
--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.3.0
 ------------------------------
-*July 19, 2022*
+*July 29, 2022*
 
 ### Added
 - Node 16 compatible version of `@justeat/f-services`.

--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.3.0
+------------------------------
+*July 19, 2022*
+
+### Added
+- Node 16 compatible version of `@justeat/f-services`.
+- Node 16 compatible version of `@justeat/f-vue-icons`.
+
 v1.2.0
  ------------------------------
  *July 19, 2022*

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",
@@ -46,8 +46,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.7.0",
-    "@justeat/f-vue-icons": "3.8.0"
+    "@justeat/f-services": "1.x",
+    "@justeat/f-vue-icons": "3.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2418,13 +2418,6 @@
   dependencies:
     babel-helper-vue-jsx-merge-props "2.0.3"
 
-"@justeat/f-vue-icons@3.8.0":
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-vue-icons/-/f-vue-icons-3.8.0.tgz#1d4ff74158a8ca63ec5fea429e772f087c365547"
-  integrity sha512-6dEkYZevqi+Do2AiC0EoseGAxoqLRWwz/VJ57owa2IYd1ubJexaRYR4H6tGCqP7Bsn7B/cQgRdbGXQubRMLeeQ==
-  dependencies:
-    babel-helper-vue-jsx-merge-props "2.0.3"
-
 "@justeat/feature-management@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@justeat/feature-management/-/feature-management-1.0.1.tgz#1c60864658400def14a9389b10af6c586b3099c7"


### PR DESCRIPTION
v1.3.0
------------------------------
*July 29, 2022*

### Added
- Node 16 compatible version of `@justeat/f-services`.
- Node 16 compatible version of `@justeat/f-vue-icons`.