### PR TITLE
f-error-message@2.3.0 - Fix font size call.

### DIFF
--- a/packages/components/atoms/f-error-message/CHANGELOG.md
+++ b/packages/components/atoms/f-error-message/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.3.0
+------------------------------
+*September 30, 2022*
+
+### Added
+- `fozzie` as peerDep so consuming applications use the correct version of `fozzie` when using `f-error-message` v2.3.0.
+
+### Fixed
+- `font-size` call to `body-s`. Version 9 of fozzie changed the way default value was used which causes the size to increase now.
+
+
 v2.2.0
 ------------------------------
 *July 15, 2022*

--- a/packages/components/atoms/f-error-message/package.json
+++ b/packages/components/atoms/f-error-message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-error-message",
   "description": "Fozzie Error Message – Generic inline error message",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "main": "dist/f-error-message.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [
@@ -49,13 +49,13 @@
     "@justeattakeaway/pie-icons-vue": "1.0.0"
   },
   "peerDependencies": {
-    "@justeat/browserslist-config-fozzie": ">=1.1.1"
+    "@justeat/browserslist-config-fozzie": ">=1.1.1",
+    "@justeat/fozzie": ">=9.0.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "4.5.16",
     "@vue/cli-plugin-unit-jest": "4.5.16",
     "@vue/test-utils": "1.0.3",
-    "@justeat/fozzie": "9.0.0-beta.2",
     "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/atoms/f-error-message/src/components/ErrorMessage.vue
+++ b/packages/components/atoms/f-error-message/src/components/ErrorMessage.vue
@@ -41,7 +41,7 @@ export default {
 .c-errorMessage {
     position: relative;
     color: f.$color-content-error;
-    @include f.font-size();
+    @include f.font-size('body-s');
     margin-top: f.spacing();
 }
 

--- a/packages/components/pages/f-registration/CHANGELOG.md
+++ b/packages/components/pages/f-registration/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.7.1
+------------------------------
+*October 03, 2022*
+
+### Changed
+- `f-http` package version.
+
+
 v3.7.0
 ------------------------------
 *August 22, 2022*

--- a/packages/components/pages/f-registration/package.json
+++ b/packages/components/pages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "main": "dist/f-registration.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [
@@ -60,7 +60,7 @@
     "@justeat/f-card": "4.x",
     "@justeat/f-error-message": "2.x",
     "@justeat/f-form-field": "6.x",
-    "@justeat/f-http": "0.x",
+    "@justeat/f-http": "1.x",
     "@justeat/f-link": "3.x"
   },
   "devDependencies": {
@@ -69,7 +69,7 @@
     "@justeat/f-card": "4.x",
     "@justeat/f-error-message": "2.x",
     "@justeat/f-form-field": "6.x",
-    "@justeat/f-http": "0.x",
+    "@justeat/f-http": "1.x",
     "@justeat/f-link": "3.x",
     "@justeat/f-vue-icons": "3.x",
     "@justeat/f-wdio-utils": "1.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2356,7 +2356,7 @@
 
 "@justeat/fozzie@8.2.0":
   version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-8.2.0.tgz#caba00d7d807c7d098b8a1c495b88c3f879efdb9"
+  resolved "https://registry.npmjs.org/@justeat/fozzie/-/fozzie-8.2.0.tgz#caba00d7d807c7d098b8a1c495b88c3f879efdb9"
   integrity sha512-Pn5Uhi/mOLe0EnXIrjXbeBWBFbcJejVqt7hYiOLnFsbLYiFLwPHZjo+DgKSGCcTGfMPZsBPqPF5/f7zONoopAw==
   dependencies:
     "@justeat/pie-design-tokens" "1.4.0"
@@ -14475,7 +14475,7 @@ imurmurhash@^0.1.4:
 
 include-media@1.4.10:
   version "1.4.10"
-  resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.10.tgz#7a311c92c396c808504ec6a5365115d30571f259"
+  resolved "https://registry.npmjs.org/include-media/-/include-media-1.4.10.tgz#7a311c92c396c808504ec6a5365115d30571f259"
   integrity sha512-TymQzKF7oWHbItEcEHOCponZ90lRr1I9QbYeD+qCxXy4Z0/pSpS4Ocz2bq3FMOERlXXrY9Sawsh9GjiObVQA6A==
 
 include-media@1.4.9:
@@ -14485,7 +14485,6 @@ include-media@1.4.9:
 
 include-media@eduardoboucas/include-media#2.0-release:
   version "2.0.0"
-  uid a3c0288e5b22cc746cc2d320d0a374b2ed9d0aeb
   resolved "https://codeload.github.com/eduardoboucas/include-media/tar.gz/a3c0288e5b22cc746cc2d320d0a374b2ed9d0aeb"
 
 indent-string@^2.1.0:


### PR DESCRIPTION
Some recent changes [here](https://github.com/justeat/fozzie/pull/385/files#diff-a005a1c33913963f88b89b0871a6cbacc564100ce5e912bdec6ed840dcb6dfddR28) have flagged some font size issues [here](https://github.com/justeat/fozzie-components/pull/2142). This PR should sort those out.

### Added
- `fozzie` as peerDep so consuming applications use the correct version of `fozzie` when using `f-error-message` v2.3.0.

### Fixed
- `font-size` call to `body-s`. Version 9 of fozzie changed the way default value was used which causes the size to increase now.
