### PR TITLE
f-mega-modal@7.6.0 - Add `position: fixed;` to fix z-index

### DIFF
--- a/packages/components/molecules/f-mega-modal/CHANGELOG.md
+++ b/packages/components/molecules/f-mega-modal/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v7.6.0
+------------------------------
+*August 8, 2023*
+
+### Added
+- `position: fixed;` to modal to allow `z-index` to apply.
+
+
 v7.5.0
 ------------------------------
 *June 13, 2023*

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-mega-modal",
   "description": "Fozzie Mega Modal – A Vue.js modal component",
-  "version": "7.5.0",
+  "version": "7.6.0",
   "main": "dist/f-mega-modal.common.js",
   "maxBundleSize": "6kB",
   "files": [

--- a/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
+++ b/packages/components/molecules/f-mega-modal/src/components/MegaModal.vue
@@ -353,6 +353,7 @@ export default {
 @use '@justeat/fozzie/src/scss/fozzie' as f;
 
 .c-megaModal {
+    position: fixed;
     z-index: f.zIndex(high);
 }
 

--- a/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
+++ b/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
@@ -40,7 +40,7 @@ export const MegaModalComponent = (args, { argTypes }) => ({
                 <h1>Some content to test stacking!</h1>
                 <p>This content should all be behind the modal.</p>
                 <ol>
-                    ${'<li>List item with a kinda long name</li>'.repeat(25)}
+                    ${'<li>List item with a kinda long name</li>'.repeat(35)}
                 </ol>
             </div>
 

--- a/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
+++ b/packages/components/molecules/f-mega-modal/stories/MegaModal.stories.js
@@ -10,31 +10,41 @@ export const MegaModalComponent = (args, { argTypes }) => ({
     components: { MegaModal },
     props: Object.keys(argTypes),
     template: `
-        <mega-modal
-            :is-open="isOpen"
-            :is-narrow="isNarrow"
-            :is-wide="isWide"
-            :is-flush="isFlush"
-            :is-full-height="isFullHeight"
-            :is-scrollable="isScrollable"
-            :is-close-fixed="isCloseFixed"
-            :is-positioned-bottom="isPositionedBottom"
-            :is-close-rounded="isCloseRounded"
-            :is-text-aligned-center="isTextAlignedCenter"
-            :has-close-button="hasCloseButton"
-            :has-overlay="hasOverlay"
-            :close-button-style="closeButtonStyle"
-            :is-mode-right-to-left="isModeRightToLeft"
-            :close-on-blur="closeOnBlur"
-            :close-button-copy="closeButtonCopy"
-            :title="titleCopy"
-            :titleHtmlTag="titleHtmlTag">
+        <div>
+            <mega-modal
+                :is-open="isOpen"
+                :is-narrow="isNarrow"
+                :is-wide="isWide"
+                :is-flush="isFlush"
+                :is-full-height="isFullHeight"
+                :is-scrollable="isScrollable"
+                :is-close-fixed="isCloseFixed"
+                :is-positioned-bottom="isPositionedBottom"
+                :is-close-rounded="isCloseRounded"
+                :is-text-aligned-center="isTextAlignedCenter"
+                :has-close-button="hasCloseButton"
+                :has-overlay="hasOverlay"
+                :close-button-style="closeButtonStyle"
+                :is-mode-right-to-left="isModeRightToLeft"
+                :close-on-blur="closeOnBlur"
+                :close-button-copy="closeButtonCopy"
+                :title="titleCopy"
+                :titleHtmlTag="titleHtmlTag">
 
-            <p data-test-id="mega-modal-content">
-                Let's find another restaurant to order from.
-            </p>
+                <p data-test-id="mega-modal-content">
+                    Let's find another restaurant to order from.
+                </p>
+            </mega-modal>
 
-        </mega-modal>
+            <div style="position: relative; z-index: 8999;">
+                <h1>Some content to test stacking!</h1>
+                <p>This content should all be behind the modal.</p>
+                <ol>
+                    ${'<li>List item with a kinda long name</li>'.repeat(25)}
+                </ol>
+            </div>
+
+        </div>
     `
 });
 


### PR DESCRIPTION
Add `position: fixed;` to allow `z-index` to apply, as it is not valid for the default value, `position: static;`.

I've also updated the story to include some text content, which should be displayed behind the modal and overlay. The modal has a `z-index` of 9000 so I've set the `z-index` of this test content to 8999 which should make it easy to spot if the modal's `z-index` decreases unexpectedly.

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [x] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
