### PR TITLE
f-account-info@v1.5.0 – Updating package.json with latest peerDeps

### DIFF
--- a/packages/components/pages/f-account-info/CHANGELOG.md
+++ b/packages/components/pages/f-account-info/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.5.0
+------------------------------
+*August 22, 2022*
+
+### Changed
+- Updating `f-alert` peerDep to `v6.x`
+
+### Removed
+- `vuex` peerDependency, as we don't need to directly specify this as Nuxt depends on Vuex (and causes `UNMET PEER DEPENDENCY` warnings that are false positives).
+
+
 v1.4.0
 ------------------------------
 *July 27, 2022*

--- a/packages/components/pages/f-account-info/package.json
+++ b/packages/components/pages/f-account-info/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-account-info",
   "description": "Fozzie Account Info - The account information page",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "dist/f-account-info.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [
@@ -58,14 +58,13 @@
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0",
-    "@justeat/f-alert": "5.x",
+    "@justeat/f-alert": "6.x",
     "@justeat/f-button": "4.x",
     "@justeat/f-card": "4.x",
     "@justeat/f-card-with-content": "3.x",
     "@justeat/f-error-message": "2.x",
     "@justeat/f-form-field": "6.x",
-    "@justeat/f-link": "3.x",
-    "vuex": ">=3.5.1"
+    "@justeat/f-link": "3.x"
   },
   "devDependencies": {
     "@justeat/f-alert": "6.x",


### PR DESCRIPTION
### Changed
- Updating `f-alert` peerDep to `v6.x`

### Removed
- `vuex` peerDependency, as we don't need to directly specify this as Nuxt depends on Vuex (and causes `UNMET PEER DEPENDENCY` warnings that are false positives).
