### PR TITLE
f-registation@3.6.1 - Add additional LoginBlock not emitted assertion

### DIFF
--- a/packages/components/pages/f-registration/CHANGELOG.md
+++ b/packages/components/pages/f-registration/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.6.1
+------------------------------
+*August 19, 2022*
+
+### Changed
+- Add LoginBlock event not emitted assertion
+
 v3.6.0
 ------------------------------
 *August 18, 2022*

--- a/packages/components/pages/f-registration/package.json
+++ b/packages/components/pages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "main": "dist/f-registration.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [

--- a/packages/components/pages/f-registration/src/components/_tests/Registration.test.js
+++ b/packages/components/pages/f-registration/src/components/_tests/Registration.test.js
@@ -256,6 +256,7 @@ describe('Registration', () => {
                 expect(mfaChallengeIssuedEvent[0][0].mfaToken).toBe('mfa-token');
                 expect(mfaChallengeIssuedEvent[0][0].mfaTarget).toBe('someone@somewhere.com');
                 expect(wrapper.emitted(EventNames.CreateAccountFailure)).toBeUndefined();
+                expect(wrapper.emitted(EventNames.LoginBlocked)).toBeUndefined();
             });
 
             it('should emit login blocked event when service responds with a 401', async () => {

--- a/packages/components/pages/f-registration/src/components/_tests/f-registration.integration.test.js
+++ b/packages/components/pages/f-registration/src/components/_tests/f-registration.integration.test.js
@@ -105,6 +105,7 @@ describe('Registration API service', () => {
         expect(mfaChallengeIssuedEvent[0][0].mfaToken).toBe('mfa-token');
         expect(mfaChallengeIssuedEvent[0][0].mfaTarget).toBe('someone@somewhere.com');
         expect(wrapper.emitted(EventNames.CreateAccountFailure)).toBeUndefined();
+        expect(wrapper.emitted(EventNames.LoginBlocked)).toBeUndefined();
     });
 
     it('responds with 401 when login blocked by ravelin or recaptcha', async () => {


### PR DESCRIPTION
## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
