### PR TITLE
#trivial - readme updates to remove snyk mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,19 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
 ## v7.57.1
 
-June 21, 2024_
+_September 10, 2024_
+
+### Changed
+
+- Update `chromedriver` to v128
+
+
+## v7.57.1
+
+_June 21, 2024_
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "7.57.1",
+  "version": "7.57.2",
   "private": true,
   "scripts": {
     "build": "NODE_OPTIONS=--openssl-legacy-provider cross-env-shell turbo run build --continue --token=${TURBO_TOKEN}",
@@ -89,7 +89,7 @@
     "babel-jest": "29.7.0",
     "babel-loader": "8.1.0",
     "bundlewatch": "0.3.3",
-    "chromedriver": "126.0.2",
+    "chromedriver": "128.0.1",
     "core-js": "3.36.1",
     "cross-env": "7.0.2",
     "css-loader": "1.0.1",

--- a/packages/components/atoms/f-button/README.md
+++ b/packages/components/atoms/f-button/README.md
@@ -12,8 +12,8 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-button.svg)](https://badge.fury.io/js/%40justeat%2Ff-button)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-button/badge.svg)](https://coveralls.io/github/justeat/f-button)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-button/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-button?targetFile=package.json)
 
+---
 
 ## Usage
 

--- a/packages/components/atoms/f-card/README.md
+++ b/packages/components/atoms/f-card/README.md
@@ -12,8 +12,8 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-card.svg)](https://badge.fury.io/js/%40justeat%2Ff-card)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-card/badge.svg)](https://coveralls.io/github/justeat/f-card)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-card/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-card?targetFile=package.json)
 
+---
 
 ## Usage
 

--- a/packages/components/atoms/f-error-message/README.md
+++ b/packages/components/atoms/f-error-message/README.md
@@ -12,8 +12,8 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-error-message.svg)](https://badge.fury.io/js/%40justeat%2Ff-error-message)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-error-message/badge.svg)](https://coveralls.io/github/justeat/f-error-message)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-error-message/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-error-message?targetFile=package.json)
 
+---
 
 ## Usage
 

--- a/packages/components/atoms/f-filter-pill/README.md
+++ b/packages/components/atoms/f-filter-pill/README.md
@@ -13,7 +13,6 @@ Fozzie Filter Pill - An interactive component for filter toggles.
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-filter-pill.svg)](https://badge.fury.io/js/%40justeat%2Ff-filter-pill)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-filter-pill/badge.svg)](https://coveralls.io/github/justeat/f-filter-pill)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-filter-pill/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-filter-pill?targetFile=package.json)
 
 ---
 

--- a/packages/components/atoms/f-form-field/README.md
+++ b/packages/components/atoms/f-form-field/README.md
@@ -13,7 +13,6 @@ Fozzie Form Field Component.
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-form-field.svg)](https://badge.fury.io/js/%40justeat%2Ff-form-field)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-form-field/badge.svg)](https://coveralls.io/github/justeat/f-form-field)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-form-field/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-form-field?targetFile=package.json)
 
 ---
 

--- a/packages/components/atoms/f-image-tile/README.md
+++ b/packages/components/atoms/f-image-tile/README.md
@@ -14,7 +14,6 @@ An interactive tile component containing an image, text and link.
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-image-tile.svg)](https://badge.fury.io/js/%40justeat%2Ff-image-tile)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-image-tile/badge.svg)](https://coveralls.io/github/justeat/f-image-tile)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-image-tile/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-image-tile?targetFile=package.json)
 
 ---
 
@@ -73,12 +72,12 @@ The props that can be defined are as follows (if any):
 | Prop  | Type  | Default | Description |
 | ----- | ----- | ------- | ----------- |
 | `href` | `String` | `null` | The link URL |
-| `tileId` | `String` | `null` | The id of the tile | 
+| `tileId` | `String` | `null` | The id of the tile |
 | `isSelected` | `Boolean` | `false` | Marks the tile as selected |
-| `isLink` | `Boolean` | `false` | Component acts as a link, rather than default toggle | 
-| `displayText` | `String` | `null` | Component display text | 
-| `imgSrc` | `String` | `''` | Component image link | 
-| `altText` | `String` | `''` | Component image alt text | 
+| `isLink` | `Boolean` | `false` | Component acts as a link, rather than default toggle |
+| `displayText` | `String` | `null` | Component display text |
+| `imgSrc` | `String` | `''` | Component image link |
+| `altText` | `String` | `''` | Component image alt text |
 | `fallbackImage` | `String` | `''` | Component fallback image url
 
 ### Events
@@ -87,7 +86,7 @@ The events that can be subscribed to are as follows (if any):
 
 | Event | Description |
 | ----- | ----------- |
-| `toggleFilter` | Fired when a tile is interacted with, toggles between selected and not selected | 
+| `toggleFilter` | Fired when a tile is interacted with, toggles between selected and not selected |
 | `handleImgError` |  Fired there is an error with the component image |
 
 ## Development

--- a/packages/components/atoms/f-link/README.md
+++ b/packages/components/atoms/f-link/README.md
@@ -13,7 +13,6 @@ Fozzie link component
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-link.svg)](https://badge.fury.io/js/%40justeat%2Ff-link)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-link/badge.svg)](https://coveralls.io/github/justeat/f-link)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-link/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-link?targetFile=package.json)
 
 ---
 

--- a/packages/components/atoms/f-popover/README.md
+++ b/packages/components/atoms/f-popover/README.md
@@ -15,7 +15,6 @@ Please note that this component is only a wrapper with the base styles for the p
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-popover.svg)](https://badge.fury.io/js/%40justeat%2Ff-popover)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-popover/badge.svg)](https://coveralls.io/github/justeat/f-popover)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-popover/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-popover?targetFile=package.json)
 
 ---
 

--- a/packages/components/atoms/f-spinner/README.md
+++ b/packages/components/atoms/f-spinner/README.md
@@ -13,7 +13,6 @@ loading indicator
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-spinner.svg)](https://badge.fury.io/js/%40justeat%2Ff-spinner)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-spinner/badge.svg)](https://coveralls.io/github/justeat/f-spinner)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-spinner/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-spinner?targetFile=package.json)
 
 ---
 

--- a/packages/components/atoms/f-toggle-switch/README.md
+++ b/packages/components/atoms/f-toggle-switch/README.md
@@ -12,7 +12,6 @@ A component to switch a single setting on/off.
 
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-toggle-switch.svg)](https://badge.fury.io/js/%40justeat%2Ff-toggle-switch)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-toggle-switch/badge.svg)](https://coveralls.io/github/justeat/f-toggle-switch)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-toggle-switch/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-toggle-switch?targetFile=package.json)
 
 ---
 

--- a/packages/components/molecules/f-breadcrumbs/README.md
+++ b/packages/components/molecules/f-breadcrumbs/README.md
@@ -12,8 +12,8 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-breadcrumbsf-breadcrumbs.svg)](https://badge.fury.io/js/%40justeat%2Ff-breadcrumbs)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-breadcrumbs/badge.svg)](https://coveralls.io/github/justeat/f-breadcrumbs)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-breadcrumbs/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-breadcrumbs?targetFile=package.json)
 
+---
 
 ## Usage
 

--- a/packages/components/molecules/f-card-with-content/README.md
+++ b/packages/components/molecules/f-card-with-content/README.md
@@ -17,7 +17,6 @@ The icon can be any image but it is recommended to use an icon from `f-vue-icons
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-card-with-content.svg)](https://badge.fury.io/js/%40justeat%2Ff-card-with-content)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-card-with-content/badge.svg)](https://coveralls.io/github/justeat/f-card-with-content)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-card-with-content/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-card-with-content?targetFile=package.json)
 
 ---
 

--- a/packages/components/molecules/f-media-element/README.md
+++ b/packages/components/molecules/f-media-element/README.md
@@ -13,7 +13,6 @@ provides ability to display text and an image in different orientations
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-media-element.svg)](https://badge.fury.io/js/%40justeat%2Ff-media-element)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-media-element/badge.svg)](https://coveralls.io/github/justeat/f-media-element)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-media-element/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-media-element?targetFile=package.json)
 
 ---
 

--- a/packages/components/molecules/f-navigation-links/README.md
+++ b/packages/components/molecules/f-navigation-links/README.md
@@ -13,7 +13,6 @@ A component to display a collection of supplied links
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-navigation-links.svg)](https://badge.fury.io/js/%40justeat%2Ff-navigation-links)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-navigation-links/badge.svg)](https://coveralls.io/github/justeat/f-navigation-links)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-navigation-links/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-navigation-links?targetFile=package.json)
 
 ---
 

--- a/packages/components/molecules/f-promotions-showcase/README.md
+++ b/packages/components/molecules/f-promotions-showcase/README.md
@@ -13,7 +13,6 @@ A place for promotional messages to be displayed
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-promotions-showcase.svg)](https://badge.fury.io/js/%40justeat%2Ff-promotions-showcase)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-promotions-showcase/badge.svg)](https://coveralls.io/github/justeat/f-promotions-showcase)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-promotions-showcase/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-promotions-showcase?targetFile=package.json)
 
 ---
 

--- a/packages/components/molecules/f-rating/README.md
+++ b/packages/components/molecules/f-rating/README.md
@@ -13,7 +13,6 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-rating.svg)](https://badge.fury.io/js/%40justeat%2Ff-rating)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-rating/badge.svg)](https://coveralls.io/github/justeat/f-rating)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-rating/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-rating?targetFile=package.json)
 
 ---
 

--- a/packages/components/molecules/f-restaurant-card/README.md
+++ b/packages/components/molecules/f-restaurant-card/README.md
@@ -13,7 +13,6 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-restaurant-card.svg)](https://badge.fury.io/js/%40justeat%2Ff-restaurant-card)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-restaurant-card/badge.svg)](https://coveralls.io/github/justeat/f-restaurant-card)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-restaurant-card/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-restaurant-card?targetFile=package.json)
 
 ---
 

--- a/packages/components/molecules/f-searchbox/README.md
+++ b/packages/components/molecules/f-searchbox/README.md
@@ -13,8 +13,8 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-searchbox.svg)](https://badge.fury.io/js/%40justeat%2Ff-searchbox)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-searchbox/badge.svg)](https://coveralls.io/github/justeat/f-searchbox)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-searchbox/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-searchbox?targetFile=package.json)
 
+---
 
 ## Usage
 

--- a/packages/components/molecules/f-skeleton-loader/README.md
+++ b/packages/components/molecules/f-skeleton-loader/README.md
@@ -13,7 +13,6 @@ Provides a visual indication that another component is loading.  A set of predef
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-skeleton-loader.svg)](https://badge.fury.io/js/%40justeat%2Ff-skeleton-loader)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-skeleton-loader/badge.svg)](https://coveralls.io/github/justeat/f-skeleton-loader)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-skeleton-loader/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-skeleton-loader?targetFile=package.json)
 
 ---
 

--- a/packages/components/molecules/f-tabs/README.md
+++ b/packages/components/molecules/f-tabs/README.md
@@ -12,8 +12,8 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-tabs.svg)](https://badge.fury.io/js/%40justeat%2Ff-tabs)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-tabs/badge.svg)](https://coveralls.io/github/justeat/f-tabs)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-tabs/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-tabs?targetFile=package.json)
 
+---
 
 ## Usage
 

--- a/packages/components/molecules/f-user-message/README.md
+++ b/packages/components/molecules/f-user-message/README.md
@@ -11,7 +11,6 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-user-message/badge.svg)](https://coveralls.io/github/justeat/f-user-message)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-user-message/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-user-message?targetFile=package.json)
 <!-- markdownlint-enable -->
 
 <!-- markdownlint-disable MD002 -->

--- a/packages/components/organisms/f-content-cards/README.md
+++ b/packages/components/organisms/f-content-cards/README.md
@@ -11,7 +11,8 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-content-cards.svg)](https://badge.fury.io/js/%40justeat%2Ff-content-cards)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-content-cards/badge.svg)](https://coveralls.io/github/justeat/f-content-cards)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-content-cards/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-content-cards?targetFile=package.json)
+
+---
 
 # Content Cards (f-content-cards)
 

--- a/packages/components/organisms/f-cookie-banner/README.md
+++ b/packages/components/organisms/f-cookie-banner/README.md
@@ -12,7 +12,8 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-cookie-banner.svg)](https://badge.fury.io/js/%40justeat%2Ff-cookie-banner)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-cookie-banner/badge.svg)](https://coveralls.io/github/justeat/f-cookie-banner)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-cookie-banner/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-cookie-banner?targetFile=package.json)
+
+---
 
 ## Usage
 

--- a/packages/components/organisms/f-cookie-banner/test/component/f-cookie-banner-legacy.component.spec.js
+++ b/packages/components/organisms/f-cookie-banner/test/component/f-cookie-banner-legacy.component.spec.js
@@ -26,8 +26,7 @@ describe('Legacy - f-cookie-banner component tests', () => {
     });
 
     const tests = [
-        { locale: 'en-AU', expectedCookiePolicyUrl: 'au/info/privacy-policy#cookies_policy' },
-        { locale: 'en-NZ', expectedCookiePolicyUrl: 'nz/info/privacy-policy#cookies_policy' }
+        { locale: 'en-AU', expectedCookiePolicyUrl: 'https://www.menulog.com.au/privacy-policy#cookies_policy' }
     ];
 
     tests.forEach(({ locale, expectedCookiePolicyUrl }) => {

--- a/packages/components/organisms/f-footer/README.md
+++ b/packages/components/organisms/f-footer/README.md
@@ -13,7 +13,6 @@ Global Footer Component for Vue.js.
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-footer.svg)](https://badge.fury.io/js/%40justeat%2Ff-footer)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-footer/badge.svg)](https://coveralls.io/github/justeat/f-footer)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-footer/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-footer?targetFile=package.json)
 
 ---
 

--- a/packages/components/organisms/f-status-banner/README.md
+++ b/packages/components/organisms/f-status-banner/README.md
@@ -13,7 +13,6 @@ Global status page
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-status-banner.svg)](https://badge.fury.io/js/%40justeat%2Ff-status-banner)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-status-banner/badge.svg)](https://coveralls.io/github/justeat/f-status-banner)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-status-banner/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-status-banner?targetFile=package.json)
 
 ---
 

--- a/packages/components/pages/f-account-info/README.md
+++ b/packages/components/pages/f-account-info/README.md
@@ -13,7 +13,6 @@ The account information page
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-account-info.svg)](https://badge.fury.io/js/%40justeat%2Ff-account-info)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-account-info/badge.svg)](https://coveralls.io/github/justeat/f-account-info)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-account-info/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-account-info?targetFile=package.json)
 
 ---
 

--- a/packages/components/pages/f-checkout/README.md
+++ b/packages/components/pages/f-checkout/README.md
@@ -12,10 +12,12 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-checkout.svg)](https://badge.fury.io/js/%40justeat%2Ff-checkout)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-checkout/badge.svg)](https://coveralls.io/github/justeat/f-checkout)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-checkout/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-checkout?targetFile=package.json)
 
+---
 
 ## Usage
+
+### Installation
 
 1.  Install the module using NPM or Yarn:
 

--- a/packages/components/pages/f-contact-preferences/README.md
+++ b/packages/components/pages/f-contact-preferences/README.md
@@ -13,7 +13,6 @@ Fozzie user contact preferences form component
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-contact-preferences.svg)](https://badge.fury.io/js/%40justeat%2Ff-contact-preferences)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-contact-preferences/badge.svg)](https://coveralls.io/github/justeat/f-contact-preferences)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-contact-preferences/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-contact-preferences?targetFile=package.json)
 
 ---
 

--- a/packages/components/pages/f-loyalty/README.md
+++ b/packages/components/pages/f-loyalty/README.md
@@ -13,7 +13,6 @@ provides a way for customers to collect loyalty stamps for restaurants
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-loyalty.svg)](https://badge.fury.io/js/%40justeat%2Ff-loyalty)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-loyalty/badge.svg)](https://coveralls.io/github/justeat/f-loyalty)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-loyalty/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-loyalty?targetFile=package.json)
 
 ---
 

--- a/packages/components/pages/f-mfa/README.md
+++ b/packages/components/pages/f-mfa/README.md
@@ -13,7 +13,6 @@ Multi-factor Authenticator - Input Form
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-mfa.svg)](https://badge.fury.io/js/%40justeat%2Ff-mfa)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-mfa/badge.svg)](https://coveralls.io/github/justeat/f-mfa)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-mfa/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-mfa?targetFile=package.json)
 
 ---
 This form is for accepting a MFA token that has been sent to a user, then submitting it to be verified, if successful then an event to passed to the parent component to return the user to where they came from.

--- a/packages/components/pages/f-offers/README.md
+++ b/packages/components/pages/f-offers/README.md
@@ -13,7 +13,6 @@ displays offers to the customers
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-offers.svg)](https://badge.fury.io/js/%40justeat%2Ff-offers)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-offers/badge.svg)](https://coveralls.io/github/justeat/f-offers)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-offers/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-offers?targetFile=package.json)
 
 ---
 

--- a/packages/components/pages/f-registration/README.md
+++ b/packages/components/pages/f-registration/README.md
@@ -13,7 +13,6 @@ Registration Component.
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-registration.svg)](https://badge.fury.io/js/%40justeat%2Ff-registration)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-registration/badge.svg)](https://coveralls.io/github/justeat/f-registration)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-registration/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-registration?targetFile=package.json)
 
 ---
 

--- a/packages/components/pages/f-self-exclusion/README.md
+++ b/packages/components/pages/f-self-exclusion/README.md
@@ -13,7 +13,6 @@ Customers must be able to voluntarily self-exclude or nominate themselves for se
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-self-exclusion.svg)](https://badge.fury.io/js/%40justeat%2Ff-self-exclusion)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-self-exclusion/badge.svg)](https://coveralls.io/github/justeat/f-self-exclusion)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-self-exclusion/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-self-exclusion?targetFile=package.json)
 
 ---
 

--- a/packages/components/pages/f-takeawaypay-activation/README.md
+++ b/packages/components/pages/f-takeawaypay-activation/README.md
@@ -13,7 +13,6 @@ Handles Takeaway Pay activation for users
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-takeawaypay-activation.svg)](https://badge.fury.io/js/%40justeat%2Ff-takeawaypay-activation)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-takeawaypay-activation/badge.svg)](https://coveralls.io/github/justeat/f-takeawaypay-activation)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-takeawaypay-activation/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-takeawaypay-activation?targetFile=package.json)
 
 ---
 

--- a/packages/components/templates/f-template-subnav/README.md
+++ b/packages/components/templates/f-template-subnav/README.md
@@ -15,7 +15,6 @@ On wider views, this will be laid out with the breadcrumb running along the top,
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-template-subnav.svg)](https://badge.fury.io/js/%40justeat%2Ff-template-subnav)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-template-subnav/badge.svg)](https://coveralls.io/github/justeat/f-template-subnav)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-template-subnav/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-template-subnav?targetFile=package.json)
 
 ---
 

--- a/packages/services/core-analytics/README.md
+++ b/packages/services/core-analytics/README.md
@@ -13,7 +13,6 @@ Encapsulates Snowplow & GTM (Google Analytics) functionality
 [![npm version](https://badge.fury.io/js/%40justeat%2Fcore-analytics.svg)](https://badge.fury.io/js/%40justeat%2Fcore-analytics)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/core-analytics/badge.svg)](https://coveralls.io/github/justeat/core-analytics)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/core-analytics/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/core-analytics?targetFile=package.json)
 
 ---
 This component abstracts away the gathering of the various data values needed for Google Analytics (GA) and the setting up of Google Tag Manager (GTM).<br>
@@ -113,7 +112,7 @@ You can see the GTM tag and any GA data by inspecting the `head` tag of the page
 
       This will be the model constructed and pushed to the `datalayer` (handy for testing and debugging)
       #### **Notes**
-      This is ideally only called everytime the `User` status changes so it might best suited in a `login` method.<br>     
+      This is ideally only called everytime the `User` status changes so it might best suited in a `login` method.<br>
       The method is very dependant on the `authToken` parameter and without it the `userData` model will only contain the anonymous user id.
       #### **Example**
       ```js

--- a/packages/services/f-analytics/README.md
+++ b/packages/services/f-analytics/README.md
@@ -13,7 +13,6 @@ Encapsulates the GTM / Google Analytics functionality
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-analytics.svg)](https://badge.fury.io/js/%40justeat%2Ff-analytics)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-analytics/badge.svg)](https://coveralls.io/github/justeat/f-analytics)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-analytics/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-analytics?targetFile=package.json)
 
 ---
 This component abstracts away the gathering of the various data values needed for Google Analytics (GA) and the setting up of Google Tag Manager (GTM).<br>

--- a/packages/services/f-braze-adapter/README.md
+++ b/packages/services/f-braze-adapter/README.md
@@ -13,7 +13,8 @@ Braze Content Cards Interface.
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-braze-adapter.svg)](https://badge.fury.io/js/%40justeat%2Ff-braze-adapter)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-braze-adapter/badge.svg)](https://coveralls.io/github/justeat/f-braze-adapter)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-braze-adapter/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-braze-adapter?targetFile=package.json)
+
+---
 
 This package provides an interface for initialising Braze and handling content cards and in-app messages.
 

--- a/packages/services/f-compatibility/README.md
+++ b/packages/services/f-compatibility/README.md
@@ -13,7 +13,6 @@ Service to check browser compatibilities and warn users with incompatible browse
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-compatibility.svg)](https://badge.fury.io/js/%40justeat%2Ff-compatibility)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-compatibility/badge.svg)](https://coveralls.io/github/justeat/f-compatibility)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-compatibility/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-compatibility?targetFile=package.json)
 
 ---
 

--- a/packages/services/f-globalisation/README.md
+++ b/packages/services/f-globalisation/README.md
@@ -12,8 +12,8 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-globalisation.svg)](https://badge.fury.io/js/%40justeat%2Ff-globalisation)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-globalisation/badge.svg)](https://coveralls.io/github/justeat/f-globalisation)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-globalisation/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-globalisation?targetFile=package.json)
 
+---
 
 ## Usage
 

--- a/packages/services/f-http/README.md
+++ b/packages/services/f-http/README.md
@@ -13,7 +13,8 @@ Javascript HTTP client for interacting with restful services
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-http.svg)](https://badge.fury.io/js/%40justeat%2Ff-http)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-http/badge.svg)](https://coveralls.io/github/justeat/f-http)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-http/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-http?targetFile=package.json)
+
+---
 
 This package exposes methods for interacting with restful services, it may abstract any number of popular NPM packages which provide the ability to perform GET, PUT, POST, PATH, DELETE requests; while also adding some additional benefits.
 

--- a/packages/services/f-performance/README.md
+++ b/packages/services/f-performance/README.md
@@ -13,7 +13,6 @@ RUM performance metric collector
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-performance.svg)](https://badge.fury.io/js/%40justeat%2Ff-performance)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-performance/badge.svg)](https://coveralls.io/github/justeat/f-performance)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-performance/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-performance?targetFile=package.json)
 
 ---
 

--- a/packages/services/f-services/README.md
+++ b/packages/services/f-services/README.md
@@ -12,7 +12,8 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-services.svg)](https://badge.fury.io/js/%40justeat%2Ff-services)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-services/badge.svg)](https://coveralls.io/github/justeat/f-services)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-services/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-services?targetFile=package.json)
+
+---
 
 ## Usage
 

--- a/packages/services/f-statistics/README.md
+++ b/packages/services/f-statistics/README.md
@@ -13,7 +13,8 @@ A service for publishing statistics from the client side
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-statistics.svg)](https://badge.fury.io/js/%40justeat%2Ff-statistics)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-statistics/badge.svg)](https://coveralls.io/github/justeat/f-statistics)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-statistics/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-statistics?targetFile=package.json)
+
+---
 
 > This package is an MVP (not yet stable), if you want to use it contact the team first.
 

--- a/packages/services/f-test-data-creator/README.md
+++ b/packages/services/f-test-data-creator/README.md
@@ -13,7 +13,6 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-test-data-creator.svg)](https://badge.fury.io/js/%40justeat%2Ff-test-data-creator)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-test-data-creator/badge.svg)](https://coveralls.io/github/justeat/f-test-data-creator)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-test-data-creator/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-test-data-creator?targetFile=package.json)
 
 ---
 

--- a/packages/services/f-wdio-utils/README.md
+++ b/packages/services/f-wdio-utils/README.md
@@ -13,7 +13,6 @@ webdriverIO page object
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-wdio-utils.svg)](https://badge.fury.io/js/%40justeat%2Ff-wdio-utils)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-wdio-utils/badge.svg)](https://coveralls.io/github/justeat/f-wdio-utils)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-wdio-utils/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-wdio-utils?targetFile=package.json)
 
 ---
 

--- a/packages/tools/f-vue-icons/README.md
+++ b/packages/tools/f-vue-icons/README.md
@@ -11,9 +11,9 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-vue-icons.svg)](https://badge.fury.io/js/%40justeat%2Ff-vue-icons)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-vue-icons/badge.svg)](https://coveralls.io/github/justeat/f-vue-icons)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-vue-icons/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-vue-icons?targetFile=package.json)
 
 ---
+
 ## Usage
 
 ### Installation

--- a/packages/tools/generator-component/README.md
+++ b/packages/tools/generator-component/README.md
@@ -13,8 +13,8 @@ A generator for Fozzie components.
 [![npm version](https://badge.fury.io/js/%40justeat%2Fgenerator-component.svg)](https://badge.fury.io/js/%40justeat%2Fgenerator-component)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/generator-component/badge.svg)](https://coveralls.io/github/justeat/generator-component)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/generator-component/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/generator-component?targetFile=package.json)
 
+---
 
 ## Usage
 

--- a/packages/tools/generator-component/generators/app/templates/README.md
+++ b/packages/tools/generator-component/generators/app/templates/README.md
@@ -13,7 +13,6 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-<%= name.default %>.svg)](https://badge.fury.io/js/%40justeat%2Ff-<%= name.default %>)
 [![CircleCI](https://circleci.com/gh/justeat/fozzie-components.svg?style=svg)](https://circleci.com/gh/justeat/workflows/fozzie-components)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-<%= name.default %>/badge.svg)](https://coveralls.io/github/justeat/f-<%= name.default %>)
-[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-<%= name.default %>/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-<%= name.default %>?targetFile=package.json)
 
 ---
 

--- a/stories/getting-started/contributing-guide.stories.mdx
+++ b/stories/getting-started/contributing-guide.stories.mdx
@@ -49,7 +49,6 @@ If you have any questions about how to implement any of these testing standards,
 
 * To report the build status you can [add a CircleCI badge](https://circleci.com/gh/justeat/workflows/fozzie-components)
 * If there are JavaScript unit tests in the package you can [add a coveralls badge](https://coveralls.io/github/justeat/)
-* Check for known vulnerabilities in your package with a [Snyk.io badge](https://snyk.io/test/)
 
 
 ## Publishing via npm

--- a/yarn.lock
+++ b/yarn.lock
@@ -10603,7 +10603,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.6.8, axios@npm:^1.6.7":
+"axios@npm:1.6.8":
   version: 1.6.8
   resolution: "axios@npm:1.6.8"
   dependencies:
@@ -10620,6 +10620,17 @@ __metadata:
   dependencies:
     follow-redirects: ^1.14.4
   checksum: 468cf496c08a6aadfb7e699bebdac02851e3043d4e7d282350804ea8900e30d368daa6e3cd4ab83b8ddb5a3b1e17a5a21ada13fc9cebd27b74828f47a4236316
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.7.4":
+  version: 1.7.7
+  resolution: "axios@npm:1.7.7"
+  dependencies:
+    follow-redirects: ^1.15.6
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 882d4fe0ec694a07c7f5c1f68205eb6dc5a62aecdb632cc7a4a3d0985188ce3030e0b277e1a8260ac3f194d314ae342117660a151fabffdc5081ca0b5a8b47fe
   languageName: node
   linkType: hard
 
@@ -12308,12 +12319,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromedriver@npm:126.0.2":
-  version: 126.0.2
-  resolution: "chromedriver@npm:126.0.2"
+"chromedriver@npm:128.0.1":
+  version: 128.0.1
+  resolution: "chromedriver@npm:128.0.1"
   dependencies:
     "@testim/chrome-version": ^1.1.4
-    axios: ^1.6.7
+    axios: ^1.7.4
     compare-versions: ^6.1.0
     extract-zip: ^2.0.1
     proxy-agent: ^6.4.0
@@ -12321,7 +12332,7 @@ __metadata:
     tcp-port-used: ^1.0.2
   bin:
     chromedriver: bin/chromedriver
-  checksum: e364a29dda69eee2c34436d465c92c2632a7cc2f33f4fdcb1d88b56d8af678e492d6a6f7a8061f7b1a2821c334edba3414945cb4226ec0000cc9ef361e8711f3
+  checksum: a6a4ecaae204d748632cfb4d19071ebeef0303019b1acf6fd9a8e844ed597b96b7b93dafbdeb4215a6b073bb1628be084635d0559e6912d09cfe688b644418a0
   languageName: node
   linkType: hard
 
@@ -29666,7 +29677,7 @@ __metadata:
     babel-jest: 29.7.0
     babel-loader: 8.1.0
     bundlewatch: 0.3.3
-    chromedriver: 126.0.2
+    chromedriver: 128.0.1
     core-js: 3.36.1
     cross-env: 7.0.2
     css-loader: 1.0.1


### PR DESCRIPTION
## v7.57.1

### Changed

- Update `chromedriver` to v128

- Readme update for all the components to remove snyk references 
- Updates legacy cookie banner test 