### PR TITLE
fozzie@v10.10.0 – Fixing broken release

### DIFF
--- a/packages/tools/fozzie/CHANGELOG.md
+++ b/packages/tools/fozzie/CHANGELOG.md
@@ -8,6 +8,16 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+
+v10.10.0
+------------------------------
+*November 29, 2022*
+
+### Fixed
+- Fix v10.9.1 Patch release, which seems to have been an undocumented version release.
+- Added node version 12 back into support list. This is just so that legacy microsites can use fozzie without having to change their build commands.
+
+
 v10.9.0
 ------------------------------
 *November 16, 2022*

--- a/packages/tools/fozzie/package.json
+++ b/packages/tools/fozzie/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "10.9.0",
+  "version": "10.10.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -31,7 +31,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^14 || ^16"
+    "node": "^12 || ^14 || ^16"
   },
   "dependencies": {
     "@justeat/pie-design-tokens": "3.2.0",


### PR DESCRIPTION
### Fixed
- Fix v10.9.1 Patch release, which seems to have been an undocumented version release.
- Added node version 12 back into support list. This is just so that legacy microsites can use fozzie without having to change their build commands.
