### PR TITLE
fozzie@v10.10.1 - Fixing SCSS tests

### DIFF
--- a/packages/tools/fozzie/CHANGELOG.md
+++ b/packages/tools/fozzie/CHANGELOG.md
@@ -8,6 +8,14 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v10.10.1
+------------------------------
+*November 30, 2022*
+
+### Fixed
+- SCSS Tests now run as part of CI (`ci:test:tools`).
+- `it()` removed from scss-setup, as causes nested test errors in Jest.
+
 
 v10.10.0
 ------------------------------

--- a/packages/tools/fozzie/package.json
+++ b/packages/tools/fozzie/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "10.10.0",
+  "version": "10.10.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -93,6 +93,7 @@
     "prepack": "concurrently -n \"lint,compile,test\" -c \"blue,yellow,green\" \"yarn lint\" \"yarn compile\" \"yarn test\" --kill-others-on-fail && yarn prepare:css",
     "prepare:css": "yarn run build:css && yarn run autoprefix:css && yarn run build:css:minified && yarn test:css-dist",
     "test": "concurrently -n \"test:js,test:scss\" -c \"cyan,magenta\" \"yarn test:js\" \"yarn test:scss\"",
+    "ci:test:tools": "yarn test",
     "test:build": "sass --no-source-map --load-path=node_modules --style=compressed src/scss:dist/css",
     "test:cover": "jest --collect-coverage",
     "test:cover:CI": "cat coverage/lcov.info | coveralls",

--- a/packages/tools/fozzie/src/test/scss/scss-setup.spec.js
+++ b/packages/tools/fozzie/src/test/scss/scss-setup.spec.js
@@ -11,15 +11,13 @@ const sassTrue = require('sass-true');
 const glob = require('glob');
 
 describe('SCSS', () => {
-    it('should find and run unit tests', () => {
-        // All Scss unit tests should follow this naming convention
-        const testFileGlob = '**/*.spec.scss';
-        const testFilePathGlob = path.resolve(process.cwd(), testFileGlob);
+    // All Scss unit tests should follow this naming convention
+    const testFileGlob = '**/*.spec.scss';
+    const testFilePathGlob = path.resolve(process.cwd(), testFileGlob);
 
-        // Find all of the Scss files that end in `*.spec.scss` in any directory of this project
-        const scssTestFiles = glob.sync(testFilePathGlob);
+    // Find all of the Scss files that end in `*.spec.scss` in any directory of this project
+    const scssTestFiles = glob.sync(testFilePathGlob);
 
-        // Run True on every file found with the describe and it methods provided
-        scssTestFiles.forEach(file => sassTrue.runSass({ file, includePaths: ['node_modules'] }, { describe, it }));
-    });
+    // Run True on every file found with the describe and it methods provided
+    scssTestFiles.forEach(file => sassTrue.runSass({ file, includePaths: ['node_modules'] }, { describe, it }));
 });


### PR DESCRIPTION
### Fixed
- SCSS Tests now run as part of CI (`ci:test:tools`).
- `it()` removed from scss-setup, as causes nested test errors in Jest.