### PR TITLE
f-rating@0.3.0 - Move icon to devDep. #trivial

### DIFF
--- a/packages/components/molecules/f-rating/CHANGELOG.md
+++ b/packages/components/molecules/f-rating/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.3.0
+------------------------------
+*October 17, 2022*
+
+### Changed
+- `@justeattakeaway/pie-icons-vue` to live as DevDep for now.
+
+
 v0.2.0
 ------------------------------
 *October 13, 2022*

--- a/packages/components/molecules/f-rating/package.json
+++ b/packages/components/molecules/f-rating/package.json
@@ -45,14 +45,14 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.x",
-    "@justeattakeaway/pie-icons-vue": "2.0.0-beta.0"
+    "@justeat/f-services": "1.x"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0",
     "@justeat/f-globalisation": "1.x"
   },
   "devDependencies": {
+    "@justeattakeaway/pie-icons-vue": "1.x",
     "@justeat/f-wdio-utils": "1.x",
     "@vue/cli-plugin-babel": "4.5.15",
     "@vue/cli-plugin-unit-jest": "4.5.15",

--- a/packages/components/molecules/f-rating/package.json
+++ b/packages/components/molecules/f-rating/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-rating",
   "description": "Fozzie Rating - Global Rating component",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/f-rating.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [


### PR DESCRIPTION
### Changed
- `@justeattakeaway/pie-icons-vue` to live as DevDep for now.
