### PR TITLE
f-cookie-banner@4.11.1 - Use latest f-mega-modal

### DIFF
--- a/packages/components/organisms/f-cookie-banner/CHANGELOG.md
+++ b/packages/components/organisms/f-cookie-banner/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v4.11.1
+------------------------------
+*August 9, 2023*
+
+### Changed
+- New version release to pick up latest f-mega-modal.
+
+
 v4.11.0
 ------------------------------
 *June 19, 2023*

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-cookie-banner",
   "description": "Fozzie Cookie Banner - Cookie Banner",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "main": "dist/f-cookie-banner.umd.min.js",
   "maxBundleSize": "80kB",
   "files": [


### PR DESCRIPTION
Version bump to pick up the latest f-mega-modal. The version is 7.x so it should include the latest when the new bundle is created.

`yalc`ed onto the homepage:

| Before | After |
| --- | --- |
| `f-cookie-banner@4.11.0` | `f-cookie-banner@4.11.1` (via yalc) |
| ![2023-08-09 13_22_01](https://github.com/justeattakeaway/fozzie-components/assets/26894168/79469446-5e80-4027-9142-c147ca2348f7) | ![2023-08-09 13_13_32](https://github.com/justeattakeaway/fozzie-components/assets/26894168/f352f4aa-be04-4918-9c34-85f919a4df58) |

---

## UI Review Checks

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [x] Chrome (latest)
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
