### PR TITLE
f-header@10.21.0 - Add support for tracking contexts

### DIFF
--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v8.9.0
+
+_June 20, 2024_
+
+### Added
+
+- New prop `globalTrackingContexts` which are passed through to f-trak for analytics events.
+
+
 ## v8.8.0
 
 _May 21, 2024_

--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## v8.9.0
 
-_June 20, 2024_
+_June 24, 2024_
 
 ### Added
 

--- a/packages/components/organisms/f-footer/CHANGELOG.md
+++ b/packages/components/organisms/f-footer/CHANGELOG.md
@@ -10,7 +10,7 @@ _June 24, 2024_
 ### Added
 
 - New prop `globalTrackingContexts` which are passed through to f-trak for analytics events.
-
+- Use `f-trak` v1+
 
 ## v8.8.0
 

--- a/packages/components/organisms/f-footer/README.md
+++ b/packages/components/organisms/f-footer/README.md
@@ -90,6 +90,7 @@ The props that can be defined are as follows (if any):
 | `showCourierLinks`    | `Bool`   | `true`  | Controls whether to show courier links in footer.                                                             |
 | `showCountrySelector` | `Bool`   | `true`  | Controls whether to show country selector in footer.                                                          |
 | `content`             | `Object` | `{}`    | Content to be displayed in the footer (sections, links, etc.)                                                 |
+| `globalTrackingContexts` | `Array` | `[]`  | Array containing the global tracking contexts to be passed through to f-trak. |
 
 ### CSS Classes
 

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -54,7 +54,7 @@
     "v-click-outside": "3.1.2"
   },
   "peerDependencies": {
-    "@justeat/f-trak": ">=0.8.0"
+    "@justeat/f-trak": "1.x"
   },
   "devDependencies": {
     "@justeat/f-wdio-utils": "1.x"

--- a/packages/components/organisms/f-footer/package.json
+++ b/packages/components/organisms/f-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/f-footer",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "main": "dist/f-footer.umd.min.js",
   "maxBundleSize": "80kB",
   "files": [
@@ -54,7 +54,7 @@
     "v-click-outside": "3.1.2"
   },
   "peerDependencies": {
-    "@justeat/f-trak": ">=0.6.0"
+    "@justeat/f-trak": ">=0.8.0"
   },
   "devDependencies": {
     "@justeat/f-wdio-utils": "1.x"

--- a/packages/components/organisms/f-footer/src/components/ButtonList.vue
+++ b/packages/components/organisms/f-footer/src/components/ButtonList.vue
@@ -28,16 +28,15 @@
 </template>
 
 <script>
+import analyticsMixin from '../mixins/analytics.mixin';
+
 export default {
+    mixins: [analyticsMixin],
+
     props: {
         buttonList: {
             type: Object,
             default: () => ({})
-        },
-
-        globalTrackingContexts: {
-            type: Array,
-            default: () => []
         }
     }
 };

--- a/packages/components/organisms/f-footer/src/components/ButtonList.vue
+++ b/packages/components/organisms/f-footer/src/components/ButtonList.vue
@@ -9,12 +9,15 @@
                 v-for="(button, i) in buttonList.buttons"
                 :key="`${i}_Button`"
                 :href="button.url"
-                :data-trak='`{
-                    "trakEvent": "click",
-                    "category": "engagement",
-                    "action": "footer",
-                    "label": "${button.gtm}"
-                }`'
+                :data-trak='JSON.stringify({
+                    trakEvent: "click",
+                    category: "engagement",
+                    action: "footer",
+                    label: button.gtm,
+                    ...(globalTrackingContexts.length ? {
+                        context: globalTrackingContexts
+                    } : {})
+                })'
                 :class="$style['c-buttonList-button']"
                 target="_blank"
                 rel="noopener noreferrer">
@@ -30,6 +33,11 @@ export default {
         buttonList: {
             type: Object,
             default: () => ({})
+        },
+
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
         }
     }
 };

--- a/packages/components/organisms/f-footer/src/components/CountrySelector.vue
+++ b/packages/components/organisms/f-footer/src/components/CountrySelector.vue
@@ -88,7 +88,9 @@ import {
     CrossIcon
 } from '@justeat/f-vue-icons';
 import vClickOutside from 'v-click-outside';
+
 import FlagIcon from './FlagIcon.vue';
+import analyticsMixin from '../mixins/analytics.mixin';
 
 export default {
     components: {
@@ -100,6 +102,8 @@ export default {
     directives: {
         clickOutside: vClickOutside.directive
     },
+
+    mixins: [analyticsMixin],
 
     props: {
         currentCountryName: {
@@ -120,11 +124,6 @@ export default {
         changeCountryText: {
             type: String,
             default: ''
-        },
-
-        globalTrackingContexts: {
-            type: Array,
-            default: () => []
         }
     },
 

--- a/packages/components/organisms/f-footer/src/components/CountrySelector.vue
+++ b/packages/components/organisms/f-footer/src/components/CountrySelector.vue
@@ -55,12 +55,15 @@
                     :key="`${i}_Country`"
                     :data-test-id="[`countrySelector-country-${country.dataTestKey}`]">
                     <a
-                        :data-trak='`{
-                            "trakEvent": "click",
-                            "category": "engagement",
-                            "action": "footer",
-                            "label": "${country.gtm}"
-                        }`'
+                        :data-trak='JSON.stringify({
+                            trakEvent: "click",
+                            category: "engagement",
+                            action: "footer",
+                            label: country.gtm,
+                            ...(globalTrackingContexts.length ? {
+                                context: globalTrackingContexts
+                            } : {})
+                        })'
                         :href="country.siteUrl"
                         :class="$style['c-countrySelector-link']"
                         data-test-id="countrySelector-countryLink">
@@ -117,6 +120,11 @@ export default {
         changeCountryText: {
             type: String,
             default: ''
+        },
+
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
         }
     },
 

--- a/packages/components/organisms/f-footer/src/components/FeedbackBlock.vue
+++ b/packages/components/organisms/f-footer/src/components/FeedbackBlock.vue
@@ -37,7 +37,11 @@
 </template>
 
 <script>
+import analyticsMixin from '../mixins/analytics.mixin';
+
 export default {
+    mixins: [analyticsMixin],
+
     props: {
         title: {
             type: String,
@@ -52,11 +56,6 @@ export default {
         buttonText: {
             type: String,
             default: ''
-        },
-
-        globalTrackingContexts: {
-            type: Array,
-            default: () => []
         }
     }
 };

--- a/packages/components/organisms/f-footer/src/components/FeedbackBlock.vue
+++ b/packages/components/organisms/f-footer/src/components/FeedbackBlock.vue
@@ -6,12 +6,15 @@
             $style['is-invisible']
         ]"
         data-gtm-feedback
-        data-trak='{
-            "trakEvent": "click",
-            "category": "engagement",
-            "action": "footer",
-            "label": "click_feedback"
-        }'>
+        :data-trak='JSON.stringify({
+            trakEvent: "click",
+            category: "engagement",
+            action: "footer",
+            label: "click_feedback",
+            ...(globalTrackingContexts.length ? {
+                context: globalTrackingContexts
+            } : {})
+        })'>
         <h2
             :class="[
                 $style['c-footer-heading'],
@@ -49,6 +52,11 @@ export default {
         buttonText: {
             type: String,
             default: ''
+        },
+
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
         }
     }
 };

--- a/packages/components/organisms/f-footer/src/components/Footer.vue
+++ b/packages/components/organisms/f-footer/src/components/Footer.vue
@@ -14,7 +14,8 @@
             <link-list
                 v-for="(section, i) in content.sections"
                 :key="`${i}_LinkList`"
-                :link-list="section" />
+                :link-list="section"
+                :global-tracking-contexts="globalTrackingContexts" />
         </div>
 
         <div :class="$style['c-footer-light']">
@@ -30,7 +31,8 @@
                     <button-list
                         v-for="(buttonList, i) in copy.linkButtonList"
                         :key="`${i}_ButtonList`"
-                        :button-list="buttonList" />
+                        :button-list="buttonList"
+                        :global-tracking-contexts="globalTrackingContexts" />
                 </div>
 
                 <div
@@ -42,18 +44,21 @@
                         :title="copy.downloadOurApps"
                         :icons="copy.appStoreIcons"
                         :locale="copy.locale"
-                        list-type="apps" />
+                        list-type="apps"
+                        :global-tracking-contexts="globalTrackingContexts" />
 
                     <feedback-block
                         :title="copy.feedback"
                         :text="copy.improveOurWebsite"
                         :button-text="copy.sendFeedback"
-                        data-test-id="feedback-block" />
+                        data-test-id="feedback-block"
+                        :global-tracking-contexts="globalTrackingContexts" />
 
                     <icon-list
                         :icons="copy.socialIcons"
                         :title="copy.followUs"
-                        list-type="social" />
+                        list-type="social"
+                        :global-tracking-contexts="globalTrackingContexts" />
                 </div>
             </div>
         </div>
@@ -73,7 +78,8 @@
                 :current-country-name="copy.currentCountryName"
                 :current-country-key="copy.currentCountryKey"
                 :countries="countryList"
-                :change-country-text="copy.changeCurrentCountry" />
+                :change-country-text="copy.changeCurrentCountry"
+                :global-tracking-contexts="globalTrackingContexts" />
 
             <legal-field
                 v-if="metaLegalFieldEnabled"
@@ -82,7 +88,8 @@
 
             <icon-list
                 :icons="copy.paymentIcons"
-                list-type="payments" />
+                list-type="payments"
+                :global-tracking-contexts="globalTrackingContexts" />
         </div>
     </footer>
 </template>
@@ -123,6 +130,10 @@ export default {
         content: {
             type: Object,
             default: () => {}
+        },
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
         }
     },
     computed: {

--- a/packages/components/organisms/f-footer/src/components/Footer.vue
+++ b/packages/components/organisms/f-footer/src/components/Footer.vue
@@ -96,6 +96,7 @@
 
 <script>
 import { globalisationServices } from '@justeat/f-services';
+
 import ButtonList from './ButtonList.vue';
 import CountrySelector from './CountrySelector.vue';
 import FeedbackBlock from './FeedbackBlock.vue';
@@ -103,9 +104,11 @@ import IconList from './IconList.vue';
 import LegalField from './LegalField.vue';
 import LinkList from './LinkList.vue';
 import { tenantConfigs, countries } from '../tenants';
+import analyticsMixin from '../mixins/analytics.mixin';
 
 export default {
     name: 'PageFooter',
+
     components: {
         ButtonList,
         CountrySelector,
@@ -114,6 +117,9 @@ export default {
         LegalField,
         LinkList
     },
+
+    mixins: [analyticsMixin],
+
     props: {
         locale: {
             type: String,
@@ -130,26 +136,27 @@ export default {
         content: {
             type: Object,
             default: () => {}
-        },
-        globalTrackingContexts: {
-            type: Array,
-            default: () => []
         }
     },
+
     computed: {
         footerLocale () {
             return globalisationServices.getLocale(tenantConfigs, this.locale, this.$i18n);
         },
+
         copy () {
             const localeConfig = tenantConfigs[this.footerLocale];
             return localeConfig;
         },
+
         theme () {
             return globalisationServices.getTheme(this.footerLocale);
         },
+
         metaLegalFieldEnabled () {
             return Object.keys(this.copy.metaLegalField).length > 0;
         },
+
         countryList () {
             return countries.filter(country => country.key !== this.copy.currentCountryKey);
         }

--- a/packages/components/organisms/f-footer/src/components/IconList.vue
+++ b/packages/components/organisms/f-footer/src/components/IconList.vue
@@ -61,12 +61,15 @@
 <script>
 import BaseProviderIcon from './BaseProviderIcon.vue';
 import AppStoreIcon from './AppStoreIcon.vue';
+import analyticsMixin from '../mixins/analytics.mixin';
 
 export default {
     components: {
         AppStoreIcon,
         BaseProviderIcon
     },
+
+    mixins: [analyticsMixin],
 
     props: {
         icons: {
@@ -87,11 +90,6 @@ export default {
         locale: {
             type: String,
             default: 'en-GB'
-        },
-
-        globalTrackingContexts: {
-            type: Array,
-            default: () => []
         }
     },
 

--- a/packages/components/organisms/f-footer/src/components/IconList.vue
+++ b/packages/components/organisms/f-footer/src/components/IconList.vue
@@ -31,12 +31,15 @@
                     :href="icon.url"
                     :title="icon.alt"
                     :class="$style['c-iconList-listLink']"
-                    :data-trak='`{
-                        "trakEvent": "click",
-                        "category": "engagement",
-                        "action": "footer",
-                        "label": "${icon.gtm}"
-                    }`'
+                    :data-trak='JSON.stringify({
+                        trakEvent: "click",
+                        category: "engagement",
+                        action: "footer",
+                        label: icon.gtm,
+                        ...(globalTrackingContexts.length ? {
+                            context: globalTrackingContexts
+                        } : {})
+                    })'
                     :data-test-id="`footerIcon ${icon.name}`">
                     <component
                         :is="iconChoice"
@@ -84,6 +87,11 @@ export default {
         locale: {
             type: String,
             default: 'en-GB'
+        },
+
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
         }
     },
 

--- a/packages/components/organisms/f-footer/src/components/LinkList.vue
+++ b/packages/components/organisms/f-footer/src/components/LinkList.vue
@@ -72,21 +72,22 @@
 import { ChevronIcon } from '@justeat/f-vue-icons';
 import { windowServices } from '@justeat/f-services';
 
+import analyticsMixin from '../mixins/analytics.mixin';
+
 export default {
     components: {
         ChevronIcon
     },
+
+    mixins: [analyticsMixin],
+
     props: {
         linkList: {
             type: Object,
             default: () => ({})
-        },
-
-        globalTrackingContexts: {
-            type: Array,
-            default: () => []
         }
     },
+
     data () {
         return {
             currentScreenWidth: 0,
@@ -94,6 +95,7 @@ export default {
             panelCollapsed: false
         };
     },
+
     computed: {
         listId () {
             return `footer-${this.linkList.name.toLowerCase().split(' ').join('-')}`;
@@ -111,15 +113,18 @@ export default {
             return this.panelCollapsed ? 'linkList-wrapper-collapsed' : 'linkList-wrapper';
         }
     },
+
     mounted () {
         this.currentScreenWidth = windowServices.getWindowWidth();
         windowServices.addEvent('resize', this.onResize, 100);
 
         this.setPanelCollapsed();
     },
+
     destroyed () {
         windowServices.removeEvent('resize', this.onResize);
     },
+
     methods: {
         /**
          * Sets Links List panel collapsed state.
@@ -134,6 +139,7 @@ export default {
                 this.panelCollapsed = false;
             }
         },
+
         /**
          * Handle click events on Link List visibility toggle.
          * Only applied to below `wide` screen width (ref. Fozzie UI breakpoints).
@@ -144,6 +150,7 @@ export default {
                 this.setPanelCollapsed();
             }
         },
+
         /**
          * Handles `resize` window events.
          * Screen width is the only factor that affects Links List presentation.

--- a/packages/components/organisms/f-footer/src/components/LinkList.vue
+++ b/packages/components/organisms/f-footer/src/components/LinkList.vue
@@ -52,12 +52,15 @@
                     :rel="link.rel"
                     :target="link.target"
                     :class="$style['c-footer-list-link']"
-                    :data-trak='`{
-                        "trakEvent": "click",
-                        "category": "engagement",
-                        "action": "footer",
-                        "label": "${link.gtmLabel}"
-                    }`'>
+                    :data-trak='JSON.stringify({
+                        trakEvent: "click",
+                        category: "engagement",
+                        action: "footer",
+                        label: link.gtmLabel,
+                        ...(globalTrackingContexts.length ? {
+                            context: globalTrackingContexts
+                        } : {})
+                    })'>
                     {{ link.text }}
                 </a>
             </li>
@@ -77,6 +80,11 @@ export default {
         linkList: {
             type: Object,
             default: () => ({})
+        },
+
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
         }
     },
     data () {

--- a/packages/components/organisms/f-footer/src/components/_tests/__snapshots__/Footer.test.js.snap
+++ b/packages/components/organisms/f-footer/src/components/_tests/__snapshots__/Footer.test.js.snap
@@ -3,26 +3,26 @@
 exports[`Footer should render default component markup 1`] = `
 <footer data-theme="je" data-test-id="footer-component">
   <div class="c-footer-row-linkLists">
-    <link-list-stub linklist="[object Object]" globaltrackingcontexts=""></link-list-stub>
-    <link-list-stub linklist="[object Object]" globaltrackingcontexts=""></link-list-stub>
-    <link-list-stub linklist="[object Object]" globaltrackingcontexts=""></link-list-stub>
-    <link-list-stub linklist="[object Object]" globaltrackingcontexts=""></link-list-stub>
-    <link-list-stub linklist="[object Object]" globaltrackingcontexts=""></link-list-stub>
+    <link-list-stub globaltrackingcontexts="" linklist="[object Object]"></link-list-stub>
+    <link-list-stub globaltrackingcontexts="" linklist="[object Object]"></link-list-stub>
+    <link-list-stub globaltrackingcontexts="" linklist="[object Object]"></link-list-stub>
+    <link-list-stub globaltrackingcontexts="" linklist="[object Object]"></link-list-stub>
+    <link-list-stub globaltrackingcontexts="" linklist="[object Object]"></link-list-stub>
   </div>
   <div>
     <div>
       <!---->
       <div class="c-footer-row-socialLinks">
-        <icon-list-stub icons="[object Object],[object Object],[object Object]" title="Download our apps" listtype="apps" locale="en-GB" globaltrackingcontexts=""></icon-list-stub>
-        <feedback-block-stub title="Feedback" text="Help us improve our website" buttontext="Send feedback" globaltrackingcontexts="" data-test-id="feedback-block"></feedback-block-stub>
-        <icon-list-stub icons="[object Object],[object Object],[object Object],[object Object],[object Object]" title="Follow us" listtype="social" locale="en-GB" globaltrackingcontexts=""></icon-list-stub>
+        <icon-list-stub globaltrackingcontexts="" icons="[object Object],[object Object],[object Object]" title="Download our apps" listtype="apps" locale="en-GB"></icon-list-stub>
+        <feedback-block-stub globaltrackingcontexts="" title="Feedback" text="Help us improve our website" buttontext="Send feedback" data-test-id="feedback-block"></feedback-block-stub>
+        <icon-list-stub globaltrackingcontexts="" icons="[object Object],[object Object],[object Object],[object Object],[object Object]" title="Follow us" listtype="social" locale="en-GB"></icon-list-stub>
       </div>
     </div>
   </div>
   <div class="">
-    <country-selector-stub currentcountryname="United Kingdom" currentcountrykey="gb" countries="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" changecountrytext="You are on the UK website, click here to change." globaltrackingcontexts="" data-test-id="country-selector"></country-selector-stub>
+    <country-selector-stub globaltrackingcontexts="" currentcountryname="United Kingdom" currentcountrykey="gb" countries="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" changecountrytext="You are on the UK website, click here to change." data-test-id="country-selector"></country-selector-stub>
     <!---->
-    <icon-list-stub icons="[object Object],[object Object],[object Object]" title="" listtype="payments" locale="en-GB" globaltrackingcontexts=""></icon-list-stub>
+    <icon-list-stub globaltrackingcontexts="" icons="[object Object],[object Object],[object Object]" title="" listtype="payments" locale="en-GB"></icon-list-stub>
   </div>
 </footer>
 `;

--- a/packages/components/organisms/f-footer/src/components/_tests/__snapshots__/Footer.test.js.snap
+++ b/packages/components/organisms/f-footer/src/components/_tests/__snapshots__/Footer.test.js.snap
@@ -3,26 +3,26 @@
 exports[`Footer should render default component markup 1`] = `
 <footer data-theme="je" data-test-id="footer-component">
   <div class="c-footer-row-linkLists">
-    <link-list-stub linklist="[object Object]"></link-list-stub>
-    <link-list-stub linklist="[object Object]"></link-list-stub>
-    <link-list-stub linklist="[object Object]"></link-list-stub>
-    <link-list-stub linklist="[object Object]"></link-list-stub>
-    <link-list-stub linklist="[object Object]"></link-list-stub>
+    <link-list-stub linklist="[object Object]" globaltrackingcontexts=""></link-list-stub>
+    <link-list-stub linklist="[object Object]" globaltrackingcontexts=""></link-list-stub>
+    <link-list-stub linklist="[object Object]" globaltrackingcontexts=""></link-list-stub>
+    <link-list-stub linklist="[object Object]" globaltrackingcontexts=""></link-list-stub>
+    <link-list-stub linklist="[object Object]" globaltrackingcontexts=""></link-list-stub>
   </div>
   <div>
     <div>
       <!---->
       <div class="c-footer-row-socialLinks">
-        <icon-list-stub icons="[object Object],[object Object],[object Object]" title="Download our apps" listtype="apps" locale="en-GB"></icon-list-stub>
-        <feedback-block-stub title="Feedback" text="Help us improve our website" buttontext="Send feedback" data-test-id="feedback-block"></feedback-block-stub>
-        <icon-list-stub icons="[object Object],[object Object],[object Object],[object Object],[object Object]" title="Follow us" listtype="social" locale="en-GB"></icon-list-stub>
+        <icon-list-stub icons="[object Object],[object Object],[object Object]" title="Download our apps" listtype="apps" locale="en-GB" globaltrackingcontexts=""></icon-list-stub>
+        <feedback-block-stub title="Feedback" text="Help us improve our website" buttontext="Send feedback" globaltrackingcontexts="" data-test-id="feedback-block"></feedback-block-stub>
+        <icon-list-stub icons="[object Object],[object Object],[object Object],[object Object],[object Object]" title="Follow us" listtype="social" locale="en-GB" globaltrackingcontexts=""></icon-list-stub>
       </div>
     </div>
   </div>
   <div class="">
-    <country-selector-stub currentcountryname="United Kingdom" currentcountrykey="gb" countries="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" changecountrytext="You are on the UK website, click here to change." data-test-id="country-selector"></country-selector-stub>
+    <country-selector-stub currentcountryname="United Kingdom" currentcountrykey="gb" countries="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" changecountrytext="You are on the UK website, click here to change." globaltrackingcontexts="" data-test-id="country-selector"></country-selector-stub>
     <!---->
-    <icon-list-stub icons="[object Object],[object Object],[object Object]" title="" listtype="payments" locale="en-GB"></icon-list-stub>
+    <icon-list-stub icons="[object Object],[object Object],[object Object]" title="" listtype="payments" locale="en-GB" globaltrackingcontexts=""></icon-list-stub>
   </div>
 </footer>
 `;

--- a/packages/components/organisms/f-footer/src/mixins/analytics.mixin.js
+++ b/packages/components/organisms/f-footer/src/mixins/analytics.mixin.js
@@ -1,0 +1,8 @@
+export default {
+    props: {
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
+        }
+    }
+};

--- a/packages/components/organisms/f-footer/stories/footer.stories.js
+++ b/packages/components/organisms/f-footer/stories/footer.stories.js
@@ -46,7 +46,8 @@ export const FooterComponent = (args, { argTypes }) => ({
             :showCourierLinks="showCourierLinks"
             :locale="locale"
             :showCountrySelector="showCountrySelector"
-            :content="contentByLocale" />`
+            :content="contentByLocale"
+            :globalTrackingContexts="globalTrackingContexts" />`
 });
 
 FooterComponent.storyName = 'f-footer';
@@ -56,7 +57,8 @@ FooterComponent.args = {
     showCourierLinks: false,
     showCountrySelector: false,
     showLinksContent: true,
-    content: contents['en-GB']
+    content: contents['en-GB'],
+    globalTrackingContexts: []
 };
 
 FooterComponent.argTypes = {
@@ -83,5 +85,10 @@ FooterComponent.argTypes = {
 
     content: {
         description: 'Consider changing the locale instead, as this determines which data file to read.'
+    },
+
+    globalTrackingContexts: {
+        control: { type: 'object' },
+        description: 'Array containing the global tracking contexts to be passed through to f-trak.'
     }
 };

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -10,6 +10,7 @@ _June 24, 2024_
 ### Added
 
 - New prop `globalTrackingContexts` which are passed through to f-trak for analytics events.
+- Use `f-trak` v1+
 
 ## v10.20.0
 

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## v10.21.0
 
-_June 20, 2024_
+_June 24, 2024_
 
 ### Added
 

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v10.21.0
+
+_June 20, 2024_
+
+### Added
+
+- New prop `globalTrackingContexts` which are passed through to f-trak for analytics events.
+
 ## v10.20.0
 
 _May 16, 2024_

--- a/packages/components/organisms/f-header/README.md
+++ b/packages/components/organisms/f-header/README.md
@@ -86,15 +86,16 @@ The props that can be defined are as follows:
 | orderCountUrl             | `String`      | `false` | ?? |
 | showDeliveryEnquiry       | `Boolean`     | `false` | Defines if it is necessary to show the "Deliver with Just Eat" link in the header. |
 | showOffersLink            | `Boolean`     | `false` | Defines whether the offers link should be shown in the navigation. |
-| showCorporateLink            | `Boolean`     | `false` | Shows the "Corporate Ordering" Link |
+| showCorporateLink         | `Boolean`     | `false` | Shows the "Corporate Ordering" Link |
 | showHelpLink              | `Boolean`     | `true`  | Defines whether the help link should be shown in the navigation. |
 | showLoginInfo             | `Boolean`     | `true`  | Defines whether the login & user info icon should be shown in the navigation. |
 | userInfoProp              | `Object`      | `{}`    | Optional object conaining user details. If not provided `userInfoProp` is set via XHR call to `/api/account/details` |
 | userInfoUrl               | `String`      | `/api/account/details` | URL to call to retrieve the userInfo (when `userInfoProp` isn't set). |
 | showCountrySelector       | `Boolean`     | `false` | Defines whether the country selector should be shown in the navigation. |
 | showSkipLink              | `Boolean`     | `true`  | Set to false if you need to remove skip-to-main-content link from the header. |
-| shouldUseJetLogo                | `Boolean`     | `false`  | Set to true if you want to show Jet logo in the header. |
-| isCondensed            | `Boolean`     | `false` | Hides Icons, reduces spacing and applies stricter friendly name truncation where appropriate |
+| shouldUseJetLogo          | `Boolean`     | `false` | Set to true if you want to show Jet logo in the header. |
+| isCondensed               | `Boolean`     | `false` | Hides Icons, reduces spacing and applies stricter friendly name truncation where appropriate |
+| globalTrackingContexts    | `Array`       | `[]`    | Array containing the global tracking contexts to be passed through to f-trak. |
 **Important:** if you're adding a new property to show/hide something on the navigation bar, you probably want to check the `hasNavigationLinks` computed property, since you might have to update it.
 
 ### CSS styles

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -56,7 +56,7 @@
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
     "@justeat/f-button": "4.x",
     "@justeat/f-popover": "3.x",
-    "@justeat/f-trak": ">=0.8.0"
+    "@justeat/f-trak": "1.x"
   },
   "devDependencies": {
     "@justeat/f-button": "4.x",

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header - Globalised Header Component",
-  "version": "10.20.0",
+  "version": "10.21.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "55kB",
   "files": [
@@ -56,7 +56,7 @@
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
     "@justeat/f-button": "4.x",
     "@justeat/f-popover": "3.x",
-    "@justeat/f-trak": ">=0.6.0"
+    "@justeat/f-trak": ">=0.8.0"
   },
   "devDependencies": {
     "@justeat/f-button": "4.x",

--- a/packages/components/organisms/f-header/src/components/CountrySelector.vue
+++ b/packages/components/organisms/f-header/src/components/CountrySelector.vue
@@ -56,6 +56,8 @@ import { ChevronRightIcon } from '@justeattakeaway/pie-icons-vue';
 import CountrySelectorPanel from './CountrySelectorPanel.vue';
 import FlagIcon from './FlagIcon.vue';
 
+import analyticsMixin from '../mixins/analytics.mixin';
+
 export default {
     components: {
         ChevronRightIcon,
@@ -63,6 +65,8 @@ export default {
         FlagIcon,
         VPopover
     },
+
+    mixins: [analyticsMixin],
 
     props: {
         copy: {
@@ -83,11 +87,6 @@ export default {
         tabindex: {
             type: Number,
             required: true
-        },
-
-        globalTrackingContexts: {
-            type: Array,
-            default: () => []
         }
     },
 

--- a/packages/components/organisms/f-header/src/components/CountrySelector.vue
+++ b/packages/components/organisms/f-header/src/components/CountrySelector.vue
@@ -43,6 +43,7 @@
                 :copy="copy"
                 :is-open="isCountrySelectorOpen"
                 :is-below-mid="isBelowMid"
+                :global-tracking-contexts="globalTrackingContexts"
                 @closeCountrySelector="closeCountrySelector"
             />
         </v-popover>
@@ -82,6 +83,11 @@ export default {
         tabindex: {
             type: Number,
             required: true
+        },
+
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
         }
     },
 

--- a/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
+++ b/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
@@ -73,6 +73,8 @@ import FlagIcon from './FlagIcon.vue';
 import NavLink from './NavLink.vue';
 import { countries } from '../tenants';
 
+import analyticsMixin from '../mixins/analytics.mixin';
+
 export default {
     components: {
         FButton,
@@ -80,6 +82,9 @@ export default {
         FlagIcon,
         NavLink
     },
+
+    mixins: [analyticsMixin],
+
     props: {
         copy: {
             type: Object,
@@ -92,17 +97,15 @@ export default {
         isBelowMid: {
             type: Boolean,
             default: false
-        },
-        globalTrackingContexts: {
-            type: Array,
-            default: () => []
         }
     },
+
     data () {
         return {
             countries
         };
     },
+
     methods: {
         /**
          * Watch tab focus changes on non mobile version to trigger close event if the user tabs away from country selector panel

--- a/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
+++ b/packages/components/organisms/f-header/src/components/CountrySelectorPanel.vue
@@ -43,7 +43,10 @@
                             trakEvent: 'click',
                             category: 'engagement',
                             action: 'header',
-                            label: `${country.gtm}`
+                            label: `${country.gtm}`,
+                            ...(globalTrackingContexts.length ? {
+                                context: globalTrackingContexts
+                            } : {})
                         }"
                         :tabindex="isOpen ? 0 : -1"
                         :text="country.localisedName"
@@ -89,6 +92,10 @@ export default {
         isBelowMid: {
             type: Boolean,
             default: false
+        },
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
         }
     },
     data () {

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -59,6 +59,8 @@ import SkipToMain from './SkipToMain.vue';
 import { tenantConfigs } from '../tenants';
 import Navigation from './Navigation.vue';
 
+import analyticsMixin from '../mixins/analytics.mixin';
+
 export default {
     name: 'VueHeader',
 
@@ -67,6 +69,8 @@ export default {
         SkipToMain,
         Navigation
     },
+
+    mixins: [analyticsMixin],
 
     props: {
         locale: {
@@ -162,11 +166,6 @@ export default {
         shouldUseJetLogo: {
             type: Boolean,
             default: false
-        },
-
-        globalTrackingContexts: {
-            type: Array,
-            default: () => []
         }
     },
 

--- a/packages/components/organisms/f-header/src/components/Header.vue
+++ b/packages/components/organisms/f-header/src/components/Header.vue
@@ -27,7 +27,8 @@
                 :logo-gtm-label="copy.logo.gtm"
                 :header-background-theme="headerBackgroundTheme"
                 :should-resize-logo="showDeliveryEnquiryWithContent && showCountrySelector"
-                :is-open="mobileNavIsOpen" />
+                :is-open="mobileNavIsOpen"
+                :global-tracking-contexts="globalTrackingContexts" />
 
             <navigation
                 :copy="copy"
@@ -45,6 +46,7 @@
                 :show-login-info="showLoginInfo"
                 :show-country-selector="showCountrySelector"
                 :is-condensed="isCondensed"
+                :global-tracking-contexts="globalTrackingContexts"
                 @onMobileNavToggle="mobileNavToggled" />
         </div>
     </header>
@@ -160,6 +162,11 @@ export default {
         shouldUseJetLogo: {
             type: Boolean,
             default: false
+        },
+
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
         }
     },
 

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -22,6 +22,8 @@ import {
     LogoJetHorizontalIcon as JetLogo
 } from '@justeat/f-vue-icons';
 
+import analyticsMixin from '../mixins/analytics.mixin';
+
 export default {
     name: 'HeaderLogo',
     components: {
@@ -29,6 +31,9 @@ export default {
         MlLogo,
         JetLogo
     },
+
+    mixins: [analyticsMixin],
+
     props: {
         theme: {
             type: String,
@@ -57,19 +62,18 @@ export default {
         shouldResizeLogo: {
             type: Boolean,
             default: false
-        },
-        globalTrackingContexts: {
-            type: Array,
-            default: () => []
         }
     },
+
     computed: {
         iconComponent () {
             return `${this.theme}-logo`;
         },
+
         linkAltText () {
             return `Go to ${this.companyName} homepage`;
         },
+
         linkProperties () {
             return this.isLogoDisabled ? {
                 'data-test-id': 'disabled-wrapper-element'
@@ -88,12 +92,14 @@ export default {
                 })
             };
         },
+
         isAltLogo () {
             const isHighlight = this.headerBackgroundTheme === 'highlight';
             const isTransparent = this.headerBackgroundTheme === 'transparent';
 
             return isHighlight || (isTransparent && !this.isOpen);
         },
+
         wrapperComponent () {
             return this.isLogoDisabled ? 'span' : 'a';
         }

--- a/packages/components/organisms/f-header/src/components/Logo.vue
+++ b/packages/components/organisms/f-header/src/components/Logo.vue
@@ -57,6 +57,10 @@ export default {
         shouldResizeLogo: {
             type: Boolean,
             default: false
+        },
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
         }
     },
     computed: {
@@ -73,12 +77,15 @@ export default {
                 'data-test-id': 'wrapper-element',
                 'aria-label': this.linkAltText,
                 href: '/',
-                'data-trak': `{
-                    "trakEvent": "click",
-                    "category": "engagement",
-                    "action": "header",
-                    "label": "${this.logoGtmLabel}"
-                }`
+                'data-trak': JSON.stringify({
+                    trakEvent: 'click',
+                    category: 'engagement',
+                    action: 'header',
+                    label: this.logoGtmLabel,
+                    ...(this.globalTrackingContexts.length ? {
+                        context: this.globalTrackingContexts
+                    } : {})
+                })
             };
         },
         isAltLogo () {

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -50,12 +50,15 @@
         <a
             v-if="showOffersLink && !navIsOpen"
             data-test-id="offers-iconLink"
-            data-trak='{
-                "trakEvent": "click",
-                "category": "header",
-                "action": "click - navigation",
-                "label": "offers_icon"
-            }'
+            :data-trak='JSON.stringify({
+                trakEvent: "click",
+                category: "header",
+                action: "click - navigation",
+                label: "offers_icon",
+                ...(globalTrackingContexts.length ? {
+                    context: globalTrackingContexts
+                } : {})
+            })'
             :href="copy.offers.url"
             :class="[
                 $style['c-nav-featureLink'],
@@ -94,7 +97,12 @@
                         :tabindex="tabIndex"
                         :text="customNavLink.text"
                         :href="customNavLink.url"
-                        :data-trak="customNavLink.gtm && analyticsObjects.navigation.clickHeaderLink({ ...customNavLink.gtm })"
+                        :data-trak="customNavLink.gtm && analyticsObjects.navigation.clickHeaderLink({
+                            ...customNavLink.gtm,
+                            ...(globalTrackingContexts.length ? {
+                                context: globalTrackingContexts
+                            } : {})
+                        })"
                         :is-alt-colour="isAltColour"
                         :is-condensed="isCondensed"
                         :background-theme="headerBackgroundTheme" />
@@ -107,7 +115,12 @@
                         :text="copy.offers.text"
                         :tabindex="tabIndex"
                         :href="copy.offers.url"
-                        :data-trak="analyticsObjects.navigation.offers.clickLink"
+                        :data-trak="JSON.stringify({
+                            ...analyticsObjects.navigation.offers.clickLink,
+                            ...(globalTrackingContexts.length ? {
+                                context: globalTrackingContexts
+                            } : {})
+                        })"
                         :is-alt-colour="isAltColour"
                         :is-condensed="isCondensed"
                         :background-theme="headerBackgroundTheme"
@@ -131,7 +144,10 @@
                         :tabindex="tabIndex"
                         :href="copy.corporate.url"
                         :data-trak="analyticsObjects.navigation.clickHeaderLink({
-                            label: copy.corporate.gtm
+                            label: copy.corporate.gtm,
+                            ...(globalTrackingContexts.length ? {
+                                context: globalTrackingContexts
+                            } : {})
                         })"
                         :is-alt-colour="isAltColour"
                         :is-condensed="isCondensed"
@@ -156,7 +172,10 @@
                         :tabindex="tabIndex"
                         :href="copy.deliveryEnquiry.url"
                         :data-trak="analyticsObjects.navigation.clickHeaderLink({
-                            label: copy.deliveryEnquiry.gtm
+                            label: copy.deliveryEnquiry.gtm,
+                            ...(globalTrackingContexts.length ? {
+                                context: globalTrackingContexts
+                            } : {})
                         })"
                         :is-alt-colour="isAltColour"
                         :is-condensed="isCondensed"
@@ -232,6 +251,7 @@
                             :is-country-selector-open="countrySelectorIsOpen"
                             :copy="copy"
                             :return-logout-url="returnLogoutUrl"
+                            :global-tracking-contexts="globalTrackingContexts"
                             @activateNav="openUserMenu"
                             @deactivateNav="closeUserMenu" />
                     </v-popover>
@@ -245,7 +265,10 @@
                         :tabindex="tabIndex"
                         :href="returnLoginUrl"
                         :data-trak="analyticsObjects.navigation.clickHeaderLink({
-                            label: copy.accountLogin.gtm
+                            label: copy.accountLogin.gtm,
+                            ...(globalTrackingContexts.length ? {
+                                context: globalTrackingContexts
+                            } : {})
                         })"
                         :is-alt-colour="isAltColour"
                         :is-condensed="isCondensed"
@@ -264,7 +287,10 @@
                         has-border-top
                         :href="copy.accountLogout.url"
                         :data-trak="analyticsObjects.navigation.clickHeaderLink({
-                            label: copy.accountLogout.gtm
+                            label: copy.accountLogout.gtm,
+                            ...(globalTrackingContexts.length ? {
+                                context: globalTrackingContexts
+                            } : {})
                         })"
                         :is-alt-colour="isAltColour"
                         :background-theme="headerBackgroundTheme"
@@ -279,7 +305,10 @@
                         :tabindex="tabIndex"
                         :href="copy.help.url"
                         :data-trak="analyticsObjects.navigation.clickHeaderLink({
-                            label: copy.help.gtm
+                            label: copy.help.gtm,
+                            ...(globalTrackingContexts.length ? {
+                                context: globalTrackingContexts
+                            } : {})
                         })"
                         :is-alt-colour="isAltColour"
                         :is-condensed="isCondensed"
@@ -304,6 +333,7 @@
                         :is-nav-open="navIsOpen"
                         :copy="copy.countrySelector"
                         :tabindex="tabIndex"
+                        :global-tracking-contexts="globalTrackingContexts"
                         data-test-id="country-selector"
                         @close-country-selector="closeCountrySelector"
                         @open-country-selector="openCountrySelector"
@@ -422,6 +452,11 @@ export default {
             type: Array,
             default: () => [],
             validator: links => links.every(link => link.text && link.url)
+        },
+
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
         }
     },
 

--- a/packages/components/organisms/f-header/src/components/Navigation.vue
+++ b/packages/components/organisms/f-header/src/components/Navigation.vue
@@ -115,12 +115,12 @@
                         :text="copy.offers.text"
                         :tabindex="tabIndex"
                         :href="copy.offers.url"
-                        :data-trak="JSON.stringify({
+                        :data-trak="{
                             ...analyticsObjects.navigation.offers.clickLink,
                             ...(globalTrackingContexts.length ? {
                                 context: globalTrackingContexts
                             } : {})
-                        })"
+                        }"
                         :is-alt-colour="isAltColour"
                         :is-condensed="isCondensed"
                         :background-theme="headerBackgroundTheme"
@@ -345,11 +345,9 @@
 </template>
 
 <script>
-// Fozzie imports
+// Fozzie/PIE imports
 import { axiosServices, windowServices } from '@justeat/f-services';
 import VPopover from '@justeat/f-popover';
-
-// Internal
 import {
     OfficeSmallIcon,
     GiftSmallIcon,
@@ -357,11 +355,14 @@ import {
     MopedSmallIcon,
     UserCircleSmallIcon
 } from '@justeattakeaway/pie-icons-vue';
+
+// Internal
 import CountrySelector from './CountrySelector.vue';
 import NavLink from './NavLink.vue';
 import UserNavigationPanel from './UserNavigationPanel.vue';
 import { countries } from '../tenants';
 import analyticsObjects from '../services/analytics/objects';
+import analyticsMixin from '../mixins/analytics.mixin';
 
 export default {
     name: 'HeaderNavigation',
@@ -376,6 +377,8 @@ export default {
         UserNavigationPanel,
         VPopover
     },
+
+    mixins: [analyticsMixin],
 
     props: {
         copy: {
@@ -452,11 +455,6 @@ export default {
             type: Array,
             default: () => [],
             validator: links => links.every(link => link.text && link.url)
-        },
-
-        globalTrackingContexts: {
-            type: Array,
-            default: () => []
         }
     },
 

--- a/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
+++ b/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
@@ -12,12 +12,15 @@
                 :tabindex="tabIndex"
                 :href="link.url"
                 :is-popover-link="!isBelowMid"
-                :data-trak="{
-                    trakEvent: 'click',
-                    category: 'engagement',
-                    action: 'header',
-                    label: `${link.gtm}`
-                }"
+                :data-trak='JSON.stringify({
+                    trakEvent: "click",
+                    category: "engagement",
+                    action: "header",
+                    label: link.gtm,
+                    ...(globalTrackingContexts.length ? {
+                        context: globalTrackingContexts
+                    } : {})
+                })'
                 :text="link.text"
                 has-border-top
                 :has-border-bottom="false"
@@ -33,12 +36,15 @@
                 :tabindex="isUserMenuOpen ? 0 : -1"
                 :href="returnLogoutUrl"
                 is-popover-link
-                :data-trak="{
-                    trakEvent: 'click',
-                    category: 'engagement',
-                    action: 'header',
-                    label: `${copy.accountLogout.gtm}`
-                }"
+                :data-trak='JSON.stringify({
+                    trakEvent: "click",
+                    category: "engagement",
+                    action: "header",
+                    label: copy.accountLogout.gtm,
+                    ...(globalTrackingContexts.length ? {
+                        context: globalTrackingContexts
+                    } : {})
+                })'
                 :text="copy.accountLogout.text"
                 has-border-top
                 :has-border-bottom="false"
@@ -80,6 +86,10 @@ export default {
         isCountrySelectorOpen: {
             type: Boolean,
             default: false
+        },
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
         }
     },
     computed: {

--- a/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
+++ b/packages/components/organisms/f-header/src/components/UserNavigationPanel.vue
@@ -12,15 +12,15 @@
                 :tabindex="tabIndex"
                 :href="link.url"
                 :is-popover-link="!isBelowMid"
-                :data-trak='JSON.stringify({
-                    trakEvent: "click",
-                    category: "engagement",
-                    action: "header",
+                :data-trak="{
+                    trakEvent: 'click',
+                    category: 'engagement',
+                    action: 'header',
                     label: link.gtm,
                     ...(globalTrackingContexts.length ? {
                         context: globalTrackingContexts
                     } : {})
-                })'
+                }"
                 :text="link.text"
                 has-border-top
                 :has-border-bottom="false"
@@ -36,15 +36,15 @@
                 :tabindex="isUserMenuOpen ? 0 : -1"
                 :href="returnLogoutUrl"
                 is-popover-link
-                :data-trak='JSON.stringify({
-                    trakEvent: "click",
-                    category: "engagement",
-                    action: "header",
+                :data-trak="{
+                    trakEvent: 'click',
+                    category: 'engagement',
+                    action: 'header',
                     label: copy.accountLogout.gtm,
                     ...(globalTrackingContexts.length ? {
                         context: globalTrackingContexts
                     } : {})
-                })'
+                }"
                 :text="copy.accountLogout.text"
                 has-border-top
                 :has-border-bottom="false"
@@ -57,11 +57,15 @@
 
 <script>
 import NavLink from './NavLink.vue';
+import analyticsMixin from '../mixins/analytics.mixin';
 
 export default {
     components: {
         NavLink
     },
+
+    mixins: [analyticsMixin],
+
     props: {
         isUserMenuOpen: {
             type: Boolean,
@@ -86,12 +90,9 @@ export default {
         isCountrySelectorOpen: {
             type: Boolean,
             default: false
-        },
-        globalTrackingContexts: {
-            type: Array,
-            default: () => []
         }
     },
+
     computed: {
         tabIndex () {
             if (this.isBelowMid && this.isNavOpen && !this.isCountrySelectorOpen) {
@@ -103,10 +104,12 @@ export default {
             return 0;
         }
     },
+
     methods: {
         activateNav () {
             this.$emit('activateNav');
         },
+
         deactivateNav () {
             this.$emit('deactivateNav');
         }

--- a/packages/components/organisms/f-header/src/components/_tests/__snapshots__/Header.test.js.snap
+++ b/packages/components/organisms/f-header/src/components/_tests/__snapshots__/Header.test.js.snap
@@ -4,8 +4,8 @@ exports[`Header should render default component markup 1`] = `
 <header data-theme="je" data-test-id="header-component" class="c-header c-header--transparent c-header--gradient">
   <skip-to-main-stub text="Skip to main content" transparentbg="true"></skip-to-main-stub>
   <div class="c-header-container">
-    <logo-stub theme="je" companyname="Just Eat" logogtmlabel="click_logo" headerbackgroundtheme="transparent" globaltrackingcontexts=""></logo-stub>
-    <navigation-stub copy="[object Object]" showdeliveryenquiry="true" showhelplink="true" showlogininfo="true" userinfourl="/api/account/details" ordercounturl="/analytics/ordercount" isordercountsupported="true" headerbackgroundtheme="transparent" customnavlinks="" globaltrackingcontexts=""></navigation-stub>
+    <logo-stub globaltrackingcontexts="" theme="je" companyname="Just Eat" logogtmlabel="click_logo" headerbackgroundtheme="transparent"></logo-stub>
+    <navigation-stub globaltrackingcontexts="" copy="[object Object]" showdeliveryenquiry="true" showhelplink="true" showlogininfo="true" userinfourl="/api/account/details" ordercounturl="/analytics/ordercount" isordercountsupported="true" headerbackgroundtheme="transparent" customnavlinks=""></navigation-stub>
   </div>
 </header>
 `;

--- a/packages/components/organisms/f-header/src/components/_tests/__snapshots__/Header.test.js.snap
+++ b/packages/components/organisms/f-header/src/components/_tests/__snapshots__/Header.test.js.snap
@@ -4,8 +4,8 @@ exports[`Header should render default component markup 1`] = `
 <header data-theme="je" data-test-id="header-component" class="c-header c-header--transparent c-header--gradient">
   <skip-to-main-stub text="Skip to main content" transparentbg="true"></skip-to-main-stub>
   <div class="c-header-container">
-    <logo-stub theme="je" companyname="Just Eat" logogtmlabel="click_logo" headerbackgroundtheme="transparent"></logo-stub>
-    <navigation-stub copy="[object Object]" showdeliveryenquiry="true" showhelplink="true" showlogininfo="true" userinfourl="/api/account/details" ordercounturl="/analytics/ordercount" isordercountsupported="true" headerbackgroundtheme="transparent" customnavlinks=""></navigation-stub>
+    <logo-stub theme="je" companyname="Just Eat" logogtmlabel="click_logo" headerbackgroundtheme="transparent" globaltrackingcontexts=""></logo-stub>
+    <navigation-stub copy="[object Object]" showdeliveryenquiry="true" showhelplink="true" showlogininfo="true" userinfourl="/api/account/details" ordercounturl="/analytics/ordercount" isordercountsupported="true" headerbackgroundtheme="transparent" customnavlinks="" globaltrackingcontexts=""></navigation-stub>
   </div>
 </header>
 `;

--- a/packages/components/organisms/f-header/src/mixins/analytics.mixin.js
+++ b/packages/components/organisms/f-header/src/mixins/analytics.mixin.js
@@ -1,0 +1,8 @@
+export default {
+    props: {
+        globalTrackingContexts: {
+            type: Array,
+            default: () => []
+        }
+    }
+};

--- a/packages/components/organisms/f-header/stories/header.stories.js
+++ b/packages/components/organisms/f-header/stories/header.stories.js
@@ -38,7 +38,8 @@ export const HeaderComponent = (args, { argTypes }) => ({
             :key="locale"
             :show-skip-link="showSkipLink"
             :tall-below-mid="tallBelowMid"
-            :should-use-jet-logo="shouldUseJetLogo" />`
+            :should-use-jet-logo="shouldUseJetLogo"
+            :global-tracking-contexts="globalTrackingContexts" />`
 });
 
 HeaderComponent.storyName = 'f-header';
@@ -57,7 +58,8 @@ HeaderComponent.args = {
     logoLinkDisabled: false,
     isCondensed: false,
     tallBelowMid: false,
-    shouldUseJetLogo: false
+    shouldUseJetLogo: false,
+    globalTrackingContexts: []
 };
 
 HeaderComponent.argTypes = {
@@ -142,5 +144,10 @@ HeaderComponent.argTypes = {
 
     tallBelowMid: {
         description: 'Makes the header taller for narrower viewports'
+    },
+
+    globalTrackingContexts: {
+        control: { type: 'object' },
+        description: 'Array containing the global tracking contexts to be passed through to f-trak.'
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3898,7 +3898,7 @@ __metadata:
     "@justeattakeaway/pie-icons-vue": 2.0.0-beta.1
     v-click-outside: 3.1.2
   peerDependencies:
-    "@justeat/f-trak": ">=0.8.0"
+    "@justeat/f-trak": 1.x
   languageName: unknown
   linkType: soft
 
@@ -3957,7 +3957,7 @@ __metadata:
     "@justeat/browserslist-config-fozzie": ">=1.1.1"
     "@justeat/f-button": 4.x
     "@justeat/f-popover": 3.x
-    "@justeat/f-trak": ">=0.8.0"
+    "@justeat/f-trak": 1.x
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3898,7 +3898,7 @@ __metadata:
     "@justeattakeaway/pie-icons-vue": 2.0.0-beta.1
     v-click-outside: 3.1.2
   peerDependencies:
-    "@justeat/f-trak": ">=0.6.0"
+    "@justeat/f-trak": ">=0.8.0"
   languageName: unknown
   linkType: soft
 
@@ -3957,7 +3957,7 @@ __metadata:
     "@justeat/browserslist-config-fozzie": ">=1.1.1"
     "@justeat/f-button": 4.x
     "@justeat/f-popover": 3.x
-    "@justeat/f-trak": ">=0.6.0"
+    "@justeat/f-trak": ">=0.8.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## f-header@10.21.0 / f-footer@8.9.0

### Added

- New prop `globalTrackingContexts` which are passed through to f-trak for analytics events.

---

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]