### PR TITLE
storybook@v0.56.0 – Fozzie docs updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v7.26.0
+------------------------------
+*August 11, 2022*
+
+### Changed
+- Small updates to Storybook config
+
 v7.25.0
 ------------------------------
 *August 11, 2022*
@@ -31,6 +38,7 @@ v7.23.0
 
 ### Changed
 - Allure report generation to execute on fail to speed up CI.
+
 
 v7.22.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "7.25.0",
+  "version": "7.26.0",
   "private": true,
   "scripts": {
     "build": "turbo run build --continue",

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.57.0
+------------------------------
+*August 17, 2022*
+
+### Changed
+- Updated the `Fozzie overview` and `Fozzie and Sass` docs pages.
+- Nav structure for the Fozzie section re-ordered.
+
+### Fixed
+- Link colours for links using the LinkTo module.
 
 v0.56.0
 ------------------------------

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private": true,
-  "version": "0.56.0",
+  "version": "0.57.0",
   "scripts": {
     "storybook:deploy": "gh-pages -d storybook-static -u \"github-actions-bot <support+actions@github.com>\"",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",


### PR DESCRIPTION
### Changed
- Updated the `Fozzie overview` and `Fozzie and Sass` docs pages.
- Nav structure for the Fozzie section re-ordered.

### Fixed
- Link colours for links using the LinkTo module.
