### PR TITLE
f-header@v10.6.0 – Fixing friendly name length

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -2,6 +2,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v10.6.0
+------------------------------
+*August 17, 2022*
+
+### Fixed
+- Friendly name now gets truncated at longer lengths on narrower screen widths. Previously, for longer names it would cause the navigation links to wrap onto two lines just above the mid breakpoint (>769px).
+
+
 v10.5.0
 ------------------------------
 *July 29, 2022*

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header - Globalised Header Component",
-  "version": "10.5.0",
+  "version": "10.6.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "45kB",
   "files": [

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -675,6 +675,7 @@ export default {
 
 .c-nav-container {
     display: none;
+
     @include f.media('>mid') {
         display: block;
         height: common.$header-height;
@@ -733,8 +734,25 @@ export default {
     @include f.font-size(common.$nav-text-size);
     color: common.$nav-text-color;
     font-weight: f.$font-weight-regular;
+
     @include f.media('>mid') {
         font-weight: common.$nav-text-weight;
+    }
+    @include f.media('>mid', '<wide') {
+        max-width: 200px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+    }
+
+    $navTextTweakpointMid: f.em(800);
+    $navTextTweakpointMidWide: f.em(900);
+    // truncate the length of user friendly name at certain breakpoints
+    @include f.media('>mid', '<=#{$navTextTweakpointMid}') {
+        max-width: 78px;
+    }
+    @include f.media('>#{$navTextTweakpointMid}', '<#{$navTextTweakpointMidWide}') {
+        max-width: 110px;
     }
 }
 
@@ -753,6 +771,7 @@ export default {
     @include f.font-size(common.$nav-text-size);
     margin-left: f.spacing(h);
     color: common.$nav-text-color;
+
     &.u-showBelowMid {
         @include f.media('>mid') {
             display: none !important;


### PR DESCRIPTION
### Fixed
- Friendly name now gets truncated at longer lengths on narrower screen widths. Previously, for longer names it would cause the navigation links to wrap onto two lines just above the mid breakpoint (>769px).

---

## UI Review Checks

[![image](https://user-images.githubusercontent.com/805184/35801356-f756b018-0a63-11e8-8ca4-ec045d43c16c.png)](https://user-images.githubusercontent.com/805184/185145470-41c3e3ee-97da-416a-9243-0b4cf4547c18.mov)

- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Mobile (iPhone X)
