### PR TITLE
f-rating@0.2.0 - Add stars implementation to initial generator code.

### DIFF
--- a/packages/components/molecules/f-rating/CHANGELOG.md
+++ b/packages/components/molecules/f-rating/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.2.0
+------------------------------
+*October 13, 2022*
+
+### Added
+- Test coverage for code changes.
+- `pie-icons-vue` repo as `dep` to pull in the star icons.
+- Stories component added.
+- Prop `starRating` added to allow the consumer to pass in a value.
+- Readme prop table.
+- Snapshot test.
+
 
 v0.1.0
 ------------------------------

--- a/packages/components/molecules/f-rating/README.md
+++ b/packages/components/molecules/f-rating/README.md
@@ -69,10 +69,10 @@ There may be props that allow you to customise its functionality.
 
 The props that can be defined are as follows (if any):
 
-| Prop          |   Type   | Required | Default | Description                                           |
-| :---          |:--------:|:--------:|:-------:|:------------------------------------------------------|
-| `starRating`  | `Number` |   Yes    |    -    | Sets the number of stars out of 5                     |
-| `maxStarRating`  | `Number` |    No    |    5    | Sets the number of max stars the consumer should use. |
+| Prop          |   Type   | Required | Default | Description                                                                                                            |
+| :---          |:--------:|:--------:|:-------:|:-----------------------------------------------------------------------------------------------------------------------|
+| `starRating`  | `Number` |   Yes    |    -    | Sets the displayed rating (filled stars). i.e. for `2 out of x`, 2 would be the `starRating`                           |
+| `maxStarRating`  | `Number` |    No    |    5    | Sets the maximum number of stars that the rating is set against. i.e. for `x out of 5`, 5 would be the `maxStarRating` |
 
 ### Events
 

--- a/packages/components/molecules/f-rating/README.md
+++ b/packages/components/molecules/f-rating/README.md
@@ -69,8 +69,9 @@ There may be props that allow you to customise its functionality.
 
 The props that can be defined are as follows (if any):
 
-| Prop  | Type  | Default | Description |
-| ----- | ----- | ------- | ----------- |
+| Prop          |   Type   | Required | Default | Description                       |
+| :---          |:--------:|:--------:|:-------:|:----------------------------------|
+| `starRating`  | `Number` |   Yes    |    -    | Sets the number of stars out of 5 |
 
 ### Events
 

--- a/packages/components/molecules/f-rating/README.md
+++ b/packages/components/molecules/f-rating/README.md
@@ -69,9 +69,10 @@ There may be props that allow you to customise its functionality.
 
 The props that can be defined are as follows (if any):
 
-| Prop          |   Type   | Required | Default | Description                       |
-| :---          |:--------:|:--------:|:-------:|:----------------------------------|
-| `starRating`  | `Number` |   Yes    |    -    | Sets the number of stars out of 5 |
+| Prop          |   Type   | Required | Default | Description                                           |
+| :---          |:--------:|:--------:|:-------:|:------------------------------------------------------|
+| `starRating`  | `Number` |   Yes    |    -    | Sets the number of stars out of 5                     |
+| `maxStarRating`  | `Number` |    No    |    5    | Sets the number of max stars the consumer should use. |
 
 ### Events
 

--- a/packages/components/molecules/f-rating/package.json
+++ b/packages/components/molecules/f-rating/package.json
@@ -45,8 +45,9 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
+    "@justeat/f-globalisation": "1.x",
     "@justeat/f-services": "1.x",
-    "@justeattakeaway/pie-icons-vue": "1.x"
+    "@justeattakeaway/pie-icons-vue": "2.0.0-beta.0"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"

--- a/packages/components/molecules/f-rating/package.json
+++ b/packages/components/molecules/f-rating/package.json
@@ -45,12 +45,12 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-globalisation": "1.x",
     "@justeat/f-services": "1.x",
     "@justeattakeaway/pie-icons-vue": "2.0.0-beta.0"
   },
   "peerDependencies": {
-    "@justeat/browserslist-config-fozzie": ">=1.2.0"
+    "@justeat/browserslist-config-fozzie": ">=1.2.0",
+    "@justeat/f-globalisation": "1.x"
   },
   "devDependencies": {
     "@justeat/f-wdio-utils": "1.x",

--- a/packages/components/molecules/f-rating/package.json
+++ b/packages/components/molecules/f-rating/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-rating",
   "description": "Fozzie Rating - Global Rating component",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/f-rating.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [
@@ -45,7 +45,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.x"
+    "@justeat/f-services": "1.x",
+    "@justeattakeaway/pie-icons-vue": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0"

--- a/packages/components/molecules/f-rating/src/components/Rating.vue
+++ b/packages/components/molecules/f-rating/src/components/Rating.vue
@@ -2,13 +2,14 @@
     <div
         :class="$style['c-rating']"
         data-test-id="rating-component">
-        <ul :class="$style['c-rating-star-wrapper']">
+        <ul
+            :class="$style['c-rating-starWrapper']">
             <li
                 v-for="star in maxStarRating"
                 :key="star"
                 :class="$style['c-rating-star']">
                 <star-filled-icon
-                    v-if="hasRating(star)"
+                    v-if="isRatingStarFilled(star)"
                     :class="$style['c-rating-star-filled']" />
                 <star-icon
                     v-else
@@ -57,8 +58,7 @@ export default {
 
     data () {
         return {
-            tenantConfigs,
-            rating: this.starRating
+            tenantConfigs
         };
     },
 
@@ -72,12 +72,12 @@ export default {
         getRatingDescription () {
             return this.starRating < 2
                 ? this.$tc('ratings.starsDescription', 1, {
-                    rating: this.rating,
+                    rating: this.starRating,
                     total: this.maxStarRating
                 })
 
                 : this.$tc('ratings.starsDescription', 2, {
-                    rating: this.rating,
+                    rating: this.starRating,
                     total: this.maxStarRating
                 });
         }
@@ -87,11 +87,11 @@ export default {
         /**
          * Check `star` against value passed by consumer to allow empty stars to render.
          *
-         * @param star
+         * @param star {Number}
          * @returns {boolean}
          */
-        hasRating (star) {
-            return star <= this.rating;
+        isRatingStarFilled (star) {
+            return star <= this.starRating;
         }
     }
 };
@@ -100,12 +100,11 @@ export default {
 <style lang="scss" module>
 @use '@justeat/fozzie/src/scss/fozzie' as f;
 
-.c-rating {
-    .c-rating-star-wrapper {
-        margin: 0;
-        padding: 0;
-        list-style-type: none;
-    }
+.c-rating-starWrapper {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+}
 
     .c-rating-star {
         display: inline-block;
@@ -123,5 +122,4 @@ export default {
             fill: f.$color-mozzarella-50;
         }
     }
-}
 </style>

--- a/packages/components/molecules/f-rating/src/components/Rating.vue
+++ b/packages/components/molecules/f-rating/src/components/Rating.vue
@@ -8,7 +8,7 @@
                 :key="star"
                 :class="$style['c-rating-star']">
                 <star-filled-icon
-                    v-if="getRating(star)"
+                    v-if="hasRating(star)"
                     :class="$style['c-rating-star-filled']" />
                 <star-icon
                     v-else
@@ -77,12 +77,12 @@ export default {
 
     methods: {
         /**
-         * Check if `star` against value passed by consumer to allow empty stars to render.
+         * Check `star` against value passed by consumer to allow empty stars to render.
          *
          * @param star
          * @returns {boolean}
          */
-        getRating (star) {
+        hasRating (star) {
             return star <= this.rating;
         }
     }

--- a/packages/components/molecules/f-rating/src/components/Rating.vue
+++ b/packages/components/molecules/f-rating/src/components/Rating.vue
@@ -14,12 +14,12 @@
                     v-else
                     :class="$style['c-rating-star-empty']" />
             </li>
-            <span
-                data-test-id="c-rating-description"
-                class="is-visuallyHidden">
-                {{ starRating }} {{ setRatingDescription }} {{ maxStarRating }}
-            </span>
         </ul>
+        <span
+            data-test-id="c-rating-description"
+            class="is-visuallyHidden">
+            {{ getRatingDescription }}
+        </span>
     </div>
 </template>
 
@@ -28,7 +28,7 @@ import {
     StarFilledIcon,
     StarIcon
 } from '@justeattakeaway/pie-icons-vue';
-import { globalisationServices } from '@justeat/f-services';
+import { VueGlobalisationMixin } from '@justeat/f-globalisation';
 import tenantConfigs from '../tenants';
 
 export default {
@@ -37,6 +37,9 @@ export default {
         StarFilledIcon,
         StarIcon
     },
+
+    mixins: [VueGlobalisationMixin],
+
     props: {
         locale: {
             type: String,
@@ -53,25 +56,30 @@ export default {
     },
 
     data () {
-        const locale = globalisationServices.getLocale(tenantConfigs, this.locale, this.$i18n);
-        const localeConfig = tenantConfigs[locale];
-
         return {
-            copy: { ...localeConfig },
+            tenantConfigs,
             rating: this.starRating
         };
     },
 
     computed: {
         /**
-         * Return singular description if one star.
+         * Return description using `vue-i18n Pluralization` if one star or an alternative if more.
+         *
          *
          * @returns {string|*}
          */
-        setRatingDescription () {
+        getRatingDescription () {
             return this.starRating < 2
-                ? this.copy.ratings.starsDescriptionSingular
-                : this.copy.ratings.starsDescription;
+                ? this.$tc('ratings.starsDescription', 1, {
+                    rating: this.rating,
+                    total: this.maxStarRating
+                })
+
+                : this.$tc('ratings.starsDescription', 2, {
+                    rating: this.rating,
+                    total: this.maxStarRating
+                });
         }
     },
 
@@ -97,22 +105,22 @@ export default {
         margin: 0;
         padding: 0;
         list-style-type: none;
+    }
 
-        .c-rating-star {
-            display: inline-block;
-            width: 15px; // Todo - decide on how to size these. Will create a ticket around this.
+    .c-rating-star {
+        display: inline-block;
+        width: 15px; // Todo - decide on how to size these. Will create a ticket around this.
+    }
+
+    .c-rating-star-filled {
+        & path {
+            fill: f.$color-support-brand-01;
         }
+    }
 
-        .c-rating-star-filled {
-            & path {
-                fill: f.$color-support-brand-01;
-            }
-        }
-
-        .c-rating-star-empty {
-            & path {
-                fill: f.$color-mozzarella-50;
-            }
+    .c-rating-star-empty {
+        & path {
+            fill: f.$color-mozzarella-50;
         }
     }
 }

--- a/packages/components/molecules/f-rating/src/components/Rating.vue
+++ b/packages/components/molecules/f-rating/src/components/Rating.vue
@@ -2,30 +2,89 @@
     <div
         :class="$style['c-rating']"
         data-test-id="rating-component">
-        {{ copy.text }}
+        <ul :class="$style['c-rating-star-wrapper']">
+            <li
+                v-for="star in maxStarRating"
+                :key="star"
+                :class="$style['c-rating-star']">
+                <star-filled-icon
+                    v-if="getRating(star)"
+                    :class="$style['c-rating-star-filled']" />
+                <star-icon
+                    v-else
+                    :class="$style['c-rating-star-empty']" />
+            </li>
+            <span
+                data-test-id="c-rating-description"
+                class="is-visuallyHidden">
+                {{ starRating }} {{ setRatingDescription }} {{ maxStarRating }}
+            </span>
+        </ul>
     </div>
 </template>
 
 <script>
+import {
+    StarFilledIcon,
+    StarIcon
+} from '@justeattakeaway/pie-icons-vue';
 import { globalisationServices } from '@justeat/f-services';
 import tenantConfigs from '../tenants';
 
 export default {
     name: 'VRating',
-    components: {},
+    components: {
+        StarFilledIcon,
+        StarIcon
+    },
     props: {
         locale: {
             type: String,
             default: ''
+        },
+        starRating: {
+            type: Number,
+            required: true
+        },
+        maxStarRating: {
+            type: Number,
+            default: 5
         }
     },
+
     data () {
         const locale = globalisationServices.getLocale(tenantConfigs, this.locale, this.$i18n);
         const localeConfig = tenantConfigs[locale];
 
         return {
-            copy: { ...localeConfig }
+            copy: { ...localeConfig },
+            rating: this.starRating
         };
+    },
+
+    computed: {
+        /**
+         * Return singular description if one star.
+         *
+         * @returns {string|*}
+         */
+        setRatingDescription () {
+            return this.starRating < 2
+                ? this.copy.ratings.starsDescriptionSingular
+                : this.copy.ratings.starsDescription;
+        }
+    },
+
+    methods: {
+        /**
+         * Check if `star` against value passed by consumer to allow empty stars to render.
+         *
+         * @param star
+         * @returns {boolean}
+         */
+        getRating (star) {
+            return star <= this.rating;
+        }
     }
 };
 </script>
@@ -34,13 +93,27 @@ export default {
 @use '@justeat/fozzie/src/scss/fozzie' as f;
 
 .c-rating {
-    display: flex;
-    justify-content: center;
-    min-height: 80vh;
-    width: 80vw;
-    margin: auto;
-    border: 1px solid red;
-    font-family: f.$font-family-base;
-    @include f.font-size(heading-m);
+    .c-rating-star-wrapper {
+        margin: 0;
+        padding: 0;
+        list-style-type: none;
+
+        .c-rating-star {
+            display: inline-block;
+            width: 15px; // Todo - decide on how to size these. Will create a ticket around this.
+        }
+
+        .c-rating-star-filled {
+            & path {
+                fill: f.$color-support-brand-01;
+            }
+        }
+
+        .c-rating-star-empty {
+            & path {
+                fill: f.$color-mozzarella-50;
+            }
+        }
+    }
 }
 </style>

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -47,6 +47,37 @@ describe('Rating', () => {
             describe('when invoked', () => {
                 it('should return truthy when the argument `star` is less than or equal to `starRating`', () => {
                     // Act
+                    const star = 1;
+                    const result = wrapper.vm.isRatingStarFilled(star);
+
+                    // Assert
+                    expect(result).toBe(true);
+                });
+
+                it.each([1, 2])('should return truthy when the argument star is %s', value => {
+                    // Arrange
+                    propsData = {
+                        starRating: value,
+                        maxStarRating: 5
+                    };
+
+                    // Act
+                    wrapper = shallowMount(VRating, {
+                        propsData,
+                        localVue,
+                        i18n,
+                        mocks: {
+                            $tc
+                        }
+                    });
+                    const result = wrapper.vm.isRatingStarFilled(value);
+
+                    // Assert
+                    expect(result).toBe(true);
+                });
+
+                it('should return truthy when the argument `star` is equal to `starRating`', () => {
+                    // Act
                     const star = 2;
                     const result = wrapper.vm.isRatingStarFilled(star);
 

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -1,28 +1,37 @@
-import { shallowMount } from '@vue/test-utils';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import { VueI18n } from '@justeat/f-globalisation';
 import VRating from '../Rating.vue';
+import i18n from './helpers/setup';
+
+const localVue = createLocalVue();
+localVue.use(VueI18n);
 
 describe('Rating', () => {
-    it('should be defined', () => {
-        const propsData = {
-            starRating: 2
+    let propsData;
+    let wrapper;
+    const $tc = jest.fn();
+
+    beforeEach(() => {
+        propsData = {
+            starRating: 2,
+            maxStarRating: 5
         };
-        const wrapper = shallowMount(VRating, { propsData });
+        wrapper = shallowMount(VRating, {
+            propsData,
+            localVue,
+            i18n,
+            mocks: {
+                $tc
+            }
+        });
+    });
+
+    it('should be defined', () => {
         expect(wrapper.exists()).toBe(true);
     });
 
     describe('methods', () => {
         describe('`hasRating`', () => {
-            let propsData;
-            let wrapper;
-
-            beforeEach(() => {
-                propsData = {
-                    starRating: 2,
-                    maxStarRating: 5
-                };
-                wrapper = shallowMount(VRating, { propsData });
-            });
-
             it('should exist', () => {
                 expect(wrapper.vm.hasRating).toBeDefined();
             });
@@ -56,45 +65,51 @@ describe('Rating', () => {
     });
 
     describe('computed', () => {
-        describe('`setRatingDescription`', () => {
-            let propsData;
-            let wrapper;
-
-            beforeEach(() => {
-                propsData = {
-                    starRating: 2,
-                    maxStarRating: 5
-                };
-                wrapper = shallowMount(VRating, { propsData });
-            });
-
+        describe('`getRatingDescription`', () => {
             it('should exist', () => {
-                expect(wrapper.vm.setRatingDescription).toBeDefined();
+                // Arrange
+                propsData.starRating = 2;
+                wrapper = shallowMount(VRating, {
+                    propsData,
+                    localVue,
+                    i18n
+                });
+
+                // Act & Assert
+                expect(wrapper.vm.getRatingDescription).toBeDefined();
             });
 
             describe('when invoked', () => {
                 it('should return a singular description if the rating is less than 2', () => {
                     // Arrange
-                    const description = 'star out of';
+                    const description = '1 star out of 5';
                     propsData = {
                         starRating: 1
                     };
-                    wrapper = shallowMount(VRating, { propsData });
+                    wrapper = shallowMount(VRating, {
+                        propsData,
+                        localVue,
+                        i18n
+                    });
 
                     // Act & Assert
-                    expect(wrapper.vm.setRatingDescription).toBe(description);
+                    expect(wrapper.vm.getRatingDescription).toBe(description);
                 });
 
                 it('should return a plural description if the rating is greater than 1', () => {
                     // Arrange
-                    const description = 'stars out of';
+                    const description = '2 stars out of 5';
                     propsData = {
                         starRating: 2
                     };
-                    wrapper = shallowMount(VRating, { propsData });
+                    wrapper = shallowMount(VRating, {
+                        propsData,
+                        localVue,
+                        i18n
+                    });
 
                     // Act & Assert
-                    expect(wrapper.vm.setRatingDescription).toBe(description);
+                    expect(wrapper.vm.getRatingDescription).toBe(description);
                 });
             });
         });

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -3,8 +3,100 @@ import VRating from '../Rating.vue';
 
 describe('Rating', () => {
     it('should be defined', () => {
-        const propsData = {};
+        const propsData = {
+            starRating: 2
+        };
         const wrapper = shallowMount(VRating, { propsData });
         expect(wrapper.exists()).toBe(true);
+    });
+
+    describe('methods', () => {
+        describe('`getRating`', () => {
+            let propsData;
+            let wrapper;
+
+            beforeEach(() => {
+                propsData = {
+                    starRating: 2,
+                    maxStarRating: 5
+                };
+                wrapper = shallowMount(VRating, { propsData });
+            });
+
+            it('should exist', () => {
+                expect(wrapper.vm.getRating).toBeDefined();
+            });
+
+            it('should contain a description `c-rating-description`', () => {
+                // Act
+                const result = wrapper.find('[data-test-id="c-rating-description"]');
+
+                // Assert
+                expect(result).toMatchSnapshot();
+            });
+
+            describe('when invoked', () => {
+                it('should return truthy when `starRating` is less than or equal to `rating`', () => {
+                    // Act
+                    const result = wrapper.vm.getRating(2);
+
+                    // Assert
+                    expect(result).toBe(true);
+                });
+
+                it('should return falsey when `starRating` is more than `rating`', () => {
+                    // Act
+                    const result = wrapper.vm.getRating(3);
+
+                    // Assert
+                    expect(result).toBe(false);
+                });
+            });
+        });
+    });
+
+    describe('computed', () => {
+        describe('`setRatingDescription`', () => {
+            let propsData;
+            let wrapper;
+
+            beforeEach(() => {
+                propsData = {
+                    starRating: 2,
+                    maxStarRating: 5
+                };
+                wrapper = shallowMount(VRating, { propsData });
+            });
+
+            it('should exist', () => {
+                expect(wrapper.vm.setRatingDescription).toBeDefined();
+            });
+
+            describe('when invoked', () => {
+                it('should return a singular description if the rating is less than 2', () => {
+                    // Arrange
+                    const description = 'star out of';
+                    propsData = {
+                        starRating: 1
+                    };
+                    wrapper = shallowMount(VRating, { propsData });
+
+                    // Act & Assert
+                    expect(wrapper.vm.setRatingDescription).toBe(description);
+                });
+
+                it('should return a plural description if the rating is greater than 1', () => {
+                    // Arrange
+                    const description = 'stars out of';
+                    propsData = {
+                        starRating: 2
+                    };
+                    wrapper = shallowMount(VRating, { propsData });
+
+                    // Act & Assert
+                    expect(wrapper.vm.setRatingDescription).toBe(description);
+                });
+            });
+        });
     });
 });

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -31,9 +31,9 @@ describe('Rating', () => {
     });
 
     describe('methods', () => {
-        describe('`hasRating`', () => {
+        describe('`isRatingStarFilled`', () => {
             it('should exist', () => {
-                expect(wrapper.vm.hasRating).toBeDefined();
+                expect(wrapper.vm.isRatingStarFilled).toBeDefined();
             });
 
             it('should contain a description `c-rating-description`', () => {
@@ -45,17 +45,19 @@ describe('Rating', () => {
             });
 
             describe('when invoked', () => {
-                it('should return truthy when `starRating` is less than or equal to `rating`', () => {
+                it('should return truthy when the argument `star` is less than or equal to `starRating`', () => {
                     // Act
-                    const result = wrapper.vm.hasRating(2);
+                    const star = 2;
+                    const result = wrapper.vm.isRatingStarFilled(star);
 
                     // Assert
                     expect(result).toBe(true);
                 });
 
-                it('should return falsey when `starRating` is more than `rating`', () => {
+                it('should return falsey when argument `star` is greater than `starRating`', () => {
                     // Act
-                    const result = wrapper.vm.hasRating(3);
+                    const star = 3;
+                    const result = wrapper.vm.isRatingStarFilled(star);
 
                     // Assert
                     expect(result).toBe(false);
@@ -82,7 +84,6 @@ describe('Rating', () => {
             describe('when invoked', () => {
                 it('should return a singular description if the rating is less than 2', () => {
                     // Arrange
-                    const description = '1 star out of 5';
                     propsData = {
                         starRating: 1
                     };
@@ -93,12 +94,11 @@ describe('Rating', () => {
                     });
 
                     // Act & Assert
-                    expect(wrapper.vm.getRatingDescription).toBe(description);
+                    expect(wrapper.vm.getRatingDescription).toMatchSnapshot();
                 });
 
                 it('should return a plural description if the rating is greater than 1', () => {
                     // Arrange
-                    const description = '2 stars out of 5';
                     propsData = {
                         starRating: 2
                     };
@@ -109,7 +109,7 @@ describe('Rating', () => {
                     });
 
                     // Act & Assert
-                    expect(wrapper.vm.getRatingDescription).toBe(description);
+                    expect(wrapper.vm.getRatingDescription).toMatchSnapshot();
                 });
             });
         });

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -11,7 +11,7 @@ describe('Rating', () => {
     });
 
     describe('methods', () => {
-        describe('`getRating`', () => {
+        describe('`hasRating`', () => {
             let propsData;
             let wrapper;
 
@@ -24,7 +24,7 @@ describe('Rating', () => {
             });
 
             it('should exist', () => {
-                expect(wrapper.vm.getRating).toBeDefined();
+                expect(wrapper.vm.hasRating).toBeDefined();
             });
 
             it('should contain a description `c-rating-description`', () => {
@@ -38,7 +38,7 @@ describe('Rating', () => {
             describe('when invoked', () => {
                 it('should return truthy when `starRating` is less than or equal to `rating`', () => {
                     // Act
-                    const result = wrapper.vm.getRating(2);
+                    const result = wrapper.vm.hasRating(2);
 
                     // Assert
                     expect(result).toBe(true);
@@ -46,7 +46,7 @@ describe('Rating', () => {
 
                 it('should return falsey when `starRating` is more than `rating`', () => {
                     // Act
-                    const result = wrapper.vm.getRating(3);
+                    const result = wrapper.vm.hasRating(3);
 
                     // Assert
                     expect(result).toBe(false);

--- a/packages/components/molecules/f-rating/src/components/_tests/__snapshots__/Rating.test.js.snap
+++ b/packages/components/molecules/f-rating/src/components/_tests/__snapshots__/Rating.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Rating methods \`getRating\` should contain a description \`c-rating-description\` 1`] = `
+<span data-test-id="c-rating-description" class="is-visuallyHidden">
+            2 stars out of 5
+        </span>
+`;

--- a/packages/components/molecules/f-rating/src/components/_tests/__snapshots__/Rating.test.js.snap
+++ b/packages/components/molecules/f-rating/src/components/_tests/__snapshots__/Rating.test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Rating methods \`hasRating\` should contain a description \`c-rating-description\` 1`] = `
 <span data-test-id="c-rating-description" class="is-visuallyHidden">
-            2 stars out of 5
-        </span>
+
+    </span>
 `;

--- a/packages/components/molecules/f-rating/src/components/_tests/__snapshots__/Rating.test.js.snap
+++ b/packages/components/molecules/f-rating/src/components/_tests/__snapshots__/Rating.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Rating methods \`getRating\` should contain a description \`c-rating-description\` 1`] = `
+exports[`Rating methods \`hasRating\` should contain a description \`c-rating-description\` 1`] = `
 <span data-test-id="c-rating-description" class="is-visuallyHidden">
             2 stars out of 5
         </span>

--- a/packages/components/molecules/f-rating/src/components/_tests/__snapshots__/Rating.test.js.snap
+++ b/packages/components/molecules/f-rating/src/components/_tests/__snapshots__/Rating.test.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Rating methods \`hasRating\` should contain a description \`c-rating-description\` 1`] = `
+exports[`Rating computed \`getRatingDescription\` when invoked should return a plural description if the rating is greater than 1 1`] = `"2 stars out of 5"`;
+
+exports[`Rating computed \`getRatingDescription\` when invoked should return a singular description if the rating is less than 2 1`] = `"1 star out of 5"`;
+
+exports[`Rating methods \`isRatingStarFilled\` should contain a description \`c-rating-description\` 1`] = `
 <span data-test-id="c-rating-description" class="is-visuallyHidden">
 
     </span>

--- a/packages/components/molecules/f-rating/src/components/_tests/helpers/setup.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/helpers/setup.js
@@ -1,0 +1,8 @@
+import tenantConfigs from '@justeat/f-rating/src/tenants';
+
+export default {
+    locale: 'en-GB',
+    messages: {
+        'en-GB': tenantConfigs['en-GB'].messages
+    }
+};

--- a/packages/components/molecules/f-rating/src/tenants/en-AU.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-AU.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'en-AU',
-    text: 'I am a VRating Component (AU)'
+    text: 'I am a VRating Component (AU)',
+    ratings: {
+        starsDescription: 'stars out of',
+        starsDescriptionSingular: 'star out of'
+    }
 };

--- a/packages/components/molecules/f-rating/src/tenants/en-AU.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-AU.js
@@ -1,6 +1,5 @@
 export default {
     locale: 'en-AU',
-    text: 'I am a VRating Component (AU)',
     ratings: {
         starsDescription: 'stars out of',
         starsDescriptionSingular: 'star out of'

--- a/packages/components/molecules/f-rating/src/tenants/en-AU.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-AU.js
@@ -1,7 +1,6 @@
 export default {
     locale: 'en-AU',
     ratings: {
-        starsDescription: 'stars out of',
-        starsDescriptionSingular: 'star out of'
+        starsDescription: '{rating} star out of {total} | {rating} stars out of {total}'
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/en-GB.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-GB.js
@@ -1,7 +1,10 @@
-export default {
+const messages = {
     locale: 'en-GB',
     ratings: {
-        starsDescription: 'stars out of',
-        starsDescriptionSingular: 'star out of'
+        starsDescription: '{rating} star out of {total} | {rating} stars out of {total}'
     }
+};
+
+export default {
+    messages
 };

--- a/packages/components/molecules/f-rating/src/tenants/en-GB.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-GB.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'en-GB',
-    text: 'I am a VRating Component (GB)'
+    text: 'I am a VRating Component (GB)',
+    ratings: {
+        starsDescription: 'stars out of',
+        starsDescriptionSingular: 'star out of'
+    }
 };

--- a/packages/components/molecules/f-rating/src/tenants/en-GB.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-GB.js
@@ -1,6 +1,5 @@
 export default {
     locale: 'en-GB',
-    text: 'I am a VRating Component (GB)',
     ratings: {
         starsDescription: 'stars out of',
         starsDescriptionSingular: 'star out of'

--- a/packages/components/molecules/f-rating/src/tenants/en-IE.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-IE.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'en-IE',
-    text: 'I am a VRating Component (IE)'
+    text: 'I am a VRating Component (IE)',
+    ratings: {
+        starsDescription: 'stars out of',
+        starsDescriptionSingular: 'star out of'
+    }
 };

--- a/packages/components/molecules/f-rating/src/tenants/en-IE.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-IE.js
@@ -1,7 +1,6 @@
 export default {
     locale: 'en-IE',
     ratings: {
-        starsDescription: 'stars out of',
-        starsDescriptionSingular: 'star out of'
+        starsDescription: '{rating} star out of {total} | {rating} stars out of {total}'
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/en-IE.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-IE.js
@@ -1,6 +1,5 @@
 export default {
     locale: 'en-IE',
-    text: 'I am a VRating Component (IE)',
     ratings: {
         starsDescription: 'stars out of',
         starsDescriptionSingular: 'star out of'

--- a/packages/components/molecules/f-rating/src/tenants/en-NZ.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-NZ.js
@@ -1,6 +1,5 @@
 export default {
     locale: 'en-NZ',
-    text: 'I am a VRating Component (NZ)',
     ratings: {
         starsDescription: 'stars out of',
         starsDescriptionSingular: 'star out of'

--- a/packages/components/molecules/f-rating/src/tenants/en-NZ.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-NZ.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'en-NZ',
-    text: 'I am a VRating Component (NZ)'
+    text: 'I am a VRating Component (NZ)',
+    ratings: {
+        starsDescription: 'stars out of',
+        starsDescriptionSingular: 'star out of'
+    }
 };

--- a/packages/components/molecules/f-rating/src/tenants/en-NZ.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-NZ.js
@@ -1,7 +1,6 @@
 export default {
     locale: 'en-NZ',
     ratings: {
-        starsDescription: 'stars out of',
-        starsDescriptionSingular: 'star out of'
+        starsDescription: '{rating} star out of {total} | {rating} stars out of {total}'
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/es-ES.js
+++ b/packages/components/molecules/f-rating/src/tenants/es-ES.js
@@ -1,7 +1,6 @@
 export default {
     locale: 'es-ES',
     ratings: {
-        starsDescription: 'stars out of',
-        starsDescriptionSingular: 'star out of'
+        starsDescription: '{rating} star out of {total} | {rating} stars out of {total}'
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/es-ES.js
+++ b/packages/components/molecules/f-rating/src/tenants/es-ES.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'es-ES',
-    text: 'I am a VRating Component (ES)'
+    text: 'I am a VRating Component (ES)',
+    ratings: {
+        starsDescription: 'stars out of',
+        starsDescriptionSingular: 'star out of'
+    }
 };

--- a/packages/components/molecules/f-rating/src/tenants/es-ES.js
+++ b/packages/components/molecules/f-rating/src/tenants/es-ES.js
@@ -1,6 +1,5 @@
 export default {
     locale: 'es-ES',
-    text: 'I am a VRating Component (ES)',
     ratings: {
         starsDescription: 'stars out of',
         starsDescriptionSingular: 'star out of'

--- a/packages/components/molecules/f-rating/src/tenants/es-ES.js
+++ b/packages/components/molecules/f-rating/src/tenants/es-ES.js
@@ -1,6 +1,6 @@
 export default {
     locale: 'es-ES',
     ratings: {
-        starsDescription: '{rating} star out of {total} | {rating} stars out of {total}'
+        starsDescription: '{rating} ADD TRANSLATION {total} | {rating} ADD TRANSLATION {total}'
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/it-IT.js
+++ b/packages/components/molecules/f-rating/src/tenants/it-IT.js
@@ -1,4 +1,8 @@
 export default {
     locale: 'it-IT',
-    text: 'I am a VRating Component (IT)'
+    text: 'I am a VRating Component (IT)',
+    ratings: {
+        starsDescription: 'stars out of',
+        starsDescriptionSingular: 'star out of'
+    }
 };

--- a/packages/components/molecules/f-rating/src/tenants/it-IT.js
+++ b/packages/components/molecules/f-rating/src/tenants/it-IT.js
@@ -1,7 +1,6 @@
 export default {
     locale: 'it-IT',
     ratings: {
-        starsDescription: 'stars out of',
-        starsDescriptionSingular: 'star out of'
+        starsDescription: '{rating} star out of {total} | {rating} stars out of {total}'
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/it-IT.js
+++ b/packages/components/molecules/f-rating/src/tenants/it-IT.js
@@ -1,6 +1,5 @@
 export default {
     locale: 'it-IT',
-    text: 'I am a VRating Component (IT)',
     ratings: {
         starsDescription: 'stars out of',
         starsDescriptionSingular: 'star out of'

--- a/packages/components/molecules/f-rating/src/tenants/it-IT.js
+++ b/packages/components/molecules/f-rating/src/tenants/it-IT.js
@@ -1,6 +1,6 @@
 export default {
     locale: 'it-IT',
     ratings: {
-        starsDescription: '{rating} star out of {total} | {rating} stars out of {total}'
+        starsDescription: '{rating} ADD TRANSLATION {total} | {rating} ADD TRANSLATION {total}'
     }
 };

--- a/packages/components/molecules/f-rating/stories/Rating.stories.js
+++ b/packages/components/molecules/f-rating/stories/Rating.stories.js
@@ -12,7 +12,9 @@ export const RatingComponent = (args, { argTypes }) => ({
 
     props: Object.keys(argTypes),
 
-    template: '<rating v-bind="$props" />'
+    template: `<rating
+                  v-bind="$props"
+                  :starRating="2" />`
 });
 
 RatingComponent.storyName = 'f-rating';

--- a/packages/components/molecules/f-rating/test/visual/f-rating.visual.spec.js
+++ b/packages/components/molecules/f-rating/test/visual/f-rating.visual.spec.js
@@ -1,8 +1,7 @@
 import Rating from '../../test-utils/component-objects/f-rating.component';
 
 const devices = [
-    'desktop',
-    'mobile'
+    'desktop'
 ];
 
 devices.forEach(device => {
@@ -14,12 +13,16 @@ devices.forEach(device => {
             }
         });
 
-        it('should display the f-rating component', async () => {
-            // Act
-            await Rating.load();
+        describe('Visually displayed', () => {
+            it('should display the f-rating component', async () => {
+                // Act
+                await Rating.load();
 
-            // Assert
-            await browser.percyScreenshot('f-rating - Visual Test', device);
+                // Assert
+                await browser.percyScreenshot('f-rating - Visual Test', device);
+            });
         });
+
+        // Add visual tests for demo variants - Ticket to be added.
     });
 });


### PR DESCRIPTION
### Added
- Test coverage for code changes.
- `pie-icons-vue` repo as `dep` to pull in the star icons.
- Stories component added.
- Prop `starRating` added to allow the consumer to pass in a value.
- Readme prop table.
- Snapshot test.

### Screenshot
![Screenshot 2022-10-13 at 13 54 42](https://user-images.githubusercontent.com/2299779/195601837-e5508bb8-1384-49f2-910b-e77a5f15e20a.png)
