### PR TITLE
f-analytics@v0.19.0 - pushEvent() - Stripped objects of reflection details

### DIFF
--- a/packages/services/f-analytics/CHANGELOG.md
+++ b/packages/services/f-analytics/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.19.0
+------------------------------
+*September 16, 2022*
+
+### Changed
+- Converted the objects being passed to `pushEvent()` to simple object which removes any unwanted reflection details
+
+
 v0.18.0
 ------------------------------
 *July 25, 2022*
@@ -17,6 +26,7 @@ v0.17.1
 
 ### Removed
 - Removed vite as a dependency and moved to monorepo root `package.json` to solve version conflict issue
+
 
 v0.17.0
 ------------------------------

--- a/packages/services/f-analytics/package.json
+++ b/packages/services/f-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-analytics",
   "description": "Fozzie Analytics - A utility that encapsulates the GTM / Google Analytics functionality",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "maxBundleSize": "200kB",
   "main": "dist/f-analytics.umd.js",
   "module": "dist/f-analytics.es.js",

--- a/packages/services/f-analytics/src/services/analytics.service.js
+++ b/packages/services/f-analytics/src/services/analytics.service.js
@@ -157,7 +157,10 @@ export default class AnalyticService {
         if (isDataLayerPresent()) {
             const events = [...this.store.state[`${this.options.namespace}`].events];
 
-            events.forEach(e => window.dataLayer.push({ ...e }));
+            // Note; we need to remove the unwanted reflection details from being pushed
+            // along with the simple object.
+            // So by converting to plain simple object using stringify/parse removes these details.
+            events.forEach(e => window.dataLayer.push(JSON.parse(JSON.stringify(e))));
 
             this.store.dispatch(`${this.options.namespace}/clearEvents`);
         }


### PR DESCRIPTION
### Changed
- Converted the objects being passed to `pushEvent()` to simple object which removes any unwanted reflection details
---
Before
![image](https://user-images.githubusercontent.com/1353060/190670692-b2e454fa-8f9d-4297-91bd-943cd385e082.png)

After
![image](https://user-images.githubusercontent.com/1353060/190670719-29457f3e-5e4d-4235-9972-eaa2011ee824.png)
