### PR TITLE
f-mfa@0.9.0 - Expect complete validateUrl rather than building up from smartGatewayBaseUrl

### DIFF
--- a/packages/components/pages/f-mfa/CHANGELOG.md
+++ b/packages/components/pages/f-mfa/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.9.0
 ------------------------------
-*August 10, 2022*
+*August 11, 2022*
 
 ### Changed
 - Take in the entire MFA `validateUrl` instead of building it up from `smartGatewayBaseUrl`.
+- Help link now points to FAQs page.
 
 ### Fixed
 - Pass `returnUrl` through to Help component.

--- a/packages/components/pages/f-mfa/CHANGELOG.md
+++ b/packages/components/pages/f-mfa/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.9.0
+------------------------------
+*August 10, 2022*
+
+### Changed
+- Take in the entire MFA `validateUrl` instead of building it up from `smartGatewayBaseUrl`.
+
+### Fixed
+- Pass `returnUrl` through to Help component.
+
+
 v0.8.2
 ------------------------------
 *August 10, 2022*

--- a/packages/components/pages/f-mfa/README.md
+++ b/packages/components/pages/f-mfa/README.md
@@ -70,12 +70,12 @@ There may be props that allow you to customise its functionality.
 
 The props that can be defined are as follows (if any):
 
-| Prop  | Type  |  Required |  default | Description |
-| ----- | ----- |  ------- |  ------- | ----------- |
-| smartGatewayBaseUrl | string | true |  - | the smartgateway host |
-| code | string | false | `''` | the mfa token to post to the api |
-| email | string | false |  `''` | the email to display on the screen |
-| returnUrl | string | false |  `/` | the return url to return to upon success |
+| Prop        | Type   | Required |  default | Description |
+| ----------- | ------ | -------- | -------- | ----------- |
+| validateUrl | string | true     | n/a      | The URL to POST the MFA validation request to. |
+| code        | string | false    | `''`     | The MFA token to POST to the API |
+| email       | string | false    | `''`     | The email to display on the page |
+| returnUrl   | string | false    |  `/`     | The URL to return the user to upon success |
 
 ### Events
 

--- a/packages/components/pages/f-mfa/package.json
+++ b/packages/components/pages/f-mfa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mfa",
   "description": "Fozzie Mfa - Multi-factor Authenticator Input Form",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "main": "dist/f-mfa.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [

--- a/packages/components/pages/f-mfa/src/components/Help.vue
+++ b/packages/components/pages/f-mfa/src/components/Help.vue
@@ -29,7 +29,7 @@
                     <i18n
                         path="helpInfo.instructionsPoint4Text"
                         tag="li">
-                        <a :href="$t('helpInfo.instructionsHelpCentreLink')">{{ $t('helpInfo.instructionsHelpCentreText') }}</a>
+                        <a :href="$t('helpInfo.instructionsHelpLink')"><strong>{{ $t('helpInfo.instructionsHelpText') }}</strong></a>
                     </i18n>
                 </ul>
 

--- a/packages/components/pages/f-mfa/src/components/Help.vue
+++ b/packages/components/pages/f-mfa/src/components/Help.vue
@@ -99,7 +99,7 @@ export default {
 
     computed: {
         loginLinkWithReturnUrl () {
-            return `/account/login?returnUrl=${this.returnUrl}`;
+            return `/account/login?returnUrl=${encodeURIComponent(this.returnUrl)}`;
         }
     }
 };

--- a/packages/components/pages/f-mfa/src/components/Mfa.vue
+++ b/packages/components/pages/f-mfa/src/components/Mfa.vue
@@ -87,6 +87,7 @@
         <help-info
             v-else-if="showHelpInfo"
             :email="email"
+            :return-url="returnUrl"
             @primary-button-click="onHideHelpInfo" />
 
         <f-card-with-content
@@ -152,7 +153,7 @@ export default {
     mixins: [VueGlobalisationMixin],
 
     props: {
-        smartGatewayBaseUrl: {
+        validateUrl: {
             type: String,
             required: true
         },
@@ -226,7 +227,7 @@ export default {
                     await (new AccountWebApi({
                         httpClient: this.$http,
                         cookies: this.$cookies,
-                        baseUrl: this.smartGatewayBaseUrl
+                        validateUrl: this.validateUrl
                     })).postValidateMfaToken({ mfa_token: this.code, otp: this.otp }); // eslint-disable-line camelcase
                     this.emitRedirectEvent(this.returnUrl); // Completed successfully, emit redirect return url
                 }

--- a/packages/components/pages/f-mfa/src/components/_tests/Mfa.test.js
+++ b/packages/components/pages/f-mfa/src/components/_tests/Mfa.test.js
@@ -8,7 +8,7 @@ import {
 
 const localVue = createLocalVue();
 localVue.use(VueI18n);
-const baseUrl = 'https://api.test.co.uk/';
+const validateUrl = 'https://localhost:8080/mfa/validate';
 let wrapper;
 let sutMocks;
 let sutProps;
@@ -71,7 +71,7 @@ describe('Mfa', () => {
             showErrorPage: false
         });
         sutProps = {
-            smartGatewayBaseUrl: baseUrl,
+            validateUrl,
             code: 'ABC123',
             email: 'jazz.man@hemail.com',
             returnUrl: '/place/i/came/from'

--- a/packages/components/pages/f-mfa/src/constants.js
+++ b/packages/components/pages/f-mfa/src/constants.js
@@ -1,5 +1,3 @@
-export const SUBMIT_LOGIN_CHALLENGE_URL = 'applications/coreweb/validate-mfa-token';
-
 export const CONVERSATION_ID_HEADER_NAME = 'x-je-conversation';
 
 export const CONVERSATION_ID_COOKIE_NAME = 'x-je-conversation';

--- a/packages/components/pages/f-mfa/src/services/AccountWeb.api.js
+++ b/packages/components/pages/f-mfa/src/services/AccountWeb.api.js
@@ -1,7 +1,6 @@
 import { v4 as uuid } from 'uuid';
 
 import {
-    SUBMIT_LOGIN_CHALLENGE_URL,
     CONVERSATION_ID_HEADER_NAME,
     CONVERSATION_ID_COOKIE_NAME
 } from '../constants';
@@ -9,12 +8,12 @@ import {
 export default class AccountWebApi {
     #httpClient;
     #cookies;
-    #baseUrl;
+    #validateUrl;
 
-    constructor ({ httpClient, cookies, baseUrl } = {}) {
+    constructor ({ httpClient, cookies, validateUrl } = {}) {
         this.#httpClient = httpClient;
         this.#cookies = cookies;
-        this.#baseUrl = baseUrl;
+        this.#validateUrl = validateUrl;
     }
 
     async postValidateMfaToken (body, conversationId = this.setConversationId()) {
@@ -22,7 +21,7 @@ export default class AccountWebApi {
             [CONVERSATION_ID_HEADER_NAME]: conversationId
         };
 
-        const response = await this.#httpClient.post(`${this.#baseUrl}/${SUBMIT_LOGIN_CHALLENGE_URL}`, body, headers);
+        const response = await this.#httpClient.post(this.#validateUrl, body, headers);
 
         return response;
     }

--- a/packages/components/pages/f-mfa/src/services/_tests/AccountWeb.api.test.js
+++ b/packages/components/pages/f-mfa/src/services/_tests/AccountWeb.api.test.js
@@ -1,14 +1,13 @@
 import AccountWebApi from '../AccountWeb.api';
 
 import {
-    SUBMIT_LOGIN_CHALLENGE_URL,
     CONVERSATION_ID_HEADER_NAME,
     CONVERSATION_ID_COOKIE_NAME
 } from '../../constants';
 import {
-    baseUrl,
     conversationId,
-    postBody
+    postBody,
+    validateUrl
 } from '../../../test-utils/setup';
 
 let apiProvider;
@@ -26,7 +25,7 @@ describe('AccountWebApi Provider', () => {
             set: cookiesSetSpy
         };
 
-        apiProvider = new AccountWebApi({ httpClient: httpClientMock, cookies: cookiesMock, baseUrl });
+        apiProvider = new AccountWebApi({ httpClient: httpClientMock, cookies: cookiesMock, validateUrl });
     });
 
     afterEach(() => {
@@ -50,7 +49,7 @@ describe('AccountWebApi Provider', () => {
     describe('When calling `postValidateMfaToken`', () => {
         it('should send the correct parameters to the api', async () => {
             // Arrange
-            const expectedUri = `${baseUrl}/${SUBMIT_LOGIN_CHALLENGE_URL}`;
+            const expectedUri = 'https://localhost:8080/mfa/validate';
             const expectedBody = postBody;
             const expectedHeaders = {
                 [CONVERSATION_ID_HEADER_NAME]: conversationId

--- a/packages/components/pages/f-mfa/src/tenants/en-GB.js
+++ b/packages/components/pages/f-mfa/src/tenants/en-GB.js
@@ -21,8 +21,8 @@ const messages = {
         instructionsPoint2Text: 'Check your spam folder',
         instructionsPoint3Text: 'Try logging in another way',
         instructionsPoint4Text: 'See our {0} if you still need help',
-        instructionsHelpCentreLink: '/help',
-        instructionsHelpCentreText: 'help centre',
+        instructionsHelpLink: 'https://www.just-eat.co.uk/help/section/201054682/how-do-i-use-this-just-eat-thing',
+        instructionsHelpText: 'FAQs',
         primaryButtonText: 'Enter code',
         secondaryButtonText: 'Log in another way'
     },

--- a/packages/components/pages/f-mfa/stories/Mfa.stories.js
+++ b/packages/components/pages/f-mfa/stories/Mfa.stories.js
@@ -32,7 +32,7 @@ export const VMfaComponent = (args, { argTypes }) => ({
 
     template: `<v-mfa
         v-bind="$props"
-        @mfa-success-return-url="mfaSuccess()" />`
+        @mfa-success-return-url="mfaSuccess" />`
 });
 
 VMfaComponent.storyName = 'f-mfa';

--- a/packages/components/pages/f-mfa/stories/Mfa.stories.js
+++ b/packages/components/pages/f-mfa/stories/Mfa.stories.js
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions';
 import { withA11y } from '@storybook/addon-a11y';
 import { locales } from '@justeat/storybook/constants/globalisation';
 import VMfa from '../src/components/Mfa.vue';
@@ -16,6 +17,10 @@ export const VMfaComponent = (args, { argTypes }) => ({
 
     props: Object.keys(argTypes, args),
 
+    methods: {
+        mfaSuccess: action('mfa-success')
+    },
+
     watch: {
         apiState: {
             immediate: true,
@@ -25,14 +30,16 @@ export const VMfaComponent = (args, { argTypes }) => ({
         }
     },
 
-    template: '<v-mfa v-bind="$props" />'
+    template: `<v-mfa
+        v-bind="$props"
+        @mfa-success-return-url="mfaSuccess()" />`
 });
 
 VMfaComponent.storyName = 'f-mfa';
 
 VMfaComponent.args = {
     locale: locales.gb,
-    smartGatewayBaseUrl: 'http://localhost:8080',
+    validateUrl: 'http://localhost:8080/mfa/validate',
     code: 'ABC123',
     email: 'harry.potter@home.com',
     returnUrl: '/where/i/came/from',

--- a/packages/components/pages/f-mfa/stories/story.helper.js
+++ b/packages/components/pages/f-mfa/stories/story.helper.js
@@ -1,7 +1,3 @@
-import {
-    SUBMIT_LOGIN_CHALLENGE_URL
-} from '../src/constants';
-
 const httpStatusCodes = {
     ok: 200,
     badrequest: 400,
@@ -21,7 +17,7 @@ const apiStates = {
 
 // Mocks for the API calls
 const otpPOST200 = {
-    url: `http://localhost:8080/${SUBMIT_LOGIN_CHALLENGE_URL}`,
+    url: 'http://localhost:8080/mfa/validate',
     method: httpVerbs.post,
     responseStatus: httpStatusCodes.ok,
     requestData: { mfa_token: 'ABC123', otp: 'otp123' }, // eslint-disable-line camelcase
@@ -29,7 +25,7 @@ const otpPOST200 = {
 };
 
 const otpPOST400 = {
-    url: `http://localhost:8080/${SUBMIT_LOGIN_CHALLENGE_URL}`,
+    url: 'http://localhost:8080/mfa/validate',
     method: httpVerbs.post,
     responseStatus: httpStatusCodes.badrequest,
     requestData: { mfa_token: 'ABC123', otp: 'otp123' }, // eslint-disable-line camelcase
@@ -37,7 +33,7 @@ const otpPOST400 = {
 };
 
 const otpPOST429 = {
-    url: `http://localhost:8080/${SUBMIT_LOGIN_CHALLENGE_URL}`,
+    url: 'http://localhost:8080/mfa/validate',
     method: httpVerbs.post,
     responseStatus: httpStatusCodes.throttledrequest,
     requestData: { mfa_token: 'ABC123', otp: 'otp123' }, // eslint-disable-line camelcase

--- a/packages/components/pages/f-mfa/test-utils/setup.js
+++ b/packages/components/pages/f-mfa/test-utils/setup.js
@@ -1,4 +1,4 @@
-export const baseUrl = 'https://smartGatewayBaseUrl.com';
+export const validateUrl = 'https://localhost:8080/mfa/validate';
 
 export const conversationId = 'b7386108-95e6-4e73-9421-5b066c089153';
 


### PR DESCRIPTION
This follows the same pattern as f-registration which also works in the same way. The API requests will be made to the same domain as the website, so no base URL is required.

Also updated storybook to emit visible events (in the actions tab) when on a (simulated) successful request.

---

### Changed
- Take in the entire MFA `validateUrl` instead of building it up from `smartGatewayBaseUrl`.

### Fixed
- Pass `returnUrl` through to Help component.