### PR TITLE
f-takeawaypay-activation@v3.5.0 – Added fozzie components as externals in Webpack config

### DIFF
--- a/packages/components/pages/f-takeawaypay-activation/CHANGELOG.md
+++ b/packages/components/pages/f-takeawaypay-activation/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v3.5.0
+------------------------------
+*November 15, 2022*
+
+### Changed
+- Added fozzie components as externals in Webpack config
+
+
 v3.4.0
 ------------------------------
 *August 2, 2022*

--- a/packages/components/pages/f-takeawaypay-activation/package.json
+++ b/packages/components/pages/f-takeawaypay-activation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-takeawaypay-activation",
   "description": "Fozzie TakeawayPay Activation - Handles Takeaway Pay activation for users",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "main": "dist/f-takeawaypay-activation.umd.min.js",
   "maxBundleSize": "45kB",
   "files": [

--- a/packages/components/pages/f-takeawaypay-activation/vue.config.js
+++ b/packages/components/pages/f-takeawaypay-activation/vue.config.js
@@ -16,6 +16,12 @@ module.exports = {
                 // eslint-disable-next-line quotes
                 additionalData: `@use "../assets/scss/common.scss";`
             });
+
+        config.externals({
+            // This just externalises the JS currently, not the CSS
+            '@justeat/f-button': '@justeat/f-button',
+            '@justeat/f-card': '@justeat/f-card'
+        });
     },
     pluginOptions: {
         lintStyleOnBuild: true


### PR DESCRIPTION
### Changed
- Added fozzie components as externals in Webpack config