### PR TITLE
f-checkout@4.7.0 - Add retrieve address from cookie logic

### DIFF
--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.7.0
+------------------------------
+*October 24, 2022*
+
+### Added
+- Get address from cookies logic
+- Get geolocation from cookies logic
+- Suburb field for address format in New Zealand
+- New prop `shouldLoadAddressFromLocalStorage`
+
+### Removed
+-  Get address from local storage logic in the handler of UPDATE_STATE mutation
 
 v4.6.1
 ------------------------------

--- a/packages/components/pages/f-checkout/README.md
+++ b/packages/components/pages/f-checkout/README.md
@@ -70,23 +70,24 @@
 
 The props that can be defined are as follows:
 
-| Prop  | Type  | Default | Description |
-| ----- | ----- | ------- | ----------- |
-| `updateCheckoutUrl` | `String` | - | URL for the API called to update the Checkout Data |
-| `getCheckoutUrl` | `String` | - | URL for the API called to load the Checkout Data.<br><br>The data returned from this API contains the serviceType, which determines if the Checkout component is created for Collection or Delivery when the user is authenticated. |
-| `checkoutAvailableFulfilmentUrl` | `String` | - | URL for the API called to load the Available Fulfilment data. |
-| `createGuestUrl` | `String` | - | URL for the API called to load the Create a Guest User. |
-| `getBasketUrl` | `String` | - | URL for the API called to get Basket Details.<br><br>The data returned from this API contains the serviceType, which determines if the Checkout component is created for Collection or Delivery when the user is not authenticated. |
-| `placeOrderUrl` | `String` | - | URL for the API called to place the order.<br><br>The data returned from this API contains the orderId, which is needed to redirect the user to the payment page. |
-| `getGeoLocationUrl` | `String` | - | URL for the API that can return geo location information (Latitude and Longitude) for a given address.<br>The `tenant` must be provided as the last segment of the URL and all calls must be authenticated. |
-| `checkoutTimeout` | `Number` | 10000 | Timeout for the different API calls in the component. |
-| `authToken` | `String` | `''` | Authorisation token used when submitting the checkout form. |
-| `otacToAuthExchanger` | `Function` | `throw new Error('otacToAuthExchanger is not implemented');` | Function to exchange OTAC to JWT auth token |
-| `loginUrl` | `String` | `-` | URL to navigate to if the user wishes to change account. |
-| `paymentPageUrlPrefix` | `String` | `-` | URL prefix to navigate to after the order has been successfully placed, so the user can pay. The `orderId` will be appended to this URL to form the full URL. |
-| `applicationName` | `String` | `-` | The name of the application using this component. |
-| `getNoteConfigUrl` | `String` | - | URL for the API called to get the note configuration for split notes |
-| `checkoutFeatures` | `Object` | - | Object containing relevant feature flags |
+| Prop  | Type       | Default                                                      | Description                                                                                                                                                                                                                         |
+| ----- |------------|--------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `updateCheckoutUrl` | `String`   | -                                                            | URL for the API called to update the Checkout Data                                                                                                                                                                                  |
+| `getCheckoutUrl` | `String`   | -                                                            | URL for the API called to load the Checkout Data.<br><br>The data returned from this API contains the serviceType, which determines if the Checkout component is created for Collection or Delivery when the user is authenticated. |
+| `checkoutAvailableFulfilmentUrl` | `String`   | -                                                            | URL for the API called to load the Available Fulfilment data.                                                                                                                                                                       |
+| `createGuestUrl` | `String`   | -                                                            | URL for the API called to load the Create a Guest User.                                                                                                                                                                             |
+| `getBasketUrl` | `String`   | -                                                            | URL for the API called to get Basket Details.<br><br>The data returned from this API contains the serviceType, which determines if the Checkout component is created for Collection or Delivery when the user is not authenticated. |
+| `placeOrderUrl` | `String`   | -                                                            | URL for the API called to place the order.<br><br>The data returned from this API contains the orderId, which is needed to redirect the user to the payment page.                                                                   |
+| `getGeoLocationUrl` | `String`   | -                                                            | URL for the API that can return geo location information (Latitude and Longitude) for a given address.<br>The `tenant` must be provided as the last segment of the URL and all calls must be authenticated.                         |
+| `checkoutTimeout` | `Number`   | 10000                                                        | Timeout for the different API calls in the component.                                                                                                                                                                               |
+| `authToken` | `String`   | `''`                                                         | Authorisation token used when submitting the checkout form.                                                                                                                                                                         |
+| `otacToAuthExchanger` | `Function` | `throw new Error('otacToAuthExchanger is not implemented');` | Function to exchange OTAC to JWT auth token                                                                                                                                                                                         |
+| `loginUrl` | `String`   | `-`                                                          | URL to navigate to if the user wishes to change account.                                                                                                                                                                            |
+| `paymentPageUrlPrefix` | `String`   | `-`                                                          | URL prefix to navigate to after the order has been successfully placed, so the user can pay. The `orderId` will be appended to this URL to form the full URL.                                                                       |
+| `applicationName` | `String`   | `-`                                                          | The name of the application using this component.                                                                                                                                                                                   |
+| `getNoteConfigUrl` | `String`   | -                                                            | URL for the API called to get the note configuration for split notes                                                                                                                                                                |
+| `checkoutFeatures` | `Object`   | -                                                            | Object containing relevant feature flags                                                                                                                                                                                            |
+| `shouldLoadAddressFromLocalStorage` | `Boolean`  | true                                                            | Flag to control where to retrieve the address from storage (local storage/cookies)                                                                                                                                                  |
 
 ### Events
 

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout - Fozzie Checkout Component",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "140kB",
   "files": [

--- a/packages/components/pages/f-checkout/src/components/Checkout.vue
+++ b/packages/components/pages/f-checkout/src/components/Checkout.vue
@@ -208,6 +208,11 @@ export default {
         checkoutFeatures: {
             type: Object,
             default: () => ({})
+        },
+
+        shouldLoadAddressFromLocalStorage: {
+            type: Boolean,
+            default: true
         }
     },
 
@@ -273,7 +278,7 @@ export default {
                 (!this.address || !this.address.line1);
         },
 
-        /* If phone number is missing both from chckout api and from
+        /* If phone number is missing both from checkout api and from
         * `state.AuthToken`, then retrieve the phone number from customer api
         * This can happen for newly created guest */
         shouldLoadCustomer () {
@@ -429,8 +434,8 @@ export default {
             this.isLoading = true;
 
             const promises = this.isLoggedIn
-                ? [this.loadBasket(), this.loadCheckout(), this.loadAvailableFulfilment()]
-                : [this.loadBasket(), this.loadAddressFromLocalStorage(), this.loadAvailableFulfilment()];
+                ? [this.loadBasket(), this.loadAddressFromStorage(), this.loadCheckout(), this.loadAvailableFulfilment()]
+                : [this.loadBasket(), this.loadAddressFromStorage(), this.loadAvailableFulfilment()];
 
             await Promise.all(promises);
 
@@ -449,11 +454,11 @@ export default {
         },
 
         /**
-         * Update address lines if localStorage is populated.
+         * Update address lines if it is saved in storage.
          *
          * */
-        loadAddressFromLocalStorage () {
-            const address = addressService.getAddressFromLocalStorage(this.tenant);
+        loadAddressFromStorage () {
+            const address = addressService.getAddressFromStorage(this.tenant, this.$cookies, this.shouldLoadAddressFromLocalStorage);
 
             if (address) {
                 this.updateAddress(address);
@@ -773,7 +778,9 @@ export default {
                             url: this.getGeoLocationUrl,
                             postData: locationData,
                             timeout: this.checkoutTimeout,
-                            tenant: this.tenant
+                            tenant: this.tenant,
+                            cookies: this.$cookies,
+                            shouldLoadAddressFromLocalStorage: this.shouldLoadAddressFromLocalStorage
                         });
                     }
                 } catch (error) {

--- a/packages/components/pages/f-checkout/src/components/CheckoutFormField.vue
+++ b/packages/components/pages/f-checkout/src/components/CheckoutFormField.vue
@@ -71,7 +71,7 @@ export default {
 
         isGrouped: {
             type: Boolean,
-            defalut: false
+            default: false
         }
     },
 

--- a/packages/components/pages/f-checkout/src/services/addressService/tenants/nz.js
+++ b/packages/components/pages/f-checkout/src/services/addressService/tenants/nz.js
@@ -6,6 +6,7 @@ function getEmptyAddress (postcode) {
     return {
         line1: '',
         line2: '',
+        line3: '',
         locality: '',
         postcode: postcode || ''
     };
@@ -15,6 +16,7 @@ function formatAddress (address) {
     return {
         line1: address.line1 || '',
         line2: address.line2 || '',
+        line3: address.line3 || '',
         locality: address.City || address.locality || '',
         postcode: address.postcode || address.PostalCode || address.ZipCode || address.postalCode || ''
     };

--- a/packages/components/pages/f-checkout/src/store/tests/__snapshots__/checkout.module.test.js.snap
+++ b/packages/components/pages/f-checkout/src/store/tests/__snapshots__/checkout.module.test.js.snap
@@ -1,17 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CheckoutModule mutations :: UPDATE_STATE :: should update address with stored address if it exists 1`] = `
-Object {
-  "administrativeArea": undefined,
-  "line1": "Flat 101",
-  "line2": "Windsor House",
-  "line3": null,
-  "line4": undefined,
-  "locality": "London",
-  "postcode": "NW1 4DE",
-}
-`;
-
 exports[`CheckoutModule mutations :: UPDATE_STATE :: should update state with delivery response. 1`] = `
 Object {
   "address": Object {

--- a/packages/components/pages/f-checkout/src/tenants/en-NZ.js
+++ b/packages/components/pages/f-checkout/src/tenants/en-NZ.js
@@ -57,6 +57,9 @@ const messages = {
                 label: 'Level or unit number (Optional)',
                 isGrouped: true
             },
+            line3: {
+                label: 'Suburb'
+            },
             locality: {
                 label: 'Town or city',
                 validationMessages: {

--- a/packages/components/pages/f-checkout/stories/helpers/addresses/nz.js
+++ b/packages/components/pages/f-checkout/stories/helpers/addresses/nz.js
@@ -15,7 +15,7 @@ const additionalAddress = {
     ZipCode: '8042',
     Line1: '42 Tintern Avenue',
     Line2: 'Flat 1',
-    Line3: 'null',
+    Line3: null,
     Line4: 'Riccarton',
     AddressId: 18086210
 };


### PR DESCRIPTION
v4.7.0
------------------------------
*October 24, 2022*

### Added
- Get address from cookies logic for international tenants
- Suburb field for address format in New Zealand

### Removed
-  Get address from local storage logic in the handler of UPDATE_STATE mutation