### PR TITLE
f-loyalty@3.1.1, f-offers@2.0.2 Rollback f-globalisation in f-offers and f-loyalty

### DIFF
--- a/packages/components/pages/f-loyalty/CHANGELOG.md
+++ b/packages/components/pages/f-loyalty/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.1.1
+------------------------------
+*May 18, 2023*
+
+### Fixed
+- Pinned to a fixed f-globalisation version to prevent localisation breaking
+
+
 v3.1.0
 ------------------------------
 *April 18, 2023*

--- a/packages/components/pages/f-loyalty/package.json
+++ b/packages/components/pages/f-loyalty/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-loyalty",
   "description": "Fozzie Loyalty - provides a way for customers to collect loyalty stamps for restaurants",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "dist/f-loyalty.umd.min.js",
   "maxBundleSize": "125kB",
   "files": [
@@ -47,7 +47,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-globalisation": "1.x",
+    "@justeat/f-globalisation": "1.2.0",
     "@justeat/f-services": "1.x",
     "jwt-decode": "3.1.2"
   },

--- a/packages/components/pages/f-offers/CHANGELOG.md
+++ b/packages/components/pages/f-offers/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.2
+------------------------------
+*May 18, 2023*
+
+### Fixed
+- Pinned to a fixed f-globalisation version to prevent localisation breaking
+
+
 v2.0.1
 ------------------------------
 *April 28, 2023*

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-offers",
   "description": "Fozzie Offers - displays offers to the customers",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "dist/f-offers.umd.min.js",
   "maxBundleSize": "150kB",
   "files": [
@@ -47,7 +47,7 @@
     "extends @justeat/browserslist-config-fozzie"
   ],
   "dependencies": {
-    "@justeat/f-globalisation": "1.x",
+    "@justeat/f-globalisation": "1.2.0",
     "@justeat/f-services": "1.x",
     "@justeattakeaway/cc-braze-adapter": "0.3.0",
     "axios": "0.21.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2702,6 +2702,13 @@
   dependencies:
     vue-i18n "8.0.0"
 
+"@justeat/f-globalisation@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-globalisation/-/f-globalisation-1.2.0.tgz#537444a3dd15752d04e8d043ce4cb68ae745cf18"
+  integrity sha512-LhixjjyVwAivTi8HAch//Obqr121C5p+2kyLvEbpvFLOVzxS37iIl0mAqe0SyHg/I0YR+5geTHBh7mtR2+knjg==
+  dependencies:
+    vue-i18n "8.0.0"
+
 "@justeat/f-icons@4.13.0":
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-4.13.0.tgz#bb24f146c6a517095f1f29ca2ae430b3f5aa510c"


### PR DESCRIPTION
This is to prevent placeholder strings being used.

---

Fixes the locked to placeholder strings issue as seen in storybook and in a rejected changeset in the pipeline.

* [f-loyalty](https://vue.pie.design/?path=/story/components-pages--v-loyalty-component)

Bug:

![Old, bugged loyalty page](https://github.com/justeattakeaway/fozzie-components/assets/6674452/32f5f418-89e6-40d1-a204-f4998ef34f2f)

Fix:

![Fixed loyalty page](https://github.com/justeattakeaway/fozzie-components/assets/6674452/982b7a04-d0e9-4dd1-8198-14399ccaf1f9)

* [f-offers](https://vue.pie.design/?path=/story/components-pages--v-offers-component)

Bug:

![Old, bugged offers page](https://github.com/justeattakeaway/fozzie-components/assets/6674452/4bca6348-c04a-4130-85d2-cf1e104fd207)

Fix:

![Fixed offers page](https://github.com/justeattakeaway/fozzie-components/assets/6674452/5ab849a6-f907-4b34-b6d2-42be6f289ece)


---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
