### PR TITLE
f-registration@3.6.0 - Add mfa challenge issued event

### DIFF
--- a/packages/components/pages/f-registration/CHANGELOG.md
+++ b/packages/components/pages/f-registration/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.6.0
+------------------------------
+*August 18, 2022*
+
+### Changed
+- Updated component to emit MfaChallengeIssue event for 403 errors
+
 v3.5.0
 ------------------------------
 *August 15, 2022*

--- a/packages/components/pages/f-registration/package.json
+++ b/packages/components/pages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "main": "dist/f-registration.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [

--- a/packages/components/pages/f-registration/src/components/Registration.vue
+++ b/packages/components/pages/f-registration/src/components/Registration.vue
@@ -498,8 +498,17 @@ export default {
                         return;
                     }
 
-                    if (status === 403 || status === 401) {
+                    if (status === 401) {
                         this.$emit(EventNames.LoginBlocked);
+                        return;
+                    }
+
+                    if (status === 403) {
+                        this.$emit(EventNames.MfaChallengeIssued, {
+                            mfaToken: error.response.data.mfa_token,
+                            mfaTarget: error.response.data.mfa_target
+                        });
+
                         return;
                     }
                 }

--- a/packages/components/pages/f-registration/src/components/_tests/Registration.test.js
+++ b/packages/components/pages/f-registration/src/components/_tests/Registration.test.js
@@ -218,7 +218,7 @@ describe('Registration', () => {
                 expect(wrapper.emitted(EventNames.CreateAccountWarning).length).toBe(1);
             });
 
-            it('should emit login blocked event when service responds with a 403', async () => {
+            it('should emit mfa challenge issued event when service responds with a 403', async () => {
                 // Arrange
                 const err = {
                     response: {
@@ -227,9 +227,13 @@ describe('Registration', () => {
                             faultId: '123',
                             traceId: '123',
                             errors: [{
-                                description: 'Failed user authentication.',
-                                errorCode: 'FailedUserAuthentication'
-                            }]
+                                description: '"MFA Challenge Issued"',
+                                errorCode: 'MFAChallengeIssued'
+                            }],
+                            // eslint-disable-next-line camelcase
+                            mfa_token: 'mfa-token',
+                            // eslint-disable-next-line camelcase
+                            mfa_target: 'someone@somewhere.com'
                         }
                     }
                 };
@@ -247,7 +251,10 @@ describe('Registration', () => {
                 await flushPromises();
 
                 // Assert
-                expect(wrapper.emitted(EventNames.LoginBlocked).length).toBe(1);
+                const mfaChallengeIssuedEvent = wrapper.emitted(EventNames.MfaChallengeIssued);
+                expect(mfaChallengeIssuedEvent.length).toBe(1);
+                expect(mfaChallengeIssuedEvent[0][0].mfaToken).toBe('mfa-token');
+                expect(mfaChallengeIssuedEvent[0][0].mfaTarget).toBe('someone@somewhere.com');
                 expect(wrapper.emitted(EventNames.CreateAccountFailure)).toBeUndefined();
             });
 

--- a/packages/components/pages/f-registration/src/components/_tests/f-registration.integration.test.js
+++ b/packages/components/pages/f-registration/src/components/_tests/f-registration.integration.test.js
@@ -86,9 +86,13 @@ describe('Registration API service', () => {
             faultId: '00000000-0000-0000-0000-000000000000',
             traceId: 'H3TKh4QSJUSwVBCBqEtkKw',
             errors: [{
-                description: 'Failed user authentication.',
-                errorCode: 'FailedUserAuthentication'
-            }]
+                description: 'MFA Challenge Issued',
+                errorCode: 'MFAChallengeIssued'
+            }],
+            // eslint-disable-next-line camelcase
+            mfa_token: 'mfa-token',
+            // eslint-disable-next-line camelcase
+            mfa_target: 'someone@somewhere.com'
         });
 
         // Act
@@ -96,7 +100,10 @@ describe('Registration API service', () => {
         await flushPromises();
 
         // Assert
-        expect(wrapper.emitted(EventNames.LoginBlocked).length).toBe(1);
+        const mfaChallengeIssuedEvent = wrapper.emitted(EventNames.MfaChallengeIssued);
+        expect(mfaChallengeIssuedEvent.length).toBe(1);
+        expect(mfaChallengeIssuedEvent[0][0].mfaToken).toBe('mfa-token');
+        expect(mfaChallengeIssuedEvent[0][0].mfaTarget).toBe('someone@somewhere.com');
         expect(wrapper.emitted(EventNames.CreateAccountFailure)).toBeUndefined();
     });
 

--- a/packages/components/pages/f-registration/src/event-names.js
+++ b/packages/components/pages/f-registration/src/event-names.js
@@ -5,6 +5,7 @@ const CreateAccountStart = 'registration-create-account-start';
 const CreateAccountInlineError = 'registration-create-account-inline-error';
 const VisitLoginPage = 'registration-visit-login-page';
 const LoginBlocked = 'registration-login-blocked';
+const MfaChallengeIssued = 'registration-mfa-challenge-issued';
 
 export default {
     CreateAccountSuccess,
@@ -13,5 +14,6 @@ export default {
     CreateAccountStart,
     CreateAccountInlineError,
     VisitLoginPage,
-    LoginBlocked
+    LoginBlocked,
+    MfaChallengeIssued
 };


### PR DESCRIPTION
## Changed

Updated handling of 403 responses to emit an MfaChallengeIssued event.

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

