### PR TITLE
f-button@5.0.0 - Split small button into productive and expressive

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -4,6 +4,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v5.0.0
+------------------------------
+*April 28, 2023*
+
+### Removed
+- `small` button size (this still remains for icon buttons)
+
+### Added
+- `small-productive` button size (not for icon buttons)
+- `small-expressive` button size (not for icon buttons)
+  - These buttons are the same height but expressive has a larger font and therefore less vertical padding.
+
+### Changed
+- Use CSS logical properties for padding, margins, heights, widths and spinner positioning.
+
+
 v4.5.0
 ------------------------------
 *March 27, 2023*

--- a/packages/components/atoms/f-button/README.md
+++ b/packages/components/atoms/f-button/README.md
@@ -83,7 +83,7 @@ The props that can be defined are as follows:
 | :---          | :---:             | :---:      | :---:    | :---        |
 | `actionType`  | `String`          | No         | `button` | Sets the action button type.<br>Options: `button`, `submit`, `reset`. |
 | `buttonType`  | `String`          | No         | `primary`| Sets the modifier theme for styling.<br>n.b. Only certain `buttonType` values are allowed in combination with the `isIcon` prop.<br>Options (when `isIcon: false`): `primary`, `secondary`, `outline`, `ghost`, `link`.<br>Options (when `isIcon: true`): `primary`, `secondary`, `ghost`, `ghostTertiary`, `inverse`, `ghostInverse`|
-| `buttonSize`  | `String`          | No         | `medium` | Sets the button size.<br>Options: `large`, `medium`, `small`, `xsmall`. |
+| `buttonSize`  | `String`          | No         | `medium` | Sets the button size.<br>Options (when `isIcon: true`): `large`, `medium`, `small-expressive`, `small-productive`, `xsmall`.<br>Options (when `isIcon: false`): `large`, `medium`, `small`, `xsmall`. |
 | `isFullWidth` | `Boolean`         | No         | `false`  | Controls whether or not to apply `fullWidth` modifier class |
 | `isIcon`      | `Boolean`         | No         | `false`  | When true, changes the button style to be displayed as an Icon Button (Icon, with no text). |
 | `isLoading`   | `Boolean`         | No         | `false`  | When true, replaces the text with a loading spinner, and it prevents any further interaction with the button (e.g. `click`). |

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "4.5.0",
+  "version": "5.0.0",
   "main": "dist/f-button.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -113,7 +113,9 @@ export default {
             if (this.buttonSize === 'xsmall') {
                 return this.buttonSize.slice(0, 2).toUpperCase() + this.buttonSize.slice(2); // xsmall -> XSmall
             }
-            return this.buttonSize.charAt(0).toUpperCase() + this.buttonSize.slice(1); // capitalize the first letter of the prop
+
+            // Convert from kebab-case (if applicable) to PascalCase
+            return this.buttonSize.split('-').map(x => x.charAt(0).toUpperCase() + x.substr(1).toLowerCase()).join('');
         },
 
         /**
@@ -172,11 +174,12 @@ export default {
 
             const validTypes = VALID_BUTTON_TYPES[componentType];
             if (!validTypes.includes(this.buttonType)) {
-                throw new TypeError(`${componentType} is set to have buttonType="${this.buttonType}", but it can only be one of the following buttonTypes: "${validTypes.join('", "')}"`);
+                throw new TypeError(`buttonType for ${componentType} is set to "${this.buttonType}", but it must be one of the following: "${validTypes.join('", "')}"`);
             }
 
-            if (!VALID_BUTTON_SIZES.includes(this.buttonSize)) {
-                throw new TypeError(`buttonSize is set to "${this.buttonSize}", but it can only be one of the following buttonSizes: "${VALID_BUTTON_SIZES.join('", "')}"`);
+            const validSizes = VALID_BUTTON_SIZES[componentType];
+            if (!validSizes.includes(this.buttonSize)) {
+                throw new TypeError(`buttonSize for ${componentType} is set to "${this.buttonSize}", but it must be one of the following: "${validSizes.join('", "')}"`);
             }
 
             if (!VALID_BUTTON_ICON_POSITION.includes(this.hasIcon)) {
@@ -193,7 +196,8 @@ export default {
 $btn-default-borderRadius              : f.$radius-rounded-e;
 $btn-default-font-size                 : 'heading-s';
 $btn-default-weight                    : f.$font-weight-bold;
-$btn-default-padding                   : 9px f.spacing(e);
+$btn-default-padding-block             : 9px;
+$btn-default-padding-inline            : f.spacing(e);
 $btn-default-loading-opacity           : 0.35;
 $btn-default-iconHeight                : 18px;
 $btn-default-iconSpacing               : 3px;
@@ -247,18 +251,28 @@ $btn-link-loading-colorOpaque          : rgba($btn-link-loading-color, $btn-defa
 $btn-disabled-bgColor                  : f.$color-disabled-01;
 $btn-disabled-textColor                : f.$color-content-disabled;
 
-$btn-sizeLarge-padding                 : 13px f.spacing(e);
+$btn-sizeLarge-padding-block           : 13px;
+$btn-sizeLarge-padding-inline          : f.spacing(e);
 $btn-sizeLarge-loading-color           : f.$color-content-interactive-light;
 $btn-sizeLarge-loading-colorOpaque     : rgba($btn-sizeLarge-loading-color, $btn-default-loading-opacity);
 
-$btn-sizeSmall-font-size               : 'body-l';
-$btn-sizeSmall-padding                 : 7px f.spacing(d);
-$btn-sizeSmall-iconHeight              : 15px;
-$btn-sizeSmall-iconSpacing             : 2.5px;
-$btn-sizeSmall-iconSideSpacing         : $btn-sizeSmall-iconSpacing + f.spacing();
+$btn-sizeSmallExpressive-font-size       : 'heading-s';
+$btn-sizeSmallExpressive-padding-block   : 5px;
+$btn-sizeSmallExpressive-padding-inline  : f.spacing(d);
+$btn-sizeSmallExpressive-iconHeight      : 15px;
+$btn-sizeSmallExpressive-iconSpacing     : 2.5px;
+$btn-sizeSmallExpressive-iconSideSpacing : $btn-sizeSmallExpressive-iconSpacing + f.spacing();
+
+$btn-sizeSmallProductive-font-size       : 'body-l';
+$btn-sizeSmallProductive-padding-block   : 7px;
+$btn-sizeSmallProductive-padding-inline  : f.spacing(d);
+$btn-sizeSmallProductive-iconHeight      : 15px;
+$btn-sizeSmallProductive-iconSpacing     : 2.5px;
+$btn-sizeSmallProductive-iconSideSpacing : $btn-sizeSmallProductive-iconSpacing + f.spacing();
 
 $btn-sizeXSmall-font-size              : 'body-s';
-$btn-sizeXSmall-padding                : 5px f.spacing();
+$btn-sizeXSmall-padding-block          : 5px;
+$btn-sizeXSmall-padding-inline         : f.spacing();
 $btn-sizeXSmall-iconHeight             : 12px;
 $btn-sizeXSmall-iconSpacing            : 2px;
 $btn-sizeXSmall-iconSideSpacing        : $btn-sizeXSmall-iconSpacing + f.spacing();
@@ -274,10 +288,11 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
 @include f.loadingIndicator('medium');
 
 .c-spinner {
-    margin: 0 auto;
+    margin-block: 0;
+    margin-inline: auto;
     position: absolute;
-    left: calc(50% - 10px); // Substract half of the size of the spinner.
-    top: calc(50% - 10px); // Substract half of the size of the spinner.
+    inset-inline-start: calc(50% - 10px); // Substract half of the size of the spinner.
+    inset-block-start: calc(50% - 10px); // Substract half of the size of the spinner.
 }
 
 .o-btn {
@@ -286,7 +301,8 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
     vertical-align: middle;
     @include f.font-size($btn-default-font-size);
     cursor: pointer;
-    padding: $btn-default-padding;
+    padding-block: $btn-default-padding-block;
+    padding-inline: $btn-default-padding-inline;
     overflow: visible;
     text-align: center;
     font-weight: $btn-default-weight;
@@ -316,7 +332,7 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
     }
 
     p + & {
-        margin-top: f.spacing(d);
+        margin-block-start: f.spacing(d);
     }
 }
     .o-button-content {
@@ -337,7 +353,7 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
 
     .o-btn-icon,
     .o-btn-icon svg {
-        height: $btn-default-iconHeight;
+        block-size: $btn-default-iconHeight;
     }
 
     .o-btn-icon svg use,
@@ -346,11 +362,11 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
     }
 
     .o-btn-icon--leading {
-        margin-right: $btn-default-iconSideSpacing;
+        margin-inline-end: $btn-default-iconSideSpacing;
     }
 
     .o-btn-icon--trailing {
-        margin-left: $btn-default-iconSideSpacing;
+        margin-inline-start: $btn-default-iconSideSpacing;
     }
 
 /**
@@ -392,6 +408,7 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
     }
 
     &.o-btn--sizeSmall,
+    &.o-btn--sizeSmallProductive,
     &.o-btn--sizeXSmall {
         @include common.background-color(f.$color-interactive-primary);
 
@@ -684,35 +701,38 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
     }
 
     svg {
-        width: $btn-icon-iconSize;
-        height: $btn-icon-iconSize;
+        inline-size: $btn-icon-iconSize;
+        block-size: $btn-icon-iconSize;
     }
-}
 
-.o-btn--icon.o-btn--sizeLarge {
-    width: $btn-icon-sizeLarge-buttonSize;
-    height: $btn-icon-sizeLarge-buttonSize;
-    padding: 0;
+    &.o-btn--sizeLarge {
+        inline-size: $btn-icon-sizeLarge-buttonSize;
+        block-size: $btn-icon-sizeLarge-buttonSize;
+        padding: 0;
 
-    svg {
-        width: $btn-icon-sizeLarge-iconSize;
-        height: $btn-icon-sizeLarge-iconSize;
+        svg {
+            inline-size: $btn-icon-sizeLarge-iconSize;
+            block-size: $btn-icon-sizeLarge-iconSize;
+        }
     }
-}
-.o-btn--icon.o-btn--sizeMedium {
-    width: $btn-icon-sizeMedium-buttonSize;
-    height: $btn-icon-sizeMedium-buttonSize;
-    padding: 0;
-}
-.o-btn--icon.o-btn--sizeSmall {
-    width: $btn-icon-sizeSmall-buttonSize;
-    height: $btn-icon-sizeSmall-buttonSize;
-    padding: 0;
-}
-.o-btn--icon.o-btn--sizeXSmall {
-    width: $btn-icon-sizeXSmall-buttonSize;
-    height: $btn-icon-sizeXSmall-buttonSize;
-    padding: 0;
+
+    &.o-btn--sizeMedium {
+        inline-size: $btn-icon-sizeMedium-buttonSize;
+        block-size: $btn-icon-sizeMedium-buttonSize;
+        padding: 0;
+    }
+
+    &.o-btn--sizeSmall {
+        inline-size: $btn-icon-sizeSmall-buttonSize;
+        block-size: $btn-icon-sizeSmall-buttonSize;
+        padding: 0;
+    }
+
+    &.o-btn--sizeXSmall {
+        inline-size: $btn-icon-sizeXSmall-buttonSize;
+        block-size: $btn-icon-sizeXSmall-buttonSize;
+        padding: 0;
+    }
 }
 
 /**
@@ -722,34 +742,60 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
  */
 
 .o-btn--sizeLarge {
-    padding: $btn-sizeLarge-padding;
+    padding-block: $btn-sizeLarge-padding-block;
+    padding-inline: $btn-sizeLarge-padding-inline;
 }
 
-.o-btn--sizeSmall {
-    @include f.font-size($btn-sizeSmall-font-size);
-    padding: $btn-sizeSmall-padding;
+.o-btn--sizeSmallExpressive {
+    @include f.font-size($btn-sizeSmallExpressive-font-size);
+    padding-block: $btn-sizeSmallExpressive-padding-block;
+    padding-inline: $btn-sizeSmallExpressive-padding-inline;
 
     .o-btn-icon {
-        margin: $btn-sizeSmall-iconSpacing;
+        margin: $btn-sizeSmallExpressive-iconSpacing;
     }
 
     .o-btn-icon,
     .o-btn-icon svg {
-        height: $btn-sizeSmall-iconHeight;
+        block-size: $btn-sizeSmallExpressive-iconHeight;
     }
 
     .o-btn-icon--leading {
-        margin-right: $btn-sizeSmall-iconSideSpacing;
+        margin-inline-end: $btn-sizeSmallExpressive-iconSideSpacing;
     }
 
     .o-btn-icon--trailing {
-        margin-left: $btn-sizeSmall-iconSideSpacing;
+        margin-inline-start: $btn-sizeSmallExpressive-iconSideSpacing;
+    }
+}
+
+.o-btn--sizeSmallProductive {
+    @include f.font-size($btn-sizeSmallProductive-font-size);
+    padding-block: $btn-sizeSmallProductive-padding-block;
+    padding-inline: $btn-sizeSmallProductive-padding-inline;
+
+    .o-btn-icon {
+        margin: $btn-sizeSmallProductive-iconSpacing;
+    }
+
+    .o-btn-icon,
+    .o-btn-icon svg {
+        block-size: $btn-sizeSmallProductive-iconHeight;
+    }
+
+    .o-btn-icon--leading {
+        margin-inline-end: $btn-sizeSmallProductive-iconSideSpacing;
+    }
+
+    .o-btn-icon--trailing {
+        margin-inline-start: $btn-sizeSmallProductive-iconSideSpacing;
     }
 }
 
 .o-btn--sizeXSmall {
     @include f.font-size($btn-sizeXSmall-font-size);
-    padding: $btn-sizeXSmall-padding;
+    padding-block: $btn-sizeXSmall-padding-block;
+    padding-inline: $btn-sizeXSmall-padding-inline;
 
     .o-btn-icon {
         margin: $btn-sizeXSmall-iconSpacing;
@@ -757,15 +803,15 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
 
     .o-btn-icon,
     .o-btn-icon svg {
-        height: $btn-sizeXSmall-iconHeight;
+        block-size: $btn-sizeXSmall-iconHeight;
     }
 
     .o-btn-icon--leading {
-        margin-right: $btn-sizeSmall-iconSideSpacing;
+        margin-inline-end: $btn-sizeXSmall-iconSideSpacing;
     }
 
     .o-btn-icon--trailing {
-        margin-left: $btn-sizeSmall-iconSideSpacing;
+        margin-inline-start: $btn-sizeXSmall-iconSideSpacing;
     }
 }
 
@@ -783,12 +829,12 @@ $btn-icon-sizeXSmall-buttonSize        : 32px;
 
 .o-btn--fullWidth {
     display: block;
-    width: 100%;
+    inline-size: 100%;
 
     // Vertically space out multiple fullWidth buttons
     // same as .o-btn--fullWidth + .o-btn--fullWidth
     & + & {
-        margin-top: f.spacing(d);
+        margin-block-start: f.spacing(d);
     }
 }
 

--- a/packages/components/atoms/f-button/src/components/_tests/Button.test.js
+++ b/packages/components/atoms/f-button/src/components/_tests/Button.test.js
@@ -22,16 +22,18 @@ describe('Button', () => {
             });
 
             it.each([
-                'xsmall',
-                'small',
-                'medium',
-                'large'
-            ])('should not throw an error when buttonSize is set to %s', buttonSize => {
+                ['xsmall', true],
+                ['xsmall', false],
+                ['small', true],
+                ['small-productive', false],
+                ['small-expressive', false],
+                ['medium', true],
+                ['medium', false],
+                ['large', true],
+                ['large', false]
+            ])('should not throw an error when buttonSize is set to %s and isIcon is %s', (buttonSize, isIcon) => {
                 // Arrange
-                const propsData = {
-                    buttonSize,
-                    isIcon: false
-                };
+                const propsData = { buttonSize, isIcon };
 
                 // Act & Assert
                 expect(() => {
@@ -40,18 +42,21 @@ describe('Button', () => {
                     .not.toThrowError();
             });
 
-            it('should throw an error when buttonSize is set to an invalid type', () => {
+            it.each(
+                ['invalid_value', true],
+                ['invalid_value', false],
+                ['small', false],
+                ['small-productive', true],
+                ['small-expressive', true]
+            )('should throw an error when buttonSize is set to %s when isIcon is %s', (buttonSize, isIcon) => {
                 // Arrange
-                const propsData = {
-                    buttonSize: 'invalid_value',
-                    isIcon: false
-                };
+                const propsData = { buttonSize, isIcon };
 
                 // Act & Assert
                 expect(() => {
                     shallowMount(FButton, { propsData });
                 })
-                    .toThrowError('buttonSize is set to "invalid_value"');
+                    .toThrowError(`buttonSize is set to "${buttonSize}"`);
             });
 
             it.each([
@@ -279,32 +284,22 @@ describe('Button', () => {
 
     describe('computed :: ', () => {
         describe('buttonSizeClassname :: ', () => {
-            it('should capitalise to first letter of `buttonSize` prop :: ', () => {
+            it.each([
+                ['xsmall', 'XSmall', false],
+                ['small', 'Small', true],
+                ['small-productive', 'SmallProductive', false],
+                ['small-expressive', 'SmallExpressive', false],
+                ['medium', 'Medium', false],
+                ['large', 'Large', false]
+            ])('should convert size %s to %s for use in class name', (buttonSize, className, isIcon) => {
                 // Arrange
-                const propsData = {
-                    buttonSize: 'medium',
-                    actionType
-                };
+                const propsData = { actionType, buttonSize, isIcon };
 
                 // Act
                 const wrapper = shallowMount(FButton, { propsData });
 
                 // Assert
-                expect(wrapper.vm.buttonSizeClassname).toEqual('Medium');
-            });
-
-            it('should capitalise to first two letters of `buttonSize` prop if `xsmall` :: ', () => {
-                // Arrange
-                const propsData = {
-                    buttonSize: 'xsmall',
-                    actionType
-                };
-
-                // Act
-                const wrapper = shallowMount(FButton, { propsData });
-
-                // Assert
-                expect(wrapper.vm.buttonSizeClassname).toEqual('XSmall');
+                expect(wrapper.vm.buttonSizeClassname).toEqual(className);
             });
         });
 

--- a/packages/components/atoms/f-button/src/components/_tests/Button.test.js
+++ b/packages/components/atoms/f-button/src/components/_tests/Button.test.js
@@ -42,21 +42,22 @@ describe('Button', () => {
                     .not.toThrowError();
             });
 
-            it.each(
+            it.each([
                 ['invalid_value', true],
                 ['invalid_value', false],
                 ['small', false],
                 ['small-productive', true],
                 ['small-expressive', true]
-            )('should throw an error when buttonSize is set to %s when isIcon is %s', (buttonSize, isIcon) => {
+            ])('should throw an error when buttonSize is set to %s when isIcon is %s', (buttonSize, isIcon) => {
                 // Arrange
                 const propsData = { buttonSize, isIcon };
+                const buttonOrIconButton = isIcon ? 'iconButton' : 'button';
 
                 // Act & Assert
                 expect(() => {
                     shallowMount(FButton, { propsData });
                 })
-                    .toThrowError(`buttonSize is set to "${buttonSize}"`);
+                    .toThrowError(`buttonSize for ${buttonOrIconButton} is set to "${buttonSize}"`);
             });
 
             it.each([
@@ -79,18 +80,20 @@ describe('Button', () => {
                     .not.toThrowError();
             });
 
-            it('should throw an error when the component is a standard button (isIcon="false") and buttonType is set to an invalid type', () => {
+            it.each([
+                true,
+                false
+            ])('should throw an error when isIcon="%s" and buttonType is invalid', isIcon => {
                 // Arrange
-                const propsData = {
-                    buttonType: 'invalid_value',
-                    isIcon: false
-                };
+                const buttonType = 'invalid_value';
+                const propsData = { buttonType, isIcon };
+                const buttonOrIconButton = isIcon ? 'iconButton' : 'button';
 
                 // Act & Assert
                 expect(() => {
                     shallowMount(FButton, { propsData });
                 })
-                    .toThrowError('button is set to have buttonType="invalid_value"');
+                    .toThrowError(`buttonType for ${buttonOrIconButton} is set to "${buttonType}"`);
             });
 
             it.each([
@@ -98,7 +101,7 @@ describe('Button', () => {
                 'secondary',
                 'ghost',
                 'ghostTertiary'
-            ])('should not throw an error when the component is an iconButton (isIcon="true") and buttonType is set to %s', buttonType => {
+            ])('should not throw an error when isIcon="true" and buttonType="%s"', buttonType => {
                 // Arrange
                 const propsData = {
                     buttonType,
@@ -110,20 +113,6 @@ describe('Button', () => {
                     shallowMount(FButton, { propsData });
                 })
                     .not.toThrowError();
-            });
-
-            it('should throw an error when the component is an iconButton (isIcon="true") and the buttonType is set to an invalid type', () => {
-                // Arrange
-                const propsData = {
-                    buttonType: 'invalid_value',
-                    isIcon: true
-                };
-
-                // Act & Assert
-                expect(() => {
-                    shallowMount(FButton, { propsData });
-                })
-                    .toThrowError('iconButton is set to have buttonType="invalid_value"');
             });
 
             it.each([

--- a/packages/components/atoms/f-button/src/constants.js
+++ b/packages/components/atoms/f-button/src/constants.js
@@ -1,9 +1,12 @@
 // eslint-disable-next-line import/prefer-default-export
 export const VALID_BUTTON_TYPES = {
-    iconButton: ['primary', 'secondary', 'ghost', 'ghostTertiary', 'inverse', 'ghostInverse'],
-    button: ['primary', 'secondary', 'outline', 'ghost', 'link']
+    button: ['primary', 'secondary', 'outline', 'ghost', 'link'],
+    iconButton: ['primary', 'secondary', 'ghost', 'ghostTertiary', 'inverse', 'ghostInverse']
 };
 
-export const VALID_BUTTON_SIZES = ['xsmall', 'small', 'medium', 'large'];
+export const VALID_BUTTON_SIZES = {
+    button: ['xsmall', 'small-productive', 'small-expressive', 'medium', 'large'],
+    iconButton: ['xsmall', 'small', 'medium', 'large']
+}
 
 export const VALID_BUTTON_ICON_POSITION = ['leading', 'trailing', false];

--- a/packages/components/atoms/f-button/src/constants.js
+++ b/packages/components/atoms/f-button/src/constants.js
@@ -7,6 +7,6 @@ export const VALID_BUTTON_TYPES = {
 export const VALID_BUTTON_SIZES = {
     button: ['xsmall', 'small-productive', 'small-expressive', 'medium', 'large'],
     iconButton: ['xsmall', 'small', 'medium', 'large']
-}
+};
 
 export const VALID_BUTTON_ICON_POSITION = ['leading', 'trailing', false];

--- a/packages/components/atoms/f-button/stories/Button.stories.js
+++ b/packages/components/atoms/f-button/stories/Button.stories.js
@@ -17,7 +17,7 @@ export const ButtonComponent = (args, { argTypes }) => ({
     template: `
     <div>
         <div
-            class="u-spacingBottom--large storybook-grid storybook-grid-columns--4 storybook-grid-stack--lessThanWide"
+            class="u-spacingBottom--large storybook-grid storybook-grid-columns--5 storybook-grid-stack--lessThanWide"
             v-for="(list, index) in buttonLists">
             <f-button
                 class="u-spacingBottom--large"
@@ -56,28 +56,32 @@ ButtonComponent.argTypes = {
 ButtonComponent.args = {
     buttonLists: [
         [
-            { type: 'primary', size: 'large', text: 'Large Primary Button' },
-            { type: 'primary', size: 'medium', text: 'Medium Primary Button' },
-            { type: 'primary', size: 'small', text: 'Small Primary Button' },
-            { type: 'primary', size: 'xsmall', text: 'Xsmall Primary Button' }
+            { type: 'primary', size: 'large', text: 'Large Primary' },
+            { type: 'primary', size: 'medium', text: 'Medium Primary' },
+            { type: 'primary', size: 'small-expressive', text: 'Small-Expressive Primary' },
+            { type: 'primary', size: 'small-productive', text: 'Small-Productive Primary' },
+            { type: 'primary', size: 'xsmall', text: 'Xsmall Primary' }
         ],
         [
-            { type: 'secondary', size: 'large', text: 'Large Secondary Button' },
-            { type: 'secondary', size: 'medium', text: 'Medium Secondary Button' },
-            { type: 'secondary', size: 'small', text: 'Small Secondary Button' },
-            { type: 'secondary', size: 'xsmall', text: 'Xsmall Secondary Button' }
+            { type: 'secondary', size: 'large', text: 'Large Secondary' },
+            { type: 'secondary', size: 'medium', text: 'Medium Secondary' },
+            { type: 'secondary', size: 'small-expressive', text: 'Small-Expressive Secondary' },
+            { type: 'secondary', size: 'small-productive', text: 'Small-Productive Secondary' },
+            { type: 'secondary', size: 'xsmall', text: 'Xsmall Secondary' }
         ],
         [
-            { type: 'outline', size: 'large', text: 'Large Outline Button' },
-            { type: 'outline', size: 'medium', text: 'Medium Outline Button' },
-            { type: 'outline', size: 'small', text: 'Small Outline Button' },
-            { type: 'outline', size: 'xsmall', text: 'Xsmall Outline Button' }
+            { type: 'outline', size: 'large', text: 'Large Outline' },
+            { type: 'outline', size: 'medium', text: 'Medium Outline' },
+            { type: 'outline', size: 'small-expressive', text: 'Small-Expressive Outline' },
+            { type: 'outline', size: 'small-productive', text: 'Small-Productive Outline' },
+            { type: 'outline', size: 'xsmall', text: 'Xsmall Outline' }
         ],
         [
-            { type: 'ghost', size: 'large', text: 'Large Ghost Button' },
-            { type: 'ghost', size: 'medium', text: 'Medium Ghost Button' },
-            { type: 'ghost', size: 'small', text: 'Small Ghost Button' },
-            { type: 'ghost', size: 'xsmall', text: 'Xsmall Ghost Button' }
+            { type: 'ghost', size: 'large', text: 'Large Ghost' },
+            { type: 'ghost', size: 'medium', text: 'Medium Ghost' },
+            { type: 'ghost', size: 'small-expressive', text: 'Small-Expressive Ghost' },
+            { type: 'ghost', size: 'small-productive', text: 'Small-Productive Ghost' },
+            { type: 'ghost', size: 'xsmall', text: 'Xsmall Ghost' }
         ]
     ]
 };

--- a/packages/components/atoms/f-button/stories/Demo.stories.js
+++ b/packages/components/atoms/f-button/stories/Demo.stories.js
@@ -46,7 +46,7 @@ DemoButtonComponent.argTypes = {
         defaultValue: 'primary'
     },
     buttonSize: {
-        control: { type: 'select', options: VALID_BUTTON_SIZES },
+        control: { type: 'select', options: VALID_BUTTON_SIZES.button },
         description: 'Choose the button size',
         defaultValue: 'medium'
     },

--- a/packages/components/atoms/f-button/stories/IconDemo.stories.js
+++ b/packages/components/atoms/f-button/stories/IconDemo.stories.js
@@ -63,7 +63,7 @@ DemoIconButtonComponent.argTypes = {
         defaultValue: 'primary'
     },
     buttonSize: {
-        control: { type: 'select', options: VALID_BUTTON_SIZES },
+        control: { type: 'select', options: VALID_BUTTON_SIZES.iconButton },
         description: 'Choose the button size',
         defaultValue: 'medium'
     },

--- a/packages/components/atoms/f-button/stories/LinkButton.stories.js
+++ b/packages/components/atoms/f-button/stories/LinkButton.stories.js
@@ -16,7 +16,7 @@ export const LinkButtonComponent = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
     template: `
     <div>
-        <div class="storybook-grid storybook-grid-columns--4 storybook-grid-stack--lessThanWide">
+        <div class="storybook-grid storybook-grid-columns--5 storybook-grid-stack--lessThanWide">
             <f-button
                 class="u-spacingRight u-spacingBottom--large"
                 v-for="(button, index) in buttonList"
@@ -46,10 +46,11 @@ LinkButtonComponent.argTypes = SharedButtonArgTypes;
 
 LinkButtonComponent.args = {
     buttonList: [
-        { size: 'large', text: 'Large Link Button' },
-        { size: 'medium', text: 'Medium Link Button' },
-        { size: 'small', text: 'Small Link Button' },
-        { size: 'xsmall', text: 'Xsmall Link Button' }
+        { size: 'large', text: 'Large Link' },
+        { size: 'medium', text: 'Medium Link' },
+        { size: 'small-expressive', text: 'Small-Expressive Link' },
+        { size: 'small-productive', text: 'Small-Productive Link' },
+        { size: 'xsmall', text: 'Xsmall Link' }
     ],
     href: 'someUrl'
 };

--- a/packages/components/atoms/f-button/stories/RouterButton.stories.js
+++ b/packages/components/atoms/f-button/stories/RouterButton.stories.js
@@ -3,6 +3,7 @@ import Router from 'vue-router';
 import { withA11y } from '@storybook/addon-a11y';
 import FButton from '../src/components/Button.vue';
 import SharedButtonArgTypes from './sharedButtonArgTypes';
+import { VALID_BUTTON_SIZES, VALID_BUTTON_TYPES } from '../src/constants';
 
 Vue.use(Router);
 
@@ -57,14 +58,14 @@ RouterLinkComponent.argTypes = {
     buttonType:
     {
         control: { type: 'select' },
-        options: ['primary', 'secondary', 'outline', 'ghost', 'link'],
+        options: VALID_BUTTON_TYPES.button,
         description: 'Choose a Button Type',
         defaultValue: 'primary'
     },
     buttonSize:
     {
         control: { type: 'select' },
-        options: ['xsmall', 'small', 'medium', 'large'],
+        options: VALID_BUTTON_SIZES.button,
         description: 'Choose a Button Size',
         defaultValue: 'medium'
     },

--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v7.4.1
+------------------------------
+*April 28, 2023*
+
+### Fixed
+- Linting warning.
+
+
 v7.4.0
 ------------------------------
 *April 12, 2023*
@@ -56,6 +64,7 @@ v7.0.0
 - peerDependency versions to use new major version.
 - devDependency version range to match peerDependencies.
 
+
 v6.0.0
 -----------------------------
 *June 20, 2022*
@@ -66,7 +75,7 @@ v6.0.0
 
 v5.1.1
 ------------------------------
-*Jun 9, 2022*
+*June 9, 2022*
 
 ### Changed
 - Bumped wdio version and fixed breaking changes.
@@ -103,6 +112,7 @@ v5.0.0
 - Close button inset positioning changed to stay in-line with the first line of title
 - Increased modal widths by 10%
 - Changed close button icon color to `$color-interactive-primary`
+
 
 v4.2.0
 ------------------------------
@@ -214,6 +224,7 @@ v0.12.0
 - Aligned to PIE designs
 - Updated version of `f-button`.
 
+
 v0.11.0
 ------------------------------
 *July 14, 2021*
@@ -288,6 +299,7 @@ v0.4.0
 
 ### Fixed
 - Readme component reference.
+
 
 v0.3.0
 ------------------------------

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "7.4.0",
+  "version": "7.4.1",
   "main": "dist/f-mega-modal.common.js",
   "maxBundleSize": "6kB",
   "files": [

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -53,8 +53,9 @@
                             button-size="xsmall"
                             data-test-id="close-modal"
                             @click.native="close">
-                            <component :is="setCloseButtonIconStyle"
-                                       :class="[$style['c-megaModal-closeIcon']]" />
+                            <component
+                                :is="setCloseButtonIconStyle"
+                                :class="[$style['c-megaModal-closeIcon']]" />
 
                             <span class="is-visuallyHidden">
                                 {{ closeButtonCopy }}

--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v4.9.1
+------------------------------
+*April 28, 2023*
+
+### Fixed
+- Linting warnings in test mock files.
+
+
 v4.9.0
 ------------------------------
 *December 1, 2022*

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout - Fozzie Checkout Component",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "main": "dist/f-checkout.umd.min.js",
   "maxBundleSize": "100kB",
   "files": [

--- a/packages/components/pages/f-checkout/stories/api/checkoutMock.js
+++ b/packages/components/pages/f-checkout/stories/api/checkoutMock.js
@@ -5,7 +5,7 @@ import mockedRequests from './responses';
 
 const mock = new MockAdapter(axios);
 
-export default function () {
+const setupMock = () => {
     mockedRequests.forEach(request => {
         const methods = {
             [httpMethods.post]: mock.onPost(request.url),
@@ -27,4 +27,6 @@ export default function () {
     });
 
     mock.onAny().passThrough();
-}
+};
+
+export default setupMock;

--- a/packages/components/pages/f-checkout/stories/api/responses/getBasket/getBasket.js
+++ b/packages/components/pages/f-checkout/stories/api/responses/getBasket/getBasket.js
@@ -9,33 +9,31 @@ const restriction = {
     Type: 'Alcohol'
 };
 
-function buildPrompts (issues) {
-    return {
-        SpendMore: null,
-        DiscountApplied: {
-            Amount: 0
-        },
-        Offers: [],
-        InvalidProducts: issues === 'invalidProduct' ? [product] : [],
-        OfflineProducts: issues === 'offlineProduct' ? [product] : [],
-        RequiresOther: false,
-        RefreshMenu: false,
-        Restrictions: issues === 'ageRestriction' ? [restriction] : [],
-        ItemDiscounts: []
-    };
-}
+const buildPrompts = issues => ({
+    SpendMore: null,
+    DiscountApplied: {
+        Amount: 0
+    },
+    Offers: [],
+    InvalidProducts: issues === 'invalidProduct' ? [product] : [],
+    OfflineProducts: issues === 'offlineProduct' ? [product] : [],
+    RequiresOther: false,
+    RefreshMenu: false,
+    Restrictions: issues === 'ageRestriction' ? [restriction] : [],
+    ItemDiscounts: []
+});
 
-export default function (serviceType = CHECKOUT_METHOD_DELIVERY, issues) {
-    return {
-        BasketId: '11111111',
-        ServiceType: serviceType,
-        RestaurantId: '99999',
-        RestaurantSeoName: 'poppies-fish-and-chips-spitalfields-aldgate',
-        BasketSummary: {
-            BasketTotals: {
-                Total: 23.55
-            },
-            Prompts: buildPrompts(issues)
-        }
-    };
-}
+const getBasket = (serviceType = CHECKOUT_METHOD_DELIVERY, issues) => ({
+    BasketId: '11111111',
+    ServiceType: serviceType,
+    RestaurantId: '99999',
+    RestaurantSeoName: 'poppies-fish-and-chips-spitalfields-aldgate',
+    BasketSummary: {
+        BasketTotals: {
+            Total: 23.55
+        },
+        Prompts: buildPrompts(issues)
+    }
+});
+
+export default getBasket;

--- a/packages/components/pages/f-checkout/stories/api/responses/getCheckout/getCheckout.js
+++ b/packages/components/pages/f-checkout/stories/api/responses/getCheckout/getCheckout.js
@@ -8,24 +8,20 @@ import {
 } from '../../../../src/constants';
 import { DELIVERY_TIMES } from '../../../helpers';
 
-function buildCustomer (tenant) {
-    return customers[tenant];
-}
+const buildCustomer = tenant => customers[tenant];
 
-function buildLocation (tenant) {
-    return Address[tenant];
-}
+const buildLocation = tenant => Address[tenant];
 
-function getNoteTypes (notes) {
+const getNoteTypes = notes => {
     const noteTypes = {
         courier: [CHECKOUT_NOTE_TYPE_COURIER],
         split: [CHECKOUT_NOTE_TYPE_COURIER, CHECKOUT_NOTE_TYPE_KITCHEN]
     };
 
     return noteTypes[notes] || null;
-}
+};
 
-function getTime (isPreOrder, scheduledTime) {
+const getTime = (isPreOrder, scheduledTime) => {
     const times = {
         [DELIVERY_TIMES.later]: {
             from: '2020-01-01T02:15:00.000Z',
@@ -47,9 +43,9 @@ function getTime (isPreOrder, scheduledTime) {
         asap: !isPreOrder,
         scheduled
     };
-}
+};
 
-export default function (serviceType = CHECKOUT_METHOD_DELIVERY, tenant = 'uk', additionalToggles) {
+const getCheckout = (serviceType = CHECKOUT_METHOD_DELIVERY, tenant = 'uk', additionalToggles) => {
     const isPreOrder = !!additionalToggles?.isPreOrder;
     const scheduledTime = additionalToggles?.scheduledTime;
     const notes = additionalToggles?.notes;
@@ -102,4 +98,6 @@ export default function (serviceType = CHECKOUT_METHOD_DELIVERY, tenant = 'uk', 
         ],
         ...(notes ? noteTypes : {})
     };
-}
+};
+
+export default getCheckout;

--- a/packages/components/pages/f-offers/CHANGELOG.md
+++ b/packages/components/pages/f-offers/CHANGELOG.md
@@ -4,9 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.1
+------------------------------
+*April 28, 2023*
+
+### Fixed
+- Linting warning.
+
+
 v2.0.0
 ------------------------------
-*February 15, 2022*
+*February 15, 2023*
 
 ### Changed
 - Updated to include the new braze adapter
@@ -15,7 +23,7 @@ v2.0.0
 
 v1.15.2
 ------------------------------
-*February 13, 2022*
+*February 13, 2023*
 
 ### Added
 - braze sk 3.3.0 under dev dependencies to allow tests to work.

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-offers",
   "description": "Fozzie Offers - displays offers to the customers",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/f-offers.umd.min.js",
   "maxBundleSize": "150kB",
   "files": [

--- a/packages/components/pages/f-offers/src/components/Results.vue
+++ b/packages/components/pages/f-offers/src/components/Results.vue
@@ -9,16 +9,16 @@
             @on-error="onError">
             <template #default="{ cards }">
                 <div :class="$style['c-offersResults-contentCards']">
-                    <template v-for="(card, i) in cards">
+                    <template
+                        v-for="(card, i) in cards"
+                        :key="i">
                         <group-header-card
                             v-if="card.type === 'Header_Card'"
                             :class="$style['c-offersResults-contentCards-groupHeader']"
-                            :key="i"
                             :title="card.title" />
                         <component
                             :is="handleCustomCardType(card.type)"
                             v-else
-                            :key="i"
                             :card="card"
                             :test-id="testIdForItemWithIndex(i)"
                             :tenant="tenant"

--- a/packages/components/pages/f-offers/src/components/Results.vue
+++ b/packages/components/pages/f-offers/src/components/Results.vue
@@ -9,16 +9,16 @@
             @on-error="onError">
             <template #default="{ cards }">
                 <div :class="$style['c-offersResults-contentCards']">
-                    <template
-                        v-for="(card, i) in cards"
-                        :key="i">
+                    <template v-for="(card, i) in cards">
                         <group-header-card
                             v-if="card.type === 'Header_Card'"
+                            :key="`group-header-card-${i}`"
                             :class="$style['c-offersResults-contentCards-groupHeader']"
                             :title="card.title" />
                         <component
                             :is="handleCustomCardType(card.type)"
                             v-else
+                            :key="`custom-card-${i}`"
                             :card="card"
                             :test-id="testIdForItemWithIndex(i)"
                             :tenant="tenant"

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.62.0
+------------------------------
+*April 28, 2023*
+
+### Added
+- Flexible-width, 5-column layout for button stories with 5 sizes.
+
+
 v0.61.0
 ------------------------------
 *March 27, 2023*

--- a/packages/storybook/config/storybook/preview-head.html
+++ b/packages/storybook/config/storybook/preview-head.html
@@ -78,6 +78,10 @@
         align-content: start;
     }
 
+    .storybook-grid-columns--5 {
+        grid-template-columns: repeat(5, auto);
+    }
+
     .storybook-grid-columns--4 {
         grid-template-columns: repeat(4, 1fr);
     }

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/storybook",
   "private": true,
-  "version": "0.61.0",
+  "version": "0.62.0",
   "scripts": {
     "storybook:deploy": "storybook-to-ghpages --existing-output-dir ./storybook-static --ci",
     "storybook:build": "vue-cli-service storybook:build -s public -c config/storybook",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2674,6 +2674,13 @@
     eslint-config-airbnb-base "15.0.0"
     eslint-plugin-vue "8.7.1"
 
+"@justeat/f-button@4.x":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-button/-/f-button-4.5.0.tgz#7b93c91c59a4be10fcb821b089aff00f9399def0"
+  integrity sha512-T6YiRjrqonWZu8NT1pVrgk/E8HnP8oHw2vbAsNqvJ4Phe8NHTZbFyUe2ldmFmP/r/AdFw4h6xJn8E56YLdM1GQ==
+  dependencies:
+    "@justeattakeaway/pie-icons-vue" "2.0.0-beta.1"
+
 "@justeat/f-dom@0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-dom/-/f-dom-0.4.0.tgz#3e838a2dd06d4d5281c17f5fb9f66d7485fd759a"


### PR DESCRIPTION
### Removed
- `small` button size (this still remains for icon buttons)

### Added
- `small-productive` button size (not for icon buttons)
- `small-expressive` button size (not for icon buttons)
  - These buttons are the same height but expressive has a larger font and therefore less vertical padding.

### Changed
- Use CSS logical properties for padding, margins, heights, widths and spinner positioning.

---

And various linting fixes for some other components

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
