### PR TITLE
Bump Node supported versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     # Setup Node 16.
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
     # Restore node_modules if cache exists. If not, cache is created at end of build.
     - name: Cache Node Modules
@@ -63,7 +63,7 @@ jobs:
     # Setup Node 16.
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
     # Restore node_modules if cache exists. If not, cache is created at end of build.
     - name: Cache Node Modules
@@ -91,7 +91,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
     # Restore node_modules - Cache should exist as one was created in previous 'install' job.
     - name: Cache Node Modules
@@ -141,7 +141,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
     # Restore node_modules - Cache should exist as one was created in previous 'install' job
     - name: Restore Cache -  Node Modules
@@ -177,7 +177,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
     # Restore node_modules - Cache should exist as one was created in previous 'install' job
     - name: Restore Cache -  Node Modules
@@ -253,7 +253,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
     # Restore node_modules - Cache should exist as one was created in previous 'install' job.
     - name: Restore Cache -  Node Modules
@@ -293,7 +293,7 @@ jobs:
       # Setup Node 16.
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'yarn'
       # Restore node_modules - Cache should exist as one was created in previous 'install' job.
       - name: Restore Cache -  Node Modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v7.55.0
+------------------------------
+*November 20, 2023*
+
+### Changed
+- Bump Node support version
+  - Drop support for v.12 and v.14
+  - Add support for v.18 and v.20
+
+
 v7.54.2
 ------------------------------
 *September 4, 2023*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ v7.55.0
 - Bump Node support version
   - Drop support for v.12 and v.14
   - Add support for v.18 and v.20
+- Storybook guides link updates
 
 
 v7.54.2

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Component Tests
  ```
 
 ## Importing optional SCSS helpers from Fozzie
-We have created several optional mixin helpers in [Fozzie](https://github.com/justeat/fozzie/tree/master/src/scss/components/optional).
+We have created several optional mixin helpers in Fozzie [optional folder](./packages/tools/fozzie/src/scss/components/optional).
 Here's an example of how to use it:
 
 Note: Importing the optional mixin and using `@include` in the `common.scss` file of your component doesn't work if you have `module` enabled on your SFC.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "7.54.2",
+  "version": "7.55.0",
   "private": true,
   "scripts": {
     "build": "cross-env-shell turbo run build --continue --token=${TURBO_TOKEN}",
@@ -137,7 +137,7 @@
     "Github contributors <https://github.com/justeat/fozzie-components/graphs/contributors>"
   ],
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "homepage": "https://github.com/justeat/fozzie-components",
   "keywords": [

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-card/package.json
+++ b/packages/components/atoms/f-card/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-error-boundary/package.json
+++ b/packages/components/atoms/f-error-boundary/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-error-message/package.json
+++ b/packages/components/atoms/f-error-message/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-filter-pill/package.json
+++ b/packages/components/atoms/f-filter-pill/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-form-field/package.json
+++ b/packages/components/atoms/f-form-field/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-image-tile/package.json
+++ b/packages/components/atoms/f-image-tile/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-link/package.json
+++ b/packages/components/atoms/f-link/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-popover/package.json
+++ b/packages/components/atoms/f-popover/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/atoms/f-spinner/package.json
+++ b/packages/components/atoms/f-spinner/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-breadcrumbs/package.json
+++ b/packages/components/molecules/f-breadcrumbs/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-card-with-content/package.json
+++ b/packages/components/molecules/f-card-with-content/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-media-element/package.json
+++ b/packages/components/molecules/f-media-element/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-mega-modal/package.json
+++ b/packages/components/molecules/f-mega-modal/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-navigation-links/package.json
+++ b/packages/components/molecules/f-navigation-links/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-promotions-showcase/package.json
+++ b/packages/components/molecules/f-promotions-showcase/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-rating/package.json
+++ b/packages/components/molecules/f-rating/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-restaurant-card/package.json
+++ b/packages/components/molecules/f-restaurant-card/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-searchbox/package.json
+++ b/packages/components/molecules/f-searchbox/package.json
@@ -26,7 +26,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-skeleton-loader/package.json
+++ b/packages/components/molecules/f-skeleton-loader/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-tabs/package.json
+++ b/packages/components/molecules/f-tabs/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/molecules/f-user-message/package.json
+++ b/packages/components/molecules/f-user-message/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/organisms/f-content-cards/package.json
+++ b/packages/components/organisms/f-content-cards/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/organisms/f-cookie-banner/package.json
+++ b/packages/components/organisms/f-cookie-banner/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/organisms/f-status-banner/package.json
+++ b/packages/components/organisms/f-status-banner/package.json
@@ -25,7 +25,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-account-info/package.json
+++ b/packages/components/pages/f-account-info/package.json
@@ -26,7 +26,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-checkout/package.json
+++ b/packages/components/pages/f-checkout/package.json
@@ -26,7 +26,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-contact-preferences/package.json
+++ b/packages/components/pages/f-contact-preferences/package.json
@@ -26,7 +26,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-loyalty/package.json
+++ b/packages/components/pages/f-loyalty/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-mfa/package.json
+++ b/packages/components/pages/f-mfa/package.json
@@ -25,7 +25,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-offers/package.json
+++ b/packages/components/pages/f-offers/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-registration/package.json
+++ b/packages/components/pages/f-registration/package.json
@@ -25,7 +25,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/pages/f-takeawaypay-activation/package.json
+++ b/packages/components/pages/f-takeawaypay-activation/package.json
@@ -25,7 +25,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/components/templates/f-template-subnav/package.json
+++ b/packages/components/templates/f-template-subnav/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/core-analytics/package.json
+++ b/packages/services/core-analytics/package.json
@@ -25,7 +25,7 @@
     },
     "license": "Apache-2.0",
     "engines": {
-        "node": "^12 || ^14 || ^16"
+        "node": "^16 || ^18 || ^20"
     },
     "keywords": [
         "fozzie"

--- a/packages/services/f-analytics/package.json
+++ b/packages/services/f-analytics/package.json
@@ -25,7 +25,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-braze-adapter/package.json
+++ b/packages/services/f-braze-adapter/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-compatibility/package.json
+++ b/packages/services/f-compatibility/package.json
@@ -25,7 +25,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-consumer-oidc/package.json
+++ b/packages/services/f-consumer-oidc/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-feature-management-vue/package.json
+++ b/packages/services/f-feature-management-vue/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-feature-management/package.json
+++ b/packages/services/f-feature-management/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-globalisation/package.json
+++ b/packages/services/f-globalisation/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-http/package.json
+++ b/packages/services/f-http/package.json
@@ -25,7 +25,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-performance/package.json
+++ b/packages/services/f-performance/package.json
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-services/package.json
+++ b/packages/services/f-services/package.json
@@ -25,7 +25,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-statistics/package.json
+++ b/packages/services/f-statistics/package.json
@@ -25,7 +25,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-test-data-creator/package.json
+++ b/packages/services/f-test-data-creator/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/services/f-wdio-utils/package.json
+++ b/packages/services/f-wdio-utils/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -38,7 +38,7 @@
     "Github contributors <https://github.com/justeat/fozzie-components/graphs/contributors>"
   ],
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/tools/f-vue-icons/package.json
+++ b/packages/tools/f-vue-icons/package.json
@@ -27,7 +27,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"

--- a/packages/tools/fozzie/package.json
+++ b/packages/tools/fozzie/package.json
@@ -31,7 +31,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "dependencies": {
     "@justeat/pie-design-tokens": "5.0.0",

--- a/packages/tools/generator-component/generators/app/templates/__package__.json
+++ b/packages/tools/generator-component/generators/app/templates/__package__.json
@@ -26,7 +26,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie"
@@ -60,5 +60,5 @@
   }<% if(config.isComponent) { %>,
   "devDependencies": {<% if(config.needsComponentTests){%>
     "@justeat/f-wdio-utils": "1.x"<% }%>
-  }<% } %>  
+  }<% } %>
 }

--- a/packages/tools/generator-component/package.json
+++ b/packages/tools/generator-component/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^16 || ^18 || ^20"
   },
   "keywords": [
     "fozzie",

--- a/stories/guides/fozzie/structure.stories.mdx
+++ b/stories/guides/fozzie/structure.stories.mdx
@@ -28,44 +28,44 @@ Fozzie SCSS is currently structured as shown below:
      ┣ fozzie.scss
 ```
 
-To see the structure of the SCSS directory in Fozzie SCSS, [check it out on Github](https://github.com/justeat/fozzie/tree/master/src/scss).
+To see the structure of the SCSS directory in Fozzie SCSS, [check it out on Github](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss).
 
 ### Key files
 
 Within Fozzie SCSS, there are a few key files that if you want to contribute back into fozzie, it's worth understanding.
 
-#### [fozzie.scss](https://github.com/justeat/fozzie/blob/master/src/scss/fozzie.scss)
+#### [fozzie.scss](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss/fozzie.scss)
 
 This is the main entry point into Fozzie SCSS.
 
 It's main purpose is to call the `_dependencies.scss` as well as providing access to `_templates.scss`, which provides a set of default styling that was available in older versions of Fozzie SCSS (mainly used to help support older web applications using Fozzie SCSS).
 
-#### [_dependencies.scss](https://github.com/justeat/fozzie/blob/master/src/scss/_dependencies.scss)
+#### [_dependencies.scss](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss/_dependencies.scss)
 
 This file is where all of the Fozzie SCSS dependencies are defined. It imports all of the SCSS files that make up the Fozzie SCSS library.
 
 It acts as a de-facto table of contents for what is available in Fozzie SCSS.
 
 
-#### [/settings/_variables.scss](https://github.com/justeat/fozzie/blob/master/src/scss/settings/_variables.scss)
+#### [/settings/_variables.scss](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss/settings/_variables.scss)
 
 Located in the `/settings` folder, this file defines the variables that are available to applications that import Fozzie SCSS.
 
 Examples include the `$type`, `$spacing` and `$zIndex` maps, and `font-family` and `font-weight` helper variables.
 
-#### [/tools/helpers/_breakpoints.scss](https://github.com/justeat/fozzie/blob/master/src/scss/tools/helpers/_breakpoints.scss)
+#### [/tools/helpers/_breakpoints.scss](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss/tools/helpers/_breakpoints.scss)
 
 This file defines the breakpoints that are available when using Fozzie SCSS.
 
 These breakpoints can be referenced when using the `@include media(…)` helper mixin ([see docs here](/story/documentation-guides-fozzie-fozzie-and-sass--page#media-query-helper-mixins)).
 
-#### [/base/_typography.scss](https://github.com/justeat/fozzie/blob/master/src/scss/base/_typography.scss)
+#### [/base/_typography.scss](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss/base/_typography.scss)
 
 This file contains the Fozzie SCSS default typographic styles.
 
 This includes styles for setting the base font-size of the application and definitions for headings, paragraphs, blockquotes etc.
 
-#### [/trumps/_utilities.scss](https://github.com/justeat/fozzie/blob/master/src/scss/trumps/_utilities.scss)
+#### [/trumps/_utilities.scss](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss/trumps/_utilities.scss)
 
 Located in the `/trumps` folder, this file contains a bunch of utility classes such as `.u-unstyled` (to unstyle list elements), `.u-ir` for background image replacement, `.is-hidden` and `is-visuallyHidden` for hiding elements with accessibility in mind etc.
 
@@ -73,21 +73,21 @@ Located in the `/trumps` folder, this file contains a bunch of utility classes s
 
 #### Base
 
-The [base folder](https://github.com/justeat/fozzie/tree/master/src/scss/base) is where the styles that make up the foundation of the Fozzie SCSS library are defined.
+The [base folder](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss/base) is where the styles that make up the foundation of the Fozzie SCSS library are defined.
 
 For example, typographic styles are defined here, as are global layout classes, normalize and print styles.
 
-n.b. We use [Normalize.css](https://github.com/justeat/fozzie/blob/master/src/scss/base/_normalize.scss) over a standard reset stylesheet. For more information on Normalize styles, [see the online docs](https://necolas.github.io/normalize.css/).
+n.b. We use [Normalize.css](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss/base/_normalize.scss) over a standard reset stylesheet. For more information on Normalize styles, [see the online docs](https://necolas.github.io/normalize.css/).
 
 #### Settings
 
-The [settings directory](https://github.com/justeat/fozzie/tree/master/src/scss/settings) should contain anything that is 'set' across your modules styles.
+The [settings directory](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss/settings) should contain anything that is 'set' across your modules styles.
 
 The most common example of this is CSS variables, such as font-sizes, grid settings and breakpoint definitions.
 
 #### Tools
 
-The [tools folder](https://github.com/justeat/fozzie/tree/master/src/scss/tools) is where global mixins and functions are located.
+The [tools folder](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss/tools) is where global mixins and functions are located.
 
 If you pull in styles from a 3rd party library (such as PrismJS which is used for code highlighting) then these should also be located in this folder.
 
@@ -98,13 +98,13 @@ Utilities and helper classes which should have the ability to override anything 
 
 #### Components & Objects
 
-The [components](https://github.com/justeat/fozzie/tree/master/src/scss/components) and [objects folders](https://github.com/justeat/fozzie/tree/master/src/scss/objects) are used to define component styles specific to that component.
+The [components](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss/components) and [objects folders](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss/objects) are used to define component styles specific to that component.
 
 Recently, we have moved towards defining component styles such as this as part of the Fozzie Vue Component mono-repo, with the styles sitting alongside the Vue Single File Component definition. Therefore, we will be looking to deprecate the Component and Object styles definitions in Fozzie SCSS and we don't recommend building new applications using these style classes – these are maintained to support legacy applications.
 
 Component filenames closely relate to their component name. So a component of `c-rating` should have its styles in a file called `_ratings.scss`.
 
-The definition of an Object is any component that can be directly linked to a native HTML element. Therefore the [objects folder](https://github.com/justeat/fozzie/tree/master/src/scss/objects) will include style definitions for buttons, form elements and links among other native element styling.
+The definition of an Object is any component that can be directly linked to a native HTML element. Therefore the [objects folder](https://github.com/justeattakeaway/fozzie-components/tree/master/packages/tools/fozzie/src/scss/objects) will include style definitions for buttons, form elements and links among other native element styling.
 
 
 ## Fozzie Vue Components

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,13 +249,6 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-annotate-as-pure@^7.22.5":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz#e7f06737b197d580a01edf75d97e2c8be99d3882"
-  integrity sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==
-  dependencies:
-    "@babel/types" "^7.22.5"
-
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.18.6":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.18.9.tgz#acd4edfd7a566d1d51ea975dff38fd52906981bb"
@@ -297,21 +290,6 @@
     "@babel/helper-optimise-call-expression" "^7.18.6"
     "@babel/helper-replace-supers" "^7.19.1"
     "@babel/helper-split-export-declaration" "^7.18.6"
-
-"@babel/helper-create-class-features-plugin@^7.21.0":
-  version "7.22.15"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.15.tgz#97a61b385e57fe458496fad19f8e63b63c867de4"
-  integrity sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.22.5"
-    "@babel/helper-environment-visitor" "^7.22.5"
-    "@babel/helper-function-name" "^7.22.5"
-    "@babel/helper-member-expression-to-functions" "^7.22.15"
-    "@babel/helper-optimise-call-expression" "^7.22.5"
-    "@babel/helper-replace-supers" "^7.22.9"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.22.5"
-    "@babel/helper-split-export-declaration" "^7.22.6"
-    semver "^6.3.1"
 
 "@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.19.0":
   version "7.19.0"
@@ -415,13 +393,6 @@
   dependencies:
     "@babel/types" "^7.18.9"
 
-"@babel/helper-member-expression-to-functions@^7.22.15", "@babel/helper-member-expression-to-functions@^7.22.5":
-  version "7.22.15"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.22.15.tgz#b95a144896f6d491ca7863576f820f3628818621"
-  integrity sha512-qLNsZbgrNh0fDQBCPocSL8guki1hcPvltGDv/NxvUoABwFq7GkKSu1nRXeJkVZc+wJvne2E0RKQz+2SQrz6eAA==
-  dependencies:
-    "@babel/types" "^7.22.15"
-
 "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.14.5", "@babel/helper-module-imports@^7.18.6", "@babel/helper-module-imports@^7.8.3":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
@@ -468,13 +439,6 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-optimise-call-expression@^7.22.5":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz#f21531a9ccbff644fdd156b4077c16ff0c3f609e"
-  integrity sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==
-  dependencies:
-    "@babel/types" "^7.22.5"
-
 "@babel/helper-plugin-utils@7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
@@ -506,15 +470,6 @@
     "@babel/traverse" "^7.19.1"
     "@babel/types" "^7.19.0"
 
-"@babel/helper-replace-supers@^7.22.9":
-  version "7.22.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.22.9.tgz#cbdc27d6d8d18cd22c81ae4293765a5d9afd0779"
-  integrity sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.22.5"
-    "@babel/helper-member-expression-to-functions" "^7.22.5"
-    "@babel/helper-optimise-call-expression" "^7.22.5"
-
 "@babel/helper-simple-access@^7.19.4", "@babel/helper-simple-access@^7.20.2":
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz#0ab452687fe0c2cfb1e2b9e0015de07fc2d62dd9"
@@ -535,13 +490,6 @@
   integrity sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==
   dependencies:
     "@babel/types" "^7.20.0"
-
-"@babel/helper-skip-transparent-expression-wrappers@^7.22.5":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz#007f15240b5751c537c40e77abb4e89eeaaa8847"
-  integrity sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==
-  dependencies:
-    "@babel/types" "^7.22.5"
 
 "@babel/helper-split-export-declaration@^7.18.6":
   version "7.18.6"
@@ -822,16 +770,6 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
-
-"@babel/plugin-proposal-private-property-in-object@7.21.11":
-  version "7.21.11"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
-  integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.18.6"
-    "@babel/helper-create-class-features-plugin" "^7.21.0"
-    "@babel/helper-plugin-utils" "^7.20.2"
-    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
 
 "@babel/plugin-proposal-private-property-in-object@^7.14.5", "@babel/plugin-proposal-private-property-in-object@^7.18.6":
   version "7.18.6"
@@ -15162,6 +15100,11 @@ include-media@1.4.9:
   version "1.4.9"
   resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.9.tgz#d0020b7be3eb2d54868a20943595ce380e0bc43b"
   integrity sha512-IUOcvWDCt6R5V0ktsGk6RbehkW9ks1dODN2ed1p+mhML82TteAl+/ElXy8AJ7ueIuVoKq2NioRVdW9FuwQNOew==
+
+include-media@2.0.0:
+  version "2.0.0"
+  resolved "https://artifactory.cd.je-labs.com:443/artifactory/api/npm/npm-virtual/include-media/-/include-media-2.0.0.tgz#21f80a4b40addd1da5d500cf8bf3b123cb1136a6"
+  integrity sha512-LSJcffPYIZ/Kln0rIi5UhqQbZxElDCMYA4dPC5MI1rkwwjptgEiOicHnzB0MMhMNJver0+4zULb4MKlgDyapZg==
 
 include-media@eduardoboucas/include-media#2.0-release:
   version "2.0.0"


### PR DESCRIPTION
---

_Removes support for deprecated Node versions (12 and 14). Adds support for Node versions 16, 18, 20. Needed bu consuming applications. Bumps up package version to minor._

---

## UI Review Checks

![image](https://user-images.githubusercontent.com/805184/35801356-f756b018-0a63-11e8-8ca4-ec045d43c16c.png)

- [ ] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
