### PR TITLE
f-checkout@4.5.1 - Fix T&Cs translation formatting

### DIFF
--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v4.5.1
+------------------------------
+*August 22, 2022*
+
+### Fixed
+- Formatting of terms and conditions translations.
+
+
 v4.5.0
 ------------------------------
 *August 1, 2022*
@@ -12,12 +21,14 @@ v4.5.0
 - Node 16 compatible version of `@justeat/f-globalisation`.
 - Node 16 compatible version of `@justeat/f-vue-icons`.
 
+
 v4.4.0
 ------------------------------
 *July 26, 2022*
 
 ### Updated
 - Bundlewatch maxSize
+
 
 v4.3.0
 ------------------------------

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout - Fozzie Checkout Component",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "140kB",
   "files": [

--- a/packages/components/pages/f-checkout/src/components/TermsAndConditions.vue
+++ b/packages/components/pages/f-checkout/src/components/TermsAndConditions.vue
@@ -1,40 +1,34 @@
 <template>
-    <div
+    <i18n
+        tag="div"
+        path="checkoutTermsAndConditions"
         data-test-id="checkout-terms-and-conditions-component"
         :class="$style['c-checkoutTermsAndConditions']">
-        <i18n path="checkoutTermsAndConditions">
-            <template #termsAndConditions>
-                <v-link
-                    is-bold
-                    is-distinct
-                    :href="$t('termsAndConditionsLinkUrl')"
-                    target="_blank"
-                    rel="noopener noreferrer">
-                    {{ $t('termsAndConditionsLinkText') }}
-                </v-link>
-            </template>
-            <template #privacyPolicy>
-                <v-link
-                    is-bold
-                    is-distinct
-                    :href="$t('privacyPolicyLinkUrl')"
-                    target="_blank"
-                    rel="noopener noreferrer">
-                    {{ $t('privacyPolicyLinkText') }}
-                </v-link>
-            </template>
-            <template #cookiePolicy>
-                <v-link
-                    is-bold
-                    is-distinct
-                    :href="$t('cookiePolicyLinkUrl')"
-                    target="_blank"
-                    rel="noopener noreferrer">
-                    {{ $t('cookiePolicyLinkText') }}
-                </v-link>
-            </template>
-        </i18n>
-    </div>
+        <v-link
+            is-bold
+            is-distinct
+            :href="$t('termsAndConditionsLinkUrl')"
+            target="_blank"
+            rel="noopener noreferrer">
+            {{ $t('termsAndConditionsLinkText') }}
+        </v-link>
+        <v-link
+            is-bold
+            is-distinct
+            :href="$t('privacyPolicyLinkUrl')"
+            target="_blank"
+            rel="noopener noreferrer">
+            {{ $t('privacyPolicyLinkText') }}
+        </v-link>
+        <v-link
+            is-bold
+            is-distinct
+            :href="$t('cookiePolicyLinkUrl')"
+            target="_blank"
+            rel="noopener noreferrer">
+            {{ $t('cookiePolicyLinkText') }}
+        </v-link>
+    </i18n>
 </template>
 
 <script>

--- a/packages/components/pages/f-checkout/src/tenants/en-GB.js
+++ b/packages/components/pages/f-checkout/src/tenants/en-GB.js
@@ -274,7 +274,7 @@ const messages = {
         delivery: 'Delivery'
     },
 
-    checkoutTermsAndConditions: 'By placing an order you agree to our {termsAndConditions}. Please read our {privacyPolicy} and {cookiePolicy}.',
+    checkoutTermsAndConditions: 'By placing an order you agree to our {0}. Please read our {1} and {2}.',
 
     termsAndConditionsLinkText: 'Terms and Conditions',
     termsAndConditionsLinkUrl: 'https://www.just-eat.co.uk/termsandconditions',


### PR DESCRIPTION
Tested by `yalc`ing into CoreWeb.

To be honest, I'm not sure why this fixes the issue (the templating looked fine before), but it does.