### PR TITLE
fozzie-components@v7.26.0 – Updating codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,17 @@
-* @justeat/ui-senior-reviewers-web @justeat/ui-reviewers-web
+# Web Core Platform reviewers file matches
+# Root Mono-repo config files
+/*.* @justeat/ui-web-core-team-reviewers
+/packages/components/atoms @justeat/ui-web-core-team-reviewers
+/packages/components/organisms/f-header @justeat/ui-web-core-team-reviewers
+/packages/components/organisms/f-footer @justeat/ui-web-core-team-reviewers
+/packages/components/organisms/f-cookie-banner @justeat/ui-web-core-team-reviewers
+
+# Test reviewers file matches
+/test @justeat/ui-web-qe-reviewers
+**/test/* @justeat/ui-web-qe-reviewers
+*.spec.js @justeat/ui-web-qe-reviewers
+*.component.js @justeat/ui-web-qe-reviewers
+*.component.spec.js @justeat/ui-web-qe-reviewers
+
+# Commented out for now, while we test other file matches
+# * @justeat/ui-web-senior-reviewers @justeat/ui-web-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,10 @@
 # Web Core Platform reviewers file matches
 # Root Mono-repo config files
 /*.* @justeat/ui-web-core-team-reviewers
+/.github/ @justeat/ui-web-core-team-reviewers
+/.circleci/ @justeat/ui-web-core-team-reviewers
+/.husky/ @justeat/ui-web-core-team-reviewers
+/config/ @justeat/ui-web-core-team-reviewers
 /packages/components/atoms @justeat/ui-web-core-team-reviewers
 /packages/components/organisms/f-header @justeat/ui-web-core-team-reviewers
 /packages/components/organisms/f-footer @justeat/ui-web-core-team-reviewers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,23 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v7.26.0
+------------------------------
+*August 23, 2022*
+
+### Changed
+- Codeowners updated to point to new Core Team for mono-repo config, atoms and core owned components (like `f-header`/`f-footer`).
+  Test files are set to be owned by the QE Reviewers team.
+
+
 v7.25.1
 ------------------------------
 *August 22, 2022*
 
 ### Fixed
 - Issue where incorrect cache was being used to deploy Storybook.
+
 
 v7.25.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "7.25.1",
+  "version": "7.26.0",
   "private": true,
   "scripts": {
     "build": "turbo run build --continue",


### PR DESCRIPTION
### Changed
- Codeowners updated to point to new Core Team for mono-repo config, atoms and core owned components (like `f-header`/`f-footer`).
  Test files are set to be owned by the QE Reviewers team.