### PR TITLE
f-mfa@v0.24.0 - add translations for es, ie and it

### DIFF
--- a/packages/components/pages/f-mfa/CHANGELOG.md
+++ b/packages/components/pages/f-mfa/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.24.0
+------------------------------
+*February 8, 2023*
+
+### Added
+- Translation content for es, ie and it for use in f-mfa page.
+
+
 v0.23.1
 ------------------------------
 *December 12, 2022*

--- a/packages/components/pages/f-mfa/package.json
+++ b/packages/components/pages/f-mfa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mfa",
   "description": "Fozzie Mfa - Multi-factor Authenticator Input Form",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "main": "dist/f-mfa.umd.min.js",
   "maxBundleSize": "30kB",
   "files": [

--- a/packages/components/pages/f-mfa/src/tenants/en-IE.js
+++ b/packages/components/pages/f-mfa/src/tenants/en-IE.js
@@ -1,4 +1,45 @@
-export default {
+const messages = {
     locale: 'en-IE',
-    text: 'I am a VMfa Component (IE)'
+    verificationPage: {
+        subTitle: "We've emailed your login code",
+        instructionsPrimaryText: "We've sent a verification code to {0} to help keep your account secure. Enter it below to log in.",
+        instructionsSecondaryText: 'Your code will be valid for 30 minutes.',
+        formField: {
+            labelText: 'Your verification code',
+            placeholderText: 'Enter code',
+            validationMessage: 'Please enter a valid code'
+        },
+        submitErrorText: 'Please check and try again',
+        primaryButtonText: 'Continue',
+        secondaryButtonText: 'Need help?'
+    },
+    helpInfo: {
+        title: 'Help',
+        subTitle: 'Need help?',
+        instructionsPrimaryText: "We've emailed a code to {0}. It will be valid for 30 minutes. If you're having trouble:",
+        instructionsPoint1Text: 'Wait a few minutes for the email to come through',
+        instructionsPoint2Text: 'Check your spam folder',
+        instructionsPoint3Text: 'Try logging in another way',
+        instructionsPoint4Text: 'See our {0} if you still need help',
+        instructionsHelpLink: 'https://www.just-eat.ie/help/article/8885964831761/why-am-i-sometimes-asked-to-enter-a-verification-code-when-using-just-eat',
+        instructionsHelpText: 'FAQs',
+        primaryButtonText: 'Got it',
+        secondaryButtonText: 'Log in another way'
+    },
+    errorMessages: {
+        validation: 'Please check and try again',
+        submitMfa: {
+            heading: 'Something went wrong',
+            description: 'Sorry about that. Please try again.'
+        },
+        loading: {
+            heading: 'Something went wrong',
+            message: 'Sorry about that. Please try again.',
+            primaryButtonText: 'Go back'
+        }
+    }
+};
+
+export default {
+    messages
 };

--- a/packages/components/pages/f-mfa/src/tenants/es-ES.js
+++ b/packages/components/pages/f-mfa/src/tenants/es-ES.js
@@ -1,4 +1,45 @@
-export default {
+const messages = {
     locale: 'es-ES',
-    text: 'I am a VMfa Component (ES)'
+    verificationPage: {
+        subTitle: 'Te hemos enviado por correo electrónico tu código de inicio de sesión',
+        instructionsPrimaryText: 'Hemos enviado un código de verificación a {0} para ayudarte a mantener tu cuenta segura. Introdúcelo a continuación para iniciar sesión.',
+        instructionsSecondaryText: 'Tu código será válido durante {0} minutos.',
+        formField: {
+            labelText: 'Tu código de verificación',
+            placeholderText: 'Introducir código',
+            validationMessage: 'Por favor, ingresa un código válido'
+        },
+        submitErrorText: 'Compruébalo y vuelve a intentarlon',
+        primaryButtonText: 'Continuar',
+        secondaryButtonText: 'Necesitas ayuda?'
+    },
+    helpInfo: {
+        title: 'Ayuda',
+        subTitle: 'Necesitas ayuda?',
+        instructionsPrimaryText: 'Hemos enviado un código al correo electrónico {0}. Será válido durante 30 minutos. Si tienes problemas:',
+        instructionsPoint1Text: 'Espera unos minutos a que llegue el correo electrónico',
+        instructionsPoint2Text: 'Comprueba tu carpeta de correo no deseado',
+        instructionsPoint3Text: 'Intenta iniciar sesión de otra forma',
+        instructionsPoint4Text: 'Consulta {0} si sigues necesitando ayuda',
+        instructionsHelpLink: 'https://www.just-eat.es/help/article/8886741560465/por-que-se-me-pide-a-veces-que-introduzca-un-codigo-de-verificacion-al-usar-just-eat',
+        instructionsHelpText: 'nuestras preguntas frecuentes',
+        primaryButtonText: 'Entendido',
+        secondaryButtonText: 'Iniciar sesión de otra forma'
+    },
+    errorMessages: {
+        validation: 'Compruébalo y vuelve a intentarlo',
+        submitMfa: {
+            heading: 'Algo salió mal',
+            description: 'Lo sentimos. Inténtalo de nuevo, por favor.'
+        },
+        loading: {
+            heading: 'Algo salió mal',
+            message: 'Lo sentimos. Inténtalo de nuevo, por favor.',
+            primaryButtonText: 'Volver'
+        }
+    }
+};
+
+export default {
+    messages
 };

--- a/packages/components/pages/f-mfa/src/tenants/es-ES.js
+++ b/packages/components/pages/f-mfa/src/tenants/es-ES.js
@@ -3,7 +3,7 @@ const messages = {
     verificationPage: {
         subTitle: 'Te hemos enviado por correo electrónico tu código de inicio de sesión',
         instructionsPrimaryText: 'Hemos enviado un código de verificación a {0} para ayudarte a mantener tu cuenta segura. Introdúcelo a continuación para iniciar sesión.',
-        instructionsSecondaryText: 'Tu código será válido durante {0} minutos.',
+        instructionsSecondaryText: 'Tu código será válido durante 30 minutos.',
         formField: {
             labelText: 'Tu código de verificación',
             placeholderText: 'Introducir código',

--- a/packages/components/pages/f-mfa/src/tenants/it-IT.js
+++ b/packages/components/pages/f-mfa/src/tenants/it-IT.js
@@ -3,7 +3,7 @@ const messages = {
     verificationPage: {
         subTitle: 'Ti abbiamo inviato un’email con il codice di accesso',
         instructionsPrimaryText: 'Abbiamo inviato un’email con il codice di verifica a {0} per garantire la sicurezza del tuo account. Inserisci il codice qui sotto per accedere.',
-        instructionsSecondaryText: 'Il tuo codice sarà valido per {0} minuti.',
+        instructionsSecondaryText: 'Il tuo codice sarà valido per 30 minuti.',
         formField: {
             labelText: 'Il tuo codice di verifica',
             placeholderText: 'Inserisci il codice',

--- a/packages/components/pages/f-mfa/src/tenants/it-IT.js
+++ b/packages/components/pages/f-mfa/src/tenants/it-IT.js
@@ -1,4 +1,45 @@
-export default {
+const messages = {
     locale: 'it-IT',
-    text: 'I am a VMfa Component (IT)'
+    verificationPage: {
+        subTitle: 'Ti abbiamo inviato un’email con il codice di accesso',
+        instructionsPrimaryText: 'Abbiamo inviato un’email con il codice di verifica a {0} per garantire la sicurezza del tuo account. Inserisci il codice qui sotto per accedere.',
+        instructionsSecondaryText: 'Il tuo codice sarà valido per {0} minuti.',
+        formField: {
+            labelText: 'Il tuo codice di verifica',
+            placeholderText: 'Inserisci il codice',
+            validationMessage: 'Si prega di inserire un codice valido'
+        },
+        submitErrorText: 'Controlla e riprova',
+        primaryButtonText: 'Continua',
+        secondaryButtonText: 'Hai bisogno di aiuto?'
+    },
+    helpInfo: {
+        title: 'Aiuto',
+        subTitle: 'Hai bisogno di aiuto?',
+        instructionsPrimaryText: 'Abbiamo inviato un codice a {0}. Il codice sarà valido per 30 minuti. In caso di problemi:',
+        instructionsPoint1Text: 'Attendi qualche minuto l’arrivo dell’email',
+        instructionsPoint2Text: 'Controlla la cartella dello spam',
+        instructionsPoint3Text: 'Prova ad accedere in un altro modo',
+        instructionsPoint4Text: 'Consulta le nostre {0} se hai ancora bisogno di aiuto',
+        instructionsHelpLink: 'https://www.justeat.it/help/article/6621416520349/perche-a-volte-mi-viene-richiesto-un-codice-di-verifica-quando-uso-just-eat',
+        instructionsHelpText: 'nuestras preguntas frecuentes',
+        primaryButtonText: 'OK',
+        secondaryButtonText: 'Accedi in un altro modo'
+    },
+    errorMessages: {
+        validation: 'Controlla e riprova',
+        submitMfa: {
+            heading: 'Qualcosa è andato storto',
+            description: 'Lo sentimos. Por favor inténtalo de nuevo.'
+        },
+        loading: {
+            heading: 'Qualcosa è andato storto',
+            message: 'Lo sentimos. Por favor inténtalo de nuevo.',
+            primaryButtonText: 'Torna indietro'
+        }
+    }
+};
+
+export default {
+    messages
 };

--- a/packages/components/pages/f-mfa/stories/Mfa.stories.js
+++ b/packages/components/pages/f-mfa/stories/Mfa.stories.js
@@ -51,7 +51,7 @@ VMfaComponent.argTypes = {
         control: {
             type: 'select'
         },
-        options: [locales.gb, locales.au, locales.nz],
+        options: [locales.gb, locales.au, locales.nz, locales.ie, locales.es, locales.it],
         description: 'Choose a locale'
     },
     apiState: {


### PR DESCRIPTION
Translations added to the MFA page component for 

- ES
- IE
- IT

ES
<img width="933" alt="Screenshot 2023-02-08 at 11 56 33" src="https://user-images.githubusercontent.com/17792007/217523729-b8c3e839-29bd-46ca-944c-78cb8a4c1854.png">

IE
<img width="774" alt="Screenshot 2023-02-08 at 11 57 58" src="https://user-images.githubusercontent.com/17792007/217523797-88f7137c-1ad3-4bf9-993d-1e1fe6d7ed54.png">

IT
<img width="827" alt="Screenshot 2023-02-08 at 11 57 41" src="https://user-images.githubusercontent.com/17792007/217523851-9e69b37b-c7f8-419b-8036-32420dc3c6f6.png">
