### PR TITLE
f-vue-icons@3.14.1 - More package updates

### DIFF
--- a/packages/tools/f-vue-icons/CHANGELOG.md
+++ b/packages/tools/f-vue-icons/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## v3.14.1
+_April 30, 2024_
+
+### Removed
+- Unused `marked` dependency.
+
+
 ## v3.14.0
 
 _March 13, 2024_
@@ -12,7 +19,6 @@ _March 13, 2024_
 - node engines in `package.json` to include all versions above 14
 - Replaced vulnerable `bili` package with rollup for generating icons
 - bumped vulnerable `marked` package (snyk vulnerability)
--
 
 ## v3.13.1
 

--- a/packages/tools/f-vue-icons/package.json
+++ b/packages/tools/f-vue-icons/package.json
@@ -60,7 +60,6 @@
     "@rollup/plugin-node-resolve": "15.1.0",
     "fs-extra": "9.0.1",
     "lodash.kebabcase": "4.1.1",
-    "marked": "2.0.0",
     "pascal-case": "3.1.2",
     "prismjs": "1.27.0",
     "rollup": "3.20.2"

--- a/packages/tools/f-vue-icons/package.json
+++ b/packages/tools/f-vue-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-vue-icons",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "main": "dist/index.cjs",
   "maxBundleSize": "155kB",
   "module": "esm/index.mjs",

--- a/packages/tools/fozzie/CHANGELOG.md
+++ b/packages/tools/fozzie/CHANGELOG.md
@@ -3,12 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
-## v11.2.1
-
-_April 10, 2024_
+## v11.2.2
+_April 30, 2024_
 
 ### Changed
+- Update `glob` to v9.
 
+
+## v11.2.1
+_April 26, 2024_
+
+### Changed
 - Update `jest` to latest version.
 
 

--- a/packages/tools/fozzie/package.json
+++ b/packages/tools/fozzie/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "11.2.1",
+  "version": "11.2.2",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/packages/tools/fozzie/package.json
+++ b/packages/tools/fozzie/package.json
@@ -56,7 +56,7 @@
     "eslint": "8.26.0",
     "eslint-plugin-import": "2.26.0",
     "fontfaceobserver": "2.3.0",
-    "glob": "8.0.3",
+    "glob": "9.0.0",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
     "postcss": "8.4.31",

--- a/packages/tools/fozzie/src/test/scss/scss-setup.spec.js
+++ b/packages/tools/fozzie/src/test/scss/scss-setup.spec.js
@@ -8,7 +8,7 @@
 
 const path = require('path');
 const sassTrue = require('sass-true');
-const glob = require('glob');
+const { globSync } = require('glob');
 
 describe('SCSS', () => {
     // All Scss unit tests should follow this naming convention
@@ -16,7 +16,7 @@ describe('SCSS', () => {
     const testFilePathGlob = path.resolve(process.cwd(), testFileGlob);
 
     // Find all of the Scss files that end in `*.spec.scss` in any directory of this project
-    const scssTestFiles = glob.sync(testFilePathGlob);
+    const scssTestFiles = globSync(testFilePathGlob);
 
     // Run True on every file found with the describe and it methods provided
     scssTestFiles.forEach(file => sassTrue.runSass({ file, includePaths: ['node_modules'] }, { describe, it }));

--- a/packages/tools/fozzie/src/utilities/getSubdirectories.js
+++ b/packages/tools/fozzie/src/utilities/getSubdirectories.js
@@ -1,11 +1,11 @@
-const glob = require('glob');
+const { globSync } = require('glob');
 
 /**
  * Get all subdirectory paths for a given source
  * @param {string} src - The source to search from for subdirectories
  * @returns {string[]} - An array of all subdirectory paths
  */
-const getAllSubdirectoryPaths = src => glob.sync(`${src}/**/`);
+const getAllSubdirectoryPaths = src => globSync(`${src}/**/`);
 
 module.exports = {
     getAllSubdirectoryPaths

--- a/yarn.lock
+++ b/yarn.lock
@@ -4537,7 +4537,6 @@ __metadata:
     "@rollup/plugin-node-resolve": 15.1.0
     fs-extra: 9.0.1
     lodash.kebabcase: 4.1.1
-    marked: 2.0.0
     pascal-case: 3.1.2
     prismjs: 1.27.0
     rollup: 3.20.2
@@ -4586,7 +4585,7 @@ __metadata:
     eslint: 8.26.0
     eslint-plugin-import: 2.26.0
     fontfaceobserver: 2.3.0
-    glob: 8.0.3
+    glob: 9.0.0
     include-media: 2.0.0
     jest: 29.7.0
     jest-environment-jsdom: 29.7.0
@@ -18284,19 +18283,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:8.0.3":
-  version: 8.0.3
-  resolution: "glob@npm:8.0.3"
-  dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^5.0.1
-    once: ^1.3.0
-  checksum: 50bcdea19d8e79d8de5f460b1939ffc2b3299eac28deb502093fdca22a78efebc03e66bf54f0abc3d3d07d8134d19a32850288b7440d77e072aa55f9d33b18c5
-  languageName: node
-  linkType: hard
-
 "glob@npm:8.1.0, glob@npm:^8.0.3":
   version: 8.1.0
   resolution: "glob@npm:8.1.0"
@@ -18307,6 +18293,18 @@ __metadata:
     minimatch: ^5.0.1
     once: ^1.3.0
   checksum: 92fbea3221a7d12075f26f0227abac435de868dd0736a17170663783296d0dd8d3d532a5672b4488a439bf5d7fb85cdd07c11185d6cd39184f0385cbdfb86a47
+  languageName: node
+  linkType: hard
+
+"glob@npm:9.0.0":
+  version: 9.0.0
+  resolution: "glob@npm:9.0.0"
+  dependencies:
+    fs.realpath: ^1.0.0
+    minimatch: ^7.3.0
+    minipass: ^4.2.4
+    path-scurry: ^1.5.0
+  checksum: a26e06d253d19ee6889a6dc67e0a456d23b13ae197d1cd945961bbba5166ce9bd46db0bc49324a6da9003217a8fe8b2052dbc35c0e97dbba61db67c87a8d03f7
   languageName: node
   linkType: hard
 
@@ -24000,15 +23998,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:2.0.0":
-  version: 2.0.0
-  resolution: "marked@npm:2.0.0"
-  bin:
-    marked: bin/marked
-  checksum: 80eadb93340cd043b69c1c7ce95836f0f2cb0355121dbd4b4189b6efb7559884e719eaf5cd9300ca51679f54a4f3d8388bc8e7ca0fd0da76619c4f238e72e1ea
-  languageName: node
-  linkType: hard
-
 "marky@npm:^1.2.2":
   version: 1.2.5
   resolution: "marky@npm:1.2.5"
@@ -24537,6 +24526,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^7.3.0":
+  version: 7.4.6
+  resolution: "minimatch@npm:7.4.6"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: 1a6c8d22618df9d2a88aabeef1de5622eb7b558e9f8010be791cb6b0fa6e102d39b11c28d75b855a1e377b12edc7db8ff12a99c20353441caa6a05e78deb5da9
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^9.0.1, minimatch@npm:^9.0.3":
   version: 9.0.4
   resolution: "minimatch@npm:9.0.4"
@@ -24666,6 +24664,13 @@ __metadata:
   dependencies:
     yallist: ^4.0.0
   checksum: a30d083c8054cee83cdcdc97f97e4641a3f58ae743970457b1489ce38ee1167b3aaf7d815cd39ec7a99b9c40397fd4f686e83750e73e652b21cb516f6d845e48
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^4.2.4":
+  version: 4.2.8
+  resolution: "minipass@npm:4.2.8"
+  checksum: 7f4914d5295a9a30807cae5227a37a926e6d910c03f315930fde52332cf0575dfbc20295318f91f0baf0e6bb11a6f668e30cde8027dea7a11b9d159867a3c830
   languageName: node
   linkType: hard
 
@@ -26674,7 +26679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-scurry@npm:^1.10.2":
+"path-scurry@npm:^1.10.2, path-scurry@npm:^1.5.0":
   version: 1.10.2
   resolution: "path-scurry@npm:1.10.2"
   dependencies:


### PR DESCRIPTION
More security package updates:

---
### fozzie
- Updated `glob` from v8 to v9.
---
### f-vue-icons
- Removed `marked` as it was not being referenced everywhere, so I think it's unused.