### PR TITLE
f-cookie-banner@v4.6.2 - update static cookie banner readme example

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.6.2
+------------------------------
+*October 11, 2022*
+
+### Updated
+- `README.md` to include `@justeat/fozzie` CSS links in static cookie banner example and explain why it is required to work
+
+
 v4.6.1
 ------------------------------
 *October 11, 2022*

--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -8,7 +8,7 @@ v4.6.2
 ------------------------------
 *October 11, 2022*
 
-### Updated
+### Changed
 - `README.md` to include `@justeat/fozzie` CSS links in static cookie banner example and explain why it is required to work
 
 

--- a/packages/components/organisms/f-cookie-banner/README.md
+++ b/packages/components/organisms/f-cookie-banner/README.md
@@ -77,13 +77,17 @@ Files can be accessed directly via CDN using [unkpg.com](https://unpkg.com/brows
 
 Using the CDN the cookie banner can be added to any web page using basic tags. The page must contain a placeholder element with the id attribute `cookie-banner` for example `<div id="cookie-banner"></div>`
 
+***In order for the static cookie banner to look correct, you must also link to the `fozzie-utilities` CSS file created by `@justeat/fozzie` (please see the example below on how to link to it). Whilst `fozzie-reset` and `fozzie-typography` are not required, we highly recommend linking to them as well***
+
 ```html
 <html>
   <head>
-    <link
-      href="https://unpkg.com/@justeat/f-cookie-banner/dist/static/en-GB.css"
-      rel="stylesheet"
-    />
+    <!-- use fozzie CSS files to provide base styles and utilities classes used by the cookie banner -->
+    <link rel="stylesheet" href="https://unpkg.com/@justeat/fozzie/dist/css/fozzie-reset.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@justeat/fozzie/dist/css/fozzie-typography.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@justeat/fozzie/dist/css/fozzie-utilities.css" />
+    <!--  use the cookie banner CSS  -->
+    <link href="https://unpkg.com/@justeat/f-cookie-banner/dist/static/en-GB.css" rel="stylesheet" />
   </head>
   <body>
     <div id="cookie-banner"></div>
@@ -95,7 +99,7 @@ Using the CDN the cookie banner can be added to any web page using basic tags. T
 </html>
 ```
 
-A working demo can be found on [codesandbax.io](https://codesandbox.io/s/static-cookie-banner-example-lgs9u)
+A working demo can be found on [codepen.io](https://codepen.io/JamieMaguireJE/pen/QWrzboo)
 
 #### Bundling Tool Implementation
 

--- a/packages/components/organisms/f-cookie-banner/README.md
+++ b/packages/components/organisms/f-cookie-banner/README.md
@@ -86,7 +86,7 @@ Using the CDN the cookie banner can be added to any web page using basic tags. T
     <link rel="stylesheet" href="https://unpkg.com/@justeat/fozzie/dist/css/fozzie-reset.css" />
     <link rel="stylesheet" href="https://unpkg.com/@justeat/fozzie/dist/css/fozzie-typography.css" />
     <link rel="stylesheet" href="https://unpkg.com/@justeat/fozzie/dist/css/fozzie-utilities.css" />
-    <!--  use the cookie banner CSS  -->
+    <!--  use the cookie banner CSS NOTE: It is important that you choose the correct tenant -->
     <link href="https://unpkg.com/@justeat/f-cookie-banner/dist/static/en-GB.css" rel="stylesheet" />
   </head>
   <body>

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner - Cookie Banner",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "80kB",
   "files": [


### PR DESCRIPTION
v4.6.2
------------------------------
*October 11, 2022*

### Updated
- `README.md` to include `@justeat/fozzie` CSS links in static cookie banner example and explain why it is required to work