### PR TITLE
f-restaurant-card@v1.5.1 - Update Restaurant Card Promoted Tag Colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+7.49.0
+------------------------------
+*April 4, 2023*
+
+### Changed
+- Update `f-restaurant-card` to v1.5.1 to change colour token used for the Promoted tag.
 
 v7.49.0
 ------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,6 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-7.49.0
-------------------------------
-*April 4, 2023*
-
-### Changed
-- Update `f-restaurant-card` to v1.5.1 to change colour token used for the Promoted tag.
 
 v7.49.0
 ------------------------------

--- a/packages/components/molecules/f-restaurant-card/CHANGELOG.md
+++ b/packages/components/molecules/f-restaurant-card/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.5.1
+------------------------------
+*April 04, 2023*
+
+### Changed
+- Background colour token changed from `$color-dark-container-dark` to `$color-container-dark` for the Promoted tag styling `c-restaurantTag--dark`
+
 
 v1.5.0
 ------------------------------

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-restaurant-card",
   "description": "Fozzie Restaurant Card -  Responsible for displaying restaurant data and linking to a restaurant",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "dist/f-restaurant-card.umd.min.js",
   "files": [
     "dist",

--- a/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTag.vue
+++ b/packages/components/molecules/f-restaurant-card/src/components/subcomponents/RestaurantTags/RestaurantTag.vue
@@ -83,7 +83,7 @@ export default {
 
 .c-restaurantTag--dark {
     color: f.$color-content-light;
-    background-color: f.$color-dark-container-dark;
+    background-color: f.$color-container-dark;
 }
 
 .c-restaurantTag--warm {


### PR DESCRIPTION
Changing the incorrect colour token for the restaurant card promoted tag from `$color-dark-container-dark`  to the correct token `$color-container-dark`

## Browsers Tested

- [ x ] Chrome (latest)
