### PR TITLE
storybook@v0.58.0 - Upgrade F-HTTP Context

### DIFF
--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.58.0
+------------------------------
+*September 21, 2022*
+
+### Changed
+- Upgraded F-HTTP dependency and context with new Conversation ID forwarding
+
+
 v0.57.0
 ------------------------------
 *September 12, 2022*

--- a/packages/storybook/context/http.context.js
+++ b/packages/storybook/context/http.context.js
@@ -1,10 +1,14 @@
 import Vue from 'vue';
 import httpModule from '@justeat/f-http';
+import Cookie from 'cookie-universal';
 
 // Refer to f-http documentation for usage
 export default () => {
+    const cookieUniversal = Cookie();
+    const getCookieFunction = (cookieName) => cookieUniversal.get(cookieName);
+
     const mockFactory = new httpModule.MockFactory();
-    const httpClient = new httpModule.CreateClient();
+    const httpClient = new httpModule.CreateClient(null, getCookieFunction);
 
     // Make the mock factory available to story files
     process.mockFactory = mockFactory;

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private": true,
-  "version": "0.57.0",
+  "version": "0.58.0",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --existing-output-dir ./storybook-static --ci",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",
@@ -15,7 +15,7 @@
     "vue-router": "3.5.2"
   },
   "devDependencies": {
-    "@justeat/f-http": "0.8.0",
+    "@justeat/f-http": "1.0.0",
     "@kazupon/vue-i18n-loader": "0.5.0",
     "@storybook/addon-a11y": "6.4.9",
     "@storybook/addon-essentials": "6.4.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,12 +2289,12 @@
   dependencies:
     vue-i18n "8.0.0"
 
-"@justeat/f-http@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-http/-/f-http-0.8.0.tgz#46a99a274d3611186d387a26920de02d5f1a05d7"
-  integrity sha512-wWDbLYXdc4bOUkMpATC9ZEB3g8x85GeajH6x4Xeo22r/GM1bG8k+1/SimbeoGQirA8acYSpkKywawGbgMuExmQ==
+"@justeat/f-http@0.x":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-http/-/f-http-0.10.0.tgz#686a230a9e27e4e39b38ba351d963d7fd6c42b70"
+  integrity sha512-HVfABkVKs6DTxNTdlrbk9Mk9fNSkNxKJ0JKhFCwZ3BRr5jfGksHu9exn1D30ddWFVMJuOyyg7X7wIOuPZ81EWg==
   dependencies:
-    axios "0.21.1"
+    axios "0.21.2"
     axios-mock-adapter "1.19.0"
 
 "@justeat/f-icons@4.11.0":
@@ -6194,13 +6194,6 @@ axios-mock-adapter@1.19.0:
   dependencies:
     fast-deep-equal "^3.1.3"
     is-buffer "^2.0.3"
-
-axios@0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
-  dependencies:
-    follow-redirects "^1.10.0"
 
 axios@0.21.2:
   version "0.21.2"
@@ -11739,7 +11732,7 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.7, follow-redirects@^1.14.9:
+follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.7, follow-redirects@^1.14.9:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==


### PR DESCRIPTION
v0.58.0
------------------------------
*September 21, 2022*

### Changed
- Upgraded F-HTTP dependency and context with new Conversation ID forwarding

<hr>

![image](https://user-images.githubusercontent.com/10741583/191464794-27f0c4f8-785b-4b5b-84c5-767ee8410e5c.png)
