### PR TITLE
f-footer@v8.5.0 - Confianza link

### DIFF
--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v8.5.0
+------------------------------
+*April 27, 2023*
+
+### Changed
+- Wrap the Confianza icon in a url pointing to confianzaonline
+
+### Added
+- Unit tests ensuring the link and icon are correctly rendered
+
+
 v8.4.0
 ------------------------------
 *March 27, 2023*

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "main": "dist/f-footer.umd.min.js",
   "maxBundleSize": "80kB",
   "files": [

--- a/packages/components/organisms/f-footer/src/components/LegalField.vue
+++ b/packages/components/organisms/f-footer/src/components/LegalField.vue
@@ -10,6 +10,7 @@
             v-if="isConfianza"
             :href="info.url"
             :aria-label="info.screenReaderText"
+            :class="$style['c-legalField-certificates-link']"
             target="_blank"
             rel="noopener noreferrer"
             data-test-id="confianza-link">
@@ -72,6 +73,10 @@ export default {
 .c-legalField-certificates-icons--confianza {
     width: 50px;
     height: 50px;
+}
+
+.c-legalField-certificates-link:focus {
+    @extend %u-elementFocus--borderless
 }
 </style>
 

--- a/packages/components/organisms/f-footer/src/components/LegalField.vue
+++ b/packages/components/organisms/f-footer/src/components/LegalField.vue
@@ -8,8 +8,8 @@
 
         <a
             v-if="isConfianza"
-            :href="confianzaUrl"
-            :aria-label="confianzaScreenReaderText"
+            :href="info.url"
+            :aria-label="info.screenReaderText"
             target="_blank"
             rel="noopener noreferrer"
             data-test-id="confianza-link">
@@ -26,7 +26,6 @@
 
 <script>
 import { CertificateConfianzaIcon as ConfianzaIcon } from '@justeat/f-vue-icons';
-import { confianzaUrl, confianzaScreenReaderText } from './constants';
 
 export default {
 
@@ -38,13 +37,6 @@ export default {
             type: Object,
             required: true
         }
-    },
-
-    data () {
-        return {
-            confianzaUrl,
-            confianzaScreenReaderText
-        };
     },
 
     computed: {

--- a/packages/components/organisms/f-footer/src/components/LegalField.vue
+++ b/packages/components/organisms/f-footer/src/components/LegalField.vue
@@ -6,17 +6,27 @@
             {{ info.textField }}
         </p>
 
-        <confianza-icon
+        <a
             v-if="isConfianza"
-            :class="[
-                $style['c-legalField-certificates-icons'],
-                $style['c-legalField-certificates-icons--confianza']
-            ]" />
+            :href="confianzaUrl"
+            :aria-label="confianzaScreenReaderText"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-test-id="confianza-link">
+            <confianza-icon
+                data-test-id="confianza-icon"
+                aria-hidden="true"
+                :class="[
+                    $style['c-legalField-certificates-icons'],
+                    $style['c-legalField-certificates-icons--confianza']
+                ]" />
+        </a>
     </div>
 </template>
 
 <script>
 import { CertificateConfianzaIcon as ConfianzaIcon } from '@justeat/f-vue-icons';
+import { confianzaUrl, confianzaScreenReaderText } from './constants';
 
 export default {
 
@@ -28,6 +38,13 @@ export default {
             type: Object,
             required: true
         }
+    },
+
+    data () {
+        return {
+            confianzaUrl,
+            confianzaScreenReaderText
+        };
     },
 
     computed: {

--- a/packages/components/organisms/f-footer/src/components/LegalField.vue
+++ b/packages/components/organisms/f-footer/src/components/LegalField.vue
@@ -75,8 +75,11 @@ export default {
     height: 50px;
 }
 
-.c-legalField-certificates-link:focus {
-    @extend %u-elementFocus--borderless
+.c-legalField-certificates-link {
+    &:focus,
+    &:focus-visible {
+        @extend %u-elementFocus--borderless;
+    }
 }
 </style>
 

--- a/packages/components/organisms/f-footer/src/components/_tests/Footer.test.js
+++ b/packages/components/organisms/f-footer/src/components/_tests/Footer.test.js
@@ -1,6 +1,7 @@
-import { shallowMount } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import Footer from '../Footer.vue';
 import content from '../../../data/en-GB.json';
+import { confianzaUrl, confianzaScreenReaderText } from '../constants';
 
 let propsData;
 
@@ -24,7 +25,7 @@ describe('Footer', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render ml themed component if AU local passed', () => {
+    it('should render ml themed component if AU locale passed', () => {
         // Arrange & Act
         propsData = {
             ...propsData,
@@ -37,7 +38,7 @@ describe('Footer', () => {
         expect(wrapper.attributes('data-theme')).toBe('ml');
     });
 
-    it('should render ml themed component if NZ local passed', () => {
+    it('should render ml themed component if NZ locale passed', () => {
         // Arrange & Act
         propsData = {
             ...propsData,
@@ -50,7 +51,7 @@ describe('Footer', () => {
         expect(wrapper.attributes('data-theme')).toBe('ml');
     });
 
-    it('should render je themed component if IE local passed', () => {
+    it('should render je themed component if IE locale passed', () => {
         // Arrange & Act
         propsData = {
             ...propsData,
@@ -89,5 +90,98 @@ describe('Footer', () => {
 
         // Assert
         expect(wrapper.find('[data-test-id="country-selector"]').exists()).toBe(true);
+    });
+
+    const localesExcludingES = [
+        'en-GB',
+        'en-AU',
+        'en-IE',
+        'en-NZ',
+        'it-IT'
+    ];
+
+    localesExcludingES.forEach(locale => {
+        it(`should not render the Confianza URL and icon when locale is ${locale}`, () => {
+            // Arrange & Act
+            propsData = {
+                ...propsData,
+                locale
+            };
+
+            const wrapper = shallowMount(Footer, { propsData });
+
+            // Assert
+            expect(wrapper.find('[data-test-id="confianza-link"]').exists()).toBe(false);
+            expect(wrapper.find('[data-test-id="confianza-icon"]').exists()).toBe(false);
+        });
+    });
+
+    describe('ES locale', () => {
+        it('should render the Confianza URL and icon', () => {
+            // Arrange & Act
+            propsData = {
+                ...propsData,
+                locale: 'es-ES'
+            };
+
+            const wrapper = mount(Footer, { propsData });
+
+            // Assert
+            expect(wrapper.find('[data-test-id="confianza-link"]').exists()).toBe(true);
+            expect(wrapper.find('[data-test-id="confianza-icon"]').exists()).toBe(true);
+        });
+
+        it('should use the correct Confianza URL', () => {
+            // Arrange & Act
+            propsData = {
+                ...propsData,
+                locale: 'es-ES'
+            };
+
+            const wrapper = mount(Footer, { propsData });
+
+            // Assert
+            expect(wrapper.find('[data-test-id="confianza-link"]').attributes('href')).toBe(confianzaUrl);
+        });
+
+        it('should provide an aria label for screen readers', () => {
+            // Arrange & Act
+            propsData = {
+                ...propsData,
+                locale: 'es-ES'
+            };
+
+            const wrapper = mount(Footer, { propsData });
+
+            // Assert
+            expect(wrapper.find('[data-test-id="confianza-link"]').attributes('aria-label')).toBe(confianzaScreenReaderText);
+        });
+
+        it('should use hide the Confianza icon from screen readers', () => {
+            // Arrange & Act
+            propsData = {
+                ...propsData,
+                locale: 'es-ES'
+            };
+
+            const wrapper = mount(Footer, { propsData });
+
+            // Assert
+            expect(wrapper.find('[data-test-id="confianza-icon"]').attributes('aria-hidden')).toBe('true');
+        });
+
+        it('should open the link in a new tab', () => {
+            // Arrange & Act
+            propsData = {
+                ...propsData,
+                locale: 'es-ES'
+            };
+
+            const wrapper = mount(Footer, { propsData });
+
+            // Assert
+            expect(wrapper.find('[data-test-id="confianza-link"]').attributes('target')).toBe('_blank');
+            expect(wrapper.find('[data-test-id="confianza-link"]').attributes('rel')).toBe('noopener noreferrer');
+        });
     });
 });

--- a/packages/components/organisms/f-footer/src/components/_tests/Footer.test.js
+++ b/packages/components/organisms/f-footer/src/components/_tests/Footer.test.js
@@ -1,7 +1,7 @@
 import { mount, shallowMount } from '@vue/test-utils';
 import Footer from '../Footer.vue';
 import content from '../../../data/en-GB.json';
-import { confianzaUrl, confianzaScreenReaderText } from '../constants';
+import { tenantConfigs } from '../../tenants';
 
 let propsData;
 
@@ -98,7 +98,7 @@ describe('Footer', () => {
         'en-IE',
         'en-NZ',
         'it-IT'
-    ])(`should not render the Confianza URL and icon when locale is %s`, locale => {
+    ])('should not render the Confianza URL and icon when locale is %s', locale => {
         // Arrange & Act
         propsData = {
             ...propsData,
@@ -137,7 +137,7 @@ describe('Footer', () => {
             const wrapper = mount(Footer, { propsData });
 
             // Assert
-            expect(wrapper.find('[data-test-id="confianza-link"]').attributes('href')).toBe(confianzaUrl);
+            expect(wrapper.find('[data-test-id="confianza-link"]').attributes('href')).toBe(tenantConfigs['es-ES'].metaLegalField.url);
         });
 
         it('should provide an aria label for screen readers', () => {
@@ -150,7 +150,7 @@ describe('Footer', () => {
             const wrapper = mount(Footer, { propsData });
 
             // Assert
-            expect(wrapper.find('[data-test-id="confianza-link"]').attributes('aria-label')).toBe(confianzaScreenReaderText);
+            expect(wrapper.find('[data-test-id="confianza-link"]').attributes('aria-label')).toBe(tenantConfigs['es-ES'].metaLegalField.screenReaderText);
         });
 
         it('should use hide the Confianza icon from screen readers', () => {

--- a/packages/components/organisms/f-footer/src/components/_tests/Footer.test.js
+++ b/packages/components/organisms/f-footer/src/components/_tests/Footer.test.js
@@ -153,7 +153,7 @@ describe('Footer', () => {
             expect(wrapper.find('[data-test-id="confianza-link"]').attributes('aria-label')).toBe(tenantConfigs['es-ES'].metaLegalField.screenReaderText);
         });
 
-        it('should use hide the Confianza icon from screen readers', () => {
+        it('should hide the Confianza icon from screen readers', () => {
             // Arrange & Act
             propsData = {
                 ...propsData,

--- a/packages/components/organisms/f-footer/src/components/_tests/Footer.test.js
+++ b/packages/components/organisms/f-footer/src/components/_tests/Footer.test.js
@@ -92,28 +92,24 @@ describe('Footer', () => {
         expect(wrapper.find('[data-test-id="country-selector"]').exists()).toBe(true);
     });
 
-    const localesExcludingES = [
+    it.each([
         'en-GB',
         'en-AU',
         'en-IE',
         'en-NZ',
         'it-IT'
-    ];
+    ])(`should not render the Confianza URL and icon when locale is %s`, locale => {
+        // Arrange & Act
+        propsData = {
+            ...propsData,
+            locale
+        };
 
-    localesExcludingES.forEach(locale => {
-        it(`should not render the Confianza URL and icon when locale is ${locale}`, () => {
-            // Arrange & Act
-            propsData = {
-                ...propsData,
-                locale
-            };
+        const wrapper = shallowMount(Footer, { propsData });
 
-            const wrapper = shallowMount(Footer, { propsData });
-
-            // Assert
-            expect(wrapper.find('[data-test-id="confianza-link"]').exists()).toBe(false);
-            expect(wrapper.find('[data-test-id="confianza-icon"]').exists()).toBe(false);
-        });
+        // Assert
+        expect(wrapper.find('[data-test-id="confianza-link"]').exists()).toBe(false);
+        expect(wrapper.find('[data-test-id="confianza-icon"]').exists()).toBe(false);
     });
 
     describe('ES locale', () => {

--- a/packages/components/organisms/f-footer/src/components/constants.js
+++ b/packages/components/organisms/f-footer/src/components/constants.js
@@ -1,0 +1,2 @@
+export const confianzaUrl = 'https://www.confianzaonline.es/empresas/justeatspain.htm';
+export const confianzaScreenReaderText = 'Accede a Confianza Online y comprueba nuestro sello de calidad en Internet';

--- a/packages/components/organisms/f-footer/src/components/constants.js
+++ b/packages/components/organisms/f-footer/src/components/constants.js
@@ -1,2 +1,0 @@
-export const confianzaUrl = 'https://www.confianzaonline.es/empresas/justeatspain.htm';
-export const confianzaScreenReaderText = 'Accede a Confianza Online y comprueba nuestro sello de calidad en Internet';

--- a/packages/components/organisms/f-footer/src/tenants/es-ES.js
+++ b/packages/components/organisms/f-footer/src/tenants/es-ES.js
@@ -69,6 +69,8 @@ export default {
     ],
     metaLegalField: {
         textField: '',
+        url: 'https://www.confianzaonline.es/empresas/justeatspain.htm',
+        screenReaderText: 'Accede a Confianza Online y comprueba nuestro sello de calidad en Internet',
         icon: {
             name: 'confianza',
             alt: 'Confianza'


### PR DESCRIPTION
v8.5.0
------------------------------
*April 27, 2023*

### Changed
- Wrap the Confianza icon in a url pointing to confianzaonline

### Added
- Unit tests ensuring the link and icon are correctly rendered

#### Screen reader narration of link
<img width="692" alt="Screenshot 2023-04-27 at 15 52 16" src="https://user-images.githubusercontent.com/16766185/234911810-203d1bb9-948c-493a-ab3e-ae2062bfdb0a.png">
