### PR TITLE
f-rating@0.5.0 - Add description to rating component & tests.

### DIFF
--- a/packages/components/molecules/f-rating/CHANGELOG.md
+++ b/packages/components/molecules/f-rating/CHANGELOG.md
@@ -3,6 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.5.0
+------------------------------
+*October 24, 2022*
+
+### Added
+- Test coverage for code changes.
+- Visual tests.
+- Prop validation.
+- Props `ratingDisplayType` & `totalReviews`.
+- Storybook contains ratings in different sizes & formats.
+
+### Changed
+- Class names to be more suitable.
+
+
 v0.4.0
 ------------------------------
 *October 19, 2022*

--- a/packages/components/molecules/f-rating/CHANGELOG.md
+++ b/packages/components/molecules/f-rating/CHANGELOG.md
@@ -11,7 +11,7 @@ v0.5.0
 - Test coverage for code changes.
 - Visual tests.
 - Prop validation.
-- Props `ratingDisplayType` & `totalReviews`.
+- Props `ratingDisplayType` & `reviewCount`.
 - Storybook contains ratings in different sizes & formats.
 
 ### Changed

--- a/packages/components/molecules/f-rating/README.md
+++ b/packages/components/molecules/f-rating/README.md
@@ -75,7 +75,7 @@ The props that can be defined are as follows (if any):
 | `maxStarRating`  | `Number` |    No    |    5    | Sets the maximum number of stars that the rating is set against. i.e. for `x out of 5`, 5 would be the `maxStarRating` | -
 | `starRatingSize`  | `String` |    No    | 'small' | Sets the component size. By default the component will use `small`.                                                    | `small` `medium` `large`
 | `ratingDisplayType`  | `String` |    No    |  null   | Sets the descriptive text which will be displayed next to the component. By default there will be no text.             | `noRating` `short` `medium` `long`
-| `totalReviews`  | `Number` |    No    |  null   | Sets the total number of reviews to display. Example: `View 499 reviews` where `499` is the total.                     | -
+| `reviewCount`  | `Number` |    No    |  null   | Sets the total number of reviews to display. Example: `View 499 reviews` where `499` is the total.                     | -
 
 ### Events
 

--- a/packages/components/molecules/f-rating/README.md
+++ b/packages/components/molecules/f-rating/README.md
@@ -69,11 +69,13 @@ There may be props that allow you to customise its functionality.
 
 The props that can be defined are as follows (if any):
 
-| Prop          |   Type   | Required | Default | Description                                                                                                            |
-| :---          |:--------:|:--------:|:-------:|:-----------------------------------------------------------------------------------------------------------------------|
-| `starRating`  | `Number` |   Yes    |    -    | Sets the displayed rating (filled stars). i.e. for `2 out of x`, 2 would be the `starRating`                           |
-| `maxStarRating`  | `Number` |    No    |    5    | Sets the maximum number of stars that the rating is set against. i.e. for `x out of 5`, 5 would be the `maxStarRating` |
-| `starRatingSize`  | `String` |    No    | 'small' | Sets the component size. By default the component will use `small` the other options are `medium` & `large`            |
+| Prop          |   Type   | Required | Default | Description                                                                                                            | Options |
+| :---          |:--------:|:--------:|:-------:|:-----------------------------------------------------------------------------------------------------------------------|---------|
+| `starRating`  | `Number` |   Yes    |    -    | Sets the displayed rating (filled stars). i.e. for `2 out of x`, 2 would be the `starRating`                           | -
+| `maxStarRating`  | `Number` |    No    |    5    | Sets the maximum number of stars that the rating is set against. i.e. for `x out of 5`, 5 would be the `maxStarRating` | -
+| `starRatingSize`  | `String` |    No    | 'small' | Sets the component size. By default the component will use `small`.                                                    | `small` `medium` `large`
+| `ratingDisplayType`  | `String` |    No    |  null   | Sets the descriptive text which will be displayed next to the component. By default there will be no text.             | `noRating` `short` `medium` `long`
+| `totalReviews`  | `Number` |    No    |  null   | Sets the total number of reviews to display. Example: `View 499 reviews` where `499` is the total.                     | -
 
 ### Events
 

--- a/packages/components/molecules/f-rating/package.json
+++ b/packages/components/molecules/f-rating/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-rating",
   "description": "Fozzie Rating - Global Rating component",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/f-rating.umd.min.js",
   "maxBundleSize": "20kB",
   "files": [

--- a/packages/components/molecules/f-rating/src/components/Rating.vue
+++ b/packages/components/molecules/f-rating/src/components/Rating.vue
@@ -23,7 +23,6 @@
                 <star-filled-icon
                     v-for="star in maxStarRating"
                     :key="star"
-                    :style="`--starRatingSize: c-rating-star--${ratingDisplayType}`"
                     :class="[
                         $style['c-rating-star'],
                         $style['c-rating-star--filled'],

--- a/packages/components/molecules/f-rating/src/components/Rating.vue
+++ b/packages/components/molecules/f-rating/src/components/Rating.vue
@@ -90,7 +90,7 @@ export default {
         },
         ratingDisplayType: {
             type: String,
-            default: 'noRating',
+            default: null,
             validator: value => VALID_STAR_RATING_DISPLAY_TYPE.includes(value)
         },
         totalReviews: {

--- a/packages/components/molecules/f-rating/src/components/Rating.vue
+++ b/packages/components/molecules/f-rating/src/components/Rating.vue
@@ -137,7 +137,7 @@ export default {
 
     methods: {
         /**
-         * Display review rating message format.
+         * Gets the correct rating display format from translations.
          *
          * @todo - If the component is using `short` as a `starRatingSize` we shouldn't display text
          * alongside it for now. (TBC with design - ticket in backlog).

--- a/packages/components/molecules/f-rating/src/components/Rating.vue
+++ b/packages/components/molecules/f-rating/src/components/Rating.vue
@@ -2,13 +2,14 @@
     <div
         :class="$style['c-rating']"
         data-test-id="rating-component">
-        <div :class="$style['c-rating-starWrapper']">
-            <div :class="$style['c-rating-container']">
+        <div :class="$style['c-rating-stars']">
+            <div :class="$style['c-rating-stars-icons']">
                 <star-icon
                     v-for="star in maxStarRating"
                     :key="star"
                     :class="[
-                        $style['c-rating-star-empty'],
+                        $style['c-rating-star'],
+                        $style['c-rating-star--empty'],
                         $style[`c-rating-star--${starRatingSize}`]
                     ]" />
             </div>
@@ -16,15 +17,16 @@
             <div
                 :class="[
                     $style['c-rating-mask'],
-                    $style['c-rating-container']
+                    $style['c-rating-stars-icons']
                 ]"
                 :style="`--starRatingPercentage: ${getRatingStarPercentage}`">
                 <star-filled-icon
                     v-for="star in maxStarRating"
                     :key="star"
-                    :style="`--starRatingSize: c-rating-star--${starRatingSize}`"
+                    :style="`--starRatingSize: c-rating-star--${ratingDisplayType}`"
                     :class="[
-                        $style['c-rating-star-filled'],
+                        $style['c-rating-star'],
+                        $style['c-rating-star--filled'],
                         $style[`c-rating-star--${starRatingSize}`]
                     ]" />
             </div>
@@ -35,6 +37,15 @@
                 {{ getRatingDescription }}
             </span>
         </div>
+
+        <span
+            v-if="ratingDisplayType"
+            data-test-id="c-rating-displayType"
+            :class="[
+                $style['c-rating-message'],
+                $style[`c-rating-message--${ratingDisplayType}`]]">
+            {{ getRatingDisplayFormat() }}
+        </span>
     </div>
 </template>
 
@@ -45,7 +56,10 @@ import {
 } from '@justeattakeaway/pie-icons-vue';
 import { VueGlobalisationMixin } from '@justeat/f-globalisation';
 import tenantConfigs from '../tenants';
-import { VALID_STAR_RATING_SIZES } from '../constants';
+import {
+    VALID_STAR_RATING_SIZES,
+    VALID_STAR_RATING_DISPLAY_TYPE
+} from '../constants';
 
 export default {
     name: 'VRating',
@@ -74,6 +88,15 @@ export default {
             type: String,
             default: 'small',
             validator: value => !!VALID_STAR_RATING_SIZES[value]
+        },
+        ratingDisplayType: {
+            type: String,
+            default: 'noRating',
+            validator: value => VALID_STAR_RATING_DISPLAY_TYPE.includes(value)
+        },
+        totalReviews: {
+            type: Number,
+            default: null
         }
     },
 
@@ -94,12 +117,12 @@ export default {
             return this.starRating < 2
                 ? this.$tc('ratings.starsDescription', 1, {
                     rating: this.starRating,
-                    total: this.maxStarRating
+                    maxStarRating: this.maxStarRating
                 })
 
                 : this.$tc('ratings.starsDescription', 2, {
                     rating: this.starRating,
-                    total: this.maxStarRating
+                    maxStarRating: this.maxStarRating
                 });
         },
 
@@ -111,6 +134,27 @@ export default {
         getRatingStarPercentage () {
             return `${(this.starRating / this.maxStarRating) * 100}%`;
         }
+    },
+
+    methods: {
+        /**
+         * Display review rating message format.
+         *
+         * @todo - If the component is using `short` as a `starRatingSize` we shouldn't display text
+         * alongside it for now. (TBC with design - ticket in backlog).
+         *
+         * @returns {string|boolean}
+         */
+        getRatingDisplayFormat () {
+            return this.ratingDisplayType
+                ?
+                this.$t(`ratings.ratingDisplayType.${this.ratingDisplayType}`, {
+                    rating: this.starRating,
+                    maxStarRating: this.maxStarRating,
+                    totalReviews: this.totalReviews
+                })
+                : false;
+        }
     }
 };
 </script>
@@ -118,37 +162,39 @@ export default {
 <style lang="scss" module>
 @use '@justeat/fozzie/src/scss/fozzie' as f;
 
-.c-rating-starWrapper {
+.c-rating {
+    display: flex;
+}
+
+.c-rating-stars {
     margin: 0;
     padding: 0;
     position: relative;
     display: inline-block;
 }
-    .c-rating-container {
+    .c-rating-stars-icons {
         display: flex;
     }
 
     .c-rating-star {
-        &--small {
-            width: 12px;
-        }
-
-        &--medium {
-            width: 16px;
-        }
-
-        &--large {
-            width: 28px;
-        }
+        width: 12px;
     }
 
-    .c-rating-star-filled {
+    .c-rating-star--medium {
+        width: 16px;
+    }
+
+    .c-rating-star--large {
+        width: 28px;
+    }
+
+    .c-rating-star--filled {
         & path {
             fill: f.$color-support-brand-01;
         }
     }
 
-    .c-rating-star-empty {
+    .c-rating-star--empty {
         & path {
             fill: f.$color-mozzarella-50;
         }
@@ -164,5 +210,13 @@ export default {
         svg {
             flex-shrink: 0;
         }
+    }
+
+    .c-rating-message {
+        display: flex;
+        align-items: center;
+        @include f.font-size('body-s');
+        font-weight: f.$font-weight-bold;
+        margin-left: f.spacing(a);
     }
 </style>

--- a/packages/components/molecules/f-rating/src/components/Rating.vue
+++ b/packages/components/molecules/f-rating/src/components/Rating.vue
@@ -93,7 +93,7 @@ export default {
             default: null,
             validator: value => VALID_STAR_RATING_DISPLAY_TYPE.includes(value)
         },
-        totalReviews: {
+        reviewCount: {
             type: Number,
             default: null
         }
@@ -142,17 +142,14 @@ export default {
          * @todo - If the component is using `short` as a `starRatingSize` we shouldn't display text
          * alongside it for now. (TBC with design - ticket in backlog).
          *
-         * @returns {string|boolean}
+         * @returns {string}
          */
         getRatingDisplayFormat () {
-            return this.ratingDisplayType
-                ?
-                this.$t(`ratings.ratingDisplayType.${this.ratingDisplayType}`, {
-                    rating: this.starRating,
-                    maxStarRating: this.maxStarRating,
-                    totalReviews: this.totalReviews
-                })
-                : false;
+            return this.$t(`ratings.ratingDisplayType.${this.ratingDisplayType}`, {
+                rating: this.starRating,
+                maxStarRating: this.maxStarRating,
+                reviewCount: this.reviewCount
+            });
         }
     }
 };

--- a/packages/components/molecules/f-rating/src/components/Rating.vue
+++ b/packages/components/molecules/f-rating/src/components/Rating.vue
@@ -19,7 +19,7 @@
                     $style['c-rating-mask'],
                     $style['c-rating-stars-icons']
                 ]"
-                :style="`--starRatingPercentage: ${getRatingStarPercentage}`">
+                :style="`--starRatingPercentage: ${getRatingStarPercentage}%`">
                 <star-filled-icon
                     v-for="star in maxStarRating"
                     :key="star"
@@ -131,7 +131,7 @@ export default {
          * @returns {string}
          */
         getRatingStarPercentage () {
-            return `${(this.starRating / this.maxStarRating) * 100}%`;
+            return (this.starRating / this.maxStarRating) * 100;
         }
     },
 

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -2,6 +2,7 @@ import { createLocalVue, shallowMount } from '@vue/test-utils';
 import { VueI18n } from '@justeat/f-globalisation';
 import VRating from '../Rating.vue';
 import i18n from './helpers/setup';
+import { VALID_STAR_RATING_DISPLAY_TYPE } from '../../constants';
 
 const localVue = createLocalVue();
 localVue.use(VueI18n);
@@ -155,6 +156,98 @@ describe('Rating', () => {
 
                 // Act & Assert
                 expect(validator(6)).toBe(false);
+            });
+        });
+
+        describe('`ratingDisplayType`', () => {
+            it.each(VALID_STAR_RATING_DISPLAY_TYPE)('should allow correct value `%s`', displayType => {
+                // Act
+                const { validator } = VRating.props.ratingDisplayType;
+
+                // Assert
+                expect(validator(displayType)).toBe(true);
+            });
+
+            describe('when `ratingDisplayType` is truthy', () => {
+                it('should display descriptive content', () => {
+                    // Arrange & Act
+                    const { validator } = VRating.props.ratingDisplayType;
+                    validator('short');
+
+                    propsData = {
+                        starRating: 2,
+                        maxStarRating: 5,
+                        ratingDisplayType: 'short'
+                    };
+                    wrapper = shallowMount(VRating, {
+                        propsData,
+                        localVue,
+                        i18n,
+                        mocks: {
+                            $tc
+                        }
+                    });
+
+                    const result = wrapper.find('[data-test-id="c-rating-displayType"]');
+
+                    // Assert
+                    expect(result.exists()).toBe(true);
+                });
+            });
+        });
+    });
+
+    describe('methods', () => {
+        describe('`getRatingDisplayFormat`', () => {
+            it('should exist', () => {
+                // Act & Assert
+                expect(wrapper.vm.getRatingDisplayFormat).toBeDefined();
+            });
+
+            describe('when invoked', () => {
+                describe('and `ratingDisplayType` is passed through', () => {
+                    it.each([
+                        ['noRating', 'No ratings yet'],
+                        ['short', '499'],
+                        ['medium', '2 of 5'],
+                        ['long', 'View 499 reviews']
+                    ])('should return the correct display type for each rating component', (type, expected) => {
+                        // Arrange
+                        propsData = {
+                            starRating: 2,
+                            totalReviews: 499,
+                            ratingDisplayType: type
+                        };
+
+                        wrapper = shallowMount(VRating, {
+                            propsData,
+                            localVue,
+                            i18n
+                        });
+
+                        // Act
+                        const result = wrapper.vm.getRatingDisplayFormat();
+
+                        // Assert
+                        expect(result).toBe(expected);
+                    });
+                });
+
+                describe('and `ratingDisplayType` is not passed through', () => {
+                    it('should return the default rating display type', () => {
+                        wrapper = shallowMount(VRating, {
+                            propsData,
+                            localVue,
+                            i18n
+                        });
+
+                        // Act
+                        const result = wrapper.vm.getRatingDisplayFormat();
+
+                        // Assert
+                        expect(result).toBe('No ratings yet');
+                    });
+                });
             });
         });
     });

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -215,7 +215,7 @@ describe('Rating', () => {
                         // Arrange
                         propsData = {
                             starRating: 2,
-                            totalReviews: 499,
+                            reviewCount: 499,
                             ratingDisplayType: type
                         };
 

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -47,7 +47,7 @@ describe('Rating', () => {
             });
 
             describe('when invoked', () => {
-                it('should return a percentage from a combination of `starRating` and `maxStarRating`', () => {
+                it('should return a correct calculated number from a combination of `starRating` and `maxStarRating`', () => {
                     // Arrange
                     propsData = {
                         starRating: 2
@@ -59,7 +59,7 @@ describe('Rating', () => {
                     });
 
                     // Act & Assert
-                    expect(wrapper.vm.getRatingStarPercentage).toBe('40%');
+                    expect(wrapper.vm.getRatingStarPercentage).toBe(40);
                 });
             });
         });
@@ -192,6 +192,30 @@ describe('Rating', () => {
 
                     // Assert
                     expect(result.exists()).toBe(true);
+                });
+            });
+
+            describe('when `ratingDisplayType` is falsey', () => {
+                it('should not display descriptive content', () => {
+                    // Arrange & Act
+                    propsData = {
+                        starRating: 2,
+                        maxStarRating: 5,
+                        ratingDisplayType: null
+                    };
+                    wrapper = shallowMount(VRating, {
+                        propsData,
+                        localVue,
+                        i18n,
+                        mocks: {
+                            $tc
+                        }
+                    });
+
+                    const result = wrapper.find('[data-test-id="c-rating-displayType"]');
+
+                    // Assert
+                    expect(result.exists()).toBe(false);
                 });
             });
         });

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -245,7 +245,7 @@ describe('Rating', () => {
                         const result = wrapper.vm.getRatingDisplayFormat();
 
                         // Assert
-                        expect(result).toBe('No ratings yet');
+                        expect(result).toBe(false);
                     });
                 });
             });

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -3,7 +3,6 @@ import { VueI18n } from '@justeat/f-globalisation';
 import VRating from '../Rating.vue';
 import i18n from './helpers/setup';
 import { VALID_STAR_RATING_DISPLAY_TYPE } from '../../constants';
-import i18nMocker from '@justeat/f-loyalty/src/components/_tests/helper';
 
 const localVue = createLocalVue();
 localVue.use(VueI18n);

--- a/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
+++ b/packages/components/molecules/f-rating/src/components/_tests/Rating.test.js
@@ -3,6 +3,7 @@ import { VueI18n } from '@justeat/f-globalisation';
 import VRating from '../Rating.vue';
 import i18n from './helpers/setup';
 import { VALID_STAR_RATING_DISPLAY_TYPE } from '../../constants';
+import i18nMocker from '@justeat/f-loyalty/src/components/_tests/helper';
 
 const localVue = createLocalVue();
 localVue.use(VueI18n);
@@ -238,14 +239,17 @@ describe('Rating', () => {
                         wrapper = shallowMount(VRating, {
                             propsData,
                             localVue,
-                            i18n
+                            i18n,
+                            mocks: {
+                                $t: () => null
+                            }
                         });
 
                         // Act
                         const result = wrapper.vm.getRatingDisplayFormat();
 
                         // Assert
-                        expect(result).toBe(false);
+                        expect(result).toBe(null);
                     });
                 });
             });

--- a/packages/components/molecules/f-rating/src/constants.js
+++ b/packages/components/molecules/f-rating/src/constants.js
@@ -4,3 +4,5 @@ export const VALID_STAR_RATING_SIZES = {
     medium: true,
     large: true
 };
+
+export const VALID_STAR_RATING_DISPLAY_TYPE = ['noRating', 'short', 'medium', 'long'];

--- a/packages/components/molecules/f-rating/src/tenants/en-AU.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-AU.js
@@ -4,9 +4,9 @@ export default {
         starsDescription: '{rating} star out of {maxStarRating} | {rating} stars out of {maxStarRating}',
         ratingDisplayType: {
             noRating: 'No ratings yet',
-            short: '{totalReviews}',
+            short: '{reviewCount}',
             medium: '{rating} of {maxStarRating}',
-            long: 'View {totalReviews} reviews'
+            long: 'View {reviewCount} reviews'
         }
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/en-AU.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-AU.js
@@ -1,6 +1,12 @@
 export default {
     locale: 'en-AU',
     ratings: {
-        starsDescription: '{rating} star out of {total} | {rating} stars out of {total}'
+        starsDescription: '{rating} star out of {maxStarRating} | {rating} stars out of {maxStarRating}',
+        ratingDisplayType: {
+            noRating: 'No ratings yet',
+            short: '{totalReviews}',
+            medium: '{rating} of {maxStarRating}',
+            long: 'View {totalReviews} reviews'
+        }
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/en-GB.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-GB.js
@@ -1,7 +1,13 @@
 const messages = {
     locale: 'en-GB',
     ratings: {
-        starsDescription: '{rating} star out of {total} | {rating} stars out of {total}'
+        starsDescription: '{rating} star out of {maxStarRating} | {rating} stars out of {maxStarRating}',
+        ratingDisplayType: {
+            noRating: 'No ratings yet',
+            short: '{totalReviews}',
+            medium: '{rating} of {maxStarRating}',
+            long: 'View {totalReviews} reviews'
+        }
     }
 };
 

--- a/packages/components/molecules/f-rating/src/tenants/en-GB.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-GB.js
@@ -4,9 +4,9 @@ const messages = {
         starsDescription: '{rating} star out of {maxStarRating} | {rating} stars out of {maxStarRating}',
         ratingDisplayType: {
             noRating: 'No ratings yet',
-            short: '{totalReviews}',
+            short: '{reviewCount}',
             medium: '{rating} of {maxStarRating}',
-            long: 'View {totalReviews} reviews'
+            long: 'View {reviewCount} reviews'
         }
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/en-IE.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-IE.js
@@ -1,6 +1,12 @@
 export default {
     locale: 'en-IE',
     ratings: {
-        starsDescription: '{rating} star out of {total} | {rating} stars out of {total}'
+        starsDescription: '{rating} star out of {maxStarRating} | {rating} stars out of {maxStarRating}',
+        ratingDisplayType: {
+            noRating: 'No ratings yet',
+            short: '{totalReviews}',
+            medium: '{rating} of {maxStarRating}',
+            long: 'View {totalReviews} reviews'
+        }
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/en-IE.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-IE.js
@@ -4,9 +4,9 @@ export default {
         starsDescription: '{rating} star out of {maxStarRating} | {rating} stars out of {maxStarRating}',
         ratingDisplayType: {
             noRating: 'No ratings yet',
-            short: '{totalReviews}',
+            short: '{reviewCount}',
             medium: '{rating} of {maxStarRating}',
-            long: 'View {totalReviews} reviews'
+            long: 'View {reviewCount} reviews'
         }
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/en-NZ.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-NZ.js
@@ -1,6 +1,12 @@
 export default {
     locale: 'en-NZ',
     ratings: {
-        starsDescription: '{rating} star out of {total} | {rating} stars out of {total}'
+        starsDescription: '{rating} star out of {maxStarRating} | {rating} stars out of {maxStarRating}',
+        ratingDisplayType: {
+            noRating: 'No ratings yet',
+            short: '{totalReviews}',
+            medium: '{rating} of {maxStarRating}',
+            long: 'View {totalReviews} reviews'
+        }
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/en-NZ.js
+++ b/packages/components/molecules/f-rating/src/tenants/en-NZ.js
@@ -4,9 +4,9 @@ export default {
         starsDescription: '{rating} star out of {maxStarRating} | {rating} stars out of {maxStarRating}',
         ratingDisplayType: {
             noRating: 'No ratings yet',
-            short: '{totalReviews}',
+            short: '{reviewCount}',
             medium: '{rating} of {maxStarRating}',
-            long: 'View {totalReviews} reviews'
+            long: 'View {reviewCount} reviews'
         }
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/es-ES.js
+++ b/packages/components/molecules/f-rating/src/tenants/es-ES.js
@@ -1,6 +1,12 @@
 export default {
     locale: 'es-ES',
     ratings: {
-        starsDescription: '{rating} ADD TRANSLATION {total} | {rating} ADD TRANSLATION {total}'
+        starsDescription: '{rating} ADD TRANSLATION {total} | {rating} ADD TRANSLATION {total}',
+        ratingDisplayType: {
+            noRating: 'ADD TRANSLATION',
+            short: '{totalReviews}',
+            medium: '{rating} ADD TRANSLATION {maxStarRating}',
+            long: 'ADD TRANSLATION {totalReviews} ADD TRANSLATION'
+        }
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/es-ES.js
+++ b/packages/components/molecules/f-rating/src/tenants/es-ES.js
@@ -4,9 +4,9 @@ export default {
         starsDescription: '{rating} ADD TRANSLATION {total} | {rating} ADD TRANSLATION {total}',
         ratingDisplayType: {
             noRating: 'ADD TRANSLATION',
-            short: '{totalReviews}',
+            short: '{reviewCount}',
             medium: '{rating} ADD TRANSLATION {maxStarRating}',
-            long: 'ADD TRANSLATION {totalReviews} ADD TRANSLATION'
+            long: 'ADD TRANSLATION {reviewCount} ADD TRANSLATION'
         }
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/it-IT.js
+++ b/packages/components/molecules/f-rating/src/tenants/it-IT.js
@@ -1,6 +1,12 @@
 export default {
     locale: 'it-IT',
     ratings: {
-        starsDescription: '{rating} ADD TRANSLATION {total} | {rating} ADD TRANSLATION {total}'
+        starsDescription: '{rating} ADD TRANSLATION {total} | {rating} ADD TRANSLATION {total}',
+        ratingDisplayType: {
+            noRating: 'ADD TRANSLATION',
+            short: '{totalReviews}',
+            medium: '{rating} ADD TRANSLATION {maxStarRating}',
+            long: 'ADD TRANSLATION {totalReviews} ADD TRANSLATION'
+        }
     }
 };

--- a/packages/components/molecules/f-rating/src/tenants/it-IT.js
+++ b/packages/components/molecules/f-rating/src/tenants/it-IT.js
@@ -4,9 +4,9 @@ export default {
         starsDescription: '{rating} ADD TRANSLATION {total} | {rating} ADD TRANSLATION {total}',
         ratingDisplayType: {
             noRating: 'ADD TRANSLATION',
-            short: '{totalReviews}',
+            short: '{reviewCount}',
             medium: '{rating} ADD TRANSLATION {maxStarRating}',
-            long: 'ADD TRANSLATION {totalReviews} ADD TRANSLATION'
+            long: 'ADD TRANSLATION {reviewCount} ADD TRANSLATION'
         }
     }
 };

--- a/packages/components/molecules/f-rating/src/tests/constants.test.js
+++ b/packages/components/molecules/f-rating/src/tests/constants.test.js
@@ -1,7 +1,10 @@
-import { VALID_STAR_RATING_SIZES } from '../constants';
+import {
+    VALID_STAR_RATING_SIZES,
+    VALID_STAR_RATING_DISPLAY_TYPE
+} from '../constants';
 
 describe('`constants`', () => {
-    describe('VALID_STAR_RATING_SIZES', () => {
+    describe('`VALID_STAR_RATING_SIZES`', () => {
         it('should contain the correct sizes', () => {
             // Arrange
             const values = {
@@ -12,6 +15,19 @@ describe('`constants`', () => {
 
             // Act & Assert
             expect(VALID_STAR_RATING_SIZES).toEqual(values);
+        });
+    });
+
+    describe('`VALID_STAR_RATING_DISPLAY_TYPE`', () => {
+        it('should contain the correct display types', () => {
+            // Arrange
+            const values = ['noRating', 'short', 'medium', 'long'];
+
+            // Act
+            const result = VALID_STAR_RATING_DISPLAY_TYPE.every(value => values.includes(value));
+
+            // Assert
+            expect(result).toBe(true);
         });
     });
 });

--- a/packages/components/molecules/f-rating/stories/Rating.stories.js
+++ b/packages/components/molecules/f-rating/stories/Rating.stories.js
@@ -12,10 +12,19 @@ export const RatingComponent = (args, { argTypes }) => ({
 
     props: Object.keys(argTypes),
 
-    template: `<rating
-                  v-bind="$props"
-                  :starRatingSize="'medium'"
-                  :starRating="2.5" />`
+    template: `
+        <div>
+            <div
+                class="u-spacingBottom--large storybook-grid storybook-grid-columns--4 storybook-grid-stack--lessThanWide"
+                v-for="(list) in ratingVariants">
+                <rating
+                    v-for="(rating) in list"
+                    v-bind="$props"
+                    :starRatingSize="rating.starRatingSize"
+                    :starRating="rating.starRating"
+                    :totalReviews="rating.totalReviews"/>
+            </div>
+        </div>`
 });
 
 RatingComponent.storyName = 'f-rating';
@@ -30,5 +39,32 @@ RatingComponent.argTypes = {
         options: [locales.gb],
         description: 'Choose a locale',
         defaultValue: locales.gb
+    },
+    ratingDisplayType: {
+        control: { type: 'select' },
+        options: ['noRating', 'short', 'medium', 'long', null],
+        description: 'Choose how to display a rating',
+        default: null
     }
+};
+
+RatingComponent.args = {
+    ratingVariants: [
+        [
+            { starRating: 0, starRatingSize: 'small', totalReviews: 499 },
+            { starRating: 2.3, starRatingSize: 'small', totalReviews: 499 },
+            { starRating: 4.5, starRatingSize: 'small', totalReviews: 499 },
+            { starRating: 1.3, starRatingSize: 'small', totalReviews: 499 },
+
+            { starRating: 0, starRatingSize: 'medium', totalReviews: 499 },
+            { starRating: 2.3, starRatingSize: 'medium', totalReviews: 499 },
+            { starRating: 4.5, starRatingSize: 'medium', totalReviews: 499 },
+            { starRating: 1.3, starRatingSize: 'medium', totalReviews: 499 },
+
+            { starRating: 0, starRatingSize: 'large', totalReviews: 499 },
+            { starRating: 2.3, starRatingSize: 'large', totalReviews: 499 },
+            { starRating: 4.5, starRatingSize: 'large', totalReviews: 499 },
+            { starRating: 1.3, starRatingSize: 'large', totalReviews: 499 }
+        ]
+    ]
 };

--- a/packages/components/molecules/f-rating/stories/Rating.stories.js
+++ b/packages/components/molecules/f-rating/stories/Rating.stories.js
@@ -22,7 +22,7 @@ export const RatingComponent = (args, { argTypes }) => ({
                     v-bind="$props"
                     :starRatingSize="rating.starRatingSize"
                     :starRating="rating.starRating"
-                    :totalReviews="rating.totalReviews"/>
+                    :reviewCount="rating.reviewCount"/>
             </div>
         </div>`
 });
@@ -51,20 +51,20 @@ RatingComponent.argTypes = {
 RatingComponent.args = {
     ratingVariants: [
         [
-            { starRating: 0, starRatingSize: 'small', totalReviews: 499 },
-            { starRating: 2.3, starRatingSize: 'small', totalReviews: 499 },
-            { starRating: 4.5, starRatingSize: 'small', totalReviews: 499 },
-            { starRating: 1.3, starRatingSize: 'small', totalReviews: 499 },
+            { starRating: 0, starRatingSize: 'small', reviewCount: 499 },
+            { starRating: 2.3, starRatingSize: 'small', reviewCount: 499 },
+            { starRating: 4.5, starRatingSize: 'small', reviewCount: 499 },
+            { starRating: 1.3, starRatingSize: 'small', reviewCount: 499 },
 
-            { starRating: 0, starRatingSize: 'medium', totalReviews: 499 },
-            { starRating: 2.3, starRatingSize: 'medium', totalReviews: 499 },
-            { starRating: 4.5, starRatingSize: 'medium', totalReviews: 499 },
-            { starRating: 1.3, starRatingSize: 'medium', totalReviews: 499 },
+            { starRating: 0, starRatingSize: 'medium', reviewCount: 499 },
+            { starRating: 2.3, starRatingSize: 'medium', reviewCount: 499 },
+            { starRating: 4.5, starRatingSize: 'medium', reviewCount: 499 },
+            { starRating: 1.3, starRatingSize: 'medium', reviewCount: 499 },
 
-            { starRating: 0, starRatingSize: 'large', totalReviews: 499 },
-            { starRating: 2.3, starRatingSize: 'large', totalReviews: 499 },
-            { starRating: 4.5, starRatingSize: 'large', totalReviews: 499 },
-            { starRating: 1.3, starRatingSize: 'large', totalReviews: 499 }
+            { starRating: 0, starRatingSize: 'large', reviewCount: 499 },
+            { starRating: 2.3, starRatingSize: 'large', reviewCount: 499 },
+            { starRating: 4.5, starRatingSize: 'large', reviewCount: 499 },
+            { starRating: 1.3, starRatingSize: 'large', reviewCount: 499 }
         ]
     ]
 };

--- a/packages/components/molecules/f-rating/test/visual/f-rating.visual.spec.js
+++ b/packages/components/molecules/f-rating/test/visual/f-rating.visual.spec.js
@@ -47,18 +47,34 @@ devices.forEach(device => {
         });
 
         describe('`starRatingSize`', () => {
-            it('should be displayed', async () => {
+            it('should be displayed at the correct size', async () => {
+                // Act
+                await Rating.load({ starRatingSize: 'small' });
+
+                // Assert
+                await browser.percyScreenshot('f-rating - Visual Test for Prop - starRatingSize = small', device);
+            });
+
+            it('should be displayed at the correct size', async () => {
                 // Act
                 await Rating.load({ starRatingSize: 'medium' });
 
                 // Assert
                 await browser.percyScreenshot('f-rating - Visual Test for Prop - starRatingSize = medium', device);
             });
+
+            it('should be displayed at the correct size', async () => {
+                // Act
+                await Rating.load({ starRatingSize: 'large' });
+
+                // Assert
+                await browser.percyScreenshot('f-rating - Visual Test for Prop - starRatingSize = large', device);
+            });
         });
 
         describe('`ratingDisplayType`', () => {
-            describe('when populated with a valid type', () => {
-                it('should be displayed', async () => {
+            describe('when populated with a `long` display type', () => {
+                it('should be displayed with the correct description', async () => {
                     // Act
                     await Rating.load({ ratingDisplayType: 'long' });
 
@@ -67,10 +83,40 @@ devices.forEach(device => {
                 });
             });
 
-            describe('when using a default type', () => {
-                it('should be displayed', async () => {
+            describe('when populated with a `short` display type', () => {
+                it('should be displayed with the correct description', async () => {
+                    // Act
+                    await Rating.load({ ratingDisplayType: 'short' });
+
+                    // Assert
+                    await browser.percyScreenshot('f-rating - Visual Test for Prop - ratingDisplayType = short', device);
+                });
+            });
+
+            describe('when populated with a `medium` display type', () => {
+                it('should be displayed with the correct description', async () => {
+                    // Act
+                    await Rating.load({ ratingDisplayType: 'medium' });
+
+                    // Assert
+                    await browser.percyScreenshot('f-rating - Visual Test for Prop - ratingDisplayType = medium', device);
+                });
+            });
+
+            describe('when populated with a `noRating` display type', () => {
+                it('should be displayed with the correct description', async () => {
                     // Act
                     await Rating.load({ ratingDisplayType: 'noRating' });
+
+                    // Assert
+                    await browser.percyScreenshot('f-rating - Visual Test for Prop - ratingDisplayType = noRating', device);
+                });
+            });
+
+            describe('when using a default display type', () => {
+                it('should be displayed with no description', async () => {
+                    // Act
+                    await Rating.load({ ratingDisplayType: null });
 
                     // Assert
                     await browser.percyScreenshot('f-rating - Visual Test for Prop - ratingDisplayType = noRating', device);

--- a/packages/components/molecules/f-rating/test/visual/f-rating.visual.spec.js
+++ b/packages/components/molecules/f-rating/test/visual/f-rating.visual.spec.js
@@ -36,13 +36,13 @@ devices.forEach(device => {
             });
         });
 
-        describe('`totalReviews`', () => {
+        describe('`reviewCount`', () => {
             it('should be displayed', async () => {
                 // Act
-                await Rating.load({ totalReviews: 700 });
+                await Rating.load({ reviewCount: 700 });
 
                 // Assert
-                await browser.percyScreenshot('f-rating - Visual Test for Prop - totalReviews = 700', device);
+                await browser.percyScreenshot('f-rating - Visual Test for Prop - reviewCount = 700', device);
             });
         });
 

--- a/packages/components/molecules/f-rating/test/visual/f-rating.visual.spec.js
+++ b/packages/components/molecules/f-rating/test/visual/f-rating.visual.spec.js
@@ -6,13 +6,6 @@ const devices = [
 
 devices.forEach(device => {
     describe('f-rating - %s - Visual tests', () => {
-        beforeEach(async () => {
-            // Arrange
-            if (device === 'mobile') {
-                await browser.setWindowSize(414, 731);
-            }
-        });
-
         describe('Visually displayed', () => {
             it('should display the f-rating component', async () => {
                 // Act
@@ -23,6 +16,66 @@ devices.forEach(device => {
             });
         });
 
-        // Add visual tests for demo variants - Ticket to be added.
+        describe('`starRating`', () => {
+            it('should be displayed', async () => {
+                // Act
+                await Rating.load({ starRating: 5 });
+
+                // Assert
+                await browser.percyScreenshot('f-rating - Visual Test for Prop - starRating = 5', device);
+            });
+        });
+
+        describe('`maxStarRating`', () => {
+            it('should be displayed', async () => {
+                // Act
+                await Rating.load({ starRating: 5 });
+
+                // Assert
+                await browser.percyScreenshot('f-rating - Visual Test for Prop - maxStarRating = 5', device);
+            });
+        });
+
+        describe('`totalReviews`', () => {
+            it('should be displayed', async () => {
+                // Act
+                await Rating.load({ totalReviews: 700 });
+
+                // Assert
+                await browser.percyScreenshot('f-rating - Visual Test for Prop - totalReviews = 700', device);
+            });
+        });
+
+        describe('`starRatingSize`', () => {
+            it('should be displayed', async () => {
+                // Act
+                await Rating.load({ starRatingSize: 'medium' });
+
+                // Assert
+                await browser.percyScreenshot('f-rating - Visual Test for Prop - starRatingSize = medium', device);
+            });
+        });
+
+        describe('`ratingDisplayType`', () => {
+            describe('when populated with a valid type', () => {
+                it('should be displayed', async () => {
+                    // Act
+                    await Rating.load({ ratingDisplayType: 'long' });
+
+                    // Assert
+                    await browser.percyScreenshot('f-rating - Visual Test for Prop - ratingDisplayType = long', device);
+                });
+            });
+
+            describe('when using a default type', () => {
+                it('should be displayed', async () => {
+                    // Act
+                    await Rating.load({ ratingDisplayType: 'noRating' });
+
+                    // Assert
+                    await browser.percyScreenshot('f-rating - Visual Test for Prop - ratingDisplayType = noRating', device);
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
### Added
- Test coverage for code changes.
- Visual tests.
- Prop validation.
- Props `ratingDisplayType` & `totalReviews`.
- Storybook contains ratings in different sizes & formats.

### Changed
- Class names to be more suitable.

## Screenshots
(The alignment for small is a bit off but for now ignore it as we need to ask design about displaying text next to small versions)
<img width="1239" alt="Screenshot 2022-10-24 at 17 34 14" src="https://user-images.githubusercontent.com/2299779/197579002-d97198f9-69fd-46a0-b629-661de873c8c2.png">
<img width="1239" alt="Screenshot 2022-10-24 at 17 34 23" src="https://user-images.githubusercontent.com/2299779/197579009-eab51aba-0843-42aa-b56e-0eb5fcb77671.png">
<img width="1234" alt="Screenshot 2022-10-24 at 17 34 35" src="https://user-images.githubusercontent.com/2299779/197579014-5b40fec5-fc11-4257-9ea8-2a2f45e21900.png">
<img width="1234" alt="Screenshot 2022-10-24 at 17 34 47" src="https://user-images.githubusercontent.com/2299779/197579021-9814d0d0-e9de-4617-87c3-546e483088b7.png">

