### PR TITLE
f-http@v1.1.0 - revert axios lazy import and trigger tests on storybook changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ commands:
             }
 
             echo 'Checking changes'
-            changes=`git diff --name-only origin/master...$CIRCLE_BRANCH | { grep -Ev '^packages/|yarn.lock|bear.png|.editorconfig' || true; }`
+            changes=`git diff --name-only origin/master...$CIRCLE_BRANCH | { grep -Ev '^packages\/(?!storybook)|yarn.lock|bear.png|.editorconfig' || true; }`
             echo 'Changes detected:'
             echo $changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v7.29.1
+------------------------------
+*September 27, 2022*
+
+### Changed
+- Include any Storybook changes in PR test triggers for CircleCI
+
+
 v7.29.0
 ------------------------------
 *September 14, 2022*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "7.29.0",
+  "version": "7.29.1",
   "private": true,
   "scripts": {
     "build": "turbo run build --continue",

--- a/packages/services/f-http/CHANGELOG.md
+++ b/packages/services/f-http/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v1.1.0
+v1.0.1
 ------------------------------
 *September 16, 2022*
 

--- a/packages/services/f-http/CHANGELOG.md
+++ b/packages/services/f-http/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v1.1.0
+------------------------------
+*September 16, 2022*
+
+### Changed
+- Normally import `Axios` rather than lazy require to fix test adapter issues
+
+
 v1.0.0
 ------------------------------
 *September 16, 2022*

--- a/packages/services/f-http/package.json
+++ b/packages/services/f-http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-http",
   "description": "Javascript HTTP client for interacting with restful services",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "maxBundleSize": "400kB",
   "main": "dist/f-http.umd.js",
   "module": "dist/f-http.es.js",

--- a/packages/services/f-http/package.json
+++ b/packages/services/f-http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-http",
   "description": "Javascript HTTP client for interacting with restful services",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "maxBundleSize": "400kB",
   "main": "dist/f-http.umd.js",
   "module": "dist/f-http.es.js",
@@ -35,7 +35,6 @@
     "build": "vite build",
     "lint": "eslint \"!(dist)/**/*.{js,vue}\"",
     "lint:fix": "yarn lint --fix",
-    "storybook:build": "vite build",
     "test": "jest",
     "ci:test:services": "yarn test",
     "test:coverage": "jest test:unit --coverage"

--- a/packages/services/f-http/src/createClient.js
+++ b/packages/services/f-http/src/createClient.js
@@ -3,6 +3,7 @@ import setAuthorisationToken from './authorisationHandler';
 import httpVerbs from './httpVerbs';
 import interceptors from './interceptors';
 import RequestDispatcher from './requestDispatcher';
+import axios from 'axios';
 
 /**
  * Create a httpClient
@@ -20,9 +21,6 @@ export default class HttpClient {
             ...defaultOptions,
             ...options
         };
-
-        // Important for Isomorphism: loads correct version of Axios for Node vs Browser
-        const axios = require('axios').default;
 
         this.axiosInstance = axios.create({
             baseURL: this.configuration.baseUrl,
@@ -60,6 +58,8 @@ export default class HttpClient {
      * @return {object} - Returns data from response
      */
     async get (resource, headers = {}) {
+        console.log('LATEST VERSION');
+
         return this.sendRequest(
             httpVerbs.GET,
             resource,

--- a/packages/services/f-http/src/createClient.js
+++ b/packages/services/f-http/src/createClient.js
@@ -58,8 +58,6 @@ export default class HttpClient {
      * @return {object} - Returns data from response
      */
     async get (resource, headers = {}) {
-        console.log('LATEST VERSION');
-
         return this.sendRequest(
             httpVerbs.GET,
             resource,

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.59.0
+------------------------------
+*September 27, 2022*
+
+### Changed
+- Changed F-HTTP to `1.x`
+
+
 v0.58.0
 ------------------------------
 *September 21, 2022*

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private": true,
-  "version": "0.58.0",
+  "version": "0.59.0",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --existing-output-dir ./storybook-static --ci",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -15,7 +15,7 @@
     "vue-router": "3.5.2"
   },
   "devDependencies": {
-    "@justeat/f-http": "1.0.0",
+    "@justeat/f-http": "1.x",
     "@kazupon/vue-i18n-loader": "0.5.0",
     "@storybook/addon-a11y": "6.4.9",
     "@storybook/addon-essentials": "6.4.9",


### PR DESCRIPTION
## Root

v7.29.1
------------------------------
*September 27, 2022*

### Changed
- Include any Storybook changes in PR test triggers for CircleCI

## f-http:

v1.0.1
------------------------------
*September 16, 2022*

### Changed
- Normally import `Axios` rather than lazy require to fix test adapter issues

## Storybook:

v0.59.0
------------------------------
*September 27, 2022*

### Changed
- Changed F-HTTP to `1.x`