### PR TITLE
f-segmented-control@v0.2.0 - remove disabled background color from selected option

### DIFF
--- a/packages/components/atoms/f-segmented-control/CHANGELOG.md
+++ b/packages/components/atoms/f-segmented-control/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.2.0
+------------------------------
+*April 25, 2023*
+
+### Changed
+- Remove background colour of `$color-disabled-01` from disabled selected option
+
+
 v0.1.0
 ------------------------------
 *April 14, 2023*

--- a/packages/components/atoms/f-segmented-control/package.json
+++ b/packages/components/atoms/f-segmented-control/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-segmented-control",
   "description": "Fozzie Segmented Control - A Segmented Control component is a group of toggle buttons that behave like a single choice element. It is useful for displaying a set of options to the user when only one option can be selected.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "maxBundleSize": "5kB",
   "main": "dist/f-segmented-control.umd.min.js",
   "files": [

--- a/packages/components/atoms/f-segmented-control/src/components/SegmentedControl.vue
+++ b/packages/components/atoms/f-segmented-control/src/components/SegmentedControl.vue
@@ -198,7 +198,6 @@ $sc-background-color-selected: f.$color-container-default;
     // Disabled state
     &:disabled {
         color: f.$color-content-disabled;
-        background-color: f.$color-disabled-01;
         cursor: not-allowed;
         pointer-events: none;
     }


### PR DESCRIPTION
v0.2.0
------------------------------
*April 25, 2023*

### Changed
- Remove background colour of `$color-disabled-01` from disabled selected option

### Before (all disabled, 1 selected)
<img width="781" alt="Screenshot 2023-04-25 at 13 50 29" src="https://user-images.githubusercontent.com/16766185/234281660-e4088bb9-0d30-4d02-94cc-cdda39c60120.png">

### After (all disabled, 1 selected)
<img width="779" alt="Screenshot 2023-04-25 at 13 51 08" src="https://user-images.githubusercontent.com/16766185/234281817-9d546914-8772-42bb-aa43-b8602663fecb.png">


