### PR TITLE
Reproduce broken Windows test functionality when importing a component object via node_modules #trivial #globalconfig

### DIFF
--- a/packages/components/atoms/f-wdio-test/.eslintignore
+++ b/packages/components/atoms/f-wdio-test/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/components/atoms/f-wdio-test/CHANGELOG.md
+++ b/packages/components/atoms/f-wdio-test/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+v0.1.0
+------------------------------
+*September 5, 2022*
+
+### Added
+- Add your change under the following headings: `Added`/`Changed`/`Deprecated`/`Removed`/`Fixed`/`Security`
+!!! Please, add your component to `.circleci/config.yml` under `save_cache_dist_directories` manually after the component is generated.

--- a/packages/components/atoms/f-wdio-test/LICENSE
+++ b/packages/components/atoms/f-wdio-test/LICENSE
@@ -1,0 +1,17 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+Copyright (c) Just Eat Holding Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/components/atoms/f-wdio-test/README.md
+++ b/packages/components/atoms/f-wdio-test/README.md
@@ -1,0 +1,127 @@
+<div align="center">
+
+# f-wdio-test
+
+<img width="125" alt="Fozzie Bear" src="../../../../bear.png" />
+
+A component to test WDIO failure
+
+</div>
+
+---
+
+[![npm version](https://badge.fury.io/js/%40justeat%2Ff-wdio-test.svg)](https://badge.fury.io/js/%40justeat%2Ff-wdio-test)
+[![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
+[![Coverage Status](https://coveralls.io/repos/github/justeat/f-wdio-test/badge.svg)](https://coveralls.io/github/justeat/f-wdio-test)
+[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-wdio-test/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-wdio-test?targetFile=package.json)
+
+---
+
+## Usage
+
+### Installation
+
+Install the module using npm or Yarn:
+
+```sh
+yarn add @justeat/f-wdio-test
+```
+
+```sh
+npm install @justeat/f-wdio-test
+```
+
+
+
+### Vue Applications
+
+You can import it in your Vue SFC like this (please note that styles have to be imported separately):
+
+```js
+import WdioTest from '@justeat/f-wdio-test';
+import '@justeat/f-wdio-test/dist/f-wdio-test.css';
+
+export default {
+    components: {
+        WdioTest
+    }
+}
+```
+
+If you are using Webpack, you can import the component dynamically to separate the `wdio-test` bundle from the main `bundle.client.js`:
+
+```js
+import '@justeat/f-wdio-test/dist/f-wdio-test.css';
+
+export default {
+    components: {
+        // …
+        WdioTest: () => import(/* webpackChunkName: "wdio-test" */ '@justeat/f-wdio-test')
+    }
+}
+```
+
+## Configuration
+
+### Props
+
+There may be props that allow you to customise its functionality.
+
+The props that can be defined are as follows (if any):
+
+| Prop  | Type  | Default | Description |
+| ----- | ----- | ------- | ----------- |
+
+### Events
+
+The events that can be subscribed to are as follows (if any):
+
+| Event | Description |
+| ----- | ----------- |
+
+## Development
+
+Start by cloning the repository and installing the required dependencies:
+
+```sh
+$ git clone git@github.com:justeat/fozzie-components.git
+$ cd fozzie-components
+$ yarn
+```
+
+Change directory to the `f-wdio-test` package:
+
+```sh
+$ cd packages/components/atoms/f-wdio-test
+```
+
+## Testing
+
+To test all components, run from root directory.
+To test only `f-wdio-test`, run from the `./fozzie-components/packages/components/atoms/f-wdio-test` directory.
+
+### Unit and Integration tests
+
+```sh
+yarn test
+```
+
+### Component and Accessibility Tests
+
+```bash
+# Note: Ensure Storybook is running when running the following commands
+cd ./fozzie-components
+
+yarn storybook:build
+yarn storybook:serve-static
+```
+
+yarn test-component:chrome
+```
+### Accessibility tests
+```bash
+yarn test-a11y:chrome
+```
+## Documentation to be completed once module is in stable state.
+
+

--- a/packages/components/atoms/f-wdio-test/babel.config.js
+++ b/packages/components/atoms/f-wdio-test/babel.config.js
@@ -1,0 +1,26 @@
+module.exports = api => {
+    // Use `isTest` to determine what presets and plugins to use with jest
+    const isTest = api.env('test');
+    const presets = [];
+    const plugins = [
+        '@babel/plugin-proposal-optional-chaining' // https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining
+    ];
+    const builtIns = (api.env('development') ? 'entry' : false);
+
+    if (!isTest) {
+        api.cache(true); // Caches the computed babel config function – https://babeljs.io/docs/en/config-files#apicache
+        presets.push(['@vue/app', { useBuiltIns: builtIns }]);
+        // Alias for @babel/preset-env
+        // Hooks into browserslist to provide smart Babel transforms
+        // https://babeljs.io/docs/en/babel-preset-env
+        presets.push('@babel/env');
+    } else {
+        // use current node version for transpiling test files
+        presets.push(['@babel/env', { targets: { node: 'current' } }]);
+    }
+
+    return {
+        presets,
+        plugins
+    };
+};

--- a/packages/components/atoms/f-wdio-test/jest.config.js
+++ b/packages/components/atoms/f-wdio-test/jest.config.js
@@ -1,0 +1,42 @@
+module.exports = {
+    moduleFileExtensions: [
+        'js',
+        'json',
+        'vue'
+    ],
+
+    transform: {
+        '^.+\\.js$': 'babel-jest',
+        '^.+\\.vue$': 'vue-jest',
+        '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub'
+    },
+
+    transformIgnorePatterns: [
+        'node_modules/(?!(lodash-es)/)'
+    ],
+
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+        '^~include-media/(.*)$': '<rootDir>../../node_modules/include-media/$1',
+        '^~@justeat/(.*)$': '<rootDir>../../node_modules/@justeat/$1',
+        '\\.(css|scss)$': 'jest-transform-stub'
+    },
+
+    snapshotSerializers: [
+        'jest-serializer-vue'
+    ],
+
+    globals: {
+        'vue-jest': {
+            hideStyleWarn: true, // We hide style warnings given the first time we run the tests it complains about some styles. The second time the tests are run, the warning disappears. https://github.com/vuejs/vue-jest/issues/178#issuecomment-529175129
+            experimentalCSSCompile: false // hoping this will be a temporary fix, as tests fail when updating to dart-sass currently with vue-cli
+        }
+    },
+
+    modulePathIgnorePatterns: [
+        './test/accessibility/',
+        './test/component/'
+    ],
+
+    testURL: 'http://localhost/'
+};

--- a/packages/components/atoms/f-wdio-test/package.json
+++ b/packages/components/atoms/f-wdio-test/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@justeat/f-wdio-test",
+  "description": "Fozzie Wdio Test - A component to test WDIO failure",
+  "version": "0.1.0",
+  "main": "dist/f-wdio-test.umd.min.js",
+  "files": [
+    "dist",
+    "test-utils"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/justeat/fozzie-components/tree/master/packages/components/atoms/f-wdio-test",
+  "contributors": [
+    "Github contributors <https://github.com/justeat/fozzie-components/graphs/contributors>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:justeat/fozzie-components.git"
+  },
+  "bugs": {
+    "url": "https://github.com/justeat/fozzie-components/issues"
+  },
+  "license": "Apache-2.0",
+  "engines": {
+    "node": "^12 || ^14 || ^16"
+  },
+  "keywords": [
+    "fozzie"
+  ],
+  "scripts": {
+    "prepublishOnly": "yarn lint && yarn test && yarn build",
+    "build": "vue-cli-service build --target lib --name f-wdio-test ./src/index.js",
+    "lint": "eslint \"!(dist)/**/*.{js,vue}\"",
+    "lint:fix": "yarn lint --fix",
+    "lint:style": "stylelint ./src/**/*.{vue,htm,html,css,sss,less,scss}",
+    "lint:style:fix": "yarn lint:style --fix",
+    "test": "vue-cli-service test:unit",
+    "test-component:chrome": "cross-env-shell TEST_TYPE=component wdio ../../../../wdio-chrome.conf.js",
+    "test-a11y:chrome": "cross-env-shell TEST_TYPE=a11y wdio ../../../../wdio-chrome.conf.js"
+  },
+  "browserslist": [
+    "extends @justeat/browserslist-config-fozzie"
+  ],
+  "dependencies": {
+    "@justeat/f-button": "^4.3.0"
+  },
+  "peerDependencies": {
+    "@justeat/browserslist-config-fozzie": ">=1.2.0"
+  },
+  "devDependencies": {
+    "@justeat/fozzie": "9.0.0-beta.2",
+    "@justeat/f-wdio-utils": "1.x",
+    "@vue/cli-plugin-babel": "4.5.15",
+    "@vue/cli-plugin-unit-jest": "4.5.15",
+    "@vue/test-utils": "1.2.2"
+  }
+}

--- a/packages/components/atoms/f-wdio-test/src/assets/scss/common.scss
+++ b/packages/components/atoms/f-wdio-test/src/assets/scss/common.scss
@@ -1,0 +1,1 @@
+// Add styles here so it can be injected first via vue.config.js.

--- a/packages/components/atoms/f-wdio-test/src/components/WdioTest.vue
+++ b/packages/components/atoms/f-wdio-test/src/components/WdioTest.vue
@@ -1,0 +1,44 @@
+<template>
+    <div
+        :class="$style['c-wdioTest']"
+        data-test-id="wdio-test-component">
+        I am a WdioTest Component (GB)
+                <f-button
+            buttonType="primary"
+            buttonSize="medium"
+            actionType="button"
+            :isLoading="isLoading"
+            :hasIcon="hasIcon">
+            Label
+        </f-button>
+    </div>
+</template>
+
+<script>
+
+
+import FButton from '@justeat/f-button';
+import '@justeat/f-button/dist/f-button.css';
+
+export default {
+    name: 'Wdiotest',
+    components: {
+        FButton
+    }
+}
+</script>
+
+<style lang="scss" module>
+@use '@justeat/fozzie/src/scss/fozzie' as f;
+
+.c-wdioTest {
+    display: flex;
+    justify-content: center;
+    min-height: 80vh;
+    width: 80vw;
+    margin: auto;
+    border: 1px solid red;
+    font-family: f.$font-family-base;
+    @include f.font-size(heading-m);
+}
+</style>

--- a/packages/components/atoms/f-wdio-test/src/components/_tests/WdioTest.test.js
+++ b/packages/components/atoms/f-wdio-test/src/components/_tests/WdioTest.test.js
@@ -1,0 +1,10 @@
+import { shallowMount } from '@vue/test-utils';
+import WdioTest from '../WdioTest.vue';
+
+describe('WdioTest', () => {
+    it('should be defined', () => {
+        const propsData = {};
+        const wrapper = shallowMount(WdioTest, { propsData });
+        expect(wrapper.exists()).toBe(true);
+    });
+});

--- a/packages/components/atoms/f-wdio-test/src/index.js
+++ b/packages/components/atoms/f-wdio-test/src/index.js
@@ -1,0 +1,35 @@
+
+/**
+ * @overview Fozzie Wdio Test Component JS Wrapper
+ *
+ * @module f-wdio-test
+ */
+
+// Import vue component
+import WdioTest from '@/components/WdioTest.vue';
+
+// Declare install function executed by Vue.use()
+export function install (Vue) {
+    if (install.installed) return;
+    install.installed = true;
+    Vue.component('WdioTest', WdioTest);
+}
+
+// Create module definition for Vue.use()
+const plugin = {
+    install
+};
+
+// Auto-install when vue is found (eg. in browser via <script> tag)
+let GlobalVue = null;
+if (typeof window !== 'undefined') {
+    GlobalVue = window.Vue;
+} else if (typeof global !== 'undefined') {
+    GlobalVue = global.Vue;
+}
+if (GlobalVue) {
+    GlobalVue.use(plugin);
+}
+
+// To allow use as module (npm/webpack/etc.) export component
+export default WdioTest;

--- a/packages/components/atoms/f-wdio-test/stories/WdioTest.stories.js
+++ b/packages/components/atoms/f-wdio-test/stories/WdioTest.stories.js
@@ -1,0 +1,23 @@
+import { withA11y } from '@storybook/addon-a11y';
+import WdioTest from '../src/components/WdioTest.vue';
+
+export default {
+    title: 'Components/Atoms',
+    decorators: [withA11y]
+};
+
+export const WdioTestComponent = (args, { argTypes }) => ({
+    components: { WdioTest },
+
+    props: Object.keys(argTypes),
+
+    template: '<wdio-test v-bind="$props" />'
+});
+
+WdioTestComponent.storyName = 'f-wdio-test';
+
+WdioTestComponent.args = {
+};
+
+WdioTestComponent.argTypes = {
+};

--- a/packages/components/atoms/f-wdio-test/test-utils/component-objects/README.md
+++ b/packages/components/atoms/f-wdio-test/test-utils/component-objects/README.md
@@ -1,0 +1,13 @@
+# What is a component object?
+A component object is a file that is used to define the UI selectors / functionality of a component that is then utilised by WebDriverIO for browser-based automation testing.
+
+# Usage
+Please add a component object if this component is interacted with as part of browser-based automation tests. This can be done either by:
+- Component tests for this component.
+In this scenario, the component object should be imported into the WebDriverIO spec file.
+
+- Component tests for a parent component.
+In this scenario, the component object should be imported into the parent component object.
+
+- System tests as part of a consuming application.
+In this scenario, the `test-utils` folder needs to be added to the `files` section within `package.json` so that it can be imported by the consuming application.

--- a/packages/components/atoms/f-wdio-test/test-utils/component-objects/f-wdio-test.component.js
+++ b/packages/components/atoms/f-wdio-test/test-utils/component-objects/f-wdio-test.component.js
@@ -1,0 +1,9 @@
+import Page from '@justeat/f-wdio-utils';
+
+class WdioTest extends Page {
+    constructor () {
+        super('atom', 'wdio-test-component');
+    }
+}
+
+export default new WdioTest();

--- a/packages/components/atoms/f-wdio-test/test/accessibility/axe-accessibility.spec.js
+++ b/packages/components/atoms/f-wdio-test/test/accessibility/axe-accessibility.spec.js
@@ -1,0 +1,12 @@
+import WdioTest from '../../test-utils/component-objects/f-wdio-test.component';
+
+describe('f-wdio-test - Accessibility tests', () => {
+    it('a11y - should test f-wdio-test component WCAG compliance', async () => {
+        // Act
+        await WdioTest.load();
+
+        // Assert
+        const axeResults = await WdioTest.getAxeResults('f-wdio-test');
+        await expect(axeResults.violations.length).toBe(0);
+    });
+});

--- a/packages/components/atoms/f-wdio-test/test/component/README.md
+++ b/packages/components/atoms/f-wdio-test/test/component/README.md
@@ -1,0 +1,3 @@
+# Usage
+This directory will contain WebDriverIO spec files that will allow you to test your component in isolation within the browser.
+If this component is a shared / common component that other components are dependent on, then you may delete this directory as it's likely the component can be tested indirectly.

--- a/packages/components/atoms/f-wdio-test/test/component/f-wdio-test.component.spec.js
+++ b/packages/components/atoms/f-wdio-test/test/component/f-wdio-test.component.spec.js
@@ -1,0 +1,13 @@
+import WdioTest from '../../test-utils/component-objects/f-wdio-test.component';
+import Button from '@justeat/f-button/test-utils/component-objects/f-button--action.component';
+
+describe('f-wdio-test - Component tests', () => {
+    it('should display the f-wdio-test component', async () => {
+        // Act
+        await WdioTest.load();
+
+        // Assert
+        const result = await Button.isComponentDisplayed();
+        await expect(result).toBe(true);
+    });
+});

--- a/packages/components/atoms/f-wdio-test/vue.config.js
+++ b/packages/components/atoms/f-wdio-test/vue.config.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+const sassOptions = require('../../../../config/sassOptions')(rootDir);
+
+// vue.config.js
+module.exports = {
+    chainWebpack: config => {
+        config.module
+            .rule('scss-importer')
+            .test(/\.scss$/)
+            .use('importer')
+            .loader('sass-loader')
+            .options({
+                ...sassOptions,
+                // eslint-disable-next-line quotes
+                additionalData: `@use "../assets/scss/common.scss";`
+            });
+    },
+    pluginOptions: {
+        lintStyleOnBuild: true
+    }
+};

--- a/wdio-shared.conf.js
+++ b/wdio-shared.conf.js
@@ -1,4 +1,4 @@
-require('@babel/register');
+require('@babel/register')({ ignore: [/node_modules\/(?!(@justeat))/] });
 global.baseDir = __dirname;
 const percySnapshot = require('@percy/webdriverio');
 const { getTestConfiguration, setTestReporters } = require('./test/configuration/configuration-helper');


### PR DESCRIPTION
**Setup steps**

- Ensure node 14.19 or 16.x are installed
- Install yarn
- Run `yarn` at the root of the monorepo
- Run `yarn build --filter=[origin/master]`
- Run the following in a terminal: `yarn storybook:serve-changed`
- Run the following commands **in a new terminal**:
-      cd packages/components/atoms/f-wdio-test
-      yarn test-component:chrome



**Background**
In this UI monorepo, we have a number of page objects for each of the contained UI components. These 'component objects' get exported as part of our published npm packages, so that WebDriverIO test frameworks in our consuming applications can use them to construct the larger page objects. An example of a large page object can be seen [here](https://gist.github.com/siggerzz/4bafd6267314a2e65aa02bc48797297b)

Recently, we refactored all WDIO code in the monorepo to be async, due to the[ Sync API being deprecated in Node 16](https://webdriver.io/blog/2021/07/28/sync-api-deprecation/)

As part of this change, we also refactored all of our component objects to use ES6 `import` syntax. An example of which can be seen [here ](https://github.com/justeat/fozzie-components/blob/wdio-bug-test/packages/components/atoms/f-wdio-test/test-utils/component-objects/f-wdio-test.component.js).


**The problem**
Whilst the tests work fine in this repo, the `import` changes have caused tests to break in our consuming applications with the following error: (I'm unable to provide code to the consuming application, hence why I've created a reproducible demo in this repo)


```
Spec file(s): /Users/ben.siggery/Code/fozzie-components/packages/components/atoms/f-wdio-test/test/component/f-wdio-test.component.spec.js
Error: /Users/ben.siggery/Code/fozzie-components/packages/components/atoms/f-button/test-utils/component-objects/f-button--action.component.js:1
import Page from '@justeat/f-wdio-utils';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at wrapSafe (internal/modules/cjs/loader.js:984:16)
    at Module._compile (internal/modules/cjs/loader.js:1032:27)
    at Module._compile (/Users/ben.siggery/Code/fozzie-components/node_modules/pirates/lib/index.js:136:24)
    at Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
    at Object.newLoader [as .js] (/Users/ben.siggery/Code/fozzie-components/node_modules/pirates/lib/index.js:141:7)
    at Module.load (internal/modules/cjs/loader.js:933:32)
    at Function.Module._load (internal/modules/cjs/loader.js:774:14)
    at Module.require (internal/modules/cjs/loader.js:957:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/Users/ben.siggery/Code/fozzie-components/packages/components/atoms/f-wdio-test/test/component/f-wdio-test.component.spec.js:2:1)
```

I believe this is due to the fact that by default, Babel does not transpile anything inside of the `node_modules`.

To get around this, we added [the following code](https://github.com/justeat/fozzie-components/blob/wdio-bug-test/wdio-shared.conf.js#L1) in our consuming applications wdio.shared.conf.js, to ensure babel only transpiles packages that live as part of the `@justeat` namespace.


This seems to fix the issue when running on Mac, however we're still seeing the following error when running the tests on Windows machines:

```
Error: Error: Cannot find module 'file:///C:/code/fozzie-components/packages/components/atoms/f-wdio-test/test/component/f-wdio-test.component.spec.js'Require stack:
- C:/code/fozzie-components/node_modules\mocha\lib\nodejs\esm-utils.js
- C:/code/fozzie-components/node_modules\mocha\lib\mocha.js
- C:/code/fozzie-components/node_modules\mocha\index.js
- C:/code/fozzie-components/node_modules\@wdio\mocha-framework\build\index.js
- C:/code/fozzie-components/node_modules\@wdio\utils\build\utils.js
- C:/code/fozzie-components/node_modules\@wdio\utils\build\initialisePlugin.js
- C:/code/fozzie-components/node_modules\@wdio\utils\build\index.js
- C:/code/fozzie-components/node_modules\@wdio\runner\build\index.js
- C:/code/fozzie-components/node_modules\@wdio\local-runner\build\run.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:101:18)
    at C:/code/fozzie-components/node_modules\mocha\lib\nodejs\/esm-utils.js:7:14
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at formattedImport (C:/code/fozzie-components/node_modules\mocha\lib\nodejs\/esm-utils.js:7:14)
    at Object.exports.requireOrImport (C:/code/fozzie-components/node_modules\mocha\lib\nodejs\/esm-utils.js:48:32)
    at Object.exports.loadFilesAsync (C:/code/fozzie-components/node_modules\mocha\lib\nodejs\/esm-utils.js:103:20)
    at MochaAdapter._loadFiles (C:/code/fozzie-components/node_modules\@wdio\mocha-framework\build\/index.js:68:13)
```

We're unsure why we're seeing this issue given it's complaining about a local file, however I did notice the following issues in the WebDriverIO and Mocha repo, and wonder if they could be related:

https://github.com/webdriverio/webdriverio/issues/8689

https://github.com/mochajs/mocha/pull/4901


The files of interest are:

Test Spec where we import a component object via npm (Normally we import these into the consuming applications page object, but it was easier for me to reproduce like this in this repo) - https://github.com/justeat/fozzie-components/blob/wdio-bug-test/packages/components/atoms/f-wdio-test/test/component/f-wdio-test.component.spec.js#L2

The component object we're importing - https://github.com/justeat/fozzie-components/blob/wdio-bug-test/packages/components/atoms/f-button/test-utils/component-objects/f-button--action.component.js

It's also worth mentioning we've followed the [Babel Setup](https://webdriver.io/docs/babel/) without any luck.

 