### PR TITLE
f-button@5.1.1 - Update outline button border colour

### DIFF
--- a/packages/components/atoms/f-button/CHANGELOG.md
+++ b/packages/components/atoms/f-button/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## v5.1.1
+
+_June 6, 2024_
+
+### Changed
+- Update outline button border colour to `color-border-strong`.
+
+
 ## v5.1.0
 
 _March 13, 2024_

--- a/packages/components/atoms/f-button/package.json
+++ b/packages/components/atoms/f-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-button",
   "description": "Fozzie Button – The generic button component",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "main": "dist/f-button.umd.min.js",
   "maxBundleSize": "5kB",
   "files": [

--- a/packages/components/atoms/f-button/src/components/Button.vue
+++ b/packages/components/atoms/f-button/src/components/Button.vue
@@ -221,7 +221,7 @@ $btn-outline-bgColor                   : transparent;
 $btn-outline-bgColor--hover            : darken(f.$color-white, f.$color-hover-01);
 $btn-outline-bgColor--active           : darken(f.$color-white, f.$color-active-01);
 $btn-outline-textColor                 : f.$color-content-interactive-tertiary;
-$btn-outline-border-color              : f.$color-border-default;
+$btn-outline-border-color              : f.$color-border-strong;
 $btn-outline-loading-color             : f.$color-content-interactive-tertiary;
 $btn-outline-loading-colorOpaque       : rgba($btn-outline-loading-color, $btn-default-loading-opacity);
 


### PR DESCRIPTION
The visual diff doesn't seem to be big enough for Percy to notice, but here's a screenshot from Storybook, note the `border-color` to the right.

| Before | After |
| --- | --- |
| ![2024-06-06 15_36_47](https://github.com/justeattakeaway/fozzie-components/assets/26894168/753e2c91-bebb-4a26-9170-b47bf8f0ce1a) | ![2024-06-06 15_33_52](https://github.com/justeattakeaway/fozzie-components/assets/26894168/c51aded2-1ad3-4ae7-a0a9-bb1b99289aea) |