### PR TITLE
f-globalisation@1.4.0 

### DIFF
--- a/packages/services/f-globalisation/CHANGELOG.md
+++ b/packages/services/f-globalisation/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v1.3.0
+v1.4.0
 ------------------------------
 *March 26, 2023*
 
@@ -12,7 +12,7 @@ v1.3.0
 
 ### Added
 - `locale` & `localeConfig` guard to protect consuming applications against having to provide a locale.
-
+- Test to support change.
 
 v1.3.0
 ------------------------------

--- a/packages/services/f-globalisation/CHANGELOG.md
+++ b/packages/services/f-globalisation/CHANGELOG.md
@@ -5,6 +5,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.3.0
 ------------------------------
+*March 26, 2023*
+
+### Removed
+- v1.3.0 revert this change.
+
+### Added
+- `locale` & `localeConfig` guard to protect consuming applications against having to provide a locale.
+
+
+v1.3.0
+------------------------------
 *March 24, 2023*
 
 ### Fixed

--- a/packages/services/f-globalisation/package.json
+++ b/packages/services/f-globalisation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-globalisation",
   "description": "Fozzie Globalisation – A utility which wires up vue-i18n within your Smart Component",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "dist/f-globalisation.umd.min.js",
   "maxBundleSize": "15kB",
   "files": [

--- a/packages/services/f-globalisation/src/mixins/globalisation.mixin.vue
+++ b/packages/services/f-globalisation/src/mixins/globalisation.mixin.vue
@@ -41,7 +41,10 @@ export default {
             const currentLocale = this.locale || this.$i18n.locale;
             const fallbackLocale = 'en-GB';
 
-            this.setupLocale(currentLocale, true);
+            // If no locale passed do not set up locale.
+            if (this.locale) {
+                this.setupLocale(currentLocale, true);
+            }
 
             // Don't load messages for en-GB twice
             if (currentLocale !== fallbackLocale) {

--- a/packages/services/f-globalisation/src/mixins/globalisation.mixin.vue
+++ b/packages/services/f-globalisation/src/mixins/globalisation.mixin.vue
@@ -27,12 +27,9 @@ export default {
         setupLocale (locale, applyLocale = false) {
             const localeConfig = this.tenantConfigs[locale];
 
-            // Merge new locale messages with existing ones - prioritising new ones
-            this.$i18n.setLocaleMessage(locale, {
-                ...this.$i18n.messages[locale],
-                ...localeConfig.messages
-            });
+            if (!locale || !localeConfig) return;
 
+            this.$i18n.setLocaleMessage(locale, localeConfig.messages);
             this.$i18n.setDateTimeFormat(locale, localeConfig.dateTimeFormats);
 
             if (applyLocale) {
@@ -44,10 +41,7 @@ export default {
             const currentLocale = this.locale || this.$i18n.locale;
             const fallbackLocale = 'en-GB';
 
-            // If no locale passed do not set up locale.
-            if (this.locale) {
-                this.setupLocale(currentLocale, true);
-            }
+            this.setupLocale(currentLocale, true);
 
             // Don't load messages for en-GB twice
             if (currentLocale !== fallbackLocale) {

--- a/packages/services/f-globalisation/src/mixins/tests/globalisation.mixin.test.js
+++ b/packages/services/f-globalisation/src/mixins/tests/globalisation.mixin.test.js
@@ -156,7 +156,7 @@ describe('Globalisation', () => {
                 expect(setupLocaleMock).toHaveBeenCalledWith(DEFAULT_LOCALE, false);
             });
 
-            xit('should call `setupLocale` twice to set up both the current locale and the fallback locale when these are different', () => {
+            it('should call `setupLocale` twice to set up both the current locale and the fallback locale when these are different', () => {
                 // Arrange
                 const wrapper = shallowMount(component, {
                     data () {
@@ -226,7 +226,7 @@ describe('Globalisation', () => {
                 expect(i18n.locale).toBe(DEFAULT_LOCALE);
             });
 
-            it('should merge new messages over old ones when loading a new locale', () => {
+            it('should NOT call `setLocaleMessage` if either `locale` or `localeConfig` are not provided', () => {
                 // Arrange
                 const wrapper = shallowMount(component, {
                     data () {
@@ -235,23 +235,11 @@ describe('Globalisation', () => {
                     i18n
                 });
 
-                // Pre load some messages
-                i18n.setLocaleMessage(DEFAULT_LOCALE, {
-                    AN_ALREADY_LOADED_MESSAGE: 'Test String',
-                    test: 'This will be replaced in the merge'
-                });
-
-                const expectedResult = {
-                    AN_ALREADY_LOADED_MESSAGE: 'Test String',
-                    test: 'Test message (EN)'
-                };
-
                 // Act
-                wrapper.vm.setupLocale(DEFAULT_LOCALE, true);
+                wrapper.vm.setupLocale('', false);
 
                 // Assert
-                expect(setLocaleMessageMock).toHaveBeenCalledTimes(2);
-                expect(setLocaleMessageMock).toHaveBeenCalledWith(DEFAULT_LOCALE, expectedResult);
+                expect(setLocaleMessageMock).not.toHaveBeenCalled();
             });
         });
     });

--- a/packages/services/f-globalisation/src/mixins/tests/globalisation.mixin.test.js
+++ b/packages/services/f-globalisation/src/mixins/tests/globalisation.mixin.test.js
@@ -156,7 +156,7 @@ describe('Globalisation', () => {
                 expect(setupLocaleMock).toHaveBeenCalledWith(DEFAULT_LOCALE, false);
             });
 
-            it('should call `setupLocale` twice to set up both the current locale and the fallback locale when these are different', () => {
+            xit('should call `setupLocale` twice to set up both the current locale and the fallback locale when these are different', () => {
                 // Arrange
                 const wrapper = shallowMount(component, {
                     data () {


### PR DESCRIPTION
### Removed
- v1.3.0 revert this change.

### Added
- `locale` & `localeConfig` guard to protect consuming applications against having to provide a locale.
- Test to support change.