### PR TITLE
f-vue-icons@3.14.2 - Fix Published NPM package is missing `esm` folder

### DIFF
--- a/packages/tools/f-vue-icons/CHANGELOG.md
+++ b/packages/tools/f-vue-icons/CHANGELOG.md
@@ -3,12 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## v3.14.2
+_June 20, 2024_
+
+### Fixes
+- Published NPM package is missing `esm` folder
+  - https://unpkg.com/browse/@justeat/f-vue-icons@3.14.1/
+
 ## v3.14.1
 _April 30, 2024_
 
 ### Removed
 - Unused `marked` dependency.
-
 
 ## v3.14.0
 

--- a/packages/tools/f-vue-icons/package.json
+++ b/packages/tools/f-vue-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-vue-icons",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "main": "dist/index.cjs",
   "maxBundleSize": "155kB",
   "module": "esm/index.mjs",


### PR DESCRIPTION
Published NPM package is missing `esm` folder
---

![Screenshot 2024-06-20 at 14 28 38](https://github.com/justeattakeaway/fozzie-components/assets/26770126/a070be66-8c3b-4edc-b5dc-1fc2fc101264)

See: https://unpkg.com/browse/@justeat/f-vue-icons@3.14.1/ 

## Fixes

 - Causes error `Module not found: Error: Can't resolve '@justeat/f-vue-icons' in '...project'`
   - Regression that seem to have been introduced since v.14

