### PR TITLE
f-registration@3.7.0 - Add rate limiting error event

### DIFF
--- a/packages/components/pages/f-registration/CHANGELOG.md
+++ b/packages/components/pages/f-registration/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.7.0
+------------------------------
+*August 22, 2022*
+
+### Changed
+- Updated component to emit RateLimitExceeded event for 429 errors
+
 v3.6.1
 ------------------------------
 *August 19, 2022*

--- a/packages/components/pages/f-registration/package.json
+++ b/packages/components/pages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "main": "dist/f-registration.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [

--- a/packages/components/pages/f-registration/src/components/Registration.vue
+++ b/packages/components/pages/f-registration/src/components/Registration.vue
@@ -511,6 +511,11 @@ export default {
 
                         return;
                     }
+
+                    if (status === 429) {
+                        this.$emit(EventNames.RateLimitExceeded);
+                        return;
+                    }
                 }
 
                 this.genericErrorMessage = this.copy.genericErrorMessage;

--- a/packages/components/pages/f-registration/src/event-names.js
+++ b/packages/components/pages/f-registration/src/event-names.js
@@ -6,6 +6,7 @@ const CreateAccountInlineError = 'registration-create-account-inline-error';
 const VisitLoginPage = 'registration-visit-login-page';
 const LoginBlocked = 'registration-login-blocked';
 const MfaChallengeIssued = 'registration-mfa-challenge-issued';
+const RateLimitExceeded = 'registration-rate-limit-exceeded';
 
 export default {
     CreateAccountSuccess,

--- a/packages/components/pages/f-registration/src/event-names.js
+++ b/packages/components/pages/f-registration/src/event-names.js
@@ -15,5 +15,6 @@ export default {
     CreateAccountInlineError,
     VisitLoginPage,
     LoginBlocked,
-    MfaChallengeIssued
+    MfaChallengeIssued,
+    RateLimitExceeded
 };


### PR DESCRIPTION
## Changed

Updated component to emit RateLimitExceeded event for 429 errors

- [X] README and/or UI Documentation has been [created|updated]
- [X] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)
