### PR TITLE
f-content-cards@v10.4.0 - updating stampcards default percentage and permitted percentage

### DIFF
--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -10,7 +10,7 @@ v10.4.0
 
 ### Updated
 - permitted percentages to include numeric version
-- updated es,it and ie tenants to include default percentage
+- updated es, it, ie and nz tenants to include default percentage
 
 
 v10.3.1

--- a/packages/components/organisms/f-content-cards/CHANGELOG.md
+++ b/packages/components/organisms/f-content-cards/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v10.4.0
+------------------------------
+*June 12, 2023*
+
+### Updated
+- permitted percentages to include numeric version
+- updated es,it and ie tenants to include default percentage
+
+
 v10.3.1
 ------------------------------
 *May 24, 2023*

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-content-cards",
   "description": "Fozzie Content Cards",
-  "version": "10.3.1",
+  "version": "10.4.0",
   "main": "dist/f-content-cards.umd.min.js",
   "maxBundleSize": "85kB",
   "files": [

--- a/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
+++ b/packages/components/organisms/f-content-cards/src/components/cardTemplates/StampCard1.vue
@@ -87,7 +87,9 @@ import makeTextAccessible from '../MakeTextAccessible';
 
 const PERMITTED_STAMPCARDS_PERCENTAGES = [
     '10',
-    '15'
+    '15',
+    10,
+    15
 ];
 
 export default {

--- a/packages/components/organisms/f-content-cards/src/tenants/en-IE.js
+++ b/packages/components/organisms/f-content-cards/src/tenants/en-IE.js
@@ -13,5 +13,6 @@ export default {
         3: 'Three stamps earned out of five.',
         4: 'Four stamps earned out of five.',
         5: 'Five stamps earned out of five.'
-    }
+    },
+    stampCardDefaultPercentage: '10'
 };

--- a/packages/components/organisms/f-content-cards/src/tenants/en-NZ.js
+++ b/packages/components/organisms/f-content-cards/src/tenants/en-NZ.js
@@ -13,5 +13,6 @@ export default {
         3: 'Three stamps earned out of five.',
         4: 'Four stamps earned out of five.',
         5: 'Five stamps earned out of five.'
-    }
+    },
+    stampCardDefaultPercentage: '10'
 };

--- a/packages/components/organisms/f-content-cards/src/tenants/es-ES.js
+++ b/packages/components/organisms/f-content-cards/src/tenants/es-ES.js
@@ -13,5 +13,6 @@ export default {
         3: 'Three stamps earned out of five.',
         4: 'Four stamps earned out of five.',
         5: 'Five stamps earned out of five.'
-    }
+    },
+    stampCardDefaultPercentage: '10'
 };

--- a/packages/components/organisms/f-content-cards/src/tenants/it-IT.js
+++ b/packages/components/organisms/f-content-cards/src/tenants/it-IT.js
@@ -13,5 +13,6 @@ export default {
         3: 'Tre punti guadagnati su cinque.',
         4: 'Quattro punti guadagnati su cinque.',
         5: 'Five stamps earned out of five.'
-    }
+    },
+    stampCardDefaultPercentage: '10'
 };

--- a/packages/components/pages/f-loyalty/CHANGELOG.md
+++ b/packages/components/pages/f-loyalty/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.2.0
+------------------------------
+*June 12, 2023*
+
+### Fixed
+- Patched content cards to the latest version 10.4.0
+
+
 v3.1.2
 ------------------------------
 *May 25, 2023*

--- a/packages/components/pages/f-loyalty/package.json
+++ b/packages/components/pages/f-loyalty/package.json
@@ -70,7 +70,7 @@
     "@justeat/f-breadcrumbs": "4.x",
     "@justeat/f-button": "4.x",
     "@justeat/f-card": "4.x",
-    "@justeat/f-content-cards": "10.3.1",
+    "@justeat/f-content-cards": "10.4.0",
     "@justeat/f-media-element": "3.x",
     "@justeat/f-tabs": "3.x",
     "@justeat/f-trak": "0.x",

--- a/packages/components/pages/f-loyalty/package.json
+++ b/packages/components/pages/f-loyalty/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-loyalty",
   "description": "Fozzie Loyalty - provides a way for customers to collect loyalty stamps for restaurants",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "main": "dist/f-loyalty.umd.min.js",
   "maxBundleSize": "125kB",
   "files": [

--- a/packages/components/pages/f-offers/CHANGELOG.md
+++ b/packages/components/pages/f-offers/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.2.0
+------------------------------
+*June 12, 2023*
+
+### Changed
+- Adding patch for content cards 10.4.0
+
+
 v2.1.3
 ------------------------------
 *June 06, 2023*
@@ -11,7 +19,6 @@ v2.1.3
 ### Changed
 - updated version of braze adapter 
 - updated the adapter to accept filters
-
 
 v2.0.3
 ------------------------------

--- a/packages/components/pages/f-offers/CHANGELOG.md
+++ b/packages/components/pages/f-offers/CHANGELOG.md
@@ -20,6 +20,7 @@ v2.1.3
 - updated version of braze adapter 
 - updated the adapter to accept filters
 
+
 v2.0.3
 ------------------------------
 *May 25, 2023*

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@braze/web-sdk": "4.5.0",
     "@justeat/f-button": "4.x",
-    "@justeat/f-content-cards": "10.3.1",
+    "@justeat/f-content-cards": "10.4.0",
     "@justeat/f-media-element": "3.x",
     "@justeat/f-mega-modal": "7.x",
     "@justeat/f-searchbox": "6.x",

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-offers",
   "description": "Fozzie Offers - displays offers to the customers",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "main": "dist/f-offers.umd.min.js",
   "maxBundleSize": "150kB",
   "files": [


### PR DESCRIPTION
updating permitted percentage and also updating the default percentage to be included in the es,it and ie tenants
