### PR TITLE
f-registration@3.11.0 - Remove asterisks from registration page form …

### DIFF
--- a/packages/components/pages/f-registration/CHANGELOG.md
+++ b/packages/components/pages/f-registration/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v3.11.0
 ------------------------------
-*November 11, 2022*
+*November 4, 2022*
 
 ### Changed
 - Removed asterisks from registration page form fields

--- a/packages/components/pages/f-registration/CHANGELOG.md
+++ b/packages/components/pages/f-registration/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.11.0
+------------------------------
+*November 11, 2022*
+
+### Changed
+- Removed asterisks from registration page form fields
+
 
 v3.10.0
 ------------------------------

--- a/packages/components/pages/f-registration/package.json
+++ b/packages/components/pages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "main": "dist/f-registration.umd.min.js",
   "maxBundleSize": "50kB",
   "files": [

--- a/packages/components/pages/f-registration/src/components/Registration.vue
+++ b/packages/components/pages/f-registration/src/components/Registration.vue
@@ -46,6 +46,7 @@
                     v-model="firstName"
                     name="firstName"
                     required
+                    :isVisuallyRequired=false
                     :label-text="$t('labels.firstName')"
                     input-type="text"
                     aria-describedby="error-message-firstname"
@@ -69,6 +70,7 @@
                     input-type="text"
                     :label-text="$t('labels.lastName')"
                     required
+                    :isVisuallyRequired=false
                     aria-describedby="error-message-lastname"
                     :aria-invalid="!!describeLastnameErrorMessage"
                     data-test-id="input-last-name"
@@ -91,6 +93,7 @@
                     input-type="email"
                     :label-text="$t('labels.email')"
                     required
+                    :isVisuallyRequired=false
                     aria-describedby="error-message-email"
                     :aria-invalid="!!describeEmailErrorMessage"
                     @blur="formFieldBlur('email')">
@@ -112,6 +115,7 @@
                     input-type="password"
                     :label-text="$t('labels.password')"
                     required
+                    :isVisuallyRequired=false
                     aria-describedby="error-message-password"
                     :aria-invalid="!!describePasswordErrorMessage"
                     @blur="formFieldBlur('password')">

--- a/packages/components/pages/f-registration/src/components/Registration.vue
+++ b/packages/components/pages/f-registration/src/components/Registration.vue
@@ -46,7 +46,7 @@
                     v-model="firstName"
                     name="firstName"
                     required
-                    :isVisuallyRequired=false
+                    :is-visually-required="false"
                     :label-text="$t('labels.firstName')"
                     input-type="text"
                     aria-describedby="error-message-firstname"
@@ -70,7 +70,7 @@
                     input-type="text"
                     :label-text="$t('labels.lastName')"
                     required
-                    :isVisuallyRequired=false
+                    :is-visually-required="false"
                     aria-describedby="error-message-lastname"
                     :aria-invalid="!!describeLastnameErrorMessage"
                     data-test-id="input-last-name"
@@ -93,7 +93,7 @@
                     input-type="email"
                     :label-text="$t('labels.email')"
                     required
-                    :isVisuallyRequired=false
+                    :is-visually-required="false"
                     aria-describedby="error-message-email"
                     :aria-invalid="!!describeEmailErrorMessage"
                     @blur="formFieldBlur('email')">
@@ -115,7 +115,7 @@
                     input-type="password"
                     :label-text="$t('labels.password')"
                     required
-                    :isVisuallyRequired=false
+                    :is-visually-required="false"
                     aria-describedby="error-message-password"
                     :aria-invalid="!!describePasswordErrorMessage"
                     @blur="formFieldBlur('password')">


### PR DESCRIPTION
## What's changed

Removed asterisks from registration page form field labels so that it aligns with the apps.

## UI Review Checks
<img width="379" alt="image" src="https://user-images.githubusercontent.com/55699680/199969875-6ab80d93-efbd-41cc-9a1d-6581f9887b79.png">

- [x] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
