### PR TITLE
f-checkout@v4.11.0 - remove fozzie components as externals in Webpack config

### DIFF
--- a/packages/components/pages/f-checkout/CHANGELOG.md
+++ b/packages/components/pages/f-checkout/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v4.11.0
+------------------------------
+*August 2, 2023*
+
+### Changed
+- Remove fozzie components as externals in Webpack config.
+
 v4.10.0
 ------------------------------
 *July 25, 2023*
@@ -46,7 +53,6 @@ v4.7.0
 
 ### Removed
 -  Get address from local storage logic in the handler of UPDATE_STATE mutation
-
 
 v4.6.1
 ------------------------------

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@justeat/f-checkout",
   "description": "Fozzie Checkout - Fozzie Checkout Component",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "main": "dist/f-checkout.umd.min.js",
-  "maxBundleSize": "100kB",
+  "maxBundleSize": "140kB",
   "files": [
     "dist",
     "test-utils",

--- a/packages/components/pages/f-checkout/vue.config.js
+++ b/packages/components/pages/f-checkout/vue.config.js
@@ -28,17 +28,6 @@ module.exports = {
             .end()
             .use('vue-svg-loader')
             .loader('vue-svg-loader');
-
-        config.externals({
-            '@justeat/f-alert': '@justeat/f-alert',
-            '@justeat/f-button': '@justeat/f-button',
-            '@justeat/f-card': '@justeat/f-card',
-            '@justeat/f-card-with-content': '@justeat/f-card-with-content',
-            '@justeat/f-error-message': '@justeat/f-error-message',
-            '@justeat/f-form-field': '@justeat/f-form-field',
-            '@justeat/f-link': '@justeat/f-link',
-            '@justeat/f-mega-modal': '@justeat/f-mega-modal'
-        });
     },
     pluginOptions: {
         lintStyleOnBuild: true


### PR DESCRIPTION
v4.11.0
------------------------------
*August 2, 2023*

### Changed
- Remove fozzie components as externals in Webpack config.