### PR TITLE
f-rating@0.4.0 - Refactor component to allow fractional stars.

### DIFF
--- a/packages/components/molecules/f-rating/CHANGELOG.md
+++ b/packages/components/molecules/f-rating/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.4.0
+------------------------------
+*October 19, 2022*
+
+### Added
+- Test coverage for code changes.
+- `starRatingSize` to allow component sizing.
+- Prop validation.
+
+### Changed
+- Refactored markup to allow fractional rating sizes.
+
 v0.2.0
 ------------------------------
 *October 13, 2022*

--- a/packages/components/molecules/f-rating/README.md
+++ b/packages/components/molecules/f-rating/README.md
@@ -73,6 +73,7 @@ The props that can be defined are as follows (if any):
 | :---          |:--------:|:--------:|:-------:|:-----------------------------------------------------------------------------------------------------------------------|
 | `starRating`  | `Number` |   Yes    |    -    | Sets the displayed rating (filled stars). i.e. for `2 out of x`, 2 would be the `starRating`                           |
 | `maxStarRating`  | `Number` |    No    |    5    | Sets the maximum number of stars that the rating is set against. i.e. for `x out of 5`, 5 would be the `maxStarRating` |
+| `starRatingSize`  | `String` |    No    | 'small' | Sets the component size. By default the component will use `small` the other options are `medium` & `large`            |
 
 ### Events
 

--- a/packages/components/molecules/f-rating/package.json
+++ b/packages/components/molecules/f-rating/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-rating",
   "description": "Fozzie Rating - Global Rating component",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "main": "dist/f-rating.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "@justeat/f-services": "1.x",
-    "@justeattakeaway/pie-icons-vue": "2.0.0-beta.0"
+    "@justeattakeaway/pie-icons-vue": "1.0.0"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0",

--- a/packages/components/molecules/f-rating/src/components/Rating.vue
+++ b/packages/components/molecules/f-rating/src/components/Rating.vue
@@ -18,10 +18,11 @@
                     $style['c-rating-mask'],
                     $style['c-rating-container']
                 ]"
-                :style="getRatingStarPercentage">
+                :style="`--starRatingPercentage: ${getRatingStarPercentage}`">
                 <star-filled-icon
                     v-for="star in maxStarRating"
                     :key="star"
+                    :style="`--starRatingSize: c-rating-star--${starRatingSize}`"
                     :class="[
                         $style['c-rating-star-filled'],
                         $style[`c-rating-star--${starRatingSize}`]
@@ -72,7 +73,7 @@ export default {
         starRatingSize: {
             type: String,
             default: 'small',
-            validator: value => VALID_STAR_RATING_SIZES.includes(value)
+            validator: value => !!VALID_STAR_RATING_SIZES[value]
         }
     },
 
@@ -108,9 +109,7 @@ export default {
          * @returns {string}
          */
         getRatingStarPercentage () {
-            const percentage = (this.starRating / this.maxStarRating) * 100;
-
-            return `width: ${percentage}%`;
+            return `${(this.starRating / this.maxStarRating) * 100}%`;
         }
     }
 };
@@ -160,6 +159,7 @@ export default {
         top: 0;
         left: 0;
         overflow: hidden;
+        width: var(--starRatingPercentage);
 
         svg {
             flex-shrink: 0;

--- a/packages/components/molecules/f-rating/src/components/Rating.vue
+++ b/packages/components/molecules/f-rating/src/components/Rating.vue
@@ -2,25 +2,38 @@
     <div
         :class="$style['c-rating']"
         data-test-id="rating-component">
-        <ul
-            :class="$style['c-rating-starWrapper']">
-            <li
-                v-for="star in maxStarRating"
-                :key="star"
-                :class="$style['c-rating-star']">
-                <star-filled-icon
-                    v-if="isRatingStarFilled(star)"
-                    :class="$style['c-rating-star-filled']" />
+        <div :class="$style['c-rating-starWrapper']">
+            <div :class="$style['c-rating-container']">
                 <star-icon
-                    v-else
-                    :class="$style['c-rating-star-empty']" />
-            </li>
-        </ul>
-        <span
-            data-test-id="c-rating-description"
-            class="is-visuallyHidden">
-            {{ getRatingDescription }}
-        </span>
+                    v-for="star in maxStarRating"
+                    :key="star"
+                    :class="[
+                        $style['c-rating-star-empty'],
+                        $style[`c-rating-star--${starRatingSize}`]
+                    ]" />
+            </div>
+
+            <div
+                :class="[
+                    $style['c-rating-mask'],
+                    $style['c-rating-container']
+                ]"
+                :style="getRatingStarPercentage">
+                <star-filled-icon
+                    v-for="star in maxStarRating"
+                    :key="star"
+                    :class="[
+                        $style['c-rating-star-filled'],
+                        $style[`c-rating-star--${starRatingSize}`]
+                    ]" />
+            </div>
+
+            <span
+                data-test-id="c-rating-description"
+                class="is-visuallyHidden">
+                {{ getRatingDescription }}
+            </span>
+        </div>
     </div>
 </template>
 
@@ -31,6 +44,7 @@ import {
 } from '@justeattakeaway/pie-icons-vue';
 import { VueGlobalisationMixin } from '@justeat/f-globalisation';
 import tenantConfigs from '../tenants';
+import { VALID_STAR_RATING_SIZES } from '../constants';
 
 export default {
     name: 'VRating',
@@ -48,11 +62,17 @@ export default {
         },
         starRating: {
             type: Number,
-            required: true
+            required: true,
+            validator: value => value >= 0 && value <= 5
         },
         maxStarRating: {
             type: Number,
             default: 5
+        },
+        starRatingSize: {
+            type: String,
+            default: 'small',
+            validator: value => VALID_STAR_RATING_SIZES.includes(value)
         }
     },
 
@@ -80,18 +100,17 @@ export default {
                     rating: this.starRating,
                     total: this.maxStarRating
                 });
-        }
-    },
+        },
 
-    methods: {
         /**
-         * Check `star` against value passed by consumer to allow empty stars to render.
+         * Calculate a percentage from the `starRating` value passed in by the consuming application.
          *
-         * @param star {Number}
-         * @returns {boolean}
+         * @returns {string}
          */
-        isRatingStarFilled (star) {
-            return star <= this.starRating;
+        getRatingStarPercentage () {
+            const percentage = (this.starRating / this.maxStarRating) * 100;
+
+            return `width: ${percentage}%`;
         }
     }
 };
@@ -103,12 +122,25 @@ export default {
 .c-rating-starWrapper {
     margin: 0;
     padding: 0;
-    list-style-type: none;
+    position: relative;
+    display: inline-block;
 }
+    .c-rating-container {
+        display: flex;
+    }
 
     .c-rating-star {
-        display: inline-block;
-        width: 15px; // Todo - decide on how to size these. Will create a ticket around this.
+        &--small {
+            width: 12px;
+        }
+
+        &--medium {
+            width: 16px;
+        }
+
+        &--large {
+            width: 28px;
+        }
     }
 
     .c-rating-star-filled {
@@ -120,6 +152,17 @@ export default {
     .c-rating-star-empty {
         & path {
             fill: f.$color-mozzarella-50;
+        }
+    }
+
+    .c-rating-mask {
+        position: absolute;
+        top: 0;
+        left: 0;
+        overflow: hidden;
+
+        svg {
+            flex-shrink: 0;
         }
     }
 </style>

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -150,7 +150,7 @@ describe('Rating', () => {
                 expect(validator(rating)).toBe(true);
             });
 
-            it('should NOT only allow values outside `0 or 5`', () => {
+            it('should NOT only allow values outside `0 - 5`', () => {
                 // Arrange
                 const { validator } = VRating.props.starRating;
 

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -2,7 +2,6 @@ import { createLocalVue, shallowMount } from '@vue/test-utils';
 import { VueI18n } from '@justeat/f-globalisation';
 import VRating from '../Rating.vue';
 import i18n from './helpers/setup';
-import { VALID_STAR_RATING_SIZES } from '../../constants';
 
 const localVue = createLocalVue();
 localVue.use(VueI18n);
@@ -59,7 +58,7 @@ describe('Rating', () => {
                     });
 
                     // Act & Assert
-                    expect(wrapper.vm.getRatingStarPercentage).toBe('width: 40%');
+                    expect(wrapper.vm.getRatingStarPercentage).toBe('40%');
                 });
             });
         });
@@ -119,12 +118,12 @@ describe('Rating', () => {
                 expect(VRating.props.starRatingSize.default).toBe('small');
             });
 
-            it.each(VALID_STAR_RATING_SIZES)('should allow valid type prop of `%s`', type => {
+            it('should return a true when type prop of exists', () => {
                 // Act
                 const { validator } = VRating.props.starRatingSize;
 
                 // Arrange
-                expect(validator(type)).toBe(true);
+                expect(validator('small')).toBe(true);
             });
 
             it('should NOT allow invalid props', () => {

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -2,6 +2,7 @@ import { createLocalVue, shallowMount } from '@vue/test-utils';
 import { VueI18n } from '@justeat/f-globalisation';
 import VRating from '../Rating.vue';
 import i18n from './helpers/setup';
+import { VALID_STAR_RATING_SIZES } from '../../constants';
 
 const localVue = createLocalVue();
 localVue.use(VueI18n);
@@ -30,74 +31,39 @@ describe('Rating', () => {
         expect(wrapper.exists()).toBe(true);
     });
 
-    describe('methods', () => {
-        describe('`isRatingStarFilled`', () => {
+    describe('computed', () => {
+        describe('`getRatingStarPercentage`', () => {
             it('should exist', () => {
-                expect(wrapper.vm.isRatingStarFilled).toBeDefined();
-            });
+                // Arrange
+                propsData.starRating = 2;
+                wrapper = shallowMount(VRating, {
+                    propsData,
+                    localVue,
+                    i18n
+                });
 
-            it('should contain a description `c-rating-description`', () => {
-                // Act
-                const result = wrapper.find('[data-test-id="c-rating-description"]');
-
-                // Assert
-                expect(result).toMatchSnapshot();
+                // Act & Assert
+                expect(wrapper.vm.getRatingStarPercentage).toBeDefined();
             });
 
             describe('when invoked', () => {
-                it('should return truthy when the argument `star` is less than or equal to `starRating`', () => {
-                    // Act
-                    const star = 1;
-                    const result = wrapper.vm.isRatingStarFilled(star);
-
-                    // Assert
-                    expect(result).toBe(true);
-                });
-
-                it.each([1, 2])('should return truthy when the argument star is %s', value => {
+                it('should return a percentage from a combination of `starRating` and `maxStarRating`', () => {
                     // Arrange
                     propsData = {
-                        starRating: value,
-                        maxStarRating: 5
+                        starRating: 2
                     };
-
-                    // Act
                     wrapper = shallowMount(VRating, {
                         propsData,
                         localVue,
-                        i18n,
-                        mocks: {
-                            $tc
-                        }
+                        i18n
                     });
-                    const result = wrapper.vm.isRatingStarFilled(value);
 
-                    // Assert
-                    expect(result).toBe(true);
-                });
-
-                it('should return truthy when the argument `star` is equal to `starRating`', () => {
-                    // Act
-                    const star = 2;
-                    const result = wrapper.vm.isRatingStarFilled(star);
-
-                    // Assert
-                    expect(result).toBe(true);
-                });
-
-                it('should return falsey when argument `star` is greater than `starRating`', () => {
-                    // Act
-                    const star = 3;
-                    const result = wrapper.vm.isRatingStarFilled(star);
-
-                    // Assert
-                    expect(result).toBe(false);
+                    // Act & Assert
+                    expect(wrapper.vm.getRatingStarPercentage).toBe('width: 40%');
                 });
             });
         });
-    });
 
-    describe('computed', () => {
         describe('`getRatingDescription`', () => {
             it('should exist', () => {
                 // Arrange
@@ -142,6 +108,54 @@ describe('Rating', () => {
                     // Act & Assert
                     expect(wrapper.vm.getRatingDescription).toMatchSnapshot();
                 });
+            });
+        });
+    });
+
+    describe('props', () => {
+        describe('`starRatingSize`', () => {
+            it('should set a default value of `small`', () => {
+                // Act & Assert
+                expect(VRating.props.starRatingSize.default).toBe('small');
+            });
+
+            it.each(VALID_STAR_RATING_SIZES)('should allow valid type prop of `%s`', type => {
+                // Act
+                const { validator } = VRating.props.starRatingSize;
+
+                // Arrange
+                expect(validator(type)).toBe(true);
+            });
+
+            it('should NOT allow invalid props', () => {
+                // Arrange
+                const { validator } = VRating.props.starRatingSize;
+
+                // Act & Assert
+                expect(validator('supernova')).toBe(false);
+            });
+        });
+
+        describe('`starRating`', () => {
+            it('should be required', () => {
+                // Act & Assert
+                expect(VRating.props.starRating.required).toBe(true);
+            });
+
+            it.each([0, 1, 2, 3, 4, 5])('should allow value `%s`', rating => {
+                // Act
+                const { validator } = VRating.props.starRating;
+
+                // Arrange
+                expect(validator(rating)).toBe(true);
+            });
+
+            it('should NOT only allow values outside `0 or 5`', () => {
+                // Arrange
+                const { validator } = VRating.props.starRating;
+
+                // Act & Assert
+                expect(validator(6)).toBe(false);
             });
         });
     });

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -146,7 +146,7 @@ describe('Rating', () => {
                 // Act
                 const { validator } = VRating.props.starRating;
 
-                // Arrange
+                // Assert
                 expect(validator(rating)).toBe(true);
             });
 

--- a/packages/components/molecules/f-rating/src/components/_tests/__snapshots__/Rating.test.js.snap
+++ b/packages/components/molecules/f-rating/src/components/_tests/__snapshots__/Rating.test.js.snap
@@ -3,9 +3,3 @@
 exports[`Rating computed \`getRatingDescription\` when invoked should return a plural description if the rating is greater than 1 1`] = `"2 stars out of 5"`;
 
 exports[`Rating computed \`getRatingDescription\` when invoked should return a singular description if the rating is less than 2 1`] = `"1 star out of 5"`;
-
-exports[`Rating methods \`isRatingStarFilled\` should contain a description \`c-rating-description\` 1`] = `
-<span data-test-id="c-rating-description" class="is-visuallyHidden">
-
-    </span>
-`;

--- a/packages/components/molecules/f-rating/src/constants.js
+++ b/packages/components/molecules/f-rating/src/constants.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const VALID_STAR_RATING_SIZES = ['small', 'medium', 'large'];

--- a/packages/components/molecules/f-rating/src/constants.js
+++ b/packages/components/molecules/f-rating/src/constants.js
@@ -1,2 +1,6 @@
 // eslint-disable-next-line import/prefer-default-export
-export const VALID_STAR_RATING_SIZES = ['small', 'medium', 'large'];
+export const VALID_STAR_RATING_SIZES = {
+    small: true,
+    medium: true,
+    large: true
+};

--- a/packages/components/molecules/f-rating/src/tests/constants.test.js
+++ b/packages/components/molecules/f-rating/src/tests/constants.test.js
@@ -4,13 +4,14 @@ describe('`constants`', () => {
     describe('VALID_STAR_RATING_SIZES', () => {
         it('should contain the correct sizes', () => {
             // Arrange
-            const values = ['small', 'medium', 'large'];
+            const values = {
+                small: true,
+                medium: true,
+                large: true
+            };
 
-            // Act
-            const result = VALID_STAR_RATING_SIZES.every(value => values.includes(value));
-
-            // Assert
-            expect(result).toBe(true);
+            // Act & Assert
+            expect(VALID_STAR_RATING_SIZES).toEqual(values);
         });
     });
 });

--- a/packages/components/molecules/f-rating/src/tests/constants.test.js
+++ b/packages/components/molecules/f-rating/src/tests/constants.test.js
@@ -1,0 +1,16 @@
+import { VALID_STAR_RATING_SIZES } from '../constants';
+
+describe('`constants`', () => {
+    describe(`${VALID_STAR_RATING_SIZES}`, () => {
+        it('should contain the correct sizes', () => {
+            // Arrange
+            const values = ['small', 'medium', 'large'];
+
+            // Act
+            const result = VALID_STAR_RATING_SIZES.every(value => values.includes(value));
+
+            // Assert
+            expect(result).toBe(true);
+        });
+    });
+});

--- a/packages/components/molecules/f-rating/src/tests/constants.test.js
+++ b/packages/components/molecules/f-rating/src/tests/constants.test.js
@@ -1,7 +1,7 @@
 import { VALID_STAR_RATING_SIZES } from '../constants';
 
 describe('`constants`', () => {
-    describe(`${VALID_STAR_RATING_SIZES}`, () => {
+    describe('VALID_STAR_RATING_SIZES', () => {
         it('should contain the correct sizes', () => {
             // Arrange
             const values = ['small', 'medium', 'large'];

--- a/packages/components/molecules/f-rating/stories/Rating.stories.js
+++ b/packages/components/molecules/f-rating/stories/Rating.stories.js
@@ -14,7 +14,8 @@ export const RatingComponent = (args, { argTypes }) => ({
 
     template: `<rating
                   v-bind="$props"
-                  :starRating="2" />`
+                  :starRatingSize="'medium'"
+                  :starRating="2.5" />`
 });
 
 RatingComponent.storyName = 'f-rating';


### PR DESCRIPTION
### Added
- Test coverage for code changes.
- `starRatingSize` to allow component sizing.
- Prop validation.

### Changed
- Refactored markup to allow fractional rating sizes.


## Firefox
 #### 5 stars out of 5
![Screenshot 2022-10-19 at 09 20 34](https://user-images.githubusercontent.com/2299779/196648331-45b88fe9-eacb-49a9-9b9a-a674c34e58c6.png)

#### 2.3 stars out of 5
<img width="1073" alt="Screenshot 2022-10-19 at 10 13 12" src="https://user-images.githubusercontent.com/2299779/196650041-0ca81232-9fbd-4d81-a7cb-a2def1bad138.png">

#### 2.5 stars out of 5

![Screenshot 2022-10-19 at 09 14 39](https://user-images.githubusercontent.com/2299779/196650206-2c5cabf0-2cb0-4a28-b291-0bef382921ce.png)


## Safari
#### 5 stars out of 5
<img width="1010" alt="Screenshot 2022-10-19 at 09 19 57" src="https://user-images.githubusercontent.com/2299779/196648433-821bcf4e-3a6c-4c07-9452-03c7ad047619.png">


#### 2.3 stars out of 5
<img width="1108" alt="Screenshot 2022-10-19 at 10 12 13" src="https://user-images.githubusercontent.com/2299779/196649243-358670f6-7876-48df-96a4-713f4fd0b89c.png">

#### 3 stars out of 5
<img width="1281" alt="Screenshot 2022-10-19 at 09 17 48" src="https://user-images.githubusercontent.com/2299779/196650634-01bf2189-ce1d-4a24-840d-9d529f9b03bd.png">


## Chrome
#### 5 stars out of 5
<img width="984" alt="Screenshot 2022-10-19 at 10 10 41" src="https://user-images.githubusercontent.com/2299779/196648932-63c487f4-9aed-45a4-aafa-430fdba2f2c9.png">

#### 2.3 stars out of 5
<img width="989" alt="Screenshot 2022-10-19 at 10 11 04" src="https://user-images.githubusercontent.com/2299779/196648952-1f521129-f234-496d-8e2e-0f29d17879aa.png">

## Edge
#### 2.3 stars out of 5
![Screenshot 2022-10-19 at 10 19 42](https://user-images.githubusercontent.com/2299779/196651537-9484a2e8-8514-4797-8c47-9fb070e5bae1.png)

#### 2.5 stars out of 5
![Screenshot 2022-10-19 at 10 20 42](https://user-images.githubusercontent.com/2299779/196651593-2ad09954-d81d-49d4-a711-a547c416c64c.png)

#### 5 stars out of 5
![Screenshot 2022-10-19 at 10 21 04](https://user-images.githubusercontent.com/2299779/196651636-c8e0f93d-be22-41c8-af58-1274dccd929e.png)

## Sizing:

### Default (small)
<img width="789" alt="Screenshot 2022-10-19 at 10 22 30" src="https://user-images.githubusercontent.com/2299779/196651885-6041309e-902e-4286-903f-30fa6260c7b7.png">

### Medium
<img width="806" alt="Screenshot 2022-10-19 at 10 22 02" src="https://user-images.githubusercontent.com/2299779/196651827-b77f70f6-795a-4c18-a8c9-f771eb1b4960.png">

### Large

<img width="798" alt="Screenshot 2022-10-19 at 10 23 07" src="https://user-images.githubusercontent.com/2299779/196652058-405c65fb-4ef7-4130-bad7-f435dd7b02db.png">



