### PR TITLE
f-error-boundary@v0.4.0

### DIFF
--- a/packages/components/atoms/f-error-boundary/CHANGELOG.md
+++ b/packages/components/atoms/f-error-boundary/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.4.0
+------------------------------
+*September 5, 2022*
+
+### Added
+- `hasError` to `on-error` emitted event.
+
+### Fixed
+- Package `main` export filename.
+
+
 v0.3.0
 ------------------------------
 *July 15, 2022*

--- a/packages/components/atoms/f-error-boundary/package.json
+++ b/packages/components/atoms/f-error-boundary/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@justeat/f-error-boundary",
   "description": "Fozzie Error Boundary - A reusable component for catching JavaScript errors and displaying fallback UIs",
-  "version": "0.3.0",
-  "main": "dist/f-error-boundary.umd.min.js",
+  "version": "0.4.0",
+  "main": "dist/f-error-boundary.umd.js",
   "module": "dist/f-error-boundary.es.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-error-boundary/src/components/ErrorBoundary.vue
+++ b/packages/components/atoms/f-error-boundary/src/components/ErrorBoundary.vue
@@ -46,6 +46,7 @@ export default {
             this.info = info;
 
             this.$emit('on-error', {
+                hasError: this.hasError,
                 error,
                 vm,
                 info,

--- a/packages/components/atoms/f-error-boundary/src/components/tests/ErrorBoundary.test.js
+++ b/packages/components/atoms/f-error-boundary/src/components/tests/ErrorBoundary.test.js
@@ -94,6 +94,7 @@ describe('ErrorBoundary', () => {
             // Assert
             const [[emittedPayload]] = wrapper.emitted('on-error');
             expect(emittedPayload).toEqual({
+                hasError: true,
                 error,
                 info,
                 loggerPayload,


### PR DESCRIPTION
### Added
- `hasError` to `on-error` emitted event.

### Fixed
- Package `main` export filename.