### PR TITLE
f-registration@v3.13.1 - Fix unit test failure on uuid

### DIFF
--- a/packages/components/pages/f-registration/CHANGELOG.md
+++ b/packages/components/pages/f-registration/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v3.13.1
+------------------------------
+*December 8, 2022*
+
+### Added
+- `crypto` setup file to handle `getRandomValues` within jest tests. This logical stems from `f-form-field`'s use of UUID.
+
 
 v3.13.0
 ------------------------------

--- a/packages/components/pages/f-registration/jest.config.js
+++ b/packages/components/pages/f-registration/jest.config.js
@@ -39,5 +39,9 @@ module.exports = {
         './test/component/',
         './test/accessibility',
         './test/visual'
+    ],
+
+    setupFiles: [
+        '<rootDir>/test-utils/settings/jest.crypto-setup.js',
     ]
 };

--- a/packages/components/pages/f-registration/package.json
+++ b/packages/components/pages/f-registration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-registration",
   "description": "Fozzie Registration Form Component",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "main": "dist/f-registration.umd.min.js",
   "maxBundleSize": "50kB",
   "files": [

--- a/packages/components/pages/f-registration/src/components/_tests/f-registration.integration.test.js
+++ b/packages/components/pages/f-registration/src/components/_tests/f-registration.integration.test.js
@@ -16,6 +16,11 @@ const localVue = createLocalVue();
 localVue.use(VueI18n);
 localVue.use(Vuex);
 
+// required for UUID mocking for snapshot testing.
+jest.mock('crypto', () => ({
+    randomBytes: num => new Array(num).fill(0)
+}));
+
 const setFormFieldValues = wrapper => {
     wrapper.find('[data-test-id="formfield-firstName-input"]').setValue(CONSUMERS_REQUEST_DATA.firstName);
     wrapper.find('[data-test-id="formfield-lastName-input"]').setValue(CONSUMERS_REQUEST_DATA.lastName);

--- a/packages/components/pages/f-registration/test-utils/settings/jest.crypto-setup.js
+++ b/packages/components/pages/f-registration/test-utils/settings/jest.crypto-setup.js
@@ -1,0 +1,5 @@
+/* eslint-disable global-require */
+global.crypto = {
+    getRandomValues: arr => require('crypto').randomBytes(arr.length)
+};
+/* eslint-enable global-require */


### PR DESCRIPTION
### Added
- `crypto` setup file to handle `getRandomValues` within jest tests. This logical stems from `f-form-field`'s use of UUID.
