### PR TITLE
f-header@10.22.0 Remove legacy account page links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## v7.57.4
+
+_January 17, 2025_
+
+### Changed
+
+- Install `chromedriver` v131
+
+
 ## v7.57.3
 
 _January 16, 2025_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "7.57.3",
+  "version": "7.57.4",
   "private": true,
   "scripts": {
     "build": "NODE_OPTIONS=--openssl-legacy-provider cross-env-shell turbo run build --continue --token=${TURBO_TOKEN}",
@@ -89,7 +89,7 @@
     "babel-jest": "29.7.0",
     "babel-loader": "8.1.0",
     "bundlewatch": "0.3.3",
-    "chromedriver": "132.0.0",
+    "chromedriver": "131.0.5",
     "core-js": "3.36.1",
     "cross-env": "7.0.2",
     "css-loader": "1.0.1",

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v10.22.0
+
+_Jan 15, 2025_
+
+### Changed
+
+- Removed deprecated account pages links from user navigation
+
 ## v10.21.1
 
 _July 05, 2024_

--- a/packages/components/organisms/f-header/CHANGELOG.md
+++ b/packages/components/organisms/f-header/CHANGELOG.md
@@ -9,7 +9,7 @@ _Jan 15, 2025_
 
 ### Changed
 
-- Removed deprecated account pages links from user navigation
+- Update and remove deprecated account pages links from user navigation
 
 ## v10.21.1
 

--- a/packages/components/organisms/f-header/package.json
+++ b/packages/components/organisms/f-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header - Globalised Header Component",
-  "version": "10.21.1",
+  "version": "10.22.0",
   "main": "dist/f-header.umd.min.js",
   "maxBundleSize": "55kB",
   "files": [

--- a/packages/components/organisms/f-header/src/tenants/en-AU.js
+++ b/packages/components/organisms/f-header/src/tenants/en-AU.js
@@ -14,7 +14,7 @@ export default {
         },
         orderHistory: {
             text: 'Orders',
-            url: '/order-history',
+            url: '/#order-history',
             gtm: 'click_account_your_orders'
         },
         accountCredit: {

--- a/packages/components/organisms/f-header/src/tenants/en-AU.js
+++ b/packages/components/organisms/f-header/src/tenants/en-AU.js
@@ -7,6 +7,11 @@ export default {
     navTitle: 'Main menu',
 
     navLinks: {
+        accountInfo: {
+            text: 'Account info',
+            url: '/#personalinfo',
+            gtm: 'click_account_your_account'
+        },
         orderHistory: {
             text: 'Orders',
             url: '/order-history',

--- a/packages/components/organisms/f-header/src/tenants/en-AU.js
+++ b/packages/components/organisms/f-header/src/tenants/en-AU.js
@@ -7,11 +7,6 @@ export default {
     navTitle: 'Main menu',
 
     navLinks: {
-        accountInfo: {
-            text: 'Account info',
-            url: '/account/info',
-            gtm: 'click_account_your_account'
-        },
         orderHistory: {
             text: 'Orders',
             url: '/order-history',
@@ -21,11 +16,6 @@ export default {
             text: 'Account credit',
             url: '/account/credit',
             gtm: 'click_account_credit'
-        },
-        addressBook: {
-            text: 'Delivery addresses',
-            url: '/account/addressbook',
-            gtm: 'click_account_address_books'
         }
     },
 

--- a/packages/components/organisms/f-header/src/tenants/en-GB.js
+++ b/packages/components/organisms/f-header/src/tenants/en-GB.js
@@ -14,7 +14,7 @@ export default {
         },
         orderHistory: {
             text: 'Your orders',
-            url: '/order-history',
+            url: '/#order-history',
             gtm: 'click_account_your_orders'
         },
         redeemAGiftcard: {

--- a/packages/components/organisms/f-header/src/tenants/en-GB.js
+++ b/packages/components/organisms/f-header/src/tenants/en-GB.js
@@ -7,25 +7,10 @@ export default {
     navTitle: 'Main menu',
 
     navLinks: {
-        accountInfo: {
-            text: 'Your account',
-            url: '/account/info',
-            gtm: 'click_account_your_account'
-        },
         orderHistory: {
             text: 'Your orders',
             url: '/order-history',
             gtm: 'click_account_your_orders'
-        },
-        savedCards: {
-            text: 'Your saved cards',
-            url: '/account/paymentoptions',
-            gtm: 'click_account_saved_cards'
-        },
-        addressBook: {
-            text: 'Your address book',
-            url: '/account/addressbook',
-            gtm: 'click_account_address_books'
         },
         redeemAGiftcard: {
             text: 'Redeem a gift card',
@@ -36,11 +21,6 @@ export default {
             text: 'Redeem a voucher',
             url: '/account/credit',
             gtm: 'click_account_redeem_voucher'
-        },
-        contactPreferences: {
-            text: 'Contact preferences',
-            url: '/account/preferences',
-            gtm: 'click_account_contact_preferences'
         }
     },
 

--- a/packages/components/organisms/f-header/src/tenants/en-GB.js
+++ b/packages/components/organisms/f-header/src/tenants/en-GB.js
@@ -7,6 +7,11 @@ export default {
     navTitle: 'Main menu',
 
     navLinks: {
+        accountInfo: {
+            text: 'Your account',
+            url: '/#personalinfo',
+            gtm: 'click_account_your_account'
+        },
         orderHistory: {
             text: 'Your orders',
             url: '/order-history',
@@ -21,6 +26,11 @@ export default {
             text: 'Redeem a voucher',
             url: '/account/credit',
             gtm: 'click_account_redeem_voucher'
+        },
+        contactPreferences: {
+            text: 'Contact preferences',
+            url: '/#personalinfo',
+            gtm: 'click_account_contact_preferences'
         }
     },
 

--- a/packages/components/organisms/f-header/src/tenants/en-IE.js
+++ b/packages/components/organisms/f-header/src/tenants/en-IE.js
@@ -7,11 +7,6 @@ export default {
     navTitle: 'Main menu',
 
     navLinks: {
-        accountInfo: {
-            text: 'Account info',
-            url: '/account/info',
-            gtm: 'click_account_your_account'
-        },
         orderHistory: {
             text: 'Orders',
             url: '/order-history',
@@ -21,21 +16,6 @@ export default {
             text: 'Redeem a gift card',
             url: '/giftcards/redeem',
             gtm: 'click_account_redeem_giftcard'
-        },
-        savedCards: {
-            text: 'Payment methods',
-            url: '/account/saved-cards',
-            gtm: 'click_account_saved_cards'
-        },
-        addressBook: {
-            text: 'Delivery addresses',
-            url: '/account/addressbook',
-            gtm: 'click_account_address_books'
-        },
-        contactPreferences: {
-            text: 'Contact preferences',
-            url: '/account/contact-preferences',
-            gtm: 'click_account_contact_preferences'
         }
     },
 

--- a/packages/components/organisms/f-header/src/tenants/en-IE.js
+++ b/packages/components/organisms/f-header/src/tenants/en-IE.js
@@ -7,6 +7,11 @@ export default {
     navTitle: 'Main menu',
 
     navLinks: {
+        accountInfo: {
+            text: 'Account info',
+            url: '/#personalinfo',
+            gtm: 'click_account_your_account'
+        },
         orderHistory: {
             text: 'Orders',
             url: '/order-history',
@@ -16,6 +21,11 @@ export default {
             text: 'Redeem a gift card',
             url: '/giftcards/redeem',
             gtm: 'click_account_redeem_giftcard'
+        },
+        contactPreferences: {
+            text: 'Contact preferences',
+            url: '/#personalinfo',
+            gtm: 'click_account_contact_preferences'
         }
     },
 

--- a/packages/components/organisms/f-header/src/tenants/en-IE.js
+++ b/packages/components/organisms/f-header/src/tenants/en-IE.js
@@ -14,7 +14,7 @@ export default {
         },
         orderHistory: {
             text: 'Orders',
-            url: '/order-history',
+            url: '/#order-history',
             gtm: 'click_account_your_orders'
         },
         redeemAGiftcard: {

--- a/packages/components/organisms/f-header/src/tenants/es-ES.js
+++ b/packages/components/organisms/f-header/src/tenants/es-ES.js
@@ -7,11 +7,6 @@ export default {
     navTitle: 'Menú principal',
 
     navLinks: {
-        accountInfo: {
-            text: 'Información de la cuenta',
-            url: '/account/info',
-            gtm: 'click_account_your_account'
-        },
         orderHistory: {
             text: 'Pedidos',
             url: '/order-history',
@@ -21,21 +16,6 @@ export default {
             text: 'Crédito de la cuenta',
             url: '/account/credit',
             gtm: 'click_account_credit'
-        },
-        savedCards: {
-            text: 'Métodos de pago',
-            url: '/account/saved-cards',
-            gtm: 'click_account_saved_cards'
-        },
-        addressBook: {
-            text: 'Direcciones de reparto',
-            url: '/account/addressbook',
-            gtm: 'click_account_address_books'
-        },
-        contactPreferences: {
-            text: 'Preferencias de contacto',
-            url: '/account/contact-preferences/',
-            gtm: 'click_account_contact_preferences'
         }
     },
 

--- a/packages/components/organisms/f-header/src/tenants/es-ES.js
+++ b/packages/components/organisms/f-header/src/tenants/es-ES.js
@@ -7,6 +7,11 @@ export default {
     navTitle: 'Menú principal',
 
     navLinks: {
+        accountInfo: {
+            text: 'Información de la cuenta',
+            url: '/#personalinfo',
+            gtm: 'click_account_your_account'
+        },
         orderHistory: {
             text: 'Pedidos',
             url: '/order-history',
@@ -16,6 +21,11 @@ export default {
             text: 'Crédito de la cuenta',
             url: '/account/credit',
             gtm: 'click_account_credit'
+        },
+        contactPreferences: {
+            text: 'Preferencias de contacto',
+            url: '/#personalinfo',
+            gtm: 'click_account_contact_preferences'
         }
     },
 

--- a/packages/components/organisms/f-header/src/tenants/es-ES.js
+++ b/packages/components/organisms/f-header/src/tenants/es-ES.js
@@ -14,7 +14,7 @@ export default {
         },
         orderHistory: {
             text: 'Pedidos',
-            url: '/order-history',
+            url: '/#order-history',
             gtm: 'click_account_your_orders'
         },
         accountCredit: {

--- a/packages/components/organisms/f-header/src/tenants/it-IT.js
+++ b/packages/components/organisms/f-header/src/tenants/it-IT.js
@@ -14,7 +14,7 @@ export default {
         },
         orderHistory: {
             text: 'Ordini',
-            url: '/order-history',
+            url: '/#order-history',
             gtm: 'click_account_your_orders'
         },
         accountCredit: {

--- a/packages/components/organisms/f-header/src/tenants/it-IT.js
+++ b/packages/components/organisms/f-header/src/tenants/it-IT.js
@@ -7,11 +7,6 @@ export default {
     navTitle: 'Menu principale',
 
     navLinks: {
-        accountInfo: {
-            text: 'Account',
-            url: '/account/info',
-            gtm: 'click_account_your_account'
-        },
         orderHistory: {
             text: 'Ordini',
             url: '/order-history',
@@ -21,21 +16,6 @@ export default {
             text: "Credito dell'account",
             url: '/account/credit',
             gtm: 'click_account_credit'
-        },
-        savedCards: {
-            text: 'Metodi di pagamento',
-            url: '/account/saved-cards',
-            gtm: 'click_account_saved_cards'
-        },
-        addressBook: {
-            text: 'Indirizzi di consegna',
-            url: '/account/addressbook',
-            gtm: 'click_account_address_books'
-        },
-        contactPreferences: {
-            text: 'Modalità di contatto',
-            url: '/account/contact-preferences/',
-            gtm: 'click_account_contact_preferences'
         }
     },
 

--- a/packages/components/organisms/f-header/src/tenants/it-IT.js
+++ b/packages/components/organisms/f-header/src/tenants/it-IT.js
@@ -7,6 +7,11 @@ export default {
     navTitle: 'Menu principale',
 
     navLinks: {
+        accountInfo: {
+            text: 'Account',
+            url: '/#personalinfo',
+            gtm: 'click_account_your_account'
+        },
         orderHistory: {
             text: 'Ordini',
             url: '/order-history',
@@ -16,6 +21,11 @@ export default {
             text: "Credito dell'account",
             url: '/account/credit',
             gtm: 'click_account_credit'
+        },
+        contactPreferences: {
+            text: 'Modalità di contatto',
+            url: '/#personalinfo',
+            gtm: 'click_account_contact_preferences'
         }
     },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12319,9 +12319,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromedriver@npm:132.0.0":
-  version: 132.0.0
-  resolution: "chromedriver@npm:132.0.0"
+"chromedriver@npm:131.0.5":
+  version: 131.0.5
+  resolution: "chromedriver@npm:131.0.5"
   dependencies:
     "@testim/chrome-version": ^1.1.4
     axios: ^1.7.4
@@ -12332,7 +12332,7 @@ __metadata:
     tcp-port-used: ^1.0.2
   bin:
     chromedriver: bin/chromedriver
-  checksum: ee8d7592688e498666ab6384be84b31e0c4a095fac53727403ec5e84b93e35a0dbfc29c82f8582660043cf7af5cc0d011697f29e0088fae293b69a0b601409a2
+  checksum: 8b571eba80bab4c793c03526b299ac3fc2e4740aed3000d09ea283c44996c75eef940151a4f8ce9e3339d88e1bacc09ea89743eadc68ad23ab1cdf280d2a942d
   languageName: node
   linkType: hard
 
@@ -29677,7 +29677,7 @@ __metadata:
     babel-jest: 29.7.0
     babel-loader: 8.1.0
     bundlewatch: 0.3.3
-    chromedriver: 132.0.0
+    chromedriver: 131.0.5
     core-js: 3.36.1
     cross-env: 7.0.2
     css-loader: 1.0.1


### PR DESCRIPTION
f-header@10.22.0 Remove legacy account page links from user navigation
-------

Remove and amend deprecated and changed links from page header for L-JE pages

## UI Review Checks

- [x] README and/or UI Documentation has been [created|updated]
- [x] Unit tests have been [created|updated]
- [x] This code has been checked with regard to [our accessibility standards](http://fozzie.just-eat.com/documentation/general/accessibility/checklist)

