### PR TITLE
f-header@v10.6.1 – Updating to use truncate mixin

### DIFF
--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -3,6 +3,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v10.6.1
+------------------------------
+*August 18, 2022*
+
+### Changed
+- Truncation now uses fozzie `truncate()` mixin (compiled CSS is exactly the same).
+
+
 v10.6.0
 ------------------------------
 *August 17, 2022*

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header - Globalised Header Component",
-  "version": "10.6.0",
+  "version": "10.6.1",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "45kB",
   "files": [

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -739,10 +739,7 @@ export default {
         font-weight: common.$nav-text-weight;
     }
     @include f.media('>mid', '<wide') {
-        max-width: 200px;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        overflow: hidden;
+        @include f.truncate(200px);
     }
 
     $navTextTweakpointMid: f.em(800);


### PR DESCRIPTION
### Changed
- Truncation now uses fozzie `truncate()` mixin (compiled CSS is exactly the same).