### PR TITLE
f-mfa@0.12.0 - List fozzie-component dependencies as externals

### DIFF
--- a/packages/components/pages/f-mfa/CHANGELOG.md
+++ b/packages/components/pages/f-mfa/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.12.0
+------------------------------
+*August 24, 2022*
+
+### Changed
+- Added fozzie components as externals in Webpack config.
+
+
 v0.11.0
 ------------------------------
 *August 19, 2022*
@@ -19,7 +27,7 @@ v0.10.0
 ### Changed
 - Changed mfa load success log message to `Info`.
 - Help screen primary button text.
-  
+
 ### Removed
 - Mfa Form field validation/message.
 

--- a/packages/components/pages/f-mfa/package.json
+++ b/packages/components/pages/f-mfa/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@justeat/f-mfa",
   "description": "Fozzie Mfa - Multi-factor Authenticator Input Form",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "main": "dist/f-mfa.umd.min.js",
-  "maxBundleSize": "100kB",
+  "maxBundleSize": "30kB",
   "files": [
     "dist",
     "test-utils",

--- a/packages/components/pages/f-mfa/vue.config.js
+++ b/packages/components/pages/f-mfa/vue.config.js
@@ -16,6 +16,14 @@ module.exports = {
                 // eslint-disable-next-line quotes
                 additionalData: `@use "../assets/scss/common.scss";`
             });
+
+        config.externals({
+            '@justeat/f-alert': '@justeat/f-alert',
+            '@justeat/f-button': '@justeat/f-button',
+            '@justeat/f-card': '@justeat/f-card',
+            '@justeat/f-card-with-content': '@justeat/f-card-with-content',
+            '@justeat/f-form-field': '@justeat/f-form-field'
+        });
     },
     pluginOptions: {
         lintStyleOnBuild: true


### PR DESCRIPTION
These dependencies were being bundled as part of the build step for this component, which meant that the floating (`.x`) versions weren't really doing anything, as the dependencies were being included at build-time.

By setting these as externals, they are not included in the build so our pattern of using peer dependencies can work as intended.

### Changed
- Added fozzie components as externals in Webpack config.

| Before | After |
| --- | --- |
| ![2022-08-24 11_57_37](https://user-images.githubusercontent.com/26894168/186404168-14fc79a0-df2a-4af8-a002-77d4c1d0a7f5.png) | ![2022-08-24 11_56_57](https://user-images.githubusercontent.com/26894168/186404187-567943ac-fb50-4471-8514-7eff4dc8fb12.png) |

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
