### PR TITLE
f-mfa@v0.23.1 - Add mocker for crypto method.

### DIFF
--- a/packages/components/pages/f-mfa/CHANGELOG.md
+++ b/packages/components/pages/f-mfa/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.23.1
+------------------------------
+*December 12, 2022*
+
+### Added
+- `crypto` setup file to handle `getRandomValues` within jest tests. This logical stems from `f-form-field`'s use of UUID.
+
 
 v0.23.0
 ------------------------------

--- a/packages/components/pages/f-mfa/jest.config.js
+++ b/packages/components/pages/f-mfa/jest.config.js
@@ -39,5 +39,9 @@ module.exports = {
         './test/visual/'
     ],
 
-    testURL: 'http://localhost/'
+    testURL: 'http://localhost/',
+
+    setupFiles: [
+        '<rootDir>/test-utils/settings/jest.crypto-setup.js',
+    ]
 };

--- a/packages/components/pages/f-mfa/package.json
+++ b/packages/components/pages/f-mfa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mfa",
   "description": "Fozzie Mfa - Multi-factor Authenticator Input Form",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "main": "dist/f-mfa.umd.min.js",
   "maxBundleSize": "30kB",
   "files": [

--- a/packages/components/pages/f-mfa/src/components/_tests/Mfa.test.js
+++ b/packages/components/pages/f-mfa/src/components/_tests/Mfa.test.js
@@ -6,6 +6,7 @@ import {
     REDIRECT_URL_EVENT_NAME
 } from '../../constants';
 
+
 const localVue = createLocalVue();
 localVue.use(VueI18n);
 const validateUrl = 'https://localhost:8080/mfa/validate';
@@ -44,6 +45,11 @@ jest.mock(
         postValidateMfaToken: mockPostValidateMfaToken
     }))
 );
+
+// required for UUID mocking for snapshot testing.
+jest.mock('crypto', () => ({
+    randomBytes: num => new Array(num).fill(0)
+}));
 
 // Provide a generic mount method to be called by each test which
 // can override mocks, props and data within each test if required

--- a/packages/components/pages/f-mfa/test-utils/settings/jest.crypto-setup.js
+++ b/packages/components/pages/f-mfa/test-utils/settings/jest.crypto-setup.js
@@ -1,0 +1,5 @@
+/* eslint-disable global-require */
+global.crypto = {
+    getRandomValues: arr => require('crypto').randomBytes(arr.length)
+};
+/* eslint-enable global-require */


### PR DESCRIPTION
### Added
- `crypto` setup file to handle `getRandomValues` within jest tests. This logical stems from `f-form-field`'s use of UUID.
