### PR TITLE
f-checkout@4.9.1 - Fix postalCode type

### DIFF
--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.9.1
+------------------------------
+*December 2, 2022*
+
+### Fixed
+- Incorrect `PostalCode` type when restoring address from cookies
+
+
 v4.9.0
 ------------------------------
 *December 1, 2022*

--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v4.9.1
 ------------------------------
-*December 2, 2022*
+*December 6, 2022*
 
 ### Fixed
 - Incorrect `PostalCode` type when restoring address from cookies

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout - Fozzie Checkout Component",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [

--- a/packages/components/pages/f-checkout/src/services/addressService/index.js
+++ b/packages/components/pages/f-checkout/src/services/addressService/index.js
@@ -209,7 +209,7 @@ function getAddressFromCookie (tenant, cookies, mapped = true) {
             Line1: `${houseNumber} ${street}`,
             Line2: unitNumber,
             Line3: sublocality,
-            PostalCode: postalCode,
+            PostalCode: postalCode.toString(),
             administrativeArea: state,
             City: city,
             Field1: latitude,

--- a/packages/components/pages/f-checkout/src/services/tests/addressService.test.js
+++ b/packages/components/pages/f-checkout/src/services/tests/addressService.test.js
@@ -347,14 +347,14 @@ describe('addressService', () => {
         describe('when the address does exist in cookies', () => {
             let get;
             let cookies;
-            const houseNumber = '35';
+            const houseNumber = 35;
             const street = 'Myrtle Bank Road';
             const unitNumber = 'Flat 1';
-            const latitude = '54.24';
-            const longitude = '0.24';
+            const latitude = 54.24;
+            const longitude = 0.24;
             const sublocality = '1';
             const state = 'TAS';
-            const postalCode = '7259';
+            const postalCode = 7259;
             const city = 'Myrtle Bank';
             const searchBoxAddress = '35 Myrtle Bank Road Flat 1, Myrtle Bank 7259 TAS, Australia';
 
@@ -381,7 +381,7 @@ describe('addressService', () => {
                     line2: unitNumber,
                     locality: city,
                     administrativeArea: state,
-                    postcode: postalCode
+                    postcode: postalCode.toString()
                 };
 
                 // Act & Assert
@@ -396,7 +396,7 @@ describe('addressService', () => {
                     Line3: sublocality,
                     administrativeArea: state,
                     City: city,
-                    PostalCode: postalCode,
+                    PostalCode: postalCode.toString(),
                     Field1: latitude,
                     Field2: longitude,
                     searchBoxAddress

--- a/packages/components/pages/f-checkout/src/store/checkout.module.js
+++ b/packages/components/pages/f-checkout/src/store/checkout.module.js
@@ -154,12 +154,12 @@ export default {
          * @param {Object} context - Vuex context object, this is the standard first parameter for actions.
          * @param {Object} payload - Parameter with the different configurations for the request.
          */
-        getCheckout: async ({ commit, state, dispatch }, { url, timeout, tenant }) => {
+        getCheckout: async ({ commit, state, dispatch }, { url, timeout }) => {
             const { data } = await checkoutApi.getCheckout(url, state, timeout);
 
             resolveCustomerDetails(data, state);
 
-            commit(UPDATE_STATE, { ...data, tenant });
+            commit(UPDATE_STATE, { ...data });
 
             commit(UPDATE_HAS_ASAP_SELECTED, data.fulfilment.time.asap);
 

--- a/packages/components/pages/f-checkout/src/store/tests/checkout.module.test.js
+++ b/packages/components/pages/f-checkout/src/store/tests/checkout.module.test.js
@@ -465,7 +465,6 @@ describe('CheckoutModule', () => {
         });
 
         describe('getCheckout ::', () => {
-            const tenant = 'uk';
             let config;
             let checkoutDeliveryCopy;
 
@@ -490,7 +489,7 @@ describe('CheckoutModule', () => {
 
                 // Assert
                 expect(checkoutApi.getCheckout).toHaveBeenCalledWith(payload.url, state, payload.timeout);
-                expect(commit).toHaveBeenCalledWith(UPDATE_STATE, { ...checkoutDeliveryCopy, tenant });
+                expect(commit).toHaveBeenCalledWith(UPDATE_STATE, checkoutDeliveryCopy);
             });
 
             it(`should update 'hasUpdatedAsap' value with ${UPDATE_HAS_ASAP_SELECTED} mutation.`, async () => {
@@ -523,7 +522,7 @@ describe('CheckoutModule', () => {
                     // Assert
                     expect(checkoutDeliveryCopy.customer).toBe(null);
                     expect(checkoutApi.getCheckout).toHaveBeenCalledWith(payload.url, state, payload.timeout);
-                    expect(commit).toHaveBeenCalledWith(UPDATE_STATE, { ...checkoutDeliveryCopy, tenant });
+                    expect(commit).toHaveBeenCalledWith(UPDATE_STATE, checkoutDeliveryCopy);
                 });
             });
 


### PR DESCRIPTION
v4.9.1
------------------------------
*December 6, 2022*

### Fixed
- Incorrect `PostalCode` type when restoring address from cookies
