### PR TITLE
f-mega-modal@7.4.0 - Add back button and rtl config.

### DIFF
--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -4,12 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v7.4.0
+v8.0.0 ** Breaking Change **
 ------------------------------
-*April 06, 2023*
+*April 12, 2023*
+
+### Changed
+- Prop `hasCloseButton` to `closeButtonStyle` allow either a chevron icon or close icon to be used.
+  - `closeButtonStyle` options: `none`, `close-small-icon`, `chevron-left-icon`.
 
 ### Added
-- `hasBackButton` prop to allow a chevron icon to be used instead of a close icon.
 - `isModeRightToLeft` prop to allow a chevron icon to be used in a right to left tenant.
 
 

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -10,7 +10,7 @@ v7.4.0
 
 ### Added
 - `hasBackButton` prop to allow a chevron icon to be used instead of a close icon.
-- `hasModeRightToLeft` prop to allow a chevron icon to be used in a right to left tenant.
+- `isModeRightToLeft` prop to allow a chevron icon to be used in a right to left tenant.
 
 
 v7.3.0

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -10,7 +10,7 @@ v8.0.0 ** Breaking Change **
 
 ### Changed
 - Prop `hasCloseButton` to `closeButtonStyle` allow either a chevron icon or close icon to be used.
-  - `closeButtonStyle` options: `none`, `close-small-icon`, `chevron-left-icon`.
+  - `closeButtonStyle` options: `''`, `close-small-icon`, `chevron-left-icon`.
 
 ### Added
 - `isModeRightToLeft` prop to allow a chevron icon to be used in a right to left tenant.

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -9,7 +9,7 @@ v8.0.0 ** Breaking Change **
 *April 12, 2023*
 
 ### Changed
-- Prop `hasCloseButton` to `closeButtonStyle` allow either a chevron icon or close icon to be used.
+- Prop `hasCloseButton` to `closeButtonStyle` allows either a chevron icon or close icon to be used or the choice not to display anything.
   - `closeButtonStyle` options: `''`, `close-small-icon`, `chevron-left-icon`.
 
 ### Added

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v7.4.0
+------------------------------
+*April 06, 2023*
+
+### Added
+- `hasBackButton` prop to allow a chevron icon to be used instead of a close icon.
+- `hasModeRightToLeft` prop to allow a chevron icon to be used in a right to left tenant.
+
+
 v7.3.0
 ------------------------------
 *March 27, 2023*

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -4,15 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-v8.0.0 ** Breaking Change **
+v7.4.0
 ------------------------------
 *April 12, 2023*
 
-### Changed
-- Prop `hasCloseButton` to `closeButtonStyle` allows either a chevron icon or close icon to be used or the choice not to display anything.
-  - `closeButtonStyle` options: `''`, `close-small-icon`, `chevron-left-icon`.
-
 ### Added
+- Prop `closeButtonStyle` allows either a chevron icon `chevron-left-icon` or close icon `close-small-icon` to be used.
 - `isModeRightToLeft` prop to allow a chevron icon to be used in a right to left tenant.
 
 

--- a/packages/components/molecules/f-mega-modal/README.md
+++ b/packages/components/molecules/f-mega-modal/README.md
@@ -119,7 +119,7 @@ The props that can be defined are as follows:
 | `is-close-fixed`       | `Boolean` | `false`         | Sets the modal close button position to `fixed`.                                                                                                                  |
 | `is-positioned-bottom` | `Boolean` | `false`         | Sets the modal position to the bottom of the viewport for all screen widths.                                                                                      |
 | `has-overlay`          | `Boolean` | `true`          | Controls whether or not to display an overlay behind the modal.                                                                                                   |
-| `close-button-style`   | `String`  | `close-small-icon`          | Controls the style of the button. Accepts `close-small-icon` & `chevron-left-icon`. If you pass an empty string '', no styles for the close button will be shown. |
+| `close-button-style`   | `String`  | `close-small-icon`          | Controls the style of the button. Accepts `close-small-icon` & `chevron-left-icon`. |
 | `close-on-blur`        | `Boolean` | `true`          | Controls whether or not to close the modal when the user clicks outside of the modal.                                                                             |
 | `close-button-copy`    | `String`  | `"Close modal"` | Sets the hidden text value for the close button which is used by screen-readers.                                                                                  |
 | `title`                | `String`  | `''`            | When set, will add a title to the top of the component. If you need to define a custom heading, ignore this prop.                                                 |

--- a/packages/components/molecules/f-mega-modal/README.md
+++ b/packages/components/molecules/f-mega-modal/README.md
@@ -119,7 +119,7 @@ The props that can be defined are as follows:
 | `is-close-fixed`       | `Boolean` | `false`         | Sets the modal close button position to `fixed`.                                                                                       |
 | `is-positioned-bottom` | `Boolean` | `false`         | Sets the modal position to the bottom of the viewport for all screen widths.                                                           |
 | `has-overlay`          | `Boolean` | `true`          | Controls whether or not to display an overlay behind the modal.                                                                        |
-| `close-button-style`   | `String`  | `close-small-icon`          | Controls the style of the button. Accepts `cross` & `chevron`.                                                               |
+| `close-button-style`   | `String`  | `cross`          | Controls the style of the button. Accepts `cross` & `chevron`.                                                               |
 | `close-on-blur`        | `Boolean` | `true`          | Controls whether or not to close the modal when the user clicks outside of the modal.                                                  |
 | `close-button-copy`    | `String`  | `"Close modal"` | Sets the hidden text value for the close button which is used by screen-readers.                                                       |
 | `title`                | `String`  | `''`            | When set, will add a title to the top of the component. If you need to define a custom heading, ignore this prop.                      |

--- a/packages/components/molecules/f-mega-modal/README.md
+++ b/packages/components/molecules/f-mega-modal/README.md
@@ -108,22 +108,24 @@ The following rudimentary example can be used as a guide for implementing this c
 
 The props that can be defined are as follows:
 
-| Prop  | Type  | Default | Description |
-| ----- | ----- | ------- | ----------- |
-| `is-open` | `Boolean` | `false` | Sets the modal to open or closed state. |
-| `is-narrow` | `Boolean` | `false` | Use the narrow visual style. |
-| `is-wide` | `Boolean` | `false` | Use the wide visual style. |
-| `is-flush` | `Boolean` | `false` | Removes passing around the modal content. |
-| `is-full-height` | `Boolean` | `false` | Sets the modal content to full height of the screen.<br/><br/><blockquote>Note this only applies to small screen devices.</blockquote> |
-| `is-scrollable` | `Boolean` | `false` | Makes the modal content scrollable. |
-| `is-close-fixed` | `Boolean` | `false` | Sets the modal close button position to `fixed`. |
-| `is-positioned-bottom` | `Boolean` | `false` | Sets the modal position to the bottom of the viewport for all screen widths. |
-| `has-overlay` | `Boolean` | `true` | Controls whether or not to display an overlay behind the modal. |
-| `has-close-button` | `Boolean` | `true` | Controls whether or not to display the modal close button. |
-| `close-on-blur` | `Boolean` | `true` | Controls whether or not to close the modal when the user clicks outside of the modal. |
-| `close-button-copy` | `String` | `"Close modal"` | Sets the hidden text value for the close button which is used by screen-readers. |
-| `title` | `String` | `''` | When set, will add a title to the top of the component. If you need to define a custom heading, ignore this prop.  |
-| `titleHtmlTag` | `String` | `h3` | Sets the tag for the component's title.<br><br>Allowed values are `h1`, `h2`, `h3`, and `h4` |
+| Prop                   | Type  | Default         | Description                                                                                                                            |
+|------------------------| ----- |-----------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `is-open`              | `Boolean` | `false`         | Sets the modal to open or closed state.                                                                                                |
+| `is-narrow`            | `Boolean` | `false`         | Use the narrow visual style.                                                                                                           |
+| `is-wide`              | `Boolean` | `false`         | Use the wide visual style.                                                                                                             |
+| `is-flush`             | `Boolean` | `false`         | Removes passing around the modal content.                                                                                              |
+| `is-full-height`       | `Boolean` | `false`         | Sets the modal content to full height of the screen.<br/><br/><blockquote>Note this only applies to small screen devices.</blockquote> |
+| `is-scrollable`        | `Boolean` | `false`         | Makes the modal content scrollable.                                                                                                    |
+| `is-close-fixed`       | `Boolean` | `false`         | Sets the modal close button position to `fixed`.                                                                                       |
+| `is-positioned-bottom` | `Boolean` | `false`         | Sets the modal position to the bottom of the viewport for all screen widths.                                                           |
+| `has-overlay`          | `Boolean` | `true`          | Controls whether or not to display an overlay behind the modal.                                                                        |
+| `has-close-button`     | `Boolean` | `true`          | Controls whether or not to display the modal close button.                                                                             |
+| `close-on-blur`        | `Boolean` | `true`          | Controls whether or not to close the modal when the user clicks outside of the modal.                                                  |
+| `close-button-copy`    | `String` | `"Close modal"` | Sets the hidden text value for the close button which is used by screen-readers.                                                       |
+| `title`                | `String` | `''`            | When set, will add a title to the top of the component. If you need to define a custom heading, ignore this prop.                      |
+| `titleHtmlTag`         | `String` | `h3`            | Sets the tag for the component's title.<br><br>Allowed values are `h1`, `h2`, `h3`, and `h4`                                           |
+| `hasBackButton`        | `Boolean` | `false`         | Controls whether or not to display the modal cheveron icon instead of a close icon button                                              |
+| `isModeRightToLeft`     | `Boolean` | `false`         | Controls whether or not to display the modal elements in a right to left direction.                                                    |
 
 ### CSS Classes
 

--- a/packages/components/molecules/f-mega-modal/README.md
+++ b/packages/components/molecules/f-mega-modal/README.md
@@ -108,23 +108,23 @@ The following rudimentary example can be used as a guide for implementing this c
 
 The props that can be defined are as follows:
 
-| Prop                   | Type      | Default         | Description                                                                                                                                                       |
-|------------------------|-----------|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `is-open`              | `Boolean` | `false`         | Sets the modal to open or closed state.                                                                                                                           |
-| `is-narrow`            | `Boolean` | `false`         | Use the narrow visual style.                                                                                                                                      |
-| `is-wide`              | `Boolean` | `false`         | Use the wide visual style.                                                                                                                                        |
-| `is-flush`             | `Boolean` | `false`         | Removes passing around the modal content.                                                                                                                         |
-| `is-full-height`       | `Boolean` | `false`         | Sets the modal content to full height of the screen.<br/><br/><blockquote>Note this only applies to small screen devices.</blockquote>                            |
-| `is-scrollable`        | `Boolean` | `false`         | Makes the modal content scrollable.                                                                                                                               |
-| `is-close-fixed`       | `Boolean` | `false`         | Sets the modal close button position to `fixed`.                                                                                                                  |
-| `is-positioned-bottom` | `Boolean` | `false`         | Sets the modal position to the bottom of the viewport for all screen widths.                                                                                      |
-| `has-overlay`          | `Boolean` | `true`          | Controls whether or not to display an overlay behind the modal.                                                                                                   |
-| `close-button-style`   | `String`  | `close-small-icon`          | Controls the style of the button. Accepts `close-small-icon` & `chevron-left-icon`. |
-| `close-on-blur`        | `Boolean` | `true`          | Controls whether or not to close the modal when the user clicks outside of the modal.                                                                             |
-| `close-button-copy`    | `String`  | `"Close modal"` | Sets the hidden text value for the close button which is used by screen-readers.                                                                                  |
-| `title`                | `String`  | `''`            | When set, will add a title to the top of the component. If you need to define a custom heading, ignore this prop.                                                 |
-| `titleHtmlTag`         | `String`  | `h3`            | Sets the tag for the component's title.<br><br>Allowed values are `h1`, `h2`, `h3`, and `h4`                                                                      |
-| `isModeRightToLeft`    | `Boolean` | `false`         | Controls whether or not to display the modal elements in a right to left direction.                                                                               |
+| Prop                   | Type      | Default         | Description                                                                                                                            |
+|------------------------|-----------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `is-open`              | `Boolean` | `false`         | Sets the modal to open or closed state.                                                                                                |
+| `is-narrow`            | `Boolean` | `false`         | Use the narrow visual style.                                                                                                           |
+| `is-wide`              | `Boolean` | `false`         | Use the wide visual style.                                                                                                             |
+| `is-flush`             | `Boolean` | `false`         | Removes passing around the modal content.                                                                                              |
+| `is-full-height`       | `Boolean` | `false`         | Sets the modal content to full height of the screen.<br/><br/><blockquote>Note this only applies to small screen devices.</blockquote> |
+| `is-scrollable`        | `Boolean` | `false`         | Makes the modal content scrollable.                                                                                                    |
+| `is-close-fixed`       | `Boolean` | `false`         | Sets the modal close button position to `fixed`.                                                                                       |
+| `is-positioned-bottom` | `Boolean` | `false`         | Sets the modal position to the bottom of the viewport for all screen widths.                                                           |
+| `has-overlay`          | `Boolean` | `true`          | Controls whether or not to display an overlay behind the modal.                                                                        |
+| `close-button-style`   | `String`  | `close-small-icon`          | Controls the style of the button. Accepts `cross` & `chevron`.                                                               |
+| `close-on-blur`        | `Boolean` | `true`          | Controls whether or not to close the modal when the user clicks outside of the modal.                                                  |
+| `close-button-copy`    | `String`  | `"Close modal"` | Sets the hidden text value for the close button which is used by screen-readers.                                                       |
+| `title`                | `String`  | `''`            | When set, will add a title to the top of the component. If you need to define a custom heading, ignore this prop.                      |
+| `titleHtmlTag`         | `String`  | `h3`            | Sets the tag for the component's title.<br><br>Allowed values are `h1`, `h2`, `h3`, and `h4`                                           |
+| `isModeRightToLeft`    | `Boolean` | `false`         | Controls whether or not to display the modal elements in a right to left direction.                                                    |
 
 ### CSS Classes
 

--- a/packages/components/molecules/f-mega-modal/README.md
+++ b/packages/components/molecules/f-mega-modal/README.md
@@ -108,24 +108,23 @@ The following rudimentary example can be used as a guide for implementing this c
 
 The props that can be defined are as follows:
 
-| Prop                   | Type  | Default         | Description                                                                                                                            |
-|------------------------| ----- |-----------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| `is-open`              | `Boolean` | `false`         | Sets the modal to open or closed state.                                                                                                |
-| `is-narrow`            | `Boolean` | `false`         | Use the narrow visual style.                                                                                                           |
-| `is-wide`              | `Boolean` | `false`         | Use the wide visual style.                                                                                                             |
-| `is-flush`             | `Boolean` | `false`         | Removes passing around the modal content.                                                                                              |
-| `is-full-height`       | `Boolean` | `false`         | Sets the modal content to full height of the screen.<br/><br/><blockquote>Note this only applies to small screen devices.</blockquote> |
-| `is-scrollable`        | `Boolean` | `false`         | Makes the modal content scrollable.                                                                                                    |
-| `is-close-fixed`       | `Boolean` | `false`         | Sets the modal close button position to `fixed`.                                                                                       |
-| `is-positioned-bottom` | `Boolean` | `false`         | Sets the modal position to the bottom of the viewport for all screen widths.                                                           |
-| `has-overlay`          | `Boolean` | `true`          | Controls whether or not to display an overlay behind the modal.                                                                        |
-| `has-close-button`     | `Boolean` | `true`          | Controls whether or not to display the modal close button.                                                                             |
-| `close-on-blur`        | `Boolean` | `true`          | Controls whether or not to close the modal when the user clicks outside of the modal.                                                  |
-| `close-button-copy`    | `String` | `"Close modal"` | Sets the hidden text value for the close button which is used by screen-readers.                                                       |
-| `title`                | `String` | `''`            | When set, will add a title to the top of the component. If you need to define a custom heading, ignore this prop.                      |
-| `titleHtmlTag`         | `String` | `h3`            | Sets the tag for the component's title.<br><br>Allowed values are `h1`, `h2`, `h3`, and `h4`                                           |
-| `hasBackButton`        | `Boolean` | `false`         | Controls whether or not to display the modal cheveron icon instead of a close icon button                                              |
-| `isModeRightToLeft`     | `Boolean` | `false`         | Controls whether or not to display the modal elements in a right to left direction.                                                    |
+| Prop                   | Type      | Default         | Description                                                                                                                                                       |
+|------------------------|-----------|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `is-open`              | `Boolean` | `false`         | Sets the modal to open or closed state.                                                                                                                           |
+| `is-narrow`            | `Boolean` | `false`         | Use the narrow visual style.                                                                                                                                      |
+| `is-wide`              | `Boolean` | `false`         | Use the wide visual style.                                                                                                                                        |
+| `is-flush`             | `Boolean` | `false`         | Removes passing around the modal content.                                                                                                                         |
+| `is-full-height`       | `Boolean` | `false`         | Sets the modal content to full height of the screen.<br/><br/><blockquote>Note this only applies to small screen devices.</blockquote>                            |
+| `is-scrollable`        | `Boolean` | `false`         | Makes the modal content scrollable.                                                                                                                               |
+| `is-close-fixed`       | `Boolean` | `false`         | Sets the modal close button position to `fixed`.                                                                                                                  |
+| `is-positioned-bottom` | `Boolean` | `false`         | Sets the modal position to the bottom of the viewport for all screen widths.                                                                                      |
+| `has-overlay`          | `Boolean` | `true`          | Controls whether or not to display an overlay behind the modal.                                                                                                   |
+| `close-button-style`   | `String`  | `close-small-icon`          | Controls the style of the button. Accepts `close-small-icon` & `chevron-left-icon`. If you pass an empty string '', no styles for the close button will be shown. |
+| `close-on-blur`        | `Boolean` | `true`          | Controls whether or not to close the modal when the user clicks outside of the modal.                                                                             |
+| `close-button-copy`    | `String`  | `"Close modal"` | Sets the hidden text value for the close button which is used by screen-readers.                                                                                  |
+| `title`                | `String`  | `''`            | When set, will add a title to the top of the component. If you need to define a custom heading, ignore this prop.                                                 |
+| `titleHtmlTag`         | `String`  | `h3`            | Sets the tag for the component's title.<br><br>Allowed values are `h1`, `h2`, `h3`, and `h4`                                                                      |
+| `isModeRightToLeft`    | `Boolean` | `false`         | Controls whether or not to display the modal elements in a right to left direction.                                                                               |
 
 ### CSS Classes
 

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "main": "dist/f-mega-modal.common.js",
   "maxBundleSize": "6kB",
   "files": [

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "8.0.0",
+  "version": "7.4.0",
   "main": "dist/f-mega-modal.common.js",
   "maxBundleSize": "6kB",
   "files": [

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "7.4.0",
+  "version": "8.0.0",
   "main": "dist/f-mega-modal.common.js",
   "maxBundleSize": "6kB",
   "files": [

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -15,6 +15,7 @@
                 [$style['c-megaModal-content--narrow']]: isNarrow,
                 [$style['c-megaModal-content--wide']]: isWide,
                 [$style['c-megaModal-content--flush']]: isFlush,
+                [$style['c-megaModal-content--right-to-left']]: hasModeRightToLeft,
                 [$style['is-fullHeight']]: isFullHeight,
                 [$style['is-positioned-bottom']]: isPositionedBottom,
                 [$style['is-text-aligned-center']]: isTextAlignedCenter
@@ -33,7 +34,10 @@
                         :is="titleHtmlTag"
                         v-if="title"
                         :id="uid"
-                        :class="['c-megaModal-title', $style['c-megaModal-title']]"
+                        :class="['c-megaModal-title', $style['c-megaModal-title'], {
+                            [$style['c-megaModal-hasBackBtn']]: hasBackButton,
+                            [$style['c-megaModal-modeRTL']]: hasModeRightToLeft
+                        }]"
                         data-test-id="mega-modal-title">
                         {{ title }}
                     </component>
@@ -43,13 +47,19 @@
                         <f-button
                             is-icon
                             :class="[$style['c-megaModal-closeBtn'], {
-                                [$style['c-megaModal-closeBtn--fixed']]: isCloseFixed || isFullHeight
+                                [$style['c-megaModal-closeBtn--fixed']]: isCloseFixed || isFullHeight,
+                                [$style['c-megaModal-backBtn']]: hasBackButton,
+                                [$style['c-megaModal-modeRTL']]: hasModeRightToLeft
                             }]"
                             button-type="inverse"
                             button-size="xsmall"
                             data-test-id="close-modal"
                             @click.native="close">
+                            <chevron-left-icon
+                                v-if="hasBackButton" />
+
                             <close-small-icon
+                                v-else
                                 :class="[$style['c-megaModal-closeIcon']]" />
 
                             <span class="is-visuallyHidden">
@@ -66,7 +76,7 @@
 </template>
 
 <script>
-import { CloseSmallIcon } from '@justeattakeaway/pie-icons-vue';
+import { CloseSmallIcon, ChevronLeftIcon } from '@justeattakeaway/pie-icons-vue';
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 import FButton from '@justeat/f-button';
 
@@ -74,6 +84,7 @@ let uid = 0;
 
 export default {
     components: {
+        ChevronLeftIcon,
         CloseSmallIcon,
         FButton
     },
@@ -133,6 +144,11 @@ export default {
             default: true
         },
 
+        hasBackButton: {
+            type: Boolean,
+            default: false
+        },
+
         closeOnBlur: {
             type: Boolean,
             default: true
@@ -147,14 +163,21 @@ export default {
             type: String,
             default: ''
         },
+
         ariaLabel: {
             type: String,
             default: ''
         },
+
         titleHtmlTag: {
             type: String,
             default: 'h3',
             validator: value => ['h1', 'h2', 'h3', 'h4'].includes(value)
+        },
+
+        hasModeRightToLeft: {
+            type: Boolean,
+            default: false
         }
     },
 
@@ -342,6 +365,10 @@ export default {
     transform: translate(50%, -50%);
     width: 95%;
 
+    &.c-megaModal-content--right-to-left {
+        direction: rtl;
+    }
+
     &.is-positioned-bottom {
         border-radius: 0;
         bottom: -100vh;
@@ -436,6 +463,16 @@ export default {
         top: 22px;
         z-index: f.zIndex(high);
 
+        &.c-megaModal-backBtn {
+            left: f.spacing(d);
+        }
+
+        &.c-megaModal-modeRTL {
+            right: f.spacing(d);
+            left: auto;
+            transform: scaleX(-1);
+        }
+
         svg path {
             fill: f.$color-interactive-primary;
             width: 17px;
@@ -461,6 +498,14 @@ export default {
 
 .c-megaModal-title {
     margin: 0 f.spacing(f) 0 0;
+
+    &.c-megaModal-hasBackBtn {
+        margin: 0 0 0 f.spacing(f);
+    }
+
+    &.c-megaModal-modeRTL {
+        margin: 0 f.spacing(f) 0 0;
+    }
 
     .is-text-aligned-center & {
         margin-left: f.spacing(e);

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -4,7 +4,7 @@
         :class="['c-megaModal',
                  $style['c-megaModal'], {
                      'u-overlay': showOverlay,
-                     [$style['c-megaModal--hasChevronIcon']]: hasChevronIcon && hasCloseButton,
+                     [$style['c-megaModal--hasBackButton']]: hasBackButton,
                      [$style['c-megaModal-modeRTL']]: isModeRightToLeft
                  }]"
         data-test-id='mega-modal-component'
@@ -192,8 +192,8 @@ export default {
         showAriaLabel () {
             return this.ariaLabel === '' ? this.uid : this.ariaLabel;
         },
-        hasChevronIcon () {
-            return this.closeButtonStyle === 'chevron';
+        hasBackButton () {
+            return this.closeButtonStyle === 'chevron' && this.hasCloseButton;
         },
         setCloseButtonIconStyle () {
             return this.closeButtonStyle.includes('cross')
@@ -492,7 +492,7 @@ export default {
         }
     }
 
-    &.c-megaModal--hasChevronIcon {
+    &.c-megaModal--hasBackButton {
         .c-megaModal-closeBtn {
             left: f.spacing(d);
         }
@@ -511,7 +511,7 @@ export default {
         margin-right: f.spacing(e);
     }
 
-    .c-megaModal--hasChevronIcon & {
+    .c-megaModal--hasBackButton & {
         margin: 0 0 0 f.spacing(f);
     }
 

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -42,7 +42,7 @@
                         {{ title }}
                     </component>
                     <slot
-                        v-if="closeButtonStyle"
+                        v-if="hasCloseButton"
                         name="close-button">
                         <f-button
                             is-icon
@@ -133,10 +133,15 @@ export default {
             default: true
         },
 
+        hasCloseButton: {
+            type: Boolean,
+            default: true
+        },
+
         closeButtonStyle: {
             type: String,
             default: 'close-small-icon',
-            validator: value => ['', 'close-small-icon', 'chevron-left-icon'].includes(value)
+            validator: value => ['close-small-icon', 'chevron-left-icon'].includes(value)
         },
 
         closeOnBlur: {
@@ -513,6 +518,11 @@ export default {
 
     .c-megaModal-modeRTL & {
         margin: 0 f.spacing(f) 0 0;
+    }
+
+    // Allow the title to sit flush when there is no close button in RTL mode.
+    .c-megaModal-modeRTL &:only-child {
+        margin: 0;
     }
 }
 </style>

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -4,7 +4,7 @@
         :class="['c-megaModal',
                  $style['c-megaModal'], {
                      'u-overlay': showOverlay,
-                     [$style['c-megaModal--hasChevronIcon']]: hasChevronIcon,
+                     [$style['c-megaModal--hasChevronIcon']]: hasChevronIcon && hasCloseButton,
                      [$style['c-megaModal-modeRTL']]: isModeRightToLeft
                  }]"
         data-test-id='mega-modal-component'
@@ -53,7 +53,7 @@
                             button-size="xsmall"
                             data-test-id="close-modal"
                             @click.native="close">
-                            <component :is="closeButtonStyle"
+                            <component :is="setCloseButtonIconStyle"
                                        :class="[$style['c-megaModal-closeIcon']]" />
 
                             <span class="is-visuallyHidden">
@@ -140,8 +140,8 @@ export default {
 
         closeButtonStyle: {
             type: String,
-            default: 'close-small-icon',
-            validator: value => ['close-small-icon', 'chevron-left-icon'].includes(value)
+            default: 'cross',
+            validator: value => ['cross', 'chevron'].includes(value)
         },
 
         closeOnBlur: {
@@ -193,7 +193,12 @@ export default {
             return this.ariaLabel === '' ? this.uid : this.ariaLabel;
         },
         hasChevronIcon () {
-            return this.closeButtonStyle === 'chevron-left-icon';
+            return this.closeButtonStyle === 'chevron';
+        },
+        setCloseButtonIconStyle () {
+            return this.closeButtonStyle.includes('cross')
+                ? 'close-small-icon'
+                : 'chevron-left-icon';
         }
     },
 

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -4,7 +4,7 @@
         :class="['c-megaModal',
                  $style['c-megaModal'], {
                      'u-overlay': showOverlay,
-                     [$style['c-megaModal--hasBackBtn']]: hasBackButton,
+                     [$style['c-megaModal--hasChevronIcon']]: hasChevronIcon,
                      [$style['c-megaModal-modeRTL']]: isModeRightToLeft
                  }]"
         data-test-id='mega-modal-component'
@@ -42,7 +42,7 @@
                         {{ title }}
                     </component>
                     <slot
-                        v-if="hasCloseButton"
+                        v-if="closeButtonStyle"
                         name="close-button">
                         <f-button
                             is-icon
@@ -53,12 +53,8 @@
                             button-size="xsmall"
                             data-test-id="close-modal"
                             @click.native="close">
-                            <chevron-left-icon
-                                v-if="hasBackButton" />
-
-                            <close-small-icon
-                                v-else
-                                :class="[$style['c-megaModal-closeIcon']]" />
+                            <component :is="closeButtonStyle"
+                                       :class="[$style['c-megaModal-closeIcon']]" />
 
                             <span class="is-visuallyHidden">
                                 {{ closeButtonCopy }}
@@ -137,14 +133,10 @@ export default {
             default: true
         },
 
-        hasCloseButton: {
-            type: Boolean,
-            default: true
-        },
-
-        hasBackButton: {
-            type: Boolean,
-            default: false
+        closeButtonStyle: {
+            type: String,
+            default: 'close-small-icon',
+            validator: value => ['', 'close-small-icon', 'chevron-left-icon'].includes(value)
         },
 
         closeOnBlur: {
@@ -194,6 +186,9 @@ export default {
         },
         showAriaLabel () {
             return this.ariaLabel === '' ? this.uid : this.ariaLabel;
+        },
+        hasChevronIcon () {
+            return this.closeButtonStyle === 'chevron-left-icon';
         }
     },
 
@@ -487,7 +482,7 @@ export default {
         }
     }
 
-    &.c-megaModal--hasBackBtn {
+    &.c-megaModal--hasChevronIcon {
         .c-megaModal-closeBtn {
             left: f.spacing(d);
         }
@@ -512,7 +507,7 @@ export default {
         margin-right: f.spacing(e);
     }
 
-    .c-megaModal--hasBackBtn & {
+    .c-megaModal--hasChevronIcon & {
         margin: 0 0 0 f.spacing(f);
     }
 

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -2,8 +2,11 @@
     <div
         ref="megaModal"
         :class="['c-megaModal',
-                 $style['c-megaModal'],
-                 { 'u-overlay': showOverlay }]"
+                 $style['c-megaModal'], {
+                     'u-overlay': showOverlay,
+                     [$style['c-megaModal--hasBackBtn']]: hasBackButton,
+                     [$style['c-megaModal-modeRTL']]: isModeRightToLeft
+                 }]"
         data-test-id='mega-modal-component'
         :aria-hidden="!isOpen"
         @click.self="overlayClose">
@@ -15,7 +18,7 @@
                 [$style['c-megaModal-content--narrow']]: isNarrow,
                 [$style['c-megaModal-content--wide']]: isWide,
                 [$style['c-megaModal-content--flush']]: isFlush,
-                [$style['c-megaModal-content--right-to-left']]: hasModeRightToLeft,
+                [$style['c-megaModal-content--rightToLeft']]: isModeRightToLeft,
                 [$style['is-fullHeight']]: isFullHeight,
                 [$style['is-positioned-bottom']]: isPositionedBottom,
                 [$style['is-text-aligned-center']]: isTextAlignedCenter
@@ -34,10 +37,7 @@
                         :is="titleHtmlTag"
                         v-if="title"
                         :id="uid"
-                        :class="['c-megaModal-title', $style['c-megaModal-title'], {
-                            [$style['c-megaModal-hasBackBtn']]: hasBackButton,
-                            [$style['c-megaModal-modeRTL']]: hasModeRightToLeft
-                        }]"
+                        :class="['c-megaModal-title', $style['c-megaModal-title']]"
                         data-test-id="mega-modal-title">
                         {{ title }}
                     </component>
@@ -47,9 +47,7 @@
                         <f-button
                             is-icon
                             :class="[$style['c-megaModal-closeBtn'], {
-                                [$style['c-megaModal-closeBtn--fixed']]: isCloseFixed || isFullHeight,
-                                [$style['c-megaModal-backBtn']]: hasBackButton,
-                                [$style['c-megaModal-modeRTL']]: hasModeRightToLeft
+                                [$style['c-megaModal-closeBtn--fixed']]: isCloseFixed || isFullHeight
                             }]"
                             button-type="inverse"
                             button-size="xsmall"
@@ -175,7 +173,7 @@ export default {
             validator: value => ['h1', 'h2', 'h3', 'h4'].includes(value)
         },
 
-        hasModeRightToLeft: {
+        isModeRightToLeft: {
             type: Boolean,
             default: false
         }
@@ -365,7 +363,7 @@ export default {
     transform: translate(50%, -50%);
     width: 95%;
 
-    &.c-megaModal-content--right-to-left {
+    .c-megaModal-modeRTL & {
         direction: rtl;
     }
 
@@ -463,16 +461,6 @@ export default {
         top: 22px;
         z-index: f.zIndex(high);
 
-        &.c-megaModal-backBtn {
-            left: f.spacing(d);
-        }
-
-        &.c-megaModal-modeRTL {
-            right: f.spacing(d);
-            left: auto;
-            transform: scaleX(-1);
-        }
-
         svg path {
             fill: f.$color-interactive-primary;
             width: 17px;
@@ -491,25 +479,45 @@ export default {
         }
     }
 
+    &.c-megaModal-modeRTL {
+        .c-megaModal-closeBtn {
+            right: f.spacing(d);
+            left: auto;
+            transform: scaleX(-1);
+        }
+    }
+
+    &.c-megaModal--hasBackBtn {
+        .c-megaModal-closeBtn {
+            left: f.spacing(d);
+        }
+    }
+
     .c-megaModal-closeBtn--fixed {
         position: fixed;
+    }
+}
+
+.c-megaModal-modeRTL {
+    & .c-megaModal-title {
+        margin: 0 f.spacing(f) 0 0;
     }
 }
 
 .c-megaModal-title {
     margin: 0 f.spacing(f) 0 0;
 
-    &.c-megaModal-hasBackBtn {
-        margin: 0 0 0 f.spacing(f);
-    }
-
-    &.c-megaModal-modeRTL {
-        margin: 0 f.spacing(f) 0 0;
-    }
-
     .is-text-aligned-center & {
         margin-left: f.spacing(e);
         margin-right: f.spacing(e);
+    }
+
+    .c-megaModal--hasBackBtn & {
+        margin: 0 0 0 f.spacing(f);
+    }
+
+    .c-megaModal-modeRTL & {
+        margin: 0 f.spacing(f) 0 0;
     }
 }
 </style>

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -5,7 +5,7 @@
                  $style['c-megaModal'], {
                      'u-overlay': showOverlay,
                      [$style['c-megaModal--hasBackButton']]: hasBackButton,
-                     [$style['c-megaModal-modeRTL']]: isModeRightToLeft
+                     [$style['c-megaModal--modeRTL']]: isModeRightToLeft
                  }]"
         data-test-id='mega-modal-component'
         :aria-hidden="!isOpen"
@@ -368,7 +368,7 @@ export default {
     transform: translate(50%, -50%);
     width: 95%;
 
-    .c-megaModal-modeRTL & {
+    .c-megaModal--modeRTL & {
         direction: rtl;
     }
 
@@ -484,7 +484,7 @@ export default {
         }
     }
 
-    &.c-megaModal-modeRTL {
+    &.c-megaModal--modeRTL {
         .c-megaModal-closeBtn {
             right: f.spacing(d);
             left: auto;
@@ -515,12 +515,12 @@ export default {
         margin: 0 0 0 f.spacing(f);
     }
 
-    .c-megaModal-modeRTL & {
+    .c-megaModal--modeRTL & {
         margin: 0 f.spacing(f) 0 0;
     }
 
     // Allow the title to sit flush when there is no close button in RTL mode.
-    .c-megaModal-modeRTL &:only-child {
+    .c-megaModal--modeRTL &:only-child {
         margin: 0;
     }
 }

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -503,12 +503,6 @@ export default {
     }
 }
 
-.c-megaModal-modeRTL {
-    & .c-megaModal-title {
-        margin: 0 f.spacing(f) 0 0;
-    }
-}
-
 .c-megaModal-title {
     margin: 0 f.spacing(f) 0 0;
 

--- a/packages/components/molecules/f-mega-modal/src/components/_tests/MegaModal.test.js
+++ b/packages/components/molecules/f-mega-modal/src/components/_tests/MegaModal.test.js
@@ -101,5 +101,39 @@ describe('MegaModal', () => {
                 expect(modalTitle.element.tagName.toLowerCase()).toBe('h3');
             });
         });
+
+        describe('`hasChevronIcon`', () => {
+            it.each([
+                ['cross', false],
+                ['chevron', true]])('should set `hasChevronIcon` when %s is passed in to %p', (icon, expected) => {
+                // Arrange
+                const propsData = {
+                    closeButtonStyle: icon
+                };
+
+                // Act
+                const wrapper = shallowMount(MegaModal, { propsData });
+
+                // Assert
+                expect(wrapper.vm.hasChevronIcon).toBe(expected);
+            });
+        });
+
+        describe('`setCloseButtonIconStyle`', () => {
+            it.each([
+                ['cross', 'close-small-icon'],
+                ['chevron', 'chevron-left-icon']])('should set the correct close button style type based on the `closeButtonStyle` value', (iconStyle, expected) => {
+                // Arrange
+                const propsData = {
+                    closeButtonStyle: iconStyle
+                };
+
+                // Act
+                const wrapper = shallowMount(MegaModal, { propsData });
+
+                // Assert
+                expect(wrapper.vm.setCloseButtonIconStyle).toBe(expected);
+            });
+        });
     });
 });

--- a/packages/components/molecules/f-mega-modal/src/components/_tests/MegaModal.test.js
+++ b/packages/components/molecules/f-mega-modal/src/components/_tests/MegaModal.test.js
@@ -102,7 +102,7 @@ describe('MegaModal', () => {
             });
         });
 
-        describe('`hasChevronIcon`', () => {
+        describe('`hasBackButton`', () => {
             it.each([
                 ['cross', false],
                 ['chevron', true]])('should set `hasChevronIcon` when %s is passed in to %p', (icon, expected) => {
@@ -115,7 +115,21 @@ describe('MegaModal', () => {
                 const wrapper = shallowMount(MegaModal, { propsData });
 
                 // Assert
-                expect(wrapper.vm.hasChevronIcon).toBe(expected);
+                expect(wrapper.vm.hasBackButton).toBe(expected);
+            });
+
+            it('should return falsey if `hasCloseButton` is passed in as `false`', () => {
+                // Arrange
+                const propsData = {
+                    closeButtonStyle: 'cross',
+                    hasCloseButton: false
+                };
+
+                // Act
+                const wrapper = shallowMount(MegaModal, { propsData });
+
+                // Assert
+                expect(wrapper.vm.hasBackButton).toBe(false);
             });
         });
 

--- a/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
+++ b/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
@@ -23,6 +23,8 @@ export const MegaModalComponent = (args, { argTypes }) => ({
             :is-text-aligned-center="isTextAlignedCenter"
             :has-overlay="hasOverlay"
             :has-close-button="hasCloseButton"
+            :has-back-button="hasBackButton"
+            :has-mode-right-to-left="hasModeRightToLeft"
             :close-on-blur="closeOnBlur"
             :close-button-copy="closeButtonCopy"
             :title="titleCopy"
@@ -49,6 +51,8 @@ MegaModalComponent.args = {
     isTextAlignedCenter: false,
     hasOverlay: true,
     hasCloseButton: true,
+    hasBackButton: false,
+    hasModeRightToLeft: false,
     closeOnBlur: true,
     closeButtonCopy: 'Close modal',
     titleCopy: 'This place isn’t taking orders',
@@ -87,6 +91,12 @@ MegaModalComponent.argTypes = {
         control: { type: 'boolean' }
     },
     hasCloseButton: {
+        control: { type: 'boolean' }
+    },
+    hasBackButton: {
+        control: { type: 'boolean' }
+    },
+    hasModeRightToLeft: {
         control: { type: 'boolean' }
     },
     closeOnBlur: {

--- a/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
+++ b/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
@@ -21,6 +21,7 @@ export const MegaModalComponent = (args, { argTypes }) => ({
             :is-positioned-bottom="isPositionedBottom"
             :is-close-rounded="isCloseRounded"
             :is-text-aligned-center="isTextAlignedCenter"
+            :has-close-button="hasCloseButton"
             :has-overlay="hasOverlay"
             :close-button-style="closeButtonStyle"
             :is-mode-right-to-left="isModeRightToLeft"
@@ -48,6 +49,7 @@ MegaModalComponent.args = {
     isPositionedBottom: false,
     isCloseRounded: false,
     isTextAlignedCenter: false,
+    hasCloseButton: true,
     hasOverlay: true,
     closeButtonStyle: 'close-small-icon',
     isModeRightToLeft: false,
@@ -85,11 +87,14 @@ MegaModalComponent.argTypes = {
     isCloseRounded: {
         control: { type: 'boolean' }
     },
+    hasCloseButton: {
+        control: { type: 'boolean' }
+    },
     hasOverlay: {
         control: { type: 'boolean' }
     },
     closeButtonStyle: {
-        control: { type: 'text' },
+        control: { type: 'select' },
         options: ['close-small-icon', 'chevron-left-icon']
     },
     isModeRightToLeft: {

--- a/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
+++ b/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
@@ -24,7 +24,7 @@ export const MegaModalComponent = (args, { argTypes }) => ({
             :has-overlay="hasOverlay"
             :has-close-button="hasCloseButton"
             :has-back-button="hasBackButton"
-            :has-mode-right-to-left="hasModeRightToLeft"
+            :is-mode-right-to-left="isModeRightToLeft"
             :close-on-blur="closeOnBlur"
             :close-button-copy="closeButtonCopy"
             :title="titleCopy"
@@ -52,7 +52,7 @@ MegaModalComponent.args = {
     hasOverlay: true,
     hasCloseButton: true,
     hasBackButton: false,
-    hasModeRightToLeft: false,
+    isModeRightToLeft: false,
     closeOnBlur: true,
     closeButtonCopy: 'Close modal',
     titleCopy: 'This place isn’t taking orders',
@@ -96,7 +96,7 @@ MegaModalComponent.argTypes = {
     hasBackButton: {
         control: { type: 'boolean' }
     },
-    hasModeRightToLeft: {
+    isModeRightToLeft: {
         control: { type: 'boolean' }
     },
     closeOnBlur: {

--- a/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
+++ b/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
@@ -22,8 +22,7 @@ export const MegaModalComponent = (args, { argTypes }) => ({
             :is-close-rounded="isCloseRounded"
             :is-text-aligned-center="isTextAlignedCenter"
             :has-overlay="hasOverlay"
-            :has-close-button="hasCloseButton"
-            :has-back-button="hasBackButton"
+            :close-button-style="closeButtonStyle"
             :is-mode-right-to-left="isModeRightToLeft"
             :close-on-blur="closeOnBlur"
             :close-button-copy="closeButtonCopy"
@@ -50,8 +49,7 @@ MegaModalComponent.args = {
     isCloseRounded: false,
     isTextAlignedCenter: false,
     hasOverlay: true,
-    hasCloseButton: true,
-    hasBackButton: false,
+    closeButtonStyle: 'close-small-icon',
     isModeRightToLeft: false,
     closeOnBlur: true,
     closeButtonCopy: 'Close modal',
@@ -90,11 +88,9 @@ MegaModalComponent.argTypes = {
     hasOverlay: {
         control: { type: 'boolean' }
     },
-    hasCloseButton: {
-        control: { type: 'boolean' }
-    },
-    hasBackButton: {
-        control: { type: 'boolean' }
+    closeButtonStyle: {
+        control: { type: 'text' },
+        options: ['close-small-icon', 'chevron-left-icon']
     },
     isModeRightToLeft: {
         control: { type: 'boolean' }

--- a/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
+++ b/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
@@ -51,7 +51,7 @@ MegaModalComponent.args = {
     isTextAlignedCenter: false,
     hasCloseButton: true,
     hasOverlay: true,
-    closeButtonStyle: 'close-small-icon',
+    closeButtonStyle: 'cross',
     isModeRightToLeft: false,
     closeOnBlur: true,
     closeButtonCopy: 'Close modal',
@@ -95,7 +95,7 @@ MegaModalComponent.argTypes = {
     },
     closeButtonStyle: {
         control: { type: 'select' },
-        options: ['close-small-icon', 'chevron-left-icon']
+        options: ['cross', 'chevron']
     },
     isModeRightToLeft: {
         control: { type: 'boolean' }

--- a/packages/components/molecules/f-mega-modal/test/visual/f-mega-modal.visual.spec.js
+++ b/packages/components/molecules/f-mega-modal/test/visual/f-mega-modal.visual.spec.js
@@ -45,7 +45,8 @@ devices.forEach(device => {
         args = [
             'isOpen',
             'hasOverlay',
-            'hasCloseButton'
+            'hasCloseButton',
+            'hasBackButton'
         ];
 
         args.forEach(arg => {

--- a/packages/components/molecules/f-mega-modal/test/visual/f-mega-modal.visual.spec.js
+++ b/packages/components/molecules/f-mega-modal/test/visual/f-mega-modal.visual.spec.js
@@ -46,7 +46,7 @@ devices.forEach(device => {
             'isOpen',
             'hasOverlay',
             'hasCloseButton',
-            'hasBackButton'
+            'closeButtonStyle'
         ];
 
         args.forEach(arg => {


### PR DESCRIPTION
### Added
- Prop `closeButtonStyle` allows either a chevron icon `chevron-left-icon` or close icon `close-small-icon` to be used.
- `isModeRightToLeft` prop to allow a chevron icon to be used in a right to left tenant.


### Screenshots:

![Screenshot 2023-04-06 at 15 37 49](https://user-images.githubusercontent.com/2299779/230417099-e3fdd310-356c-422a-93f3-be01ae6828ab.png)

### RTL:
![Screenshot 2023-04-06 at 15 38 01](https://user-images.githubusercontent.com/2299779/230417116-fa05a1cd-7fb4-46e3-9b86-6d4c763300ab.png)

