### PR TITLE
fozzie-components@v7.45.0 – pie-icons-vue pkg update #globalconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v7.45.0
+------------------------------
+*December 5, 2022*
+
+### Changed
+- Updated packages to the new `pie-icons-vue` beta release.
+
+
 v7.44.0
 ------------------------------
 *November 30, 2022*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "7.44.0",
+  "version": "7.45.0",
   "private": true,
   "scripts": {
     "build": "turbo run build --continue",

--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+Latest (merge into next release)
+------------------------------
+*December 5, 2022*
+
+### Changed
+- Updated to the new `pie-icons-vue` beta release.
+
+
 v4.4.0
 ------------------------------
 *November 1, 2022*

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -59,8 +59,10 @@
     "vue": "2.x",
     "vue-router": ">=3.4.8"
   },
+  "dependencies": {
+    "@justeattakeaway/pie-icons-vue": "2.0.0-beta.1"
+  },
   "devDependencies": {
-    "@justeattakeaway/pie-icons-vue": "1.0.0",
     "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/atoms/f-error-message/CHANGELOG.md
+++ b/packages/components/atoms/f-error-message/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (merge into next release)
+------------------------------
+*December 5, 2022*
+
+### Changed
+- Updated to the new `pie-icons-vue` beta release.
+
+
 v2.3.0
 ------------------------------
 *September 30, 2022*

--- a/packages/components/atoms/f-error-message/package.json
+++ b/packages/components/atoms/f-error-message/package.json
@@ -46,7 +46,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeattakeaway/pie-icons-vue": "1.0.0"
+    "@justeattakeaway/pie-icons-vue": "2.0.0-beta.1"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",

--- a/packages/components/atoms/f-form-field/CHANGELOG.md
+++ b/packages/components/atoms/f-form-field/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (merge into next release)
+------------------------------
+*December 5, 2022*
+
+### Changed
+- Updated to the new `pie-icons-vue` beta release.
+
+
 v6.4.0
 ------------------------------
 *November 23, 2022*

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "@justeat/f-services": "1.x",
-    "@justeattakeaway/pie-icons-vue": "1.x",
+    "@justeattakeaway/pie-icons-vue": "2.0.0-beta.1",
     "uuid": "9.0.0"
   },
   "peerDependencies": {

--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (merge into next release)
+------------------------------
+*December 5, 2022*
+
+### Changed
+- Updated to the new `pie-icons-vue` beta release.
+
+
 v6.2.0
  ------------------------------
  *July 19, 2022*

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -48,7 +48,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.x"
+    "@justeat/f-services": "1.x",
+    "@justeattakeaway/pie-icons-vue": "2.0.0-beta.1"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
@@ -56,7 +57,6 @@
   },
   "devDependencies": {
     "@justeat/f-button": "4.x",
-    "@justeat/f-wdio-utils": "1.x",
-    "@justeattakeaway/pie-icons-vue": "1.0.0"
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -3,8 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (merge into next release)
+------------------------------
+*December 5, 2022*
+
+### Changed
+- Updated to the new `pie-icons-vue` beta release.
+
+
 v7.2.1
- ------------------------------
+------------------------------
  *August 31, 2022*
 
  ### Fixed
@@ -12,7 +21,7 @@ v7.2.1
 
 
 v7.2.0
- ------------------------------
+------------------------------
  *July 19, 2022*
 
  ### Added

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -52,10 +52,12 @@
     "@justeat/f-button": "4.x",
     "body-scroll-lock": "3.x"
   },
+  "dependencies": {
+    "@justeattakeaway/pie-icons-vue": "2.0.0-beta.1"
+  },
   "devDependencies": {
     "@justeat/f-button": "4.x",
     "@justeat/f-wdio-utils": "1.x",
-    "@justeattakeaway/pie-icons-vue": "1.0.0",
     "@vue/cli-plugin-babel": "4.5.16",
     "body-scroll-lock": "3.0.3"
   }

--- a/packages/components/molecules/f-rating/CHANGELOG.md
+++ b/packages/components/molecules/f-rating/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (merge into next release)
+------------------------------
+*December 5, 2022*
+
+### Changed
+- Updated to the new `pie-icons-vue` beta release.
+
+
 v0.13.0
 ------------------------------
 *November 28, 2022*

--- a/packages/components/molecules/f-rating/package.json
+++ b/packages/components/molecules/f-rating/package.json
@@ -49,14 +49,14 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.x"
+    "@justeat/f-services": "1.x",
+    "@justeattakeaway/pie-icons-vue": "2.0.0-beta.1"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.2.0",
     "@justeat/f-globalisation": "1.x"
   },
   "devDependencies": {
-    "@justeat/f-wdio-utils": "1.x",
-    "@justeattakeaway/pie-icons-vue": "1.x"
+    "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/components/molecules/f-user-message/CHANGELOG.md
+++ b/packages/components/molecules/f-user-message/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (merge into next release)
+------------------------------
+*December 5, 2022*
+
+### Changed
+- Updated to the new `pie-icons-vue` beta release.
+
+
 v4.3.0
 ------------------------------
 *July 28, 2022*

--- a/packages/components/molecules/f-user-message/package.json
+++ b/packages/components/molecules/f-user-message/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "@justeat/f-services": "1.x",
-    "@justeattakeaway/pie-icons-vue": "1.x",
+    "@justeattakeaway/pie-icons-vue": "2.0.0-beta.1",
     "axios": "0.21.2",
     "lodash-es": "4.17.21"
   },

--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (merge into next release)
+------------------------------
+*December 5, 2022*
+
+### Changed
+- Updated to the new `pie-icons-vue` beta release.
+
+
 v8.3.0
 ------------------------------
 *July 29, 2022*
@@ -18,7 +27,7 @@ v8.2.0
 ### Added
 - Node 16 support.
 
- 
+
 v8.1.0
 ------------------------------
 *July 7, 2022*

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "@justeat/f-services": "1.x",
-    "@justeattakeaway/pie-icons-vue": "1.0.0",
+    "@justeattakeaway/pie-icons-vue": "2.0.0-beta.1",
     "@justeat/f-vue-icons": "3.x",
     "v-click-outside": "3.1.2"
   },

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -2,6 +2,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+Latest (merge into next release)
+------------------------------
+*December 5, 2022*
+
+### Changed
+- Updated to the new `pie-icons-vue` beta release.
+
+
 v10.11.0
 ------------------------------
 *November 23, 2022*

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -49,7 +49,8 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-services": "1.x"
+    "@justeat/f-services": "1.x",
+    "@justeattakeaway/pie-icons-vue": "2.0.0-beta.1"
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
@@ -61,7 +62,6 @@
     "@justeat/f-button": "4.x",
     "@justeat/f-popover": "3.x",
     "@justeat/f-vue-icons": "3.x",
-    "@justeattakeaway/pie-icons-vue": "1.x",
     "@justeat/f-wdio-utils": "1.x"
   }
 }

--- a/packages/tools/fozzie/CHANGELOG.md
+++ b/packages/tools/fozzie/CHANGELOG.md
@@ -8,6 +8,14 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v10.10.3
+------------------------------
+*December 4, 2022*
+
+### Fixed
+- Security patch – v10.10.2 was released as a malicious package.
+
+
 v10.10.1
 ------------------------------
 *November 30, 2022*

--- a/packages/tools/fozzie/package.json
+++ b/packages/tools/fozzie/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "10.10.1",
+  "version": "10.10.3",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/stories/guides/typography.stories.mdx
+++ b/stories/guides/typography.stories.mdx
@@ -4,7 +4,17 @@
 
 ## The JETSansDigital Fontpack
 
-On JET Platforms, we use our custom font `JETSansDigital`. The full fontpack for these fonts [can be downloaded here](https://d30v2pzvrfyzpo.cloudfront.net/fonts/jetsansdigital-fontpack.zip).
+On JET Platforms, we use our custom font `JETSansDigital`. The full fontpack for these fonts [can be downloaded here](https://d30v2pzvrfyzpo.cloudfront.net/fonts/jetsansdigital-fontpack.zip). we recommend that you use the fonts via CDN, and they are all available on these links:
+
+```shell
+# For the base subset
+# Switch out *Regular* for *Bold* or *ExtraBold*. woff and woff2 files are available
+https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Regular-optimised.woff2
+
+# For the base subset
+# Switch out *Regular* for *Bold* or *ExtraBold*. woff and woff2 files are available
+https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Regular-optimised-extended.woff2
+```
 
 This fontpack includes Regular, Bold and ExtraBold variations (in `.woff` and `.woff2` formats) for the following subsets:
 


### PR DESCRIPTION
### Changed
- Updated packages to the new `pie-icons-vue` beta release.
- Pushed a fozzie security patch update (this change has already been published, as was urgent security fix)
- Tiny docs update