### PR TITLE
f-registration@3.8.0 Use Vue I18n

### DIFF
--- a/packages/components/pages/f-registration/CHANGELOG.md
+++ b/packages/components/pages/f-registration/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v3.7.3
+v3.8.0
 ------------------------------
 *October 26, 2022*
 

--- a/packages/components/pages/f-registration/CHANGELOG.md
+++ b/packages/components/pages/f-registration/CHANGELOG.md
@@ -5,10 +5,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v3.8.0
 ------------------------------
-*October 26, 2022*
+*October 27, 2022*
 
 ### Changed
-- Update component to use Vue I18n
+- Update component to use Vue I18n.
 - Added translations for form error message.
 
 v3.7.2

--- a/packages/components/pages/f-registration/CHANGELOG.md
+++ b/packages/components/pages/f-registration/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.7.3
+------------------------------
+*October 26, 2022*
+
+### Changed
+- Update component to use Vue I18n
+- Added translations for form error message.
+
 v3.7.2
 ------------------------------
 *October 13, 2022*

--- a/packages/components/pages/f-registration/package.json
+++ b/packages/components/pages/f-registration/package.json
@@ -3,7 +3,7 @@
   "description": "Fozzie Registration Form Component",
   "version": "3.7.3",
   "main": "dist/f-registration.umd.min.js",
-  "maxBundleSize": "70kB",
+  "maxBundleSize": "75kB",
   "files": [
     "dist",
     "test-utils",

--- a/packages/components/pages/f-registration/package.json
+++ b/packages/components/pages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "main": "dist/f-registration.umd.min.js",
   "maxBundleSize": "70kB",
   "files": [

--- a/packages/components/pages/f-registration/package.json
+++ b/packages/components/pages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "3.7.3",
+  "version": "3.8.0",
   "main": "dist/f-registration.umd.min.js",
   "maxBundleSize": "75kB",
   "files": [

--- a/packages/components/pages/f-registration/src/components/Registration.vue
+++ b/packages/components/pages/f-registration/src/components/Registration.vue
@@ -2,7 +2,7 @@
     <div :class="$style['c-registration']">
         <card-component
             :data-theme-registration="theme"
-            :card-heading="copy.labels.createAccountTitle"
+            :card-heading="$t('labels.createAccountTitle')"
             is-page-content-wrapper
             card-heading-position="center"
             data-test-id="registration-component"
@@ -20,7 +20,7 @@
                     is-bold
                     is-distinct
                     :href="loginUrl">
-                    {{ copy.navLinks.login.text }}
+                    {{ $t('navLinks.login.text') }}
                 </v-link>
             </p>
             <form
@@ -46,7 +46,7 @@
                     v-model="firstName"
                     name="firstName"
                     required
-                    :label-text="copy.labels.firstName"
+                    :label-text="$t('labels.firstName')"
                     input-type="text"
                     aria-describedby="error-message-firstname"
                     :aria-invalid="!!describeFirstnameErrorMessage"
@@ -67,7 +67,7 @@
                     v-model="lastName"
                     name="lastName"
                     input-type="text"
-                    :label-text="copy.labels.lastName"
+                    :label-text="$t('labels.lastName')"
                     required
                     aria-describedby="error-message-lastname"
                     :aria-invalid="!!describeLastnameErrorMessage"
@@ -89,7 +89,7 @@
                     v-model="email"
                     name="email"
                     input-type="email"
-                    :label-text="copy.labels.email"
+                    :label-text="$t('labels.email')"
                     required
                     aria-describedby="error-message-email"
                     :aria-invalid="!!describeEmailErrorMessage"
@@ -110,7 +110,7 @@
                     v-model="password"
                     name="password"
                     input-type="password"
-                    :label-text="copy.labels.password"
+                    :label-text="$t('labels.password')"
                     required
                     aria-describedby="error-message-password"
                     :aria-invalid="!!describePasswordErrorMessage"
@@ -134,49 +134,50 @@
                     is-full-width
                     action-type="submit"
                     :disabled="shouldDisableCreateAccountButton">
-                    {{ copy.labels.createAccountBtn }}
+                    {{ $t('labels.createAccountBtn') }}
                 </f-button>
             </form>
             <p
                 :class="[
                     $style['c-registration-link'],
                     $style['c-registration-link--bottomSpacing']]">
-                {{ copy.navLinks.termsAndConditions.prefix }}
+                {{ $t('navLinks.termsAndConditions.prefix') }}
                 <v-link
                     is-bold
                     is-distinct
                     data-test-id="ts-and-cs-link"
-                    :href="copy.navLinks.termsAndConditions.url"
+                    :href="$t('navLinks.termsAndConditions.url')"
                     target="_blank"
                     rel="noopener noreferrer">
-                    {{ copy.navLinks.termsAndConditions.text }}
-                </v-link>{{ copy.navLinks.termsAndConditions.suffix }}
-                {{ copy.navLinks.privacyPolicy.prefix }}
+                    {{ $t('navLinks.termsAndConditions.text') }}
+                </v-link>{{ $t('navLinks.termsAndConditions.suffix') }}
+                {{ $t('navLinks.privacyPolicy.prefix') }}
                 <v-link
                     is-bold
                     is-distinct
                     data-test-id="privacy-policy-link"
-                    :href="copy.navLinks.privacyPolicy.url"
+                    :href="$t('navLinks.privacyPolicy.url')"
                     target="_blank"
                     rel="noopener noreferrer">
-                    {{ copy.navLinks.privacyPolicy.text }}
+                    {{ $t('navLinks.privacyPolicy.text') }}
                 </v-link>
-                {{ copy.navLinks.cookiesPolicy.prefix }}
+                {{ $t('navLinks.cookiesPolicy.prefix') }}
                 <v-link
                     is-bold
                     is-distinct
                     data-test-id="cookies-policy-link"
-                    :href="copy.navLinks.cookiesPolicy.url"
+                    :href="$t('navLinks.cookiesPolicy.url')"
                     target="_blank"
                     rel="noopener noreferrer">
-                    {{ copy.navLinks.cookiesPolicy.text }}
-                </v-link>{{ copy.navLinks.cookiesPolicy.suffix }}
+                    {{ $t('navLinks.cookiesPolicy.text') }}
+                </v-link>{{ $t('navLinks.cookiesPolicy.suffix') }}
             </p>
         </card-component>
     </div>
 </template>
 
 <script>
+import { VueGlobalisationMixin } from '@justeat/f-globalisation';
 import { globalisationServices } from '@justeat/f-services';
 import { validationMixin } from 'vuelidate';
 import {
@@ -248,7 +249,10 @@ export default {
         VLink
     },
 
-    mixins: [validationMixin],
+    mixins: [
+        validationMixin,
+        VueGlobalisationMixin
+    ],
 
     props: {
         locale: {
@@ -270,12 +274,9 @@ export default {
     },
 
     data () {
-        const locale = globalisationServices.getLocale(tenantConfigs, this.locale, this.$i18n);
-        const localeConfig = tenantConfigs[locale];
-        const theme = globalisationServices.getTheme(locale);
+        const theme = globalisationServices.getTheme(this.locale);
 
         return {
-            copy: { ...localeConfig },
             theme,
             firstName: null,
             lastName: null,
@@ -284,7 +285,8 @@ export default {
             shouldDisableCreateAccountButton: false,
             genericErrorMessage: null,
             formStarted: false,
-            conflictedEmailAddress: ''
+            conflictedEmailAddress: '',
+            tenantConfigs
         };
     },
 
@@ -298,64 +300,64 @@ export default {
 
         describeFirstnameErrorMessage () {
             if (this.$v.firstName.$dirty) {
-                const messages = this.copy.validationMessages.firstName;
+                const textKeyPrefix = 'validationMessages.firstName.';
 
                 if (!this.$v.firstName.required) {
-                    return messages.requiredError;
+                    return this.$t(`${textKeyPrefix}requiredError`);
                 }
                 if (!this.$v.firstName.maxLength) {
-                    return messages.maxLengthError;
+                    return this.$t(`${textKeyPrefix}maxLengthError`);
                 }
                 if (!this.$v.firstName.meetsCharacterValidationRules) {
-                    return messages.invalidCharError;
+                    return this.$t(`${textKeyPrefix}invalidCharError`);
                 }
             }
             return '';
         },
         describeLastnameErrorMessage () {
             if (this.$v.lastName.$dirty) {
-                const messages = this.copy.validationMessages.lastName;
+                const textKeyPrefix = 'validationMessages.lastName.';
 
                 if (!this.$v.lastName.required) {
-                    return messages.requiredError;
+                    return this.$t(`${textKeyPrefix}requiredError`);
                 }
                 if (!this.$v.lastName.maxLength) {
-                    return messages.maxLengthError;
+                    return this.$t(`${textKeyPrefix}maxLengthError`);
                 }
                 if (!this.$v.lastName.meetsCharacterValidationRules) {
-                    return messages.invalidCharError;
+                    return this.$t(`${textKeyPrefix}invalidCharError`);
                 }
             }
             return '';
         },
         describeEmailErrorMessage () {
             if (this.$v.email.$dirty) {
-                const messages = this.copy.validationMessages.email;
+                const textKeyPrefix = 'validationMessages.email.';
 
                 if (!this.$v.email.required) {
-                    return messages.requiredError;
+                    return this.$t(`${textKeyPrefix}requiredError`);
                 }
                 if (!this.$v.email.maxLength) {
-                    return messages.maxLengthError;
+                    return this.$t(`${textKeyPrefix}maxLengthError`);
                 }
                 if (!this.$v.email.email) {
-                    return messages.invalidEmailError;
+                    return this.$t(`${textKeyPrefix}invalidEmailError`);
                 }
                 if (!this.$v.email.isValidEmailAddress) {
-                    return messages.alreadyExistsError;
+                    return this.$t(`${textKeyPrefix}alreadyExistsError`);
                 }
             }
             return '';
         },
         describePasswordErrorMessage () {
             if (this.$v.password.$dirty) {
-                const messages = this.copy.validationMessages.password;
+                const textKeyPrefix = 'validationMessages.password.';
 
                 if (!this.$v.password.required) {
-                    return messages.requiredError;
+                    return this.$t(`${textKeyPrefix}requiredError`);
                 }
                 if (!this.$v.password.minLength) {
-                    return messages.minLengthError;
+                    return this.$t(`${textKeyPrefix}minLengthError`);
                 }
             }
             return '';
@@ -518,7 +520,7 @@ export default {
                     }
                 }
 
-                this.genericErrorMessage = this.copy.genericErrorMessage;
+                this.genericErrorMessage = this.$t('genericErrorMessage');
                 this.$emit(EventNames.CreateAccountFailure, this.genericErrorMessage);
             } finally {
                 this.shouldDisableCreateAccountButton = false;
@@ -541,7 +543,7 @@ export default {
             v.email.$touch();
             v.password.$touch();
             if (v.$invalid) {
-                this.genericErrorMessage = `There are ${countErrors()} errors in the form.`;
+                this.genericErrorMessage = this.$t('validationMessages.formError', { errorCount: countErrors() });
                 return true;
             }
             this.genericErrorMessage = '';

--- a/packages/components/pages/f-registration/src/components/Registration.vue
+++ b/packages/components/pages/f-registration/src/components/Registration.vue
@@ -547,7 +547,7 @@ export default {
 
                 this.genericErrorMessage = errorCount === 1
                     ? this.$t('validationMessages.singleFieldError')
-                    : this.$t('validationMessages.multipleFieldErrors', { errorCount: errorCount });
+                    : this.$t('validationMessages.multipleFieldErrors', { errorCount });
 
                 return true;
             }

--- a/packages/components/pages/f-registration/src/components/Registration.vue
+++ b/packages/components/pages/f-registration/src/components/Registration.vue
@@ -543,7 +543,12 @@ export default {
             v.email.$touch();
             v.password.$touch();
             if (v.$invalid) {
-                this.genericErrorMessage = this.$t('validationMessages.formError', { errorCount: countErrors() });
+                const errorCount = countErrors();
+
+                this.genericErrorMessage = errorCount === 1
+                    ? this.$t('validationMessages.singleFieldError')
+                    : this.$t('validationMessages.multipleFieldErrors', { errorCount: errorCount });
+
                 return true;
             }
             this.genericErrorMessage = '';

--- a/packages/components/pages/f-registration/src/components/_tests/Registration.test.js
+++ b/packages/components/pages/f-registration/src/components/_tests/Registration.test.js
@@ -1,17 +1,29 @@
 import {
     mount,
-    shallowMount
+    shallowMount,
+    createLocalVue
 } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
+import Vuex from 'vuex';
 import RegistrationServiceApi from '../../services/RegistrationServiceApi';
 import Registration from '../Registration.vue';
 import EventNames from '../../event-names';
+import { VueI18n } from '@justeat/f-globalisation';
+
+import {
+    i18n
+} from './helpers/setup';
 
 jest.mock('../../services/RegistrationServiceApi', () => ({
     createAccount: jest.fn()
 }));
 
 let wrapper;
+
+const localVue = createLocalVue();
+
+localVue.use(VueI18n);
+localVue.use(Vuex);
 
 describe('Registration', () => {
     const propsData = {
@@ -24,7 +36,9 @@ describe('Registration', () => {
     it('should be defined', () => {
         // Arrange & Act
         wrapper = shallowMount(Registration, {
-            propsData
+            propsData,
+            localVue,
+            i18n
         });
 
         // Assert
@@ -34,7 +48,9 @@ describe('Registration', () => {
     it('should have one form with method "post"', () => {
         // Arrange
         wrapper = mount(Registration, {
-            propsData
+            propsData,
+            localVue,
+            i18n
         });
 
         // Act
@@ -48,7 +64,9 @@ describe('Registration', () => {
     it('should have a button', () => {
         // Arrange
         wrapper = shallowMount(Registration, {
-            propsData
+            propsData,
+            localVue,
+            i18n
         });
 
         // Act
@@ -66,7 +84,9 @@ describe('Registration', () => {
                     createAccountUrl: 'http://localhost/account/register',
                     showLoginLink: true,
                     loginUrl: '/account/register'
-                }
+                },
+                localVue,
+                i18n
             });
 
             // Act
@@ -83,7 +103,9 @@ describe('Registration', () => {
                     createAccountUrl: 'http://localhost/account/register',
                     showLoginLink: false,
                     loginUrl: ''
-                }
+                },
+                localVue,
+                i18n
             });
 
             // Act
@@ -96,7 +118,9 @@ describe('Registration', () => {
         it('should show the login link if showLoginLink prop not set', () => {
             // Arrange
             wrapper = shallowMount(Registration, {
-                propsData
+                propsData,
+                localVue,
+                i18n
             });
 
             // Act
@@ -113,7 +137,9 @@ describe('Registration', () => {
                     createAccountUrl: 'http://localhost/account/register',
                     showLoginLink: true,
                     loginUrl: '/account/register'
-                }
+                },
+                localVue,
+                i18n
             });
 
             // Act
@@ -137,7 +163,9 @@ describe('Registration', () => {
                     $cookies: {
                         remove: jest.fn()
                     }
-                }
+                },
+                localVue,
+                i18n
             });
         };
 

--- a/packages/components/pages/f-registration/src/components/_tests/Registration.test.js
+++ b/packages/components/pages/f-registration/src/components/_tests/Registration.test.js
@@ -4,15 +4,12 @@ import {
     createLocalVue
 } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
+import { VueI18n } from '@justeat/f-globalisation';
 import Vuex from 'vuex';
 import RegistrationServiceApi from '../../services/RegistrationServiceApi';
 import Registration from '../Registration.vue';
 import EventNames from '../../event-names';
-import { VueI18n } from '@justeat/f-globalisation';
-
-import {
-    i18n
-} from './helpers/setup';
+import { i18n, defaultPropData } from './helpers/setup';
 
 jest.mock('../../services/RegistrationServiceApi', () => ({
     createAccount: jest.fn()
@@ -26,12 +23,7 @@ localVue.use(VueI18n);
 localVue.use(Vuex);
 
 describe('Registration', () => {
-    const propsData = {
-        locale: 'en-GB',
-        createAccountUrl: 'http://localhost/account/register',
-        showLoginLink: true,
-        loginUrl: '/account/register'
-    };
+    const propsData = defaultPropData;
 
     it('should be defined', () => {
         // Arrange & Act

--- a/packages/components/pages/f-registration/src/components/_tests/f-registration.integration.test.js
+++ b/packages/components/pages/f-registration/src/components/_tests/f-registration.integration.test.js
@@ -1,10 +1,17 @@
 import httpModule from '@justeat/f-http';
-import { mount } from '@vue/test-utils';
+import { mount, createLocalVue } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
 
 import Registration from '../Registration.vue';
 import EventNames from '../../event-names';
 import CONSUMERS_REQUEST_DATA from '../../../test/constants/consumer';
+
+import Vuex from 'vuex';
+import { VueI18n } from '@justeat/f-globalisation';
+
+import {
+    i18n
+} from './helpers/setup';
 
 const propsData = {
     locale: 'en-GB',
@@ -12,6 +19,11 @@ const propsData = {
     showLoginLink: true,
     loginUrl: '/account/register'
 };
+
+const localVue = createLocalVue();
+
+localVue.use(VueI18n);
+localVue.use(Vuex);
 
 const setFormFieldValues = wrapper => {
     wrapper.find('[data-test-id="formfield-firstName-input"]').setValue(CONSUMERS_REQUEST_DATA.firstName);
@@ -36,7 +48,9 @@ describe('Registration API service', () => {
                 $cookies: {
                     remove: jest.fn()
                 }
-            }
+            },
+            localVue,
+            i18n
         });
 
         setFormFieldValues(wrapper);

--- a/packages/components/pages/f-registration/src/components/_tests/f-registration.integration.test.js
+++ b/packages/components/pages/f-registration/src/components/_tests/f-registration.integration.test.js
@@ -2,23 +2,14 @@ import httpModule from '@justeat/f-http';
 import { mount, createLocalVue } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
 
+import { VueI18n } from '@justeat/f-globalisation';
+import Vuex from 'vuex';
 import Registration from '../Registration.vue';
 import EventNames from '../../event-names';
 import CONSUMERS_REQUEST_DATA from '../../../test/constants/consumer';
+import { i18n, defaultPropData } from './helpers/setup';
 
-import Vuex from 'vuex';
-import { VueI18n } from '@justeat/f-globalisation';
-
-import {
-    i18n
-} from './helpers/setup';
-
-const propsData = {
-    locale: 'en-GB',
-    createAccountUrl: 'http://localhost/consumer/uk',
-    showLoginLink: true,
-    loginUrl: '/account/register'
-};
+const propsData = defaultPropData;
 
 const localVue = createLocalVue();
 

--- a/packages/components/pages/f-registration/src/components/_tests/helpers/setup.js
+++ b/packages/components/pages/f-registration/src/components/_tests/helpers/setup.js
@@ -4,7 +4,7 @@ const defaultPropData = {
     locale: 'en-GB',
     createAccountUrl: 'http://localhost/account/register',
     showLoginLink: true,
-    loginUrl: '/account/register'
+    loginUrl: '/account/login'
 };
 
 const i18n = {

--- a/packages/components/pages/f-registration/src/components/_tests/helpers/setup.js
+++ b/packages/components/pages/f-registration/src/components/_tests/helpers/setup.js
@@ -1,0 +1,15 @@
+import tenantConfigs from '../../../tenants';
+
+const i18n = {
+    locale: 'en-GB',
+    messages: {
+        'en-GB': tenantConfigs['en-GB'].messages
+    },
+    dateTimeFormats: {
+        'en-GB': tenantConfigs['en-GB'].dateTimeFormats
+    }
+};
+
+export {
+    i18n
+};

--- a/packages/components/pages/f-registration/src/components/_tests/helpers/setup.js
+++ b/packages/components/pages/f-registration/src/components/_tests/helpers/setup.js
@@ -1,15 +1,20 @@
 import tenantConfigs from '../../../tenants';
 
+const defaultPropData = {
+    locale: 'en-GB',
+    createAccountUrl: 'http://localhost/account/register',
+    showLoginLink: true,
+    loginUrl: '/account/register'
+};
+
 const i18n = {
     locale: 'en-GB',
     messages: {
         'en-GB': tenantConfigs['en-GB'].messages
-    },
-    dateTimeFormats: {
-        'en-GB': tenantConfigs['en-GB'].dateTimeFormats
     }
 };
 
 export {
+    defaultPropData,
     i18n
 };

--- a/packages/components/pages/f-registration/src/tenants/en-AU.js
+++ b/packages/components/pages/f-registration/src/tenants/en-AU.js
@@ -1,62 +1,59 @@
 export default {
-    locale: 'en-AU',
-    genericErrorMessage: 'Unable to Create Account at this time',
-
-    navLinks: {
-        termsAndConditions: {
-            prefix: 'By creating an account you agree to our ',
-            suffix: '.',
-            text: 'Terms and Conditions',
-            url: '/info/privacy-policy'
+    messages: {
+        locale: 'en-AU',
+        genericErrorMessage: 'Unable to Create Account at this time',
+        navLinks: {
+            termsAndConditions: {
+                prefix: 'By creating an account you agree to our ',
+                suffix: '.',
+                text: 'Terms and Conditions',
+                url: '/info/privacy-policy'
+            },
+            privacyPolicy: {
+                prefix: 'Please read our ',
+                text: 'Privacy Policy',
+                url: '/info/privacy-policy'
+            },
+            cookiesPolicy: {
+                prefix: ' and ',
+                suffix: '.',
+                text: 'Cookie Policy',
+                url: '/info/privacy-policy'
+            },
+            login: {
+                text: 'Already on Menulog?'
+            }
         },
-        privacyPolicy: {
-            prefix: 'Please read our ',
-            text: 'Privacy Policy',
-            url: '/info/privacy-policy'
+        labels: {
+            createAccountTitle: 'Create account',
+            createAccountBtn: 'Create account',
+            firstName: 'First name',
+            lastName: 'Last name',
+            email: 'Email',
+            password: 'Password'
         },
-        cookiesPolicy: {
-            prefix: ' and ',
-            suffix: '.',
-            text: 'Cookie Policy',
-            url: '/info/privacy-policy'
-        },
-        login: {
-            text: 'Already on Menulog?'
-        }
-    },
-
-    labels: {
-        createAccountTitle: 'Create account',
-        createAccountBtn: 'Create account',
-        firstName: 'First name',
-        lastName: 'Last name',
-        email: 'Email',
-        password: 'Password'
-    },
-
-    validationMessages: {
-        firstName: {
-            requiredError: 'Please include your first name',
-            maxLengthError: 'First name exceeds 50 characters',
-            invalidCharError: 'Your name can only contain letters, hyphens or apostrophes'
-        },
-
-        lastName: {
-            requiredError: 'Please include your last name',
-            maxLengthError: 'Last name exceeds 50 characters',
-            invalidCharError: 'Your last name can only contain letters, hyphens or apostrophes'
-        },
-
-        email: {
-            requiredError: 'Please include your email address',
-            maxLengthError: 'Email address exceeds 50 characters',
-            invalidEmailError: 'Please enter your email address correctly',
-            alreadyExistsError: 'Email address is already registered'
-        },
-
-        password: {
-            requiredError: 'Please enter a password',
-            minLengthError: 'Password is less than ten characters '
+        validationMessages: {
+            formError: 'There are {errorCount} errors in the form',
+            firstName: {
+                requiredError: 'Please include your first name',
+                maxLengthError: 'First name exceeds 50 characters',
+                invalidCharError: 'Your name can only contain letters, hyphens or apostrophes'
+            },
+            lastName: {
+                requiredError: 'Please include your last name',
+                maxLengthError: 'Last name exceeds 50 characters',
+                invalidCharError: 'Your last name can only contain letters, hyphens or apostrophes'
+            },
+            email: {
+                requiredError: 'Please include your email address',
+                maxLengthError: 'Email address exceeds 50 characters',
+                invalidEmailError: 'Please enter your email address correctly',
+                alreadyExistsError: 'Email address is already registered'
+            },
+            password: {
+                requiredError: 'Please enter a password',
+                minLengthError: 'Password is less than ten characters '
+            }
         }
     }
 };

--- a/packages/components/pages/f-registration/src/tenants/en-AU.js
+++ b/packages/components/pages/f-registration/src/tenants/en-AU.js
@@ -33,7 +33,8 @@ export default {
             password: 'Password'
         },
         validationMessages: {
-            formError: 'There are {errorCount} errors in the form',
+            singleFieldError: 'There is 1 error in the form',
+            multipleFieldErrors: 'There are {errorCount} errors in the form',
             firstName: {
                 requiredError: 'Please include your first name',
                 maxLengthError: 'First name exceeds 50 characters',

--- a/packages/components/pages/f-registration/src/tenants/en-GB.js
+++ b/packages/components/pages/f-registration/src/tenants/en-GB.js
@@ -1,62 +1,60 @@
 export default {
-    locale: 'en-GB',
-    genericErrorMessage: 'Unable to Create Account at this time',
-
-    navLinks: {
-        termsAndConditions: {
-            prefix: 'By creating an account you agree to our ',
-            suffix: '.',
-            text: 'Terms and Conditions',
-            url: '/info/terms-and-conditions'
+    messages: {
+        locale: 'en-GB',
+        genericErrorMessage: 'Unable to Create Account at this time',
+        navLinks: {
+            termsAndConditions: {
+                prefix: 'By creating an account you agree to our ',
+                suffix: '.',
+                text: 'Terms and Conditions',
+                url: '/info/terms-and-conditions'
+            },
+            privacyPolicy: {
+                prefix: 'Please read our ',
+                text: 'Privacy Policy',
+                url: '/info/privacy-policy'
+            },
+            cookiesPolicy: {
+                prefix: ' and ',
+                text: 'Cookie Policy',
+                url: '/info/cookies-policy',
+                suffix: '.'
+            },
+            login: {
+                text: 'Already on Just Eat?'
+            }
         },
-        privacyPolicy: {
-            prefix: 'Please read our ',
-            text: 'Privacy Policy',
-            url: '/info/privacy-policy'
+        labels: {
+            createAccountTitle: 'Create account',
+            createAccountBtn: 'Create account',
+            firstName: 'First name',
+            lastName: 'Last name',
+            email: 'Email',
+            password: 'Password'
         },
-        cookiesPolicy: {
-            prefix: ' and ',
-            text: 'Cookie Policy',
-            url: '/info/cookies-policy',
-            suffix: '.'
-        },
-        login: {
-            text: 'Already on Just Eat?'
-        }
-    },
+        validationMessages: {
+            formError: 'There are {errorCount} errors in the form',
+            firstName: {
+                requiredError: 'Please include your first name',
+                maxLengthError: 'First name exceeds 50 characters',
+                invalidCharError: 'Your name can only contain letters, hyphens or apostrophes'
+            },
+            lastName: {
+                requiredError: 'Please include your last name',
+                maxLengthError: 'Last name exceeds 50 characters',
+                invalidCharError: 'Your last name can only contain letters, hyphens or apostrophes'
+            },
+            email: {
+                requiredError: 'Please include your email address',
+                maxLengthError: 'Email address exceeds 50 characters',
+                invalidEmailError: 'Please enter your email address correctly',
+                alreadyExistsError: 'Email address is already registered'
+            },
 
-    labels: {
-        createAccountTitle: 'Create account',
-        createAccountBtn: 'Create account',
-        firstName: 'First name',
-        lastName: 'Last name',
-        email: 'Email',
-        password: 'Password'
-    },
-
-    validationMessages: {
-        firstName: {
-            requiredError: 'Please include your first name',
-            maxLengthError: 'First name exceeds 50 characters',
-            invalidCharError: 'Your name can only contain letters, hyphens or apostrophes'
-        },
-
-        lastName: {
-            requiredError: 'Please include your last name',
-            maxLengthError: 'Last name exceeds 50 characters',
-            invalidCharError: 'Your last name can only contain letters, hyphens or apostrophes'
-        },
-
-        email: {
-            requiredError: 'Please include your email address',
-            maxLengthError: 'Email address exceeds 50 characters',
-            invalidEmailError: 'Please enter your email address correctly',
-            alreadyExistsError: 'Email address is already registered'
-        },
-
-        password: {
-            requiredError: 'Please enter a password',
-            minLengthError: 'Password is less than ten characters'
+            password: {
+                requiredError: 'Please enter a password',
+                minLengthError: 'Password is less than ten characters'
+            }
         }
     }
 };

--- a/packages/components/pages/f-registration/src/tenants/en-GB.js
+++ b/packages/components/pages/f-registration/src/tenants/en-GB.js
@@ -33,7 +33,8 @@ export default {
             password: 'Password'
         },
         validationMessages: {
-            formError: 'There are {errorCount} errors in the form',
+            singleFieldError: 'There is 1 error in the form',
+            multipleFieldErrors: 'There are {errorCount} errors in the form',
             firstName: {
                 requiredError: 'Please include your first name',
                 maxLengthError: 'First name exceeds 50 characters',

--- a/packages/components/pages/f-registration/src/tenants/en-IE.js
+++ b/packages/components/pages/f-registration/src/tenants/en-IE.js
@@ -33,7 +33,8 @@ export default {
             password: 'Password'
         },
         validationMessages: {
-            formError: 'There are {errorCount} errors in the form',
+            singleFieldError: 'There is 1 error in the form',
+            multipleFieldErrors: 'There are {errorCount} errors in the form',
             firstName: {
                 requiredError: 'Please include your first name',
                 maxLengthError: 'First name exceeds 50 characters',

--- a/packages/components/pages/f-registration/src/tenants/en-IE.js
+++ b/packages/components/pages/f-registration/src/tenants/en-IE.js
@@ -1,62 +1,59 @@
 export default {
-    locale: 'en-IE',
-    genericErrorMessage: 'Unable to Create Account at this time',
-
-    navLinks: {
-        termsAndConditions: {
-            prefix: 'By creating an account you agree to our ',
-            suffix: '.',
-            text: 'Terms and Conditions',
-            url: '/info/terms-and-conditions'
+    messages: {
+        locale: 'en-IE',
+        genericErrorMessage: 'Unable to Create Account at this time',
+        navLinks: {
+            termsAndConditions: {
+                prefix: 'By creating an account you agree to our ',
+                suffix: '.',
+                text: 'Terms and Conditions',
+                url: '/info/terms-and-conditions'
+            },
+            privacyPolicy: {
+                prefix: 'Please read our ',
+                text: 'Privacy Policy',
+                url: '/info/privacy-policy'
+            },
+            cookiesPolicy: {
+                prefix: ' and ',
+                text: 'Cookie Policy',
+                url: '/info/cookies-policy',
+                suffix: '.'
+            },
+            login: {
+                text: 'Already on Just Eat?'
+            }
         },
-        privacyPolicy: {
-            prefix: 'Please read our ',
-            text: 'Privacy Policy',
-            url: '/info/privacy-policy'
+        labels: {
+            createAccountTitle: 'Create account',
+            createAccountBtn: 'Create account',
+            firstName: 'First name',
+            lastName: 'Last name',
+            email: 'Email',
+            password: 'Password'
         },
-        cookiesPolicy: {
-            prefix: ' and ',
-            text: 'Cookie Policy',
-            url: '/info/cookies-policy',
-            suffix: '.'
-        },
-        login: {
-            text: 'Already on Just Eat?'
-        }
-    },
-
-    labels: {
-        createAccountTitle: 'Create account',
-        createAccountBtn: 'Create account',
-        firstName: 'First name',
-        lastName: 'Last name',
-        email: 'Email',
-        password: 'Password'
-    },
-
-    validationMessages: {
-        firstName: {
-            requiredError: 'Please include your first name',
-            maxLengthError: 'First name exceeds 50 characters',
-            invalidCharError: 'Your name can only contain letters, hyphens or apostrophes'
-        },
-
-        lastName: {
-            requiredError: 'Please include your last name',
-            maxLengthError: 'Last name exceeds 50 characters',
-            invalidCharError: 'Your last name can only contain letters, hyphens or apostrophes'
-        },
-
-        email: {
-            requiredError: 'Please include your email address',
-            maxLengthError: 'Email address exceeds 50 characters',
-            invalidEmailError: 'Please enter your email address correctly',
-            alreadyExistsError: 'Email address is already registered'
-        },
-
-        password: {
-            requiredError: 'Please enter a password',
-            minLengthError: 'Password is less than ten characters'
+        validationMessages: {
+            formError: 'There are {errorCount} errors in the form',
+            firstName: {
+                requiredError: 'Please include your first name',
+                maxLengthError: 'First name exceeds 50 characters',
+                invalidCharError: 'Your name can only contain letters, hyphens or apostrophes'
+            },
+            lastName: {
+                requiredError: 'Please include your last name',
+                maxLengthError: 'Last name exceeds 50 characters',
+                invalidCharError: 'Your last name can only contain letters, hyphens or apostrophes'
+            },
+            email: {
+                requiredError: 'Please include your email address',
+                maxLengthError: 'Email address exceeds 50 characters',
+                invalidEmailError: 'Please enter your email address correctly',
+                alreadyExistsError: 'Email address is already registered'
+            },
+            password: {
+                requiredError: 'Please enter a password',
+                minLengthError: 'Password is less than ten characters'
+            }
         }
     }
 };

--- a/packages/components/pages/f-registration/src/tenants/en-NZ.js
+++ b/packages/components/pages/f-registration/src/tenants/en-NZ.js
@@ -1,62 +1,59 @@
 export default {
-    locale: 'en-NZ',
-    genericErrorMessage: 'Unable to Create Account at this time',
-
-    navLinks: {
-        termsAndConditions: {
-            prefix: 'By creating an account you agree to our ',
-            suffix: '.',
-            text: 'Terms and Conditions',
-            url: '/info/privacy-policy'
+    messages: {
+        locale: 'en-NZ',
+        genericErrorMessage: 'Unable to Create Account at this time',
+        navLinks: {
+            termsAndConditions: {
+                prefix: 'By creating an account you agree to our ',
+                suffix: '.',
+                text: 'Terms and Conditions',
+                url: '/info/privacy-policy'
+            },
+            privacyPolicy: {
+                prefix: 'Please read our ',
+                text: 'Privacy Policy',
+                url: '/info/privacy-policy'
+            },
+            cookiesPolicy: {
+                prefix: ' and ',
+                suffix: '.',
+                text: 'Cookie Policy',
+                url: '/info/privacy-policy'
+            },
+            login: {
+                text: 'Already on Menulog?'
+            }
         },
-        privacyPolicy: {
-            prefix: 'Please read our ',
-            text: 'Privacy Policy',
-            url: '/info/privacy-policy'
+        labels: {
+            createAccountTitle: 'Create account',
+            createAccountBtn: 'Create account',
+            firstName: 'First name',
+            lastName: 'Last name',
+            email: 'Email',
+            password: 'Password'
         },
-        cookiesPolicy: {
-            prefix: ' and ',
-            suffix: '.',
-            text: 'Cookie Policy',
-            url: '/info/privacy-policy'
-        },
-        login: {
-            text: 'Already on Menulog?'
-        }
-    },
-
-    labels: {
-        createAccountTitle: 'Create account',
-        createAccountBtn: 'Create account',
-        firstName: 'First name',
-        lastName: 'Last name',
-        email: 'Email',
-        password: 'Password'
-    },
-
-    validationMessages: {
-        firstName: {
-            requiredError: 'Please include your first name',
-            maxLengthError: 'First name exceeds 50 characters',
-            invalidCharError: 'Your name can only contain letters, hyphens or apostrophes'
-        },
-
-        lastName: {
-            requiredError: 'Please include your last name',
-            maxLengthError: 'Last name exceeds 50 characters',
-            invalidCharError: 'Your last name can only contain letters, hyphens or apostrophes'
-        },
-
-        email: {
-            requiredError: 'Please include your email address',
-            maxLengthError: 'Email address exceeds 50 characters',
-            invalidEmailError: 'Please enter your email address correctly',
-            alreadyExistsError: 'Email address is already registered'
-        },
-
-        password: {
-            requiredError: 'Please enter a password',
-            minLengthError: 'Password is less than ten characters '
+        validationMessages: {
+            formError: 'There are {errorCount} errors in the form',
+            firstName: {
+                requiredError: 'Please include your first name',
+                maxLengthError: 'First name exceeds 50 characters',
+                invalidCharError: 'Your name can only contain letters, hyphens or apostrophes'
+            },
+            lastName: {
+                requiredError: 'Please include your last name',
+                maxLengthError: 'Last name exceeds 50 characters',
+                invalidCharError: 'Your last name can only contain letters, hyphens or apostrophes'
+            },
+            email: {
+                requiredError: 'Please include your email address',
+                maxLengthError: 'Email address exceeds 50 characters',
+                invalidEmailError: 'Please enter your email address correctly',
+                alreadyExistsError: 'Email address is already registered'
+            },
+            password: {
+                requiredError: 'Please enter a password',
+                minLengthError: 'Password is less than ten characters '
+            }
         }
     }
 };

--- a/packages/components/pages/f-registration/src/tenants/en-NZ.js
+++ b/packages/components/pages/f-registration/src/tenants/en-NZ.js
@@ -33,7 +33,8 @@ export default {
             password: 'Password'
         },
         validationMessages: {
-            formError: 'There are {errorCount} errors in the form',
+            singleFieldError: 'There is 1 error in the form',
+            multipleFieldErrors: 'There are {errorCount} errors in the form',
             firstName: {
                 requiredError: 'Please include your first name',
                 maxLengthError: 'First name exceeds 50 characters',

--- a/packages/components/pages/f-registration/src/tenants/es-ES.js
+++ b/packages/components/pages/f-registration/src/tenants/es-ES.js
@@ -1,62 +1,59 @@
 export default {
-    locale: 'es-ES',
-    genericErrorMessage: 'No es posible crear una cuenta en este momento',
-
-    navLinks: {
-        termsAndConditions: {
-            prefix: 'Al crear una cuenta, aceptas nuestros ',
-            suffix: '.',
-            text: 'Términos y Condiciones',
-            url: '/info/terms-and-conditions'
+    messages: {
+        locale: 'es-ES',
+        genericErrorMessage: 'No es posible crear una cuenta en este momento',
+        navLinks: {
+            termsAndConditions: {
+                prefix: 'Al crear una cuenta, aceptas nuestros ',
+                suffix: '.',
+                text: 'Términos y Condiciones',
+                url: '/info/terms-and-conditions'
+            },
+            privacyPolicy: {
+                prefix: 'Por favor, lee nuestra ',
+                text: 'Política de Privacidad',
+                url: '/info/privacy-policy'
+            },
+            cookiesPolicy: {
+                prefix: ' y ',
+                text: 'Política de Cookie',
+                url: '/info/cookies-policy',
+                suffix: '.'
+            },
+            login: {
+                text: '¿Ya formas parte de Just Eat?'
+            }
         },
-        privacyPolicy: {
-            prefix: 'Por favor, lee nuestra ',
-            text: 'Política de Privacidad',
-            url: '/info/privacy-policy'
+        labels: {
+            createAccountTitle: 'Crear cuenta',
+            createAccountBtn: 'Crear cuenta',
+            firstName: 'Nombre',
+            lastName: 'Apellido',
+            email: 'Correo electrónico',
+            password: 'Contraseña'
         },
-        cookiesPolicy: {
-            prefix: ' y ',
-            text: 'Política de Cookie',
-            url: '/info/cookies-policy',
-            suffix: '.'
-        },
-        login: {
-            text: '¿Ya formas parte de Just Eat?'
-        }
-    },
-
-    labels: {
-        createAccountTitle: 'Crear cuenta',
-        createAccountBtn: 'Crear cuenta',
-        firstName: 'Nombre',
-        lastName: 'Apellido',
-        email: 'Correo electrónico',
-        password: 'Contraseña'
-    },
-
-    validationMessages: {
-        firstName: {
-            requiredError: 'Por favor, introduce tu nombre',
-            maxLengthError: 'El nombre supera los 50 caracteres',
-            invalidCharError: 'Tu nombre solo puede tener letras, guiones o apóstrofes'
-        },
-
-        lastName: {
-            requiredError: 'Por favor, introduce tu apellido',
-            maxLengthError: 'El apellido supera los 50 caracteres',
-            invalidCharError: 'Tu apellido solo puede tener letras, guiones o apóstrofes'
-        },
-
-        email: {
-            requiredError: 'Por favor, introduce tu correo electrónico',
-            maxLengthError: 'El correo electrónico supera los 50 caracteres',
-            invalidEmailError: 'Por favor, introduce un correo electrónico válido',
-            alreadyExistsError: 'Este correo electrónico ya está registrado'
-        },
-
-        password: {
-            requiredError: 'Por favor, introduce una contraseña',
-            minLengthError: 'Tu contraseña debe tener al menos 10 caracteres'
+        validationMessages: {
+            formError: 'Hay {errorCount} errores en el formulario',
+            firstName: {
+                requiredError: 'Por favor, introduce tu nombre',
+                maxLengthError: 'El nombre supera los 50 caracteres',
+                invalidCharError: 'Tu nombre solo puede tener letras, guiones o apóstrofes'
+            },
+            lastName: {
+                requiredError: 'Por favor, introduce tu apellido',
+                maxLengthError: 'El apellido supera los 50 caracteres',
+                invalidCharError: 'Tu apellido solo puede tener letras, guiones o apóstrofes'
+            },
+            email: {
+                requiredError: 'Por favor, introduce tu correo electrónico',
+                maxLengthError: 'El correo electrónico supera los 50 caracteres',
+                invalidEmailError: 'Por favor, introduce un correo electrónico válido',
+                alreadyExistsError: 'Este correo electrónico ya está registrado'
+            },
+            password: {
+                requiredError: 'Por favor, introduce una contraseña',
+                minLengthError: 'Tu contraseña debe tener al menos 10 caracteres'
+            }
         }
     }
 };

--- a/packages/components/pages/f-registration/src/tenants/es-ES.js
+++ b/packages/components/pages/f-registration/src/tenants/es-ES.js
@@ -33,7 +33,8 @@ export default {
             password: 'Contraseña'
         },
         validationMessages: {
-            formError: 'Hay {errorCount} errores en el formulario',
+            singleFieldError: 'Hay 1 error en el formulario',
+            multipleFieldErrors: 'Hay {errorCount} errores en el formulario',
             firstName: {
                 requiredError: 'Por favor, introduce tu nombre',
                 maxLengthError: 'El nombre supera los 50 caracteres',

--- a/packages/components/pages/f-registration/src/tenants/index.js
+++ b/packages/components/pages/f-registration/src/tenants/index.js
@@ -1,11 +1,17 @@
-import uk from './en-GB';
 import au from './en-AU';
+import es from './es-ES';
+import ie from './en-IE';
+import it from './it-IT';
 import nz from './en-NZ';
+import uk from './en-GB';
 
 const tenantConfigs = {
-    'en-GB': uk,
     'en-AU': au,
-    'en-NZ': nz
+    'es-ES': es,
+    'en-IE': ie,
+    'it-IT': it,
+    'en-NZ': nz,
+    'en-GB': uk
 };
 
 export default tenantConfigs;

--- a/packages/components/pages/f-registration/src/tenants/it-IT.js
+++ b/packages/components/pages/f-registration/src/tenants/it-IT.js
@@ -33,7 +33,8 @@ export default {
             password: 'Password'
         },
         validationMessages: {
-            formError: 'Ci sono {errorCount} errori nel modulo',
+            singleFieldError: 'C’è un errore nel modulo',
+            multipleFieldErrors: 'Ci sono {errorCount} errori nel modulo',
             firstName: {
                 requiredError: 'Inserisci il tuo nome',
                 maxLengthError: 'Il nome supera 50 caratteri',

--- a/packages/components/pages/f-registration/src/tenants/it-IT.js
+++ b/packages/components/pages/f-registration/src/tenants/it-IT.js
@@ -1,62 +1,59 @@
 export default {
-    locale: 'it-IT',
-    genericErrorMessage: 'Al momento non è possibile creare un account',
-
-    navLinks: {
-        termsAndConditions: {
-            prefix: 'Creando un account, accetti i nostri ',
-            suffix: '.',
-            text: 'Termini e condizioni d\'uso',
-            url: '/info/terms-and-conditions'
+    messages: {
+        locale: 'it-IT',
+        genericErrorMessage: 'Al momento non è possibile creare un account',
+        navLinks: {
+            termsAndConditions: {
+                prefix: 'Creando un account, accetti i nostri ',
+                suffix: '.',
+                text: 'Termini e condizioni d\'uso',
+                url: '/info/terms-and-conditions'
+            },
+            privacyPolicy: {
+                prefix: 'Leggi la nostra informativa sulla ',
+                text: 'Privacy',
+                url: '/info/privacy-policy'
+            },
+            cookiesPolicy: {
+                prefix: ' e sui ',
+                text: 'Cookie',
+                url: '/info/cookies-policy',
+                suffix: '.'
+            },
+            login: {
+                text: 'Hai già un account?'
+            }
         },
-        privacyPolicy: {
-            prefix: 'Leggi la nostra informativa sulla ',
-            text: 'Privacy',
-            url: '/info/privacy-policy'
+        labels: {
+            createAccountTitle: 'Crea un account',
+            createAccountBtn: 'Crea un account',
+            firstName: 'Nome',
+            lastName: 'Cognome',
+            email: 'Email',
+            password: 'Password'
         },
-        cookiesPolicy: {
-            prefix: ' e sui ',
-            text: 'Cookie',
-            url: '/info/cookies-policy',
-            suffix: '.'
-        },
-        login: {
-            text: 'Hai già un account?'
-        }
-    },
-
-    labels: {
-        createAccountTitle: 'Crea un account',
-        createAccountBtn: 'Crea un account',
-        firstName: 'Nome',
-        lastName: 'Cognome',
-        email: 'Email',
-        password: 'Password'
-    },
-
-    validationMessages: {
-        firstName: {
-            requiredError: 'Inserisci il tuo nome',
-            maxLengthError: 'Il nome supera 50 caratteri',
-            invalidCharError: 'Il tuo nome può contenere solo lettere, trattini o apostrofi'
-        },
-
-        lastName: {
-            requiredError: 'Inserisci il tuo cognome',
-            maxLengthError: 'Il cognome supera i 50 caratteri',
-            invalidCharError: 'Il tuo cognome può contenere solo lettere, trattini o apostrofi'
-        },
-
-        email: {
-            requiredError: 'Inserisci la tua email',
-            maxLengthError: 'L\'indirizzo email supera i 50 caratteri',
-            invalidEmailError: 'Si prega di inserire un indirizzo email valido',
-            alreadyExistsError: 'Indirizzo email già registrato'
-        },
-
-        password: {
-            requiredError: 'Inserisci una password',
-            minLengthError: 'La password deve essere composta da almeno 10 caratteri'
+        validationMessages: {
+            formError: 'Ci sono {errorCount} errori nel modulo',
+            firstName: {
+                requiredError: 'Inserisci il tuo nome',
+                maxLengthError: 'Il nome supera 50 caratteri',
+                invalidCharError: 'Il tuo nome può contenere solo lettere, trattini o apostrofi'
+            },
+            lastName: {
+                requiredError: 'Inserisci il tuo cognome',
+                maxLengthError: 'Il cognome supera i 50 caratteri',
+                invalidCharError: 'Il tuo cognome può contenere solo lettere, trattini o apostrofi'
+            },
+            email: {
+                requiredError: 'Inserisci la tua email',
+                maxLengthError: 'L\'indirizzo email supera i 50 caratteri',
+                invalidEmailError: 'Si prega di inserire un indirizzo email valido',
+                alreadyExistsError: 'Indirizzo email già registrato'
+            },
+            password: {
+                requiredError: 'Inserisci una password',
+                minLengthError: 'La password deve essere composta da almeno 10 caratteri'
+            }
         }
     }
 };

--- a/packages/components/pages/f-registration/stories/Registration.stories.js
+++ b/packages/components/pages/f-registration/stories/Registration.stories.js
@@ -19,7 +19,7 @@ export const RegistrationComponent = () => ({
     components: { Registration },
     props: {
         locale: {
-            default: select('Locale', ['en-GB', 'en-AU'])
+            default: select('Locale', ['en-GB', 'en-AU', 'en-IE', 'en-NZ', 'es-ES', 'it-IT'])
         },
         title: {
             default: text('Title', 'Create Account')


### PR DESCRIPTION
---

This PR updates f-registration to use Vue I18n for text localization as opposed to manually pulling them in for the current locale and exposing through a `copy` property. We now also show the correct form error message when we have 1 or many errors.

The reason for this change was two fold; firstly to bring f-registration into line with other components and secondly to leverage translated interpolated strings using the I18n framework.

---

## UI Review Checks

I haven't changed the UI with my change but thought it useful to show the translations

_en-GB_
![image](https://user-images.githubusercontent.com/7453217/198112820-2cbacde4-4ea8-46d9-aff2-7dd6325a9410.png)

_en-GB - single error_
![image](https://user-images.githubusercontent.com/7453217/198345541-bb69fd21-1839-4c3c-b34a-7eafff246543.png)

_it-IT_
![image](https://user-images.githubusercontent.com/7453217/198114926-427d5f39-c668-4f21-b586-c4f888b3f31b.png)

_it-IT - single error_
![image](https://user-images.githubusercontent.com/7453217/198345860-b9fff3f5-6dd6-4c23-8e5c-90ca755414d1.png)

_en-NZ_
![image](https://user-images.githubusercontent.com/7453217/198113326-37212375-e59c-4b98-9c9a-0fe2eab68958.png)

_es-ES_
![image](https://user-images.githubusercontent.com/7453217/198346049-1b372b54-219e-4291-8ac6-47297a24f4f8.png)

_es-ES - single error_
![image](https://user-images.githubusercontent.com/7453217/198346153-f400dd06-ac3e-4dfe-ab3d-a81ecdd202ce.png)

- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)