### PR TITLE
f-alert@6.3.1 f-header@10.21.1 Dependency update `f-button@5.x`

### DIFF
--- a/packages/components/molecules/f-alert/CHANGELOG.md
+++ b/packages/components/molecules/f-alert/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v6.3.1
+
+_July 05, 2024_
+
+### Changed
+
+- Updated `@justeat/f-button@5.x` due to Node compatibility
+
 ## v6.3.0
 
 _March 13, 2024_
@@ -17,7 +25,7 @@ _December 5, 2022_
 
 - Updated to the new `pie-icons-vue` beta release.
 
-v6.2.0
+## v6.2.0
 
 ---
 

--- a/packages/components/molecules/f-alert/package.json
+++ b/packages/components/molecules/f-alert/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-alert",
   "description": "Fozzie Alert – Fozzie Alert Component",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "main": "dist/f-alert.umd.min.js",
   "maxBundleSize": "27kB",
   "files": [
@@ -53,10 +53,10 @@
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
-    "@justeat/f-button": "4.x"
+    "@justeat/f-button": "5.x"
   },
   "devDependencies": {
-    "@justeat/f-button": "4.x",
+    "@justeat/f-button": "5.x",
     "@justeat/f-wdio-utils": "1.x"
   },
   "volta": {

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v10.21.1
+
+_July 05, 2024_
+
+### Changed
+
+- Updated `@justeat/f-button@5.x` due to Node compatibility
+
 ## v10.21.0
 
 _June 24, 2024_

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header - Globalised Header Component",
-  "version": "10.21.0",
+  "version": "10.21.1",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "55kB",
   "files": [
@@ -54,12 +54,12 @@
   },
   "peerDependencies": {
     "@justeat/browserslist-config-fozzie": ">=1.1.1",
-    "@justeat/f-button": "4.x",
+    "@justeat/f-button": "5.x",
     "@justeat/f-popover": "3.x",
     "@justeat/f-trak": "1.x"
   },
   "devDependencies": {
-    "@justeat/f-button": "4.x",
+    "@justeat/f-button": "5.x",
     "@justeat/f-popover": "3.x",
     "@justeat/f-vue-icons": "3.x",
     "@justeat/f-wdio-utils": "1.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3542,13 +3542,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@justeat/f-alert@workspace:packages/components/molecules/f-alert"
   dependencies:
-    "@justeat/f-button": 4.x
+    "@justeat/f-button": 5.x
     "@justeat/f-services": 1.x
     "@justeat/f-wdio-utils": 1.x
     "@justeattakeaway/pie-icons-vue": 2.0.0-beta.1
   peerDependencies:
     "@justeat/browserslist-config-fozzie": ">=1.1.1"
-    "@justeat/f-button": 4.x
+    "@justeat/f-button": 5.x
   languageName: unknown
   linkType: soft
 
@@ -3947,7 +3947,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@justeat/f-header@workspace:packages/components/organisms/f-header"
   dependencies:
-    "@justeat/f-button": 4.x
+    "@justeat/f-button": 5.x
     "@justeat/f-popover": 3.x
     "@justeat/f-services": 1.x
     "@justeat/f-vue-icons": 3.x
@@ -3955,7 +3955,7 @@ __metadata:
     "@justeattakeaway/pie-icons-vue": 2.0.0-beta.1
   peerDependencies:
     "@justeat/browserslist-config-fozzie": ">=1.1.1"
-    "@justeat/f-button": 4.x
+    "@justeat/f-button": 5.x
     "@justeat/f-popover": 3.x
     "@justeat/f-trak": 1.x
   languageName: unknown


### PR DESCRIPTION
Updated `@justeat/f-button` dependency with v.5.x for `f-alert` and `f-header`
---

Using Fozzie `f-button@4.x` component in the project displays Node compatibility error message. 

### With `@justeat/f-button@4.5.0` 
![Screenshot 2024-07-05 at 16 33 22](https://github.com/justeattakeaway/fozzie-components/assets/26770126/ae00a15e-3dbd-4cd6-9458-15c5f08a91f3)

When version is updated to `5.x`, `f-alert` and `f-header` show incompatibility messages. See screenshots attached. 

### With `@justeat/f-button@5.x`
![Screenshot 2024-07-05 at 15 16 12](https://github.com/justeattakeaway/fozzie-components/assets/26770126/84df8969-e7a4-4671-9cf5-4ffc479fd74a)

---

## UI Review Checks

- [x] CHANGELOG and/or UI Documentation has been [created|updated]
- [ ] Unit tests have been [created|updated]
- [ ] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

## Browsers Tested

- [ ] Chrome (latest)
- [ ] Internet Explorer 11
- [ ] Mobile (Please list device/browser – Ideally one iPhone model and one Android)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
