### PR TITLE
Automatically detect Chromedriver version #trivial #globalconfig

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.1.3
+  browser-tools: circleci/browser-tools@1.4.0
 
 commands:
   set_deploy_key:
@@ -270,6 +271,8 @@ jobs:
     executor: node
     steps:
       - checkout
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - install_node_dependencies
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ executors:
   node:
     docker:
       # specify the version you desire here
-      - image: circleci/node:14.18.1-browsers # For latest available images check – https://circleci.com/docs/2.0/docker-image-tags.json
+      - image: cimg/node:14.20.0-browsers # For latest available images check – https://circleci.com/developer/images/image/cimg/node
 
     resource_class: large
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,8 @@ jobs:
     steps:
       - checkout
       - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
+      - browser-tools/install-chromedriver:
+          install-dir: test/chromedriver
       - install_node_dependencies
       - persist_to_workspace:
           root: .

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+detect_chromedriver_version=true

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "babel-jest": "26.1.0",
     "babel-loader": "8.1.0",
     "bundlewatch": "0.3.1",
-    "chromedriver": "96.0.0",
+    "chromedriver": "103.0.0",
     "cross-env": "7.0.2",
     "css-loader": "1.0.1",
     "danger": "10.2.1",

--- a/test/chromedriver/README.md
+++ b/test/chromedriver/README.md
@@ -1,0 +1,1 @@
+This directory is where Chromedriver will be installed when running in CI.

--- a/test/configuration/circleci.config.js
+++ b/test/configuration/circleci.config.js
@@ -16,7 +16,7 @@ const configuration = {
             args: ['--whitelisted-ips=127.0.0.1', '--disable-dev-shm-usage'],
             headless: true,
             path: '/',
-            chromedriverCustomPath: '/usr/local/bin'
+            chromedriverCustomPath: './test/chromedriver'
         },
         percy: {
             viewports: {

--- a/test/configuration/circleci.config.js
+++ b/test/configuration/circleci.config.js
@@ -15,7 +15,8 @@ const configuration = {
         chromedriver: {
             args: ['--whitelisted-ips=127.0.0.1', '--disable-dev-shm-usage'],
             headless: true,
-            path: '/'
+            path: '/',
+            chromedriverCustomPath: '/usr/local/bin'
         },
         percy: {
             viewports: {

--- a/test/configuration/local.config.js
+++ b/test/configuration/local.config.js
@@ -21,6 +21,7 @@ const configuration = {
         chromedriver: {
             headless: false,
             path: '/',
+            chromedriverCustomPath: './node_modules/chromedriver/bin',
             args: []
         }
     },

--- a/wdio-chrome.conf.js
+++ b/wdio-chrome.conf.js
@@ -13,7 +13,9 @@ exports.config = merge(sharedConf.config, {
     // Services take over a specific job you don't want to take care of. They enhance
     // your test setup with almost no effort. Unlike plugins, they don't add new
     // commands. Instead, they hook themselves up into the test process.
-    services: ['chromedriver'],
+    services: [['chromedriver', {
+        chromedriverCustomPath: configuration.availableServices.chromedriver.chromedriverCustomPath
+    }]],
     // ============
     // Capabilities
     // ============

--- a/yarn.lock
+++ b/yarn.lock
@@ -3849,7 +3849,7 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@testim/chrome-version@^1.0.7":
+"@testim/chrome-version@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.1.2.tgz#092005c5b77bd3bb6576a4677110a11485e11864"
   integrity sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw==
@@ -6212,7 +6212,7 @@ axios@0.21.2:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@0.21.4, axios@^0.21.1, axios@^0.21.2:
+axios@0.21.4, axios@^0.21.1:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
@@ -6239,6 +6239,14 @@ axios@^0.19.0:
   integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
+
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -8075,13 +8083,13 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-chromedriver@96.0.0:
-  version "96.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-96.0.0.tgz#c8473498e4c94950fa168187b112019cce9e5c6c"
-  integrity sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==
+chromedriver@103.0.0:
+  version "103.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-103.0.0.tgz#2ef086d62076e3ff6df6cfb84895d11d2c18d9cf"
+  integrity sha512-7BHf6HWt0PeOHCzWO8qlnD13sARzr5AKTtG8Csn+czsuAsajwPxdLNtry5GPh8HYFyl+i0M+yg3bT43AGfgU9w==
   dependencies:
-    "@testim/chrome-version" "^1.0.7"
-    axios "^0.21.2"
+    "@testim/chrome-version" "^1.1.2"
+    axios "^0.27.2"
     del "^6.0.0"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.0"
@@ -11740,7 +11748,7 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.7:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.7, follow-redirects@^1.14.9:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
@@ -11819,6 +11827,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"


### PR DESCRIPTION
This PR:
- Updates CircleCI to use the latest image / version of Chrome (v103)
- Adds an `.npmrc`file to tell Chromedriver to download the version that corresponds with the version on CI / on your local dev machine.