### PR TITLE
f-mfa@0.15.0 - Fixes from staff beta

### DIFF
--- a/packages/components/pages/f-mfa/CHANGELOG.md
+++ b/packages/components/pages/f-mfa/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.13.0
+------------------------------
+*September 5, 2022*
+
+### Changed
+- Logs for 400/429 errors to warnings.
+
+
 v0.12.0
 ------------------------------
 *August 24, 2022*

--- a/packages/components/pages/f-mfa/CHANGELOG.md
+++ b/packages/components/pages/f-mfa/CHANGELOG.md
@@ -12,6 +12,7 @@ v0.14.0
 - Only make a new API call if there isn't one already in flight.
 - Move query string validation from CSR to SSR.
 - Logs for 400/429 errors to warnings.
+- Protect against null/undefined query string values.
 
 
 v0.13.0

--- a/packages/components/pages/f-mfa/CHANGELOG.md
+++ b/packages/components/pages/f-mfa/CHANGELOG.md
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.13.0
 ------------------------------
-*September 5, 2022*
+*September 6, 2022*
 
 ### Changed
+- Move query string validation from CSR to SSR.
 - Logs for 400/429 errors to warnings.
 
 

--- a/packages/components/pages/f-mfa/CHANGELOG.md
+++ b/packages/components/pages/f-mfa/CHANGELOG.md
@@ -9,6 +9,7 @@ v0.14.0
 *September 6, 2022*
 
 ### Changed
+- Only make a new API call if there isn't one already in flight.
 - Move query string validation from CSR to SSR.
 - Logs for 400/429 errors to warnings.
 

--- a/packages/components/pages/f-mfa/package.json
+++ b/packages/components/pages/f-mfa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mfa",
   "description": "Fozzie Mfa - Multi-factor Authenticator Input Form",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "main": "dist/f-mfa.umd.min.js",
   "maxBundleSize": "30kB",
   "files": [

--- a/packages/components/pages/f-mfa/src/components/Help.vue
+++ b/packages/components/pages/f-mfa/src/components/Help.vue
@@ -107,7 +107,7 @@ export default {
 
     computed: {
         loginLinkWithReturnUrl () {
-            return `/account/login?returnUrl=${encodeURIComponent(this.returnUrl)}`;
+            return `/account/login?returnUrl=${encodeURIComponent(this.returnUrl || '/')}`;
         }
     },
 

--- a/packages/components/pages/f-mfa/src/components/Mfa.vue
+++ b/packages/components/pages/f-mfa/src/components/Mfa.vue
@@ -194,7 +194,7 @@ export default {
         }
     },
 
-    mounted () {
+    created () {
         this.initialise();
     },
 

--- a/packages/components/pages/f-mfa/src/components/Mfa.vue
+++ b/packages/components/pages/f-mfa/src/components/Mfa.vue
@@ -188,7 +188,7 @@ export default {
 
         errorPrimaryButton () {
             return {
-                href: this.cleanUrl(this.returnUrl),
+                href: this.cleanUrl(this.returnUrl || '/'),
                 text: this.$t('errorMessages.loading.primaryButtonText')
             };
         }
@@ -210,7 +210,7 @@ export default {
         initialise () {
             this.showErrorPage = false;
             this.validateProperty(this.returnUrl, 'returnUrl', RETURN_URL_REGEX);
-            this.validateProperty(this.email.toLowerCase(), 'email', EMAIL_RFC5322_REGEX);
+            this.validateProperty(this.email?.toLowerCase(), 'email', EMAIL_RFC5322_REGEX);
             this.validateProperty(this.code, 'code', MFA_CODE_REGEX);
 
             if (this.showErrorPage) {
@@ -246,7 +246,7 @@ export default {
                     validateUrl: this.validateUrl
                 })).postValidateMfaToken({ mfa_token: this.code, otp: this.otp.toUpperCase() }); // eslint-disable-line camelcase
                 this.$gtm.pushEvent(buildEvent(MFA_SUCCESS));
-                this.emitRedirectEvent(this.returnUrl); // Completed successfully, emit redirect return url
+                this.emitRedirectEvent(this.returnUrl || '/'); // Completed successfully, emit redirect return url
             } catch (error) {
                 this.hasSubmitError = true;
                 if (error.response && error.response.status) {
@@ -291,7 +291,7 @@ export default {
         * @param {object} regex - The regex to validate the value against.
         */
         validateProperty (value, propertyName, regex) {
-            if (!regex.test(value)) {
+            if ([null, undefined].includes(value) || !regex.test(value)) {
                 this.showErrorPage = true;
                 this.$log.warn(`Error validating mfa property '${propertyName}' - Regex Failed`, standardLogTags);
             }

--- a/packages/components/pages/f-mfa/src/components/Mfa.vue
+++ b/packages/components/pages/f-mfa/src/components/Mfa.vue
@@ -247,15 +247,17 @@ export default {
 
                     // Bad request
                     if (status === 400) {
-                        this.$log.error('Bad request when submitting MFA', error, standardLogTags);
+                        this.$log.warn('Bad request when submitting MFA', error, standardLogTags);
                         return;
                     }
 
                     // Too many requests
                     if (status === 429) {
-                        this.$log.error('Throttled when submitting MFA', error, standardLogTags);
+                        this.$log.warn('Throttled when submitting MFA', error, standardLogTags);
                         return;
                     }
+
+                    this.$log.error(`Unexpected ${status} response when submitting MFA`, error, standardLogTags);
                 }
             } finally {
                 this.isSubmitting = false;

--- a/packages/components/pages/f-mfa/src/components/Mfa.vue
+++ b/packages/components/pages/f-mfa/src/components/Mfa.vue
@@ -224,6 +224,7 @@ export default {
 
         /**
         * Raises the isSubmitting flag which disables the Submit button.
+        * If the flag is already raised, do nothing.
         * Sets the hasSubmitError flag to false, so it is clean before we start.
         * Posts the form data to the api.
         * Then upon success emits an event to the parent component to redirect to the supplied returnUrl.
@@ -231,6 +232,10 @@ export default {
         * true, which displays the alert message below the form field plus logs the issue.
         */
         async onFormSubmit () {
+            if (this.isSubmitting) {
+                return; // Prevents multiple requests, especially on slow networks
+            }
+
             this.isSubmitting = true;
             this.hasSubmitError = false;
 

--- a/packages/components/pages/f-mfa/src/components/_tests/Mfa.test.js
+++ b/packages/components/pages/f-mfa/src/components/_tests/Mfa.test.js
@@ -245,7 +245,7 @@ describe('Mfa', () => {
                 await wrapper.vm.onFormSubmit();
 
                 // Assert
-                expect(errorLogSpy).toHaveBeenCalledWith(logMessage, errLogged, ['account-pages', 'mfa']);
+                expect(warnLogSpy).toHaveBeenCalledWith(logMessage, errLogged, ['account-pages', 'mfa']);
                 expect(wrapper.vm.isSubmitting).toBe(false);
                 expect(pushEventSpy).toMatchSnapshot();
             });

--- a/packages/components/pages/f-mfa/src/components/_tests/Mfa.test.js
+++ b/packages/components/pages/f-mfa/src/components/_tests/Mfa.test.js
@@ -267,5 +267,28 @@ describe('Mfa', () => {
                 expect(pushEventSpy).toMatchSnapshot();
             });
         });
+
+        it('should not make another API call if `isSubmitting` is already true', async () => {
+            // Arrange
+            mockPostValidateMfaToken = jest.fn();
+            wrapper = await mountSut({
+                propsData: {
+                    ...sutProps,
+                    code: 'XYZ1234'
+                }
+            });
+            await wrapper.setData({
+                isSubmitting: true
+            });
+            pushEventSpy.mockClear();
+
+            // Act
+            await wrapper.vm.onFormSubmit();
+
+            // Assert
+            expect(mockPostValidateMfaToken).not.toHaveBeenCalled();
+            expect(pushEventSpy).not.toHaveBeenCalled();
+            expect(wrapper.vm.isSubmitting).toBe(true);
+        });
     });
 });


### PR DESCRIPTION
### Changed
- Only make a new API call if there isn't one already in flight.
- Move query string validation from CSR to SSR.
- Logs for 400/429 errors to warnings.
- Protect against null/undefined query string values.

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
