### PR TITLE
fozzie-components@v7.44.1 - Fix issue current lerna version + npm automation tokens

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -402,4 +402,4 @@ jobs:
       - name: Auth with NPM
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
       - name: Publish unreleased package versions to npm
-        run: yarn lerna publish from-package --ignore-scripts --yes
+        run: yarn lerna publish from-package --ignore-scripts --yes --no-verify-access

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v7.44.1
+------------------------------
+*December 06, 2022*
+
+### Fixed
+- Provide `--no-verify-access` to Github Actions config to get around issue where npm automation tokens don't work with current lerna version. - https://github.com/lerna/lerna/issues/2788 
+
+
 v7.44.0
 ------------------------------
 *November 30, 2022*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "7.44.0",
+  "version": "7.44.1",
   "private": true,
   "scripts": {
     "build": "turbo run build --continue",


### PR DESCRIPTION
**fozzie-components**

v7.44.1
------------------------------
*December 06, 2022*

### Fixed
- Provide `--no-verify-access` to Github Actions config to get around issue where npm automation tokens don't work with current lerna version. - https://github.com/lerna/lerna/issues/2788 