### PR TITLE
f-http@v1.0.0 - Pass Conversation ID Headers

### DIFF
--- a/packages/services/f-http/.eslintrc.js
+++ b/packages/services/f-http/.eslintrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+    root: true,
+    env: {
+        browser: true,
+        node: true
+    },
+    parser: "babel-eslint",
+    overrides: [
+        {
+            files: [
+                '**/*.js'
+            ],
+            rules: {
+                'global-require': 'off'
+            }
+        }
+    ]
+};

--- a/packages/services/f-http/CHANGELOG.md
+++ b/packages/services/f-http/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.11.0
+------------------------------
+*September 16, 2022*
+
+### Added
+- Now accepts a function to load cookies
+- Now attempts to append conversation id headers to each call (driven by cookie value)
+
+### Fixed
+- Isomorphism error when using http serverside
+
+
 v0.10.0
 ------------------------------
 *July 25, 2022*

--- a/packages/services/f-http/CHANGELOG.md
+++ b/packages/services/f-http/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v0.11.0
+v1.0.0
 ------------------------------
 *September 16, 2022*
 

--- a/packages/services/f-http/README.md
+++ b/packages/services/f-http/README.md
@@ -26,8 +26,6 @@ This package exposes methods for interacting with restful services, it may abstr
 
 ## Benefits (Soon)
 - _Opt-in ability to use dynamic timeouts_
-- _Opt-in automatic providing of diagnostic headers, such as je-conversation_
-- _Opt-in automatic providing of headers, such as accept-tenant_
 
 ## Usage
 
@@ -51,7 +49,11 @@ const options = { // Options are described later
     baseUrl: 'https://jsonplaceholder.typicode.com'
 };
 
-const httpClient = new httpModule.CreateClient(options);
+// Optional: Implement wrapper using cookie tech you have available
+// Enables conversation ID to be automatically provided with requests
+const getCookieFunction = cookieName => app.$cookies.get(cookieName);
+
+const httpClient = new httpModule.CreateClient(options, getCookieFunction);
 
 // WHEN: Using a Nuxt Plugin
 inject('http', httpClient);
@@ -139,6 +141,17 @@ mockFactory.reset();
 // Setup a fake response
 mockFactory.setupMockResponse(httpVerbs.POST, '/URL', REQUEST_DATA, 201);
 ```
+
+## Parameters
+None of these parameters are required, but using them enables you to customise your http client
+
+Option | Description | Type | Default
+------------- | ------------- | ------------- | -------------
+options | An object containing options you wish to override (see below) | object | {}
+getCookieFunction | Wrapper function providing ability to read cookies | function | null
+statisticsClient | Instance of f-statistics to capture dependency timings | object | null
+
+<hr>
 
 ## Options
 All options are optional, you don't need to specify any overrides if you are happy with the default values

--- a/packages/services/f-http/package.json
+++ b/packages/services/f-http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-http",
   "description": "Javascript HTTP client for interacting with restful services",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "main": "dist/f-http.umd.js",
   "module": "dist/f-http.es.js",
   "source": "src/index.js",
@@ -47,6 +47,7 @@
     "axios-mock-adapter": "1.19.0"
   },
   "devDependencies": {
+    "babel-eslint": "10.1.0",
     "core-js": "3.6.5",
     "eslint": "7.32.0",
     "jest-extended": "0.11.5"

--- a/packages/services/f-http/package.json
+++ b/packages/services/f-http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-http",
   "description": "Javascript HTTP client for interacting with restful services",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "main": "dist/f-http.umd.js",
   "module": "dist/f-http.es.js",
   "source": "src/index.js",

--- a/packages/services/f-http/package.json
+++ b/packages/services/f-http/package.json
@@ -2,6 +2,7 @@
   "name": "@justeat/f-http",
   "description": "Javascript HTTP client for interacting with restful services",
   "version": "1.0.0",
+  "maxBundleSize": "400kB",
   "main": "dist/f-http.umd.js",
   "module": "dist/f-http.es.js",
   "source": "src/index.js",

--- a/packages/services/f-http/src/createClient.js
+++ b/packages/services/f-http/src/createClient.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import defaultOptions from './defaultOptions';
 import setAuthorisationToken from './authorisationHandler';
 import httpVerbs from './httpVerbs';
@@ -11,12 +10,19 @@ import RequestDispatcher from './requestDispatcher';
  * @return {object} - Returns an object with restful request methods
  */
 export default class HttpClient {
-    constructor (options = {}, statsClient = null) {
+    constructor (
+        options = {},
+        getCookieFunction = null,
+        statsClient = null
+    ) {
         // Merge default configuration with overrides
         this.configuration = {
             ...defaultOptions,
             ...options
         };
+
+        // Important for Isomorphism: loads correct version of Axios for Node vs Browser
+        const axios = require('axios').default;
 
         this.axiosInstance = axios.create({
             baseURL: this.configuration.baseUrl,
@@ -25,6 +31,8 @@ export default class HttpClient {
                 'Content-Type': this.configuration.contentType
             }
         });
+
+        this.getCookieFunction = getCookieFunction;
 
         if (statsClient) {
             // Only add interceptors when capturing statistics
@@ -37,6 +45,14 @@ export default class HttpClient {
         this.setAuthorisationToken = setAuthorisationToken;
     }
 
+    getConversationIdHeader () {
+        const conversationId = this.getCookieFunction && this.getCookieFunction('x-je-conversation');
+
+        return conversationId
+            ? { 'x-je-conversation': conversationId }
+            : null;
+    }
+
     /**
      * Get a resource
      * @param {string} resource - The resource to get (URL)
@@ -44,7 +60,11 @@ export default class HttpClient {
      * @return {object} - Returns data from response
      */
     async get (resource, headers = {}) {
-        return this.sendRequest(httpVerbs.GET, resource, headers);
+        return this.sendRequest(
+            httpVerbs.GET,
+            resource,
+            { ...headers, ...this.getConversationIdHeader() }
+        );
     }
 
     /**
@@ -55,7 +75,13 @@ export default class HttpClient {
      * @return {object} - Returns data from response
      */
     async post (resource, body, headers = {}) {
-        return this.sendRequestWithBody(httpVerbs.POST, resource, body, headers);
+        console.log(headers);
+        return this.sendRequestWithBody(
+            httpVerbs.POST,
+            resource,
+            body,
+            { ...headers, ...this.getConversationIdHeader() }
+        );
     }
 
     /**
@@ -66,7 +92,12 @@ export default class HttpClient {
      * @return {object} - Returns data from response
      */
     async patch (resource, body, headers = {}) {
-        return this.sendRequestWithBody(httpVerbs.PATCH, resource, body, headers);
+        return this.sendRequestWithBody(
+            httpVerbs.PATCH,
+            resource,
+            body,
+            { ...headers, ...this.getConversationIdHeader() }
+        );
     }
 
     /**
@@ -77,7 +108,12 @@ export default class HttpClient {
      * @return {object} - Returns data from response
      */
     async put (resource, body, headers = {}) {
-        return this.sendRequestWithBody(httpVerbs.PUT, resource, body, headers);
+        return this.sendRequestWithBody(
+            httpVerbs.PUT,
+            resource,
+            body,
+            { ...headers, ...this.getConversationIdHeader() }
+        );
     }
 
     /**
@@ -87,7 +123,11 @@ export default class HttpClient {
      * @return {object} - Returns data from response
      */
     async delete (resource, headers = {}) {
-        this.sendRequest(httpVerbs.DELETE, resource, headers);
+        this.sendRequest(
+            httpVerbs.DELETE,
+            resource,
+            { ...headers, ...this.getConversationIdHeader() }
+        );
     }
 
     setAuthorisationToken (authorisationToken) {

--- a/packages/services/f-http/src/createClient.js
+++ b/packages/services/f-http/src/createClient.js
@@ -75,7 +75,6 @@ export default class HttpClient {
      * @return {object} - Returns data from response
      */
     async post (resource, body, headers = {}) {
-        console.log(headers);
         return this.sendRequestWithBody(
             httpVerbs.POST,
             resource,

--- a/packages/services/f-http/src/requestDispatcher.js
+++ b/packages/services/f-http/src/requestDispatcher.js
@@ -20,7 +20,8 @@ export default class RequestDispatcher {
 
             return {
                 statusCode: response.status,
-                data: response.data
+                data: response.data,
+                headers: response.config.headers
             };
         } catch (error) {
             return handleError(error, this.configuration.errorCallback);

--- a/packages/services/f-http/src/tests/createClient.test.js
+++ b/packages/services/f-http/src/tests/createClient.test.js
@@ -1,3 +1,5 @@
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter';
 import CreateClient from '../createClient';
 
 describe('createClient', () => {
@@ -60,6 +62,27 @@ describe('createClient', () => {
 
             // Assert
             expect(mergedOptions).toStrictEqual(expectedResult);
+        });
+
+        it('should provide conversation header when cookie function is supplied', async () => {
+            // Arrange
+            const getCookieFunction = (cookieName) => {
+                return `${cookieName}-123456`
+            }
+
+            const axiosMock = new MockAdapter(axios);
+            axiosMock.onGet('/test.json').reply(200, {
+                fakeResult: null
+            });
+
+            const httpClient = new CreateClient(null, getCookieFunction);
+
+            // Act
+            const result = await httpClient.get('/test.json')
+
+            // Assert
+            expect(result.data).toEqual({ fakeResult: null});
+            expect(result.headers['x-je-conversation']).toEqual('x-je-conversation-123456');
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,6 +151,15 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
+"@babel/generator@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.19.0.tgz#785596c06425e59334df2ccee63ab166b738419a"
+  integrity sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==
+  dependencies:
+    "@babel/types" "^7.19.0"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
 "@babel/helper-annotate-as-pure@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz#eaa49f6f80d5a33f9a5dd2276e6d6e451be0a6bb"
@@ -256,6 +265,14 @@
   dependencies:
     "@babel/template" "^7.18.6"
     "@babel/types" "^7.18.9"
+
+"@babel/helper-function-name@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
+  integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==
+  dependencies:
+    "@babel/template" "^7.18.10"
+    "@babel/types" "^7.19.0"
 
 "@babel/helper-hoist-variables@^7.18.6":
   version "7.18.6"
@@ -398,6 +415,11 @@
   version "7.18.13"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.13.tgz#5b2dd21cae4a2c5145f1fbd8ca103f9313d3b7e4"
   integrity sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==
+
+"@babel/parser@^7.19.1", "@babel/parser@^7.7.0":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.1.tgz#6f6d6c2e621aad19a92544cc217ed13f1aac5b4c"
+  integrity sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1336,10 +1358,35 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.7.0":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.19.1.tgz#0fafe100a8c2a603b4718b1d9bf2568d1d193347"
+  integrity sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.19.0"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.19.1"
+    "@babel/types" "^7.19.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.14.8", "@babel/types@^7.14.9", "@babel/types@^7.18.10", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.18.8", "@babel/types@^7.18.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.1", "@babel/types@^7.9.6":
   version "7.18.13"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.13.tgz#30aeb9e514f4100f7c1cb6e5ba472b30e48f519a"
   integrity sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==
+  dependencies:
+    "@babel/helper-string-parser" "^7.18.10"
+    "@babel/helper-validator-identifier" "^7.18.6"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.19.0", "@babel/types@^7.7.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.0.tgz#75f21d73d73dc0351f3368d28db73465f4814600"
+  integrity sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==
   dependencies:
     "@babel/helper-string-parser" "^7.18.10"
     "@babel/helper-validator-identifier" "^7.18.6"
@@ -6207,6 +6254,18 @@ babel-core@7.0.0-bridge.0, babel-core@^7.0.0-bridge.0:
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
 
+babel-eslint@10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
+  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.7.0"
+    "@babel/traverse" "^7.7.0"
+    "@babel/types" "^7.7.0"
+    eslint-visitor-keys "^1.0.0"
+    resolve "^1.12.0"
+
 babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
@@ -10725,7 +10784,7 @@ eslint-utils@^3.0.0:
   dependencies:
     eslint-visitor-keys "^2.0.0"
 
-eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==


### PR DESCRIPTION
## Q&A

<details>
    <summary>Why accept a function rather than just check cookies?</summary>
Because this needs to work isomorphically, it isn't possible to get cookies serverside without access to req + res, it isn't possible to access res/req here so providing a function from higher in the lifecycle is needed
</details>

<details>
    <summary>Why accept a function wrapper rather than an instance of cookies-universal</summary>
Because not all clients will make the same choice around libraries they use. So a simple wrapper makes this a bit simpler
</details>

![image](https://user-images.githubusercontent.com/10741583/190655287-c3cd8f2b-6687-412b-839c-420bbbd984f0.png)

## Changes

v0.11.0
------------------------------
*September 16, 2022*

### Added
- Now accepts a function to load cookies
- Now attempts to append conversation id headers to each call (driven by cookie value)

### Fixed
- Isomorphism error when using http serverside