### PR TITLE
f-offers@v2.0.0 - new content cards

### DIFF
--- a/packages/components/pages/f-offers/CHANGELOG.md
+++ b/packages/components/pages/f-offers/CHANGELOG.md
@@ -12,6 +12,15 @@ v1.15.2
 - braze sk 3.3.0 under dev dependencies to allow tests to work.
 
 
+v2.0.0
+------------------------------
+*December 12, 2022*
+
+### Changed
+- Updated to include the new braze adapter
+- also updated to the latest version of content cards
+
+
 v1.15.1
 ------------------------------
 *November 21, 2022*

--- a/packages/components/pages/f-offers/CHANGELOG.md
+++ b/packages/components/pages/f-offers/CHANGELOG.md
@@ -4,21 +4,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0
+------------------------------
+*February 15, 2022*
+
+### Changed
+- Updated to include the new braze adapter
+- also updated to the latest version of content cards
+
+
 v1.15.2
 ------------------------------
 *February 13, 2022*
 
 ### Added
 - braze sk 3.3.0 under dev dependencies to allow tests to work.
-
-
-v2.0.0
-------------------------------
-*December 12, 2022*
-
-### Changed
-- Updated to include the new braze adapter
-- also updated to the latest version of content cards
 
 
 v1.15.1

--- a/packages/components/pages/f-offers/jest.config.js
+++ b/packages/components/pages/f-offers/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
     },
 
     transformIgnorePatterns: [
-        'node_modules/(?!(lodash-es)/)'
+        'node_modules/(?!(lodash-es|@justeattakeaway/cc-stampcards-adapter|@justeattakeaway/cc-braze-adapter|@justeattakeaway/cc-utils|@justeattakeaway/cc-filters|@braze/web-sdk)/)'
     ],
 
     moduleNameMapper: {

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-offers",
   "description": "Fozzie Offers - displays offers to the customers",
-  "version": "1.15.2",
+  "version": "2.0.0",
   "main": "dist/f-offers.umd.min.js",
   "maxBundleSize": "150kB",
   "files": [
@@ -49,6 +49,7 @@
   "dependencies": {
     "@justeat/f-globalisation": "1.x",
     "@justeat/f-services": "1.x",
+    "@justeattakeaway/cc-braze-adapter": "0.3.0",
     "axios": "0.21.2",
     "jwt-decode": "3.1.2"
   },
@@ -59,14 +60,15 @@
     "@justeat/f-mega-modal": "7.x",
     "@justeat/f-searchbox": "6.x",
     "@justeat/f-trak": "0.x",
-    "@braze/web-sdk": "3.3.0",
+    "@justeat/f-content-cards": "10.x",
+    "@braze/web-sdk": ">=4.5.0",
     "js-cookie": "2.2.1",
     "vuex": ">=3.5.1"
   },
   "devDependencies": {
-    "@braze/web-sdk": "3.3.0",
+    "@braze/web-sdk": "4.5.0",
     "@justeat/f-button": "4.x",
-    "@justeat/f-content-cards": "9.x",
+    "@justeat/f-content-cards": "10.x",
     "@justeat/f-media-element": "3.x",
     "@justeat/f-mega-modal": "7.x",
     "@justeat/f-searchbox": "6.x",

--- a/packages/components/pages/f-offers/stories/Offers.stories.js
+++ b/packages/components/pages/f-offers/stories/Offers.stories.js
@@ -103,8 +103,8 @@ export const VOffersComponent = (args, { argTypes }) => ({
 VOffersComponent.storyName = 'f-offers';
 
 VOffersComponent.args = {
-    authToken: '__TEST_TOKEN__',
-    brazeApiKey: '__TEST_BRAZE_SDK_KEY__'
+    authToken: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOi8vZXhhbXBsZS5jb20vbG95YWx0eSIsImlhdCI6MTY2OTczNTg3NiwiZXhwIjoxNzAxMjcxODc2LCJhdWQiOiJodHRwOi8vZXhhbXBsZS5jb20vbG95YWx0eSIsInN1YiI6IjE3OTg0NzA4IiwiZW1haWwiOiJqb2huc21pdGhAZXhhbXBsZS5jb20iLCJuYW1lIjoiSm9obiBTbWl0aCIsImdsb2JhbF91c2VyX2lkIjoiMTIzNDU2Nzg5IiwiZ2l2ZW5fbmFtZSI6IkpvaG4iLCJyb2xlIjoiUmVnaXN0ZXJlZCIsImZhbWlseV9uYW1lIjoiU21pdGgifQ.d__NTXKO7y3I1scfi11wkC4MtNhANzziTDH831T3shI',
+    brazeApiKey: 'e7d83458-a234-4ea6-aa43-a92496fbafc9'
 };
 
 VOffersComponent.argTypes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2664,15 +2664,6 @@
     eslint-config-airbnb-base "15.0.0"
     eslint-plugin-vue "8.7.1"
 
-"@justeat/f-content-cards@9.x":
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-content-cards/-/f-content-cards-9.1.0.tgz#e12ff1c0b1e26d8c26fcbfca729e8a7fb7f95ac4"
-  integrity sha512-uQmPGcleY1cQOnXrQwWeg0ptoURxWSXOdU3Y3WHdn6mapqtKM+c10TtA99RCK/Sa66hJtwCi8SvTQf7WJDutfQ==
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "7.12.13"
-    "@justeat/f-services" "1.x"
-    core-js "3.6.5"
-
 "@justeat/f-dom@0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-dom/-/f-dom-0.4.0.tgz#3e838a2dd06d4d5281c17f5fb9f66d7485fd759a"
@@ -2777,6 +2768,15 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@justeattakeaway/cc-braze-adapter/-/cc-braze-adapter-0.2.0.tgz#aedd7ddc8b0455dcd8aefaf7ec1921df24230a0e"
   integrity sha512-gyxZTiM117xxdjJX3hYpF/m1RUtTzTI8EZ1s/axqIVGTE3/QiBd0+ElBNYg2NwJP9gPUtbHOn6U+Txs3MDjl+g==
+  dependencies:
+    "@justeattakeaway/cc-filters" "0.1.0"
+    "@justeattakeaway/cc-utils" "0.1.0"
+    lodash-es "4.17.21"
+
+"@justeattakeaway/cc-braze-adapter@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@justeattakeaway/cc-braze-adapter/-/cc-braze-adapter-0.3.0.tgz#2cbe5bcc6f6122f8176ac13a7045af558053ed87"
+  integrity sha512-uDybXmr7nax8MTMF/KJgyveZEo4Behkeh3bpC61mfuw68y3bYlhBsX0l1Jnajxijlubrj1k1zPQeoxMtPVzN+g==
   dependencies:
     "@justeattakeaway/cc-filters" "0.1.0"
     "@justeattakeaway/cc-utils" "0.1.0"


### PR DESCRIPTION
This PR updates the braze adapter to the new version. Also upgrading the braze sdk to 4.5

## UI Review Checks

<img width="1164" alt="Screenshot 2023-02-15 at 08 53 32" src="https://user-images.githubusercontent.com/15876339/218979882-430c7004-82a3-4197-be56-dad9c95ed5e5.png">

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]

## Browsers Tested

- [x] Chrome (latest)
