### PR TITLE
f-account-info@v1.9.0 - Update GET Consumer Details route

### DIFF
--- a/packages/components/pages/f-account-info/CHANGELOG.md
+++ b/packages/components/pages/f-account-info/CHANGELOG.md
@@ -9,7 +9,6 @@ _November 27, 2024_
 
 ### Changed
 
-- Move `GET /consumer` request to `GET /applications/uk/consumer/me`
 - Send `Accept-Tenant` header for `ConsumerAPI` requests
 
 ## v1.8.1

--- a/packages/components/pages/f-account-info/CHANGELOG.md
+++ b/packages/components/pages/f-account-info/CHANGELOG.md
@@ -3,7 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v1.9.0
+
+_November 27, 2024_
+
+### Changed
+
+- Move `GET /consumer` request to `GET /applications/uk/consumer/me`
+- Send `Accept-Tenant` header for `ConsumerAPI` requests
+
 ## v1.8.1
+
 
 _April 29, 2024_
 

--- a/packages/components/pages/f-account-info/CHANGELOG.md
+++ b/packages/components/pages/f-account-info/CHANGELOG.md
@@ -13,7 +13,6 @@ _November 27, 2024_
 
 ## v1.8.1
 
-
 _April 29, 2024_
 
 ### Changed

--- a/packages/components/pages/f-account-info/package.json
+++ b/packages/components/pages/f-account-info/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-account-info",
   "description": "Fozzie Account Info - The account information page",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "main": "dist/f-account-info.umd.min.js",
   "maxBundleSize": "55kB",
   "files": [

--- a/packages/components/pages/f-account-info/src/constants.js
+++ b/packages/components/pages/f-account-info/src/constants.js
@@ -3,7 +3,9 @@ export const UPDATE_CONSUMER_DETAIL = 'updateConsumerDetail';
 
 export const EVENT_SPINNER_STOP_LOADING = 'stop-spinner';
 
-export const CONSUMER_DETAILS_URL = 'consumer';
+export const GET_CONSUMER_DETAILS_URL = 'applications/uk/consumer/me';
+export const PATCH_CONSUMER_DETAILS_URL = 'consumer';
 export const CONSUMER_ADDRESSES_URL = 'consumer/addresses';
 
 export const AUTHORISATION_HEADER_NAME = 'Authorization';
+export const ACCEPT_TENANT_HEADER_NAME = 'Accept-Tenant';

--- a/packages/components/pages/f-account-info/src/constants.js
+++ b/packages/components/pages/f-account-info/src/constants.js
@@ -3,8 +3,7 @@ export const UPDATE_CONSUMER_DETAIL = 'updateConsumerDetail';
 
 export const EVENT_SPINNER_STOP_LOADING = 'stop-spinner';
 
-export const GET_CONSUMER_DETAILS_URL = 'applications/uk/consumer/me';
-export const PATCH_CONSUMER_DETAILS_URL = 'consumer';
+export const CONSUMER_DETAILS_URL = 'consumer';
 export const CONSUMER_ADDRESSES_URL = 'consumer/addresses';
 
 export const AUTHORISATION_HEADER_NAME = 'Authorization';

--- a/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
+++ b/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
@@ -1,12 +1,15 @@
 import {
-    CONSUMER_DETAILS_URL,
+    GET_CONSUMER_DETAILS_URL,
+    PATCH_CONSUMER_DETAILS_URL,
     CONSUMER_ADDRESSES_URL,
-    AUTHORISATION_HEADER_NAME
+    AUTHORISATION_HEADER_NAME,
+    ACCEPT_TENANT_HEADER_NAME
 } from '../../constants';
 
 const BuildHeaders = authToken => {
     const headers = {
-        [AUTHORISATION_HEADER_NAME]: authToken ? `Bearer ${authToken}` : ''
+        [AUTHORISATION_HEADER_NAME]: authToken ? `Bearer ${authToken}` : '',
+        [ACCEPT_TENANT_HEADER_NAME]: 'uk',
     };
 
     return headers;
@@ -24,7 +27,7 @@ export default class ConsumerApi {
     async getConsumerDetails (authToken) {
         const headers = BuildHeaders(authToken);
 
-        const response = await this.#httpClient.get(`${this.#baseUrl}/${CONSUMER_DETAILS_URL}`, headers);
+        const response = await this.#httpClient.get(`${this.#baseUrl}/${GET_CONSUMER_DETAILS_URL}`, headers);
 
         return response;
     }
@@ -40,7 +43,7 @@ export default class ConsumerApi {
     async patchConsumer (authToken, body) {
         const headers = BuildHeaders(authToken);
 
-        const response = await this.#httpClient.patch(`${this.#baseUrl}/${CONSUMER_DETAILS_URL}`, body, headers);
+        const response = await this.#httpClient.patch(`${this.#baseUrl}/${PATCH_CONSUMER_DETAILS_URL}`, body, headers);
 
         return response;
     }

--- a/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
+++ b/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
@@ -9,7 +9,7 @@ import {
 const BuildHeaders = authToken => {
     const headers = {
         [AUTHORISATION_HEADER_NAME]: authToken ? `Bearer ${authToken}` : '',
-        [ACCEPT_TENANT_HEADER_NAME]: 'uk',
+        [ACCEPT_TENANT_HEADER_NAME]: 'uk'
     };
 
     return headers;

--- a/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
+++ b/packages/components/pages/f-account-info/src/services/providers/Consumer.api.js
@@ -1,6 +1,5 @@
 import {
-    GET_CONSUMER_DETAILS_URL,
-    PATCH_CONSUMER_DETAILS_URL,
+    CONSUMER_DETAILS_URL,
     CONSUMER_ADDRESSES_URL,
     AUTHORISATION_HEADER_NAME,
     ACCEPT_TENANT_HEADER_NAME
@@ -27,7 +26,7 @@ export default class ConsumerApi {
     async getConsumerDetails (authToken) {
         const headers = BuildHeaders(authToken);
 
-        const response = await this.#httpClient.get(`${this.#baseUrl}/${GET_CONSUMER_DETAILS_URL}`, headers);
+        const response = await this.#httpClient.get(`${this.#baseUrl}/${CONSUMER_DETAILS_URL}`, headers);
 
         return response;
     }
@@ -43,7 +42,7 @@ export default class ConsumerApi {
     async patchConsumer (authToken, body) {
         const headers = BuildHeaders(authToken);
 
-        const response = await this.#httpClient.patch(`${this.#baseUrl}/${PATCH_CONSUMER_DETAILS_URL}`, body, headers);
+        const response = await this.#httpClient.patch(`${this.#baseUrl}/${CONSUMER_DETAILS_URL}`, body, headers);
 
         return response;
     }

--- a/packages/components/pages/f-account-info/src/services/providers/_tests/Consumer.api.test.js
+++ b/packages/components/pages/f-account-info/src/services/providers/_tests/Consumer.api.test.js
@@ -1,8 +1,7 @@
 import ConsumerApi from '../Consumer.api';
 
 import {
-    GET_CONSUMER_DETAILS_URL,
-    PATCH_CONSUMER_DETAILS_URL,
+    CONSUMER_DETAILS_URL,
     CONSUMER_ADDRESSES_URL,
     AUTHORISATION_HEADER_NAME,
     ACCEPT_TENANT_HEADER_NAME
@@ -54,7 +53,7 @@ describe('ConsumerApi Provider', () => {
     describe('When calling `getConsumerDetails`', () => {
         it('should send the correct parameters', async () => {
             // Arrange
-            const expectedUri = `${baseUrl}/${GET_CONSUMER_DETAILS_URL}`;
+            const expectedUri = `${baseUrl}/${CONSUMER_DETAILS_URL}`;
             const expectedHeaders = {
                 [AUTHORISATION_HEADER_NAME]: `Bearer ${token}`,
                 [ACCEPT_TENANT_HEADER_NAME]: 'uk'
@@ -88,7 +87,7 @@ describe('ConsumerApi Provider', () => {
     describe('When calling `patchConsumer`', () => {
         it('should send the correct parameters', async () => {
             // Arrange
-            const expectedUri = `${baseUrl}/${PATCH_CONSUMER_DETAILS_URL}`;
+            const expectedUri = `${baseUrl}/${CONSUMER_DETAILS_URL}`;
             const expectedBody = consumerUpdateBody;
             const expectedHeaders = {
                 [AUTHORISATION_HEADER_NAME]: `Bearer ${token}`,

--- a/packages/components/pages/f-account-info/src/services/providers/_tests/Consumer.api.test.js
+++ b/packages/components/pages/f-account-info/src/services/providers/_tests/Consumer.api.test.js
@@ -1,9 +1,11 @@
 import ConsumerApi from '../Consumer.api';
 
 import {
-    CONSUMER_DETAILS_URL,
+    GET_CONSUMER_DETAILS_URL,
+    PATCH_CONSUMER_DETAILS_URL,
     CONSUMER_ADDRESSES_URL,
-    AUTHORISATION_HEADER_NAME
+    AUTHORISATION_HEADER_NAME,
+    ACCEPT_TENANT_HEADER_NAME
 } from '../../../constants';
 import {
     baseUrl,
@@ -52,9 +54,10 @@ describe('ConsumerApi Provider', () => {
     describe('When calling `getConsumerDetails`', () => {
         it('should send the correct parameters', async () => {
             // Arrange
-            const expectedUri = `${baseUrl}/${CONSUMER_DETAILS_URL}`;
+            const expectedUri = `${baseUrl}/${GET_CONSUMER_DETAILS_URL}`;
             const expectedHeaders = {
-                [AUTHORISATION_HEADER_NAME]: `Bearer ${token}`
+                [AUTHORISATION_HEADER_NAME]: `Bearer ${token}`,
+                [ACCEPT_TENANT_HEADER_NAME]: 'uk'
             };
 
             // Act
@@ -70,7 +73,8 @@ describe('ConsumerApi Provider', () => {
             // Arrange
             const expectedUri = `${baseUrl}/${CONSUMER_ADDRESSES_URL}`;
             const expectedHeaders = {
-                [AUTHORISATION_HEADER_NAME]: `Bearer ${token}`
+                [AUTHORISATION_HEADER_NAME]: `Bearer ${token}`,
+                [ACCEPT_TENANT_HEADER_NAME]: 'uk'
             };
 
             // Act
@@ -84,10 +88,11 @@ describe('ConsumerApi Provider', () => {
     describe('When calling `patchConsumer`', () => {
         it('should send the correct parameters', async () => {
             // Arrange
-            const expectedUri = `${baseUrl}/${CONSUMER_DETAILS_URL}`;
+            const expectedUri = `${baseUrl}/${PATCH_CONSUMER_DETAILS_URL}`;
             const expectedBody = consumerUpdateBody;
             const expectedHeaders = {
-                [AUTHORISATION_HEADER_NAME]: `Bearer ${token}`
+                [AUTHORISATION_HEADER_NAME]: `Bearer ${token}`,
+                [ACCEPT_TENANT_HEADER_NAME]: 'uk'
             };
 
             // Act


### PR DESCRIPTION

- Send `Accept-Tenant` header for `ConsumerAPI` requests

No visual changes, this just ensures we're sending all expected headers.
